### PR TITLE
Adding abstract syntax tree types and API

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -61,7 +61,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 ExperimentalAutoDetectBinPacking: true
 FixNamespaceComments: false
 # ForEachMacros: ['']

--- a/.clang-format
+++ b/.clang-format
@@ -66,16 +66,18 @@ ExperimentalAutoDetectBinPacking: true
 FixNamespaceComments: false
 # ForEachMacros: ['']
 IncludeCategories:
-  - Regex:           '^<hpx/config\.hpp>'
+  - Regex:           '^<phylanx/config\.hpp>'
     Priority:        1
-  - Regex:           '^<hpx/.*\.hpp>'
+  - Regex:           '^<phylanx/.*\.hpp>'
     Priority:        2
-  - Regex:           '^<hpx/parallel/.*\.hpp>'
+  - Regex:           '^<hpx/.*\.hpp>'
     Priority:        3
-  - Regex:           '^<.*'
+  - Regex:           '^<hpx/parallel/.*\.hpp>'
     Priority:        4
-  - Regex:           '.*'
+  - Regex:           '^<.*'
     Priority:        5
+  - Regex:           '.*'
+    Priority:        6
 # IncludeIsMainRegex: ''
 IndentCaseLabels: false
 IndentWidth: 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,6 +246,11 @@ phylanx_option(
   "Enable or disable the compilation of unit tests"
   ON ADVANCED CATEGORY "Build")
 
+phylanx_option(
+  PHYLANX_WITH_EXAMPLES BOOL
+  "Enable or disable the compilation of the examples"
+  ON ADVANCED CATEGORY "Build")
+
 if(MSVC)
   hpx_option(PHYLANX_WITH_PSEUDO_DEPENDENCIES BOOL
     "Force creating pseudo targets and pseudo dependencies (default OFF)."

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2017 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(subdirs
+    ast
+   )
+
+foreach(subdir ${subdirs})
+  add_phylanx_pseudo_target(examples.${subdir}_)
+  add_subdirectory(${subdir})
+  add_phylanx_pseudo_dependencies(examples examples.${subdir}_)
+endforeach()
+

--- a/examples/ast/CMakeLists.txt
+++ b/examples/ast/CMakeLists.txt
@@ -4,7 +4,8 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(example_programs
-    traverse_ast
+    generate
+    traverse
    )
 
 foreach(example_program ${example_programs})
@@ -19,7 +20,7 @@ foreach(example_program ${example_programs})
   add_phylanx_executable(${example_program}
                      SOURCES ${sources}
                      ${${example_program}_FLAGS}
-                     FOLDER "Examples/AST/${example_program}")
+                     FOLDER "Examples/AST")
 
   # add a custom target for this example
   add_phylanx_pseudo_target(examples.ast_.${example_program})

--- a/examples/ast/CMakeLists.txt
+++ b/examples/ast/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) 2017 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(example_programs
+    traverse_ast
+   )
+
+foreach(example_program ${example_programs})
+
+  set(${example_program}_FLAGS DEPENDENCIES iostreams_component)
+
+  set(sources ${example_program}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_phylanx_executable(${example_program}
+                     SOURCES ${sources}
+                     ${${example_program}_FLAGS}
+                     FOLDER "Examples/AST/${example_program}")
+
+  # add a custom target for this example
+  add_phylanx_pseudo_target(examples.ast_.${example_program})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_phylanx_pseudo_dependencies(examples.ast_
+                              examples.ast_.${example_program})
+
+  # add dependencies to pseudo-target
+  add_phylanx_pseudo_dependencies(examples.ast_.${example_program}
+                              ${example_program}_exe)
+endforeach()
+

--- a/examples/ast/generate.cpp
+++ b/examples/ast/generate.cpp
@@ -1,0 +1,71 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+#include <hpx/hpx_main.hpp>
+
+#include <fstream>
+#include <iostream>
+#include <iterator>
+
+struct traverse_ast
+{
+    template <typename T>
+    bool operator()(T const& val) const
+    {
+        strm << val << '\n';
+        return true;
+    }
+
+    std::stringstream& strm;
+};
+
+void generate(std::istream& in, bool print_source_code)
+{
+    std::string source_code;
+    in.unsetf(std::ios::skipws);    // disable white space skipping
+    std::copy(
+        std::istream_iterator<char>(in),
+        std::istream_iterator<char>(),
+        std::back_inserter(source_code));
+
+    try {
+        phylanx::ast::expression ast = phylanx::ast::generate_ast(source_code);
+
+        std::stringstream strm;
+        phylanx::ast::traverse(ast, traverse_ast{strm});
+
+        if (print_source_code)
+            std::cout << "source code:\n" << source_code << std::endl;
+        std::cout << "generated ast:\n" << strm.str() << std::endl;
+    }
+    catch (hpx::exception const& e) {
+        if (print_source_code)
+            std::cout << "source code:\n" << source_code << std::endl;
+        std::cout << "generated error:\n" << hpx::get_error_what(e) << std::endl;
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    if (argc > 1)
+    {
+        std::ifstream in(argv[1], std::ios_base::in);
+        if (!in)
+        {
+            std::cerr
+                << "Error: Could not open input file: "
+                << argv[1] << std::endl;
+            return -1;
+        }
+        generate(in, true);
+    }
+    else
+    {
+        generate(std::cin, false);
+    }
+    return 0;
+}
+

--- a/examples/ast/generate.cpp
+++ b/examples/ast/generate.cpp
@@ -10,16 +10,21 @@
 #include <iostream>
 #include <iterator>
 
-struct traverse_ast
+struct traverse_ast : phylanx::ast::static_visitor
 {
+    traverse_ast(std::stringstream& strm)
+      : strm_(strm)
+    {
+    }
+
     template <typename T>
     bool operator()(T const& val) const
     {
-        strm << val << '\n';
+        strm_ << val << '\n';
         return true;
     }
 
-    std::stringstream& strm;
+    std::stringstream& strm_;
 };
 
 void generate(std::istream& in, bool print_source_code)

--- a/examples/ast/traverse.cpp
+++ b/examples/ast/traverse.cpp
@@ -1,13 +1,14 @@
-//   Copyright (c) 2001-2017 Hartmut Kaiser
+//   Copyright (c) 2017 Hartmut Kaiser
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
+#include <hpx/hpx_main.hp>
 
 #include <iostream>
 
-struct traverse_ast : phylanx::ast::static_visitor
+struct traverse_ast
 {
     template <typename T>
     bool operator()(T const& val) const
@@ -19,17 +20,15 @@ struct traverse_ast : phylanx::ast::static_visitor
 
 int main(int argc, char* argv[])
 {
-    phylanx::ast::primary_expr<double> p1{
-        phylanx::ir::node_data<double>{3.14}};
+    phylanx::ast::primary_expr p1{phylanx::ir::node_data<double>{3.14}};
 
-    phylanx::ast::operand<double> op1{p1};
-    phylanx::ast::expression<double> e1{op1};
+    phylanx::ast::operand op1{p1};
+    phylanx::ast::expression e1{op1};
 
-    phylanx::ast::operation<double> u1{
-        phylanx::ast::optoken::op_plus, std::move(op1)};
+    phylanx::ast::operation u1{phylanx::ast::optoken::op_plus, std::move(op1)};
     e1.append(u1);
 
-    std::list<phylanx::ast::operation<double>> ops = {u1, u1};
+    std::list<phylanx::ast::operation> ops = {u1, u1};
     e1.append(ops);
 
     phylanx::ast::traverse(e1, traverse_ast{});

--- a/examples/ast/traverse.cpp
+++ b/examples/ast/traverse.cpp
@@ -4,16 +4,23 @@
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
-#include <hpx/hpx_main.hp>
+#include <hpx/hpx_main.hpp>
 
 #include <iostream>
 
-struct traverse_ast
+struct traverse_ast : phylanx::ast::static_visitor
 {
     template <typename T>
-    bool operator()(T const& val) const
+    bool on_enter(T const& val) const
     {
-        std::cout << val << std::endl;
+        std::cout << "->" << val << std::endl;
+        return true;
+    }
+
+    template <typename T>
+    bool on_exit(T const& val) const
+    {
+        std::cout << "<-" << val << std::endl;
         return true;
     }
 };

--- a/examples/ast/traverse_ast.cpp
+++ b/examples/ast/traverse_ast.cpp
@@ -1,0 +1,38 @@
+//   Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <iostream>
+
+struct traverse_ast : phylanx::ast::static_visitor
+{
+    template <typename T>
+    bool operator()(T const& val) const
+    {
+        std::cout << val << std::endl;
+        return true;
+    }
+};
+
+int main(int argc, char* argv[])
+{
+    phylanx::ast::primary_expr<double> p1{
+        phylanx::ir::node_data<double>{3.14}};
+
+    phylanx::ast::operand<double> op1{p1};
+    phylanx::ast::expression<double> e1{op1};
+
+    phylanx::ast::operation<double> u1{
+        phylanx::ast::optoken::op_plus, std::move(op1)};
+    e1.append(u1);
+
+    std::list<phylanx::ast::operation<double>> ops = {u1, u1};
+    e1.append(ops);
+
+    phylanx::ast::traverse(e1, traverse_ast{});
+
+    return 0;
+}

--- a/phylanx/ast/generate_ast.hpp
+++ b/phylanx/ast/generate_ast.hpp
@@ -3,12 +3,14 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_AST_HPP)
-#define PHYLANX_AST_HPP
-
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
-#include <phylanx/ast/traverse.hpp>
-#include <phylanx/ast/generate_ast.hpp>
 
-#endif
+#include <string>
+
+namespace phylanx { namespace ast
+{
+    PHYLANX_EXPORT ast::expression generate_ast(std::string const& input);
+}}
+
+

--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -104,6 +104,77 @@ namespace phylanx { namespace ast
         op_post_decr,
     };
 
+    char const* const optoken_names[] =
+    {
+        "op_unknown",
+
+        // precedence 1
+        "op_comma",
+
+        // precedence 2
+        "op_assign",
+        "op_plus_assign",
+        "op_minus_assign",
+        "op_times_assign",
+        "op_divide_assign",
+        "op_mod_assign",
+        "op_bit_and_assign",
+        "op_bit_xor_assign",
+        "op_bitor_assign",
+        "op_shift_left_assign",
+        "op_shift_right_assign",
+
+        // precedence 3
+        "op_logical_or",
+
+        // precedence 4
+        "op_logical_and",
+
+        // precedence 5
+        "op_bit_or",
+
+        // precedence 6
+        "op_bit_xor",
+
+        // precedence 7
+        "op_bit_and",
+
+        // precedence 8
+        "op_equal",
+        "op_not_equal",
+
+        // precedence 9
+        "op_less",
+        "op_less_equal",
+        "op_greater",
+        "op_greater_equal",
+
+        // precedence 10
+        "op_shift_left",
+        "op_shift_right",
+
+        // precedence 11
+        "op_plus",
+        "op_minus",
+
+        // precedence 12
+        "op_times",
+        "op_divide",
+        "op_mod",
+
+        // precedence 13
+        "op_positive",
+        "op_negative",
+        "op_pre_incr",
+        "op_pre_decr",
+        "op_compl",
+        "op_not",
+
+        // precedence 14
+        "op_post_incr",
+        "op_post_decr",
+    };
+
     template <typename Archive>
     void load(Archive& ar, optoken& id, unsigned)
     {
@@ -538,6 +609,7 @@ namespace phylanx { namespace ast
 //         using function_list = std::list<function>;
 //     };
 
+    ///////////////////////////////////////////////////////////////////////////
     // print functions for debugging
     inline std::ostream& operator<<(std::ostream& out, nil)
     {
@@ -545,9 +617,50 @@ namespace phylanx { namespace ast
         return out;
     }
 
+    inline std::ostream& operator<<(std::ostream& out, optoken op)
+    {
+        out << optoken_names[static_cast<int>(op)];
+        return out;
+    }
+
     inline std::ostream& operator<<(std::ostream& out, identifier const& id)
     {
-        out << id.name;
+        out << "identifier: " << id.name;
+        return out;
+    }
+
+    template <typename T>
+    inline std::ostream& operator<<(std::ostream& out, primary_expr<T> const& p)
+    {
+        out << "primary_expr<T>";
+        return out;
+    }
+
+    template <typename T>
+    inline std::ostream& operator<<(std::ostream& out, operand<T> const& p)
+    {
+        out << "operand<T>";
+        return out;
+    }
+
+    template <typename T>
+    inline std::ostream& operator<<(std::ostream& out, unary_expr<T> const& p)
+    {
+        out << "unary_expr<T>";
+        return out;
+    }
+
+    template <typename T>
+    inline std::ostream& operator<<(std::ostream& out, operation<T> const& p)
+    {
+        out << "operation<T>";
+        return out;
+    }
+
+    template <typename T>
+    inline std::ostream& operator<<(std::ostream& out, expression<T> const& p)
+    {
+        out << "expression<T>";
         return out;
     }
 }}

--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -1,0 +1,555 @@
+//   Copyright (c) 2001-2011 Joel de Guzman
+//   Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_NODE_HPP)
+#define PHYLANX_AST_NODE_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <phylanx/util/serialization/optional.hpp>
+#include <phylanx/util/serialization/variant.hpp>
+
+#include <hpx/include/serialization.hpp>
+
+#include <iosfwd>
+#include <list>
+#include <string>
+#include <utility>
+
+namespace phylanx { namespace ast
+{
+    ///////////////////////////////////////////////////////////////////////////
+    //  The AST
+    struct tagged
+    {
+//         int id; // Used to annotate the AST with the iterator position.
+//                 // This id is used as a key to a map<int, Iterator>
+//                 // (not really part of the AST.)
+    };
+
+    enum class optoken
+    {
+        op_unknown,
+
+        // precedence 1
+        op_comma,
+
+        // precedence 2
+        op_assign,
+        op_plus_assign,
+        op_minus_assign,
+        op_times_assign,
+        op_divide_assign,
+        op_mod_assign,
+        op_bit_and_assign,
+        op_bit_xor_assign,
+        op_bitor_assign,
+        op_shift_left_assign,
+        op_shift_right_assign,
+
+        // precedence 3
+        op_logical_or,
+
+        // precedence 4
+        op_logical_and,
+
+        // precedence 5
+        op_bit_or,
+
+        // precedence 6
+        op_bit_xor,
+
+        // precedence 7
+        op_bit_and,
+
+        // precedence 8
+        op_equal,
+        op_not_equal,
+
+        // precedence 9
+        op_less,
+        op_less_equal,
+        op_greater,
+        op_greater_equal,
+
+        // precedence 10
+        op_shift_left,
+        op_shift_right,
+
+        // precedence 11
+        op_plus,
+        op_minus,
+
+        // precedence 12
+        op_times,
+        op_divide,
+        op_mod,
+
+        // precedence 13
+        op_positive,
+        op_negative,
+        op_pre_incr,
+        op_pre_decr,
+        op_compl,
+        op_not,
+
+        // precedence 14
+        op_post_incr,
+        op_post_decr,
+    };
+
+    template <typename Archive>
+    void load(Archive& ar, optoken& id, unsigned)
+    {
+        int val;
+        ar >> val;
+        id = static_cast<optoken>(val);
+    }
+
+    template <typename Archive>
+    void save(Archive& ar, optoken const& id, unsigned)
+    {
+        int val = static_cast<int>(id);
+        ar << val;
+    }
+    HPX_SERIALIZATION_SPLIT_FREE(optoken);
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct nil {};
+
+    constexpr inline bool operator==(nil const&, nil const&)
+    {
+        return true;
+    }
+    constexpr inline bool operator!=(nil const&, nil const&)
+    {
+        return false;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct identifier : tagged
+    {
+        identifier() = default;
+
+        explicit identifier(std::string const& name)
+        : name(name)
+        {
+        }
+        explicit identifier(std::string && name)
+          : name(std::move(name))
+        {
+        }
+
+        std::string name;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & name;
+        }
+    };
+
+    inline bool operator==(identifier const& lhs, identifier const& rhs)
+    {
+        return lhs.name == rhs.name;
+    }
+    inline bool operator!=(identifier const& lhs, identifier const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T> struct unary_expr;
+    template <typename T> struct function_call;
+    template <typename T> struct expression;
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct primary_expr : tagged
+    {
+        using expr_node_type = phylanx::util::variant<
+                nil
+              , bool
+              , phylanx::ir::node_data<T>
+              , identifier
+              , phylanx::util::recursive_wrapper<expression<T>>
+            >;
+
+        expr_node_type value;
+
+        primary_expr() = default;
+        explicit primary_expr(bool val)
+          : value(val)
+        {
+        }
+
+        explicit primary_expr(phylanx::ir::node_data<T> const& val)
+          : value(val)
+        {
+        }
+        explicit primary_expr(phylanx::ir::node_data<T> && val)
+          : value(std::move(val))
+        {
+        }
+
+        explicit primary_expr(identifier const& val)
+          : value(val)
+        {
+        }
+        explicit primary_expr(identifier && val)
+          : value(std::move(val))
+        {
+        }
+
+        explicit primary_expr(expression<T> const& val)
+          : value(val)
+        {
+        }
+        explicit primary_expr(expression<T> && val)
+          : value(std::move(val))
+        {
+        }
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & value;
+        }
+    };
+
+    template <typename T>
+    bool operator==(primary_expr<T> const& lhs, primary_expr<T> const& rhs)
+    {
+        return lhs.value == rhs.value;
+    }
+    template <typename T>
+    bool operator!=(primary_expr<T> const& lhs, primary_expr<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct operand : tagged
+    {
+        using operand_node_type = phylanx::util::variant<
+                nil
+              , phylanx::util::recursive_wrapper<primary_expr<T>>
+              , phylanx::util::recursive_wrapper<unary_expr<T>>
+//                   , phylanx::util::recursive_wrapper<function_call>
+            >;
+
+        operand_node_type value;
+
+        operand() = default;
+
+        explicit operand(primary_expr<T> const& val)
+          : value(val)
+        {
+        }
+        explicit operand(primary_expr<T> && val)
+          : value(std::move(val))
+        {
+        }
+
+        explicit operand(unary_expr<T> const& val)
+          : value(val)
+        {
+        }
+        explicit operand(unary_expr<T> && val)
+          : value(std::move(val))
+        {
+        }
+
+//         operand(function_call const& val)
+//             : value(val)
+//         {
+//         }
+//         operand(function_call && val)
+//             : value(std::move(val))
+//         {
+//         }
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & value;
+        }
+    };
+
+    template <typename T>
+    bool operator==(operand<T> const& lhs, operand<T> const& rhs)
+    {
+        return lhs.value == rhs.value;
+    }
+    template <typename T>
+    bool operator!=(operand<T> const& lhs, operand<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct unary_expr : tagged
+    {
+        unary_expr()
+          : operator_(optoken::op_unknown)
+        {}
+
+        explicit unary_expr(optoken id, operand<T> const& op)
+          : operator_(id)
+          , operand_(op)
+        {}
+        explicit unary_expr(optoken id, operand<T> && op)
+          : operator_(id)
+          , operand_(std::move(op))
+        {}
+
+        optoken operator_;
+        phylanx::util::recursive_wrapper<operand<T>> operand_;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & operator_ & operand_;
+        }
+    };
+
+    template <typename T>
+    bool operator==(unary_expr<T> const& lhs, unary_expr<T> const& rhs)
+    {
+        return lhs.operator_ == rhs.operator_ &&
+            lhs.operand_ == rhs.operand_;
+    }
+    template <typename T>
+    bool operator!=(unary_expr<T> const& lhs, unary_expr<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct operation
+    {
+        operation()
+          : operator_(optoken::op_unknown)
+        {}
+
+        explicit operation(optoken id, operand<T> const& op)
+          : operator_(id)
+          , operand_(op)
+        {}
+        explicit operation(optoken id, operand<T> && op)
+          : operator_(id)
+          , operand_(std::move(op))
+        {}
+
+        optoken operator_;
+        operand<T> operand_;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & operator_ & operand_;
+        }
+    };
+
+    template <typename T>
+    bool operator==(operation<T> const& lhs, operation<T> const& rhs)
+    {
+        return lhs.operator_ == rhs.operator_ &&
+            lhs.operand_ == rhs.operand_;
+    }
+    template <typename T>
+    bool operator!=(operation<T> const& lhs, operation<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+//         struct function_call
+//         {
+//             identifier function_name;
+//             std::list<expression> args;
+//
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & function_name & args;
+//             }
+//         };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct expression
+    {
+        expression() = default;
+
+        explicit expression(operand<T> const& f)
+          : first(f)
+        {}
+        explicit expression(operand<T> && f)
+          : first(std::move(f))
+        {}
+
+        void append(operation<T> const& op)
+        {
+            rest.push_back(op);
+        }
+        void append(operation<T> && op)
+        {
+            rest.emplace_back(std::move(op));
+        }
+        void append(std::list<operation<T>> const& l)
+        {
+            std::copy(l.begin(), l.end(), std::back_inserter(rest));
+        }
+        void append(std::list<operation<T>> && l)
+        {
+            std::move(l.begin(), l.end(), std::back_inserter(rest));
+        }
+
+        operand<T> first;
+        std::list<operation<T>> rest;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & first & rest;
+        }
+    };
+
+    template <typename T>
+    bool operator==(expression<T> const& lhs, expression<T> const& rhs)
+    {
+        return lhs.first == rhs.first && lhs.rest == rhs.rest;
+    }
+    template <typename T>
+    bool operator!=(expression<T> const& lhs, expression<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+//         struct assignment
+//         {
+//             identifier lhs;
+//             optoken operator_;
+//             expression rhs;
+//
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & lhs & operator_ & rhs;
+//             }
+//         };
+//
+//         struct variable_declaration
+//         {
+//             identifier lhs;
+//             phylanx::util::optional<expression> rhs;
+//
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & lhs & rhs;
+//             }
+//         };
+//
+//         struct if_statement;
+//         struct while_statement;
+//         struct statement_list;
+//         struct return_statement;
+//
+//         using statement = phylanx::util::variant<
+//                 nil
+//               , variable_declaration
+//               , assignment
+//               , phylanx::util::recursive_wrapper<if_statement>
+//               , phylanx::util::recursive_wrapper<while_statement>
+//               , phylanx::util::recursive_wrapper<return_statement>
+//               , phylanx::util::recursive_wrapper<statement_list>
+//               , phylanx::util::recursive_wrapper<expression>
+//             >;
+//
+//         struct statement_list : std::list<statement>
+//         {
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & *static_cast<std::list<statement>>(this);
+//             }
+//         };
+//
+//         struct if_statement
+//         {
+//             expression condition;
+//             statement then;
+//             phylanx::util::optional<statement> else_;
+//
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & condition & then & else_;
+//             }
+//         };
+//
+//         struct while_statement
+//         {
+//             expression condition;
+//             statement body;
+//
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & condition & body;
+//             }
+//         };
+//
+//         struct return_statement : tagged
+//         {
+//             phylanx::util::optional<expression> expr;
+//
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & expr;
+//             }
+//         };
+//
+//         struct function
+//         {
+//             std::string return_type;
+//             identifier function_name;
+//             std::list<identifier> args;
+//             phylanx::util::optional<statement_list> body;
+//
+//             template <typename Archive>
+//             void serialize(Archive& ar, unsigned)
+//             {
+//                 ar & return_type & function_name & args & body;
+//             }
+//         };
+//
+//         using function_list = std::list<function>;
+//     };
+
+    // print functions for debugging
+    inline std::ostream& operator<<(std::ostream& out, nil)
+    {
+        out << "nil";
+        return out;
+    }
+
+    inline std::ostream& operator<<(std::ostream& out, identifier const& id)
+    {
+        out << id.name;
+        return out;
+    }
+}}
+
+#endif

--- a/phylanx/ast/parser/annotation.hpp
+++ b/phylanx/ast/parser/annotation.hpp
@@ -1,0 +1,108 @@
+//  Copyright (c) 2001-2011 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_ANNOTATION_HPP)
+#define PHYLANX_AST_PARSER_ANNOTATION_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/parser/ast.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <cstddef>
+#include <map>
+#include <type_traits>
+#include <vector>
+
+namespace phylanx { namespace ast { namespace parser
+{
+    ///////////////////////////////////////////////////////////////////////////////
+    //  The annotation handler links the AST to a map of iterator positions
+    //  for the purpose of subsequent semantic error handling when the
+    //  program is being compiled.
+    template <typename Iterator>
+    struct annotation
+    {
+        template <typename, typename>
+        struct result
+        {
+            typedef void type;
+        };
+
+        std::vector<Iterator>& iters;
+
+        annotation(std::vector<Iterator>& iters)
+          : iters(iters)
+        {
+        }
+
+        struct set_id
+        {
+            using result_type = void;
+
+            std::size_t id;
+
+            set_id(std::size_t id)
+              : id(id)
+            {
+            }
+
+//             void operator()(ast::function_call& x) const
+//             {
+//                 x.function_name.id = id;
+//             }
+
+            void operator()(ast::identifier& x) const
+            {
+                x.id = id;
+            }
+
+            template <typename T>
+            void operator()(T& x) const
+            {
+                // no-op
+            }
+        };
+
+        void operator()(ast::operand& ast, Iterator pos) const
+        {
+            std::size_t id = iters.size();
+            iters.push_back(pos);
+//             ast.apply_visitor(set_id(id));
+            visit(set_id(id), ast);
+        }
+
+//         void operator()(ast::variable_declaration& ast, Iterator pos) const
+//         {
+//             int id = iters.size();
+//             iters.push_back(pos);
+//             ast.lhs.id = id;
+//         }
+//
+//         void operator()(ast::assignment& ast, Iterator pos) const
+//         {
+//             int id = iters.size();
+//             iters.push_back(pos);
+//             ast.lhs.id = id;
+//         }
+//
+//         void operator()(ast::return_statement& ast, Iterator pos) const
+//         {
+//             int id = iters.size();
+//             iters.push_back(pos);
+//             ast.id = id;
+//         }
+
+        void operator()(ast::identifier& ast, Iterator pos) const
+        {
+            int id = iters.size();
+            iters.push_back(pos);
+            ast.id = id;
+        }
+    };
+}}}
+
+#endif
+

--- a/phylanx/ast/parser/ast.hpp
+++ b/phylanx/ast/parser/ast.hpp
@@ -1,0 +1,87 @@
+//  Copyright (c) 2001-2011 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_AST_HPP)
+#define PHYLANX_AST_PARSER_AST_HPP
+
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ast/parser/extended_variant.hpp>
+#include <phylanx/ast/parser/variant_traits.hpp>
+#include <phylanx/util/optional.hpp>
+
+#include <boost/fusion/include/sequence.hpp>
+#include <boost/fusion/include/adapt_struct.hpp>
+#include <boost/spirit/include/support_attributes.hpp>
+
+#include <list>
+#include <string>
+
+BOOST_FUSION_ADAPT_STRUCT(
+    phylanx::ast::unary_expr,
+    (phylanx::ast::optoken, operator_)
+    (phylanx::ast::operand, operand_)
+)
+
+BOOST_FUSION_ADAPT_STRUCT(
+    phylanx::ast::operation,
+    (phylanx::ast::optoken, operator_)
+    (phylanx::ast::operand, operand_)
+)
+
+BOOST_FUSION_ADAPT_STRUCT(
+    phylanx::ast::expression,
+    (phylanx::ast::operand, first)
+    (std::list<phylanx::ast::operation>, rest)
+)
+
+// BOOST_FUSION_ADAPT_STRUCT(
+//     phylanx::ast::function_call,
+//     (phylanx::ast::identifier, function_name)
+//     (std::list<phylanx::ast::expression>, args)
+// )
+//
+// BOOST_FUSION_ADAPT_STRUCT(
+//     phylanx::ast::variable_declaration,
+//     (phylanx::ast::identifier, lhs)
+//     (phylanx::util::optional<phylanx::ast::expression>, rhs)
+// )
+//
+// BOOST_FUSION_ADAPT_STRUCT(
+//     phylanx::ast::assignment,
+//     (phylanx::ast::identifier, lhs)
+//     (phylanx::ast::optoken, operator_)
+//     (phylanx::ast::expression, rhs)
+// )
+//
+// BOOST_FUSION_ADAPT_STRUCT(
+//     phylanx::ast::if_statement,
+//     (phylanx::ast::expression, condition)
+//     (phylanx::ast::statement, then)
+//     (phylanx::util::optional<phylanx::ast::statement>, else_)
+// )
+//
+// BOOST_FUSION_ADAPT_STRUCT(
+//     phylanx::ast::while_statement,
+//     (phylanx::ast::expression, condition)
+//     (phylanx::ast::statement, body)
+// )
+//
+// BOOST_FUSION_ADAPT_STRUCT(
+//     phylanx::ast::return_statement,
+//     (phylanx::util::optional<phylanx::ast::expression>, expr)
+// )
+//
+// BOOST_FUSION_ADAPT_STRUCT(
+//     phylanx::ast::function,
+//     (std::string, return_type)
+//     (phylanx::ast::identifier, function_name)
+//     (std::list<phylanx::ast::identifier>, args)
+//     (phylanx::util::optional<phylanx::ast::statement_list>, body)
+// )
+
+#endif
+
+

--- a/phylanx/ast/parser/error_handler.hpp
+++ b/phylanx/ast/parser/error_handler.hpp
@@ -1,0 +1,100 @@
+//  Copyright (c) 2001-2011 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_ERROR_HANDLER_HPP)
+#define PHYLANX_AST_PARSER_ERROR_HANDLER_HPP
+
+#include <phylanx/config.hpp>
+
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace ast { namespace parser
+{
+    ///////////////////////////////////////////////////////////////////////////
+    //  The error handler
+    template <typename Iterator>
+    struct error_handler
+    {
+        template <typename, typename, typename>
+        struct result
+        {
+            typedef void type;
+        };
+
+        error_handler(Iterator first, Iterator last, std::ostream& ostr)
+          : first(first)
+          , last(last)
+          , out(ostr)
+        {
+        }
+
+        template <typename Message, typename What>
+        void operator()(Message const& message,
+            What const& what,
+            Iterator err_pos) const
+        {
+            int line;
+            Iterator line_start = get_pos(err_pos, line);
+            if (err_pos != last)
+            {
+                out << message << what << " line " << line << ':' << std::endl;
+                out << get_line(line_start) << std::endl;
+                for (; line_start != err_pos; ++line_start)
+                    out << '~';
+                out << '^' << std::endl;
+            }
+            else
+            {
+                out << "Unexpected end of file. ";
+                out << message << what << " line " << line << std::endl;
+            }
+        }
+
+        Iterator get_pos(Iterator err_pos, int& line) const
+        {
+            line = 1;
+            Iterator i = first;
+            Iterator line_start = first;
+            while (i != err_pos)
+            {
+                bool eol = false;
+                if (i != err_pos && *i == '\r')    // CR
+                {
+                    eol = true;
+                    line_start = ++i;
+                }
+                if (i != err_pos && *i == '\n')    // LF
+                {
+                    eol = true;
+                    line_start = ++i;
+                }
+                if (eol)
+                    ++line;
+                else
+                    ++i;
+            }
+            return line_start;
+        }
+
+        std::string get_line(Iterator err_pos) const
+        {
+            Iterator i = err_pos;
+            // position i to the next EOL
+            while (i != last && (*i != '\r' && *i != '\n'))
+                ++i;
+            return std::string(err_pos, i);
+        }
+
+        Iterator first;
+        Iterator last;
+        std::ostream& out;
+        std::vector<Iterator> iters;
+    };
+}}}
+
+#endif

--- a/phylanx/ast/parser/expression.hpp
+++ b/phylanx/ast/parser/expression.hpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2001-2011 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_EXPRESSION_HPP)
+#define PHYLANX_AST_PARSER_EXPRESSION_HPP
+
+///////////////////////////////////////////////////////////////////////////////
+// Spirit v2.5 allows you to suppress automatic generation
+// of predefined terminals to speed up complation. With
+// BOOST_SPIRIT_NO_PREDEFINED_TERMINALS defined, you are
+// responsible in creating instances of the terminals that
+// you need (e.g. see qi::uint_type uint_ below).
+#define BOOST_SPIRIT_NO_PREDEFINED_TERMINALS
+
+// Uncomment this if you want to enable debugging
+// #define BOOST_SPIRIT_QI_DEBUG
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/parser/ast.hpp>
+#include <phylanx/ast/parser/error_handler.hpp>
+#include <phylanx/ast/parser/skipper.hpp>
+
+#include <boost/spirit/include/qi.hpp>
+
+namespace phylanx { namespace ast { namespace parser
+{
+    namespace qi = boost::spirit::qi;
+    namespace ascii = boost::spirit::ascii;
+
+    ///////////////////////////////////////////////////////////////////////////
+    //  The expression grammar
+    template <typename Iterator>
+    struct expression
+      : qi::grammar<Iterator, ast::expression(), skipper<Iterator>>
+    {
+        expression(error_handler<Iterator>& error_handler);
+
+        qi::rule<Iterator, ast::expression(), skipper<Iterator>> expr;
+
+        qi::rule<Iterator, ast::operand(), skipper<Iterator>> unary_expr;
+        qi::rule<Iterator, ast::operand(), skipper<Iterator>> primary_expr;
+
+//         qi::rule<Iterator, ast::function_call(), skipper<Iterator>>
+//             function_call;
+// 
+//         qi::rule<Iterator, std::list<ast::expression>(), skipper<Iterator>>
+//             argument_list;
+
+        qi::rule<Iterator, std::string(), skipper<Iterator>> identifier;
+
+        qi::symbols<char, ast::optoken> unary_op;
+        qi::symbols<char, ast::optoken> binary_op;
+        qi::symbols<char> keywords;
+    };
+}}}
+
+#endif

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -1,0 +1,141 @@
+//  Copyright (c) 2001-2011 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_EXPRESSION_DEF_HPP)
+#define PHYLANX_AST_PARSER_EXPRESSION_DEF_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/parser/ast.hpp>
+#include <phylanx/ast/parser/annotation.hpp>
+#include <phylanx/ast/parser/error_handler.hpp>
+#include <phylanx/ast/parser/expression.hpp>
+
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/phoenix_function.hpp>
+
+namespace phylanx { namespace ast { namespace parser
+{
+    template <typename Iterator>
+    expression<Iterator>::expression(error_handler<Iterator>& error_handler)
+      : expression::base_type(expr)
+    {
+        qi::_1_type _1;
+        qi::_3_type _3;
+        qi::_4_type _4;
+
+        qi::char_type char_;
+        qi::double_type double_;
+        qi::_val_type _val;
+        qi::raw_type raw;
+        qi::lexeme_type lexeme;
+        qi::alpha_type alpha;
+        qi::alnum_type alnum;
+        qi::bool_type bool_;
+
+        using qi::on_error;
+        using qi::on_success;
+        using qi::fail;
+        using qi::as;
+
+        using error_handler_function =
+            boost::phoenix::function<ast::parser::error_handler<Iterator>>;
+        using annotation_function =
+            boost::phoenix::function<ast::parser::annotation<Iterator>>;
+
+        ///////////////////////////////////////////////////////////////////////
+        // Tokens
+        binary_op.add
+            ("||", ast::optoken::op_logical_or)
+            ("&&", ast::optoken::op_logical_and)
+            ("==", ast::optoken::op_equal)
+            ("!=", ast::optoken::op_not_equal)
+            ("<", ast::optoken::op_less)
+            ("<=", ast::optoken::op_less_equal)
+            (">", ast::optoken::op_greater)
+            (">=", ast::optoken::op_greater_equal)
+            ("+", ast::optoken::op_plus)
+            ("-", ast::optoken::op_minus)
+            ("*", ast::optoken::op_times)
+            ("/", ast::optoken::op_divide)
+            ;
+
+        unary_op.add
+            ("+", ast::optoken::op_positive)
+            ("-", ast::optoken::op_negative)
+            ("!", ast::optoken::op_not)
+            ;
+
+        keywords.add
+            ("true")
+            ("false")
+            ("if")
+            ("else")
+            ("while")
+            ("var")
+            ("void")
+            ("return")
+            ;
+
+        ///////////////////////////////////////////////////////////////////////
+        // Main expression grammar
+        expr =
+                unary_expr
+            >> *(binary_op > unary_expr)
+            ;
+
+        unary_expr =
+                primary_expr
+            |   as<ast::unary_expr>()[unary_op > unary_expr]
+            ;
+
+        primary_expr =
+                double_
+//             |   function_call
+            |   identifier
+            |   bool_
+            |   '(' > expr > ')'
+            ;
+
+//         function_call =
+//                 (identifier >> '(')
+//             >   argument_list
+//             >   ')'
+//             ;
+
+//         argument_list = -(expr % ',');
+
+        identifier =
+                !lexeme[keywords >> !(alnum | '_')]
+            >>  raw[lexeme[(alpha | '_') >> *(alnum | '_')]]
+            ;
+
+        ///////////////////////////////////////////////////////////////////////
+        // Debugging and error handling and reporting support.
+        BOOST_SPIRIT_DEBUG_NODES(
+            (expr)
+            (unary_expr)
+            (primary_expr)
+//             (function_call)
+//             (argument_list)
+            (identifier)
+        );
+
+        ///////////////////////////////////////////////////////////////////////
+        // Error handling: on error in expr, call error_handler.
+        static constexpr char const* const error_msg = "Error! Expecting ";
+
+        on_error<fail>(
+            expr, error_handler_function(error_handler)(error_msg, _4, _3));
+
+        ///////////////////////////////////////////////////////////////////////
+        // Annotation: on success in primary_expr, call annotation.
+        on_success(primary_expr,
+            annotation_function(error_handler.iters)(_val, _1));
+    }
+}}}
+
+#endif
+

--- a/phylanx/ast/parser/extended_variant.hpp
+++ b/phylanx/ast/parser/extended_variant.hpp
@@ -12,6 +12,9 @@
 
 #include <boost/mpl/vector.hpp>
 
+#include <type_traits>
+#include <utility>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace ast { namespace parser
 {
@@ -28,39 +31,23 @@ namespace phylanx { namespace ast { namespace parser
         extended_variant() = default;
 
         template <typename T>
-        extended_variant(T const& var)
-          : var(var)
-        {
-        }
-
-        template <typename T>
-        extended_variant(T& var)
-          : var(var)
+        extended_variant(T && var)
+          : var(std::forward<T>(var))
         {
         }
 
         template <typename F>
-        auto apply_visitor(F const& v) -> decltype(util::visit(var, v))
+        auto apply_visitor(F && v) -> decltype(
+            util::visit(std::declval<variant_type>(), std::forward<F>(v)))
         {
-            return util::visit(var, v);
+            return util::visit(var, std::forward<F>(v));
         }
 
         template <typename F>
-        auto apply_visitor(F const& v) const -> decltype(util::visit(var, v))
+        auto apply_visitor(F && v) const -> decltype(
+            util::visit(std::declval<variant_type>(), std::forward<F>(v)))
         {
-            return util::visit(var, v);
-        }
-
-        template <typename F>
-        auto apply_visitor(F& v) -> decltype(util::visit(var, v))
-        {
-            return util::visit(var, v);
-        }
-
-        template <typename F>
-        auto apply_visitor(F& v) const -> decltype(util::visit(var, v))
-        {
-            return util::visit(var, v);
+            return util::visit(var, std::forward<F>(v));
         }
 
         variant_type const& get() const

--- a/phylanx/ast/parser/extended_variant.hpp
+++ b/phylanx/ast/parser/extended_variant.hpp
@@ -1,0 +1,149 @@
+//  Copyright (c) 2001-2011 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_EXTENDED_VARIANT_HPP)
+#define PHYLANX_AST_PARSER_EXTENDED_VARIANT_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <boost/mpl/vector.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace ast { namespace parser
+{
+    template <typename ... Ts>
+    struct extended_variant
+    {
+        // tell spirit that this is an adapted variant
+        struct adapted_variant_tag;
+
+        using variant_type = util::variant<Ts...>;
+        using types = boost::mpl::vector<Ts...>;
+        using base_type = extended_variant<Ts...>;
+
+        extended_variant() = default;
+
+        template <typename T>
+        extended_variant(T const& var)
+          : var(var)
+        {
+        }
+
+        template <typename T>
+        extended_variant(T& var)
+          : var(var)
+        {
+        }
+
+        template <typename F>
+        auto apply_visitor(F const& v) -> decltype(util::visit(var, v))
+        {
+            return util::visit(var, v);
+        }
+
+        template <typename F>
+        auto apply_visitor(F const& v) const -> decltype(util::visit(var, v))
+        {
+            return util::visit(var, v);
+        }
+
+        template <typename F>
+        auto apply_visitor(F& v) -> decltype(util::visit(var, v))
+        {
+            return util::visit(var, v);
+        }
+
+        template <typename F>
+        auto apply_visitor(F& v) const -> decltype(util::visit(var, v))
+        {
+            return util::visit(var, v);
+        }
+
+        variant_type const& get() const
+        {
+            return var;
+        }
+
+        variant_type& get()
+        {
+            return var;
+        }
+
+        void swap(extended_variant& rhs) noexcept(var.swap(rhs.var))
+        {
+            var.swap(rhs.var);
+        }
+
+        variant_type var;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename... Ts>
+    bool operator==(
+        extended_variant<Ts...> const& lhs, extended_variant<Ts...> const& rhs)
+    {
+        return lhs.var == rhs.var;
+    }
+    template <typename... Ts>
+    bool operator!=(
+        extended_variant<Ts...> const& lhs, extended_variant<Ts...> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Archive, typename ... Ts>
+    void serialize(Archive& ar, extended_variant<Ts...>& v, unsigned)
+    {
+        ar & v.var;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename ... Ts>
+    auto visit(F && f, extended_variant<Ts...> const& v)
+    {
+        return util::visit(std::forward<F>(f), v.var);
+    }
+    template <typename F, typename ... Ts>
+    auto visit(F && f, extended_variant<Ts...>& v)
+    {
+        return util::visit(std::forward<F>(f), v.var);
+    }
+}}}
+
+namespace boost
+{
+    template <typename T, typename... Types>
+    inline T const&
+    get(phylanx::ast::parser::extended_variant<Types...> const& x)
+    {
+        return boost::get<T>(x.get());
+    }
+
+    template <typename T, typename... Types>
+    inline T&
+    get(phylanx::ast::parser::extended_variant<Types...>& x)
+    {
+        return boost::get<T>(x.get());
+    }
+
+    template <typename T, typename... Types>
+    inline T const*
+    get(phylanx::ast::parser::extended_variant<Types...> const* x)
+    {
+        return boost::get<T>(&x->get());
+    }
+
+    template <typename T, typename... Types>
+    inline T*
+    get(phylanx::ast::parser::extended_variant<Types...>* x)
+    {
+        return boost::get<T>(&x->get());
+    }
+}
+
+#endif

--- a/phylanx/ast/parser/skipper.hpp
+++ b/phylanx/ast/parser/skipper.hpp
@@ -1,0 +1,41 @@
+//  Copyright (c) 2001-2011 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_SKIPPER_HPP)
+#define PHYLANX_AST_PARSER_SKIPPER_HPP
+
+#include <phylanx/config.hpp>
+
+#include <boost/spirit/include/qi.hpp>
+
+namespace phylanx { namespace ast { namespace parser
+{
+    namespace qi = boost::spirit::qi;
+    namespace ascii = boost::spirit::ascii;
+
+    ///////////////////////////////////////////////////////////////////////////
+    //  The skipper grammar
+    template <typename Iterator>
+    struct skipper : qi::grammar<Iterator>
+    {
+        skipper() : skipper::base_type(start)
+        {
+            qi::char_type char_;
+            ascii::space_type space;
+
+            start =
+                    space                               // tab/space/cr/lf
+                |   "/*" >> *(char_ - "*/") >> "*/"     // C-style comments
+                ;
+        }
+
+        qi::rule<Iterator> start;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/ast/parser/variant_traits.hpp
+++ b/phylanx/ast/parser/variant_traits.hpp
@@ -1,0 +1,95 @@
+//  Copyright (c) 2001-2010 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_PARSER_VARIANT_TRAITS_HPP)
+#define PHYLANX_AST_PARSER_VARIANT_TRAITS_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <boost/spirit/home/qi/detail/assign_to.hpp>
+#include <boost/spirit/home/qi/detail/pass_container.hpp>
+#include <boost/spirit/home/support/attributes.hpp>
+#include <boost/mpl/bool.hpp>
+
+namespace boost { namespace spirit { namespace traits
+{
+    template <typename Domain, typename ... Ts>
+    struct not_is_variant<phylanx::util::variant<Ts...>, Domain>
+      : mpl::false_
+    {};
+
+//     template <typename T, typename ... Ts>
+//     struct assign_to_attribute_from_value<phylanx::util::variant<Ts...>, T>
+//     {
+//         static void
+//         call(T const& val, phylanx::util::variant<Ts...>& attr)
+//         {
+//             attr = val;
+//         }
+//     };
+
+    template <typename T, typename Expected>
+    struct is_weak_substitute<phylanx::util::variant<T>, Expected>
+      : is_weak_substitute<T, Expected>
+    {};
+
+    template <typename T0, typename T1, typename... TN, typename Expected>
+    struct is_weak_substitute<phylanx::util::variant<T0, T1, TN...>, Expected>
+      : mpl::bool_<
+            is_weak_substitute<T0, Expected>::type::value &&
+            is_weak_substitute<
+                phylanx::util::variant<T1, TN...>, Expected
+            >::type::value>
+    {};
+
+    template <typename T>
+    struct is_container<phylanx::util::variant<T>>
+      : is_container<T>
+    {};
+
+    template <typename T0, typename T1, typename... TN>
+    struct is_container<phylanx::util::variant<T0, T1, TN...>>
+      : mpl::bool_<is_container<T0>::value ||
+            is_container<phylanx::util::variant<T1, TN...>>::value>
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    // return the type currently stored in the given variant
+    template <typename ... Ts>
+    struct variant_which<phylanx::util::variant<Ts...> >
+    {
+        static int call(phylanx::util::variant<Ts...> const& v)
+        {
+            return v.index();
+        }
+    };
+}}}
+
+namespace boost { namespace spirit { namespace qi { namespace detail
+{
+    template <typename Container, typename ValueType, typename Sequence,
+        typename T>
+    struct pass_through_container<Container, ValueType,
+            phylanx::util::variant<T>, Sequence>
+      : pass_through_container<Container, ValueType, T, Sequence>
+    {};
+
+    template <typename Container, typename ValueType, typename Sequence,
+        typename T0, typename... TN>
+    struct pass_through_container<Container, ValueType,
+            phylanx::util::variant<T0, TN...>, Sequence>
+      : mpl::bool_<
+            pass_through_container<
+                Container, ValueType, T0, Sequence
+            >::type::value ||
+            pass_through_container<
+                Container, ValueType, phylanx::util::variant<TN...>, Sequence
+            >::type::value>
+    {};
+}}}}
+
+#endif

--- a/phylanx/ast/traverse.hpp
+++ b/phylanx/ast/traverse.hpp
@@ -14,13 +14,21 @@
 namespace phylanx { namespace ast
 {
     ///////////////////////////////////////////////////////////////////////////
-    struct static_visitor {};
-
-    ///////////////////////////////////////////////////////////////////////////
     template <typename F, typename Ast>
     bool traverse(phylanx::util::recursive_wrapper<Ast> const& rw, F && f)
     {
         return traverse(rw.get(), std::forward<F>(f));
+    }
+
+    template <typename F, typename T>
+    bool traverse(std::list<T> const& l, F && f)
+    {
+        for (auto const& val : l)
+        {
+            if (!traverse(val, std::forward<F>(f)))
+                return false;
+        }
+        return true;
     }
 
     template <typename F>
@@ -29,8 +37,8 @@ namespace phylanx { namespace ast
         return hpx::util::invoke(f, b);
     }
 
-    template <typename T, typename F>
-    bool traverse(phylanx::ir::node_data<T> const& data, F && f)
+    template <typename F>
+    bool traverse(phylanx::ir::node_data<double> const& data, F && f)
     {
         return hpx::util::invoke(f, data);
     }
@@ -53,20 +61,44 @@ namespace phylanx { namespace ast
         return hpx::util::invoke(f, id);
     }
 
-    template <typename T, typename F>
-    bool traverse(primary_expr<T> const& pe, F && f);
+    template <typename F>
+    bool traverse(primary_expr const& pe, F && f);
 
-    template <typename T, typename F>
-    bool traverse(operand<T> const& op, F && f);
+    template <typename F>
+    bool traverse(operand const& op, F && f);
 
-    template <typename T, typename F>
-    bool traverse(unary_expr<T> const& ue, F && f);
+    template <typename F>
+    bool traverse(unary_expr const& ue, F && f);
 
-    template <typename T, typename F>
-    bool traverse(operation<T> const& op, F && f);
+    template <typename F>
+    bool traverse(operation const& op, F && f);
 
-    template <typename T, typename F>
-    bool traverse(expression<T> const& expr, F && f);
+    template <typename F>
+    bool traverse(expression const& expr, F && f);
+
+//     template <typename F>
+//     bool traverse(function_call const& op, F && f);
+//
+//     template <typename F>
+//     bool traverse(assignment const& op, F && f);
+//
+//     template <typename F>
+//     bool traverse(variable_declaration const& op, F && f);
+//
+//     template <typename F>
+//     bool traverse(statement const& op, F && f);
+//
+//     template <typename F>
+//     bool traverse(if_statement const& op, F && f);
+//
+//     template <typename F>
+//     bool traverse(while_statement const& op, F && f);
+//
+//     template <typename F>
+//     bool traverse(return_statement const& op, F && f);
+//
+//     template <typename F>
+//     bool traverse(function const& op, F && f);
 
     namespace detail
     {
@@ -95,42 +127,40 @@ namespace phylanx { namespace ast
         }
     }
 
-    template <typename T, typename F>
-    bool traverse(primary_expr<T> const& pe, F && f)
+    template <typename F>
+    bool traverse(primary_expr const& pe, F && f)
     {
         if (hpx::util::invoke(f, pe))
         {
-            return phylanx::util::visit(
-                detail::make_unwrap_visitor(std::forward<F>(f)), pe.value);
+            return visit(detail::make_unwrap_visitor(std::forward<F>(f)), pe);
         }
         return false;
     }
 
-    template <typename T, typename F>
-    bool traverse(operand<T> const& op, F && f)
+    template <typename F>
+    bool traverse(operand const& op, F && f)
     {
         if (hpx::util::invoke(f, op))
         {
-            return phylanx::util::visit(
-                detail::make_unwrap_visitor(std::forward<F>(f)), op.value);
+            return visit(detail::make_unwrap_visitor(std::forward<F>(f)), op);
         }
         return false;
     }
 
-    template <typename T, typename F>
-    bool traverse(unary_expr<T> const& ue, F && f)
+    template <typename F>
+    bool traverse(unary_expr const& ue, F && f)
     {
         if (hpx::util::invoke(f, ue))
         {
-            if (!traverse(ue.operand_, std::forward<F>(f)))
+            if (!traverse(ue.operator_, std::forward<F>(f)))
                 return false;
-            return traverse(ue.operator_, std::forward<F>(f));
+            return traverse(ue.operand_, std::forward<F>(f));
         }
         return false;
     }
 
-    template <typename T, typename F>
-    bool traverse(operation<T> const& op, F && f)
+    template <typename F>
+    bool traverse(operation const& op, F && f)
     {
         if (hpx::util::invoke(f, op))
         {
@@ -141,8 +171,8 @@ namespace phylanx { namespace ast
         return false;
     }
 
-    template <typename T, typename F>
-    bool traverse(expression<T> const& expr, F && f)
+    template <typename F>
+    bool traverse(expression const& expr, F && f)
     {
         if (hpx::util::invoke(f, expr))
         {
@@ -157,6 +187,112 @@ namespace phylanx { namespace ast
         }
         return true;
     }
+
+//     template <typename F>
+//     bool traverse(function_call const& fc, F && f)
+//     {
+//         if (hpx::util::invoke(f, fc))
+//         {
+//             if (!traverse(fc.function_name, std::forward<F>(f)))
+//                 return false;
+//             return traverse(fc.args, std::forward<F>(f));
+//         }
+//         return false;
+//     }
+//
+//     template <typename F>
+//     bool traverse(assignment const& assign, F && f)
+//     {
+//         if (hpx::util::invoke(f, assign))
+//         {
+//             if (!traverse(assign.lhs, std::forward<F>(f)))
+//                 return false;
+//             if (!traverse(assign.operator_, std::forward<F>(f)))
+//                 return false;
+//             return traverse(assign.rhs, std::forward<F>(f));
+//         }
+//         return false;
+//     }
+//
+//     template <typename F>
+//     bool traverse(variable_declaration const& vd, F && f)
+//     {
+//         if (hpx::util::invoke(f, vd))
+//         {
+//             if (!traverse(vd.lhs, std::forward<F>(f)))
+//                 return false;
+//             if (vd.rhs.has_value())
+//                 return traverse(vd.rhs, std::forward<F>(f));
+//             return true;
+//         }
+//         return false;
+//     }
+//
+//     template <typename F>
+//     bool traverse(statement const& stmt, F && f)
+//     {
+//         if (hpx::util::invoke(f, stmt))
+//         {
+//             return visit(detail::make_unwrap_visitor(std::forward<F>(f)), stmt);
+//         }
+//         return false;
+//     }
+//
+//     template <typename F>
+//     bool traverse(if_statement const& if_, F && f)
+//     {
+//         if (hpx::util::invoke(f, if_))
+//         {
+//             if (!traverse(if_.condition, std::forward<F>(f)))
+//                 return false;
+//             if (!traverse(if_.then, std::forward<F>(f)))
+//                 return false;
+//             if (if_.else_.has_value())
+//                 return traverse(if_.else_, std::forward<F>(f));
+//             return true;
+//         }
+//         return false;
+//     }
+//
+//     template <typename F>
+//     bool traverse(while_statement const& while_, F && f)
+//     {
+//         if (hpx::util::invoke(f, while_))
+//         {
+//             if (!traverse(while_.condition, std::forward<F>(f)))
+//                 return false;
+//             return traverse(while_.body, std::forward<F>(f));
+//         }
+//         return false;
+//     }
+//
+//     template <typename F>
+//     bool traverse(return_statement const& ret, F && f)
+//     {
+//         if (hpx::util::invoke(f, ret))
+//         {
+//             if (ret.expr.has_value())
+//                 return traverse(ret.expr, std::forward<F>(f));
+//             return true;
+//         }
+//         return false;
+//     }
+//
+//     template <typename F>
+//     bool traverse(function const& func, F && f)
+//     {
+//         if (hpx::util::invoke(f, func))
+//         {
+//             if (!traverse(func.function_name, std::forward<F>(f)))
+//                 return false;
+//             if (!traverse(func.args, std::forward<F>(f)))
+//                 return false;
+//             if (func.body.has_value())
+//                 return traverse(func.body, std::forward<F>(f));
+//             return true;
+//         }
+//         return false;
+//     }
 }}
 
 #endif

--- a/phylanx/ast/traverse.hpp
+++ b/phylanx/ast/traverse.hpp
@@ -1,0 +1,163 @@
+//   Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_TRAVERSE_HPP)
+#define PHYLANX_AST_TRAVERSE_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+
+#include <hpx/util/invoke.hpp>
+
+namespace phylanx { namespace ast
+{
+    ///////////////////////////////////////////////////////////////////////////
+    struct static_visitor {};
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename Ast>
+    bool traverse(phylanx::util::recursive_wrapper<Ast> const& rw, F && f)
+    {
+        return traverse(rw.get(), std::forward<F>(f));
+    }
+
+    template <typename F>
+    bool traverse(bool b, F && f)
+    {
+        return hpx::util::invoke(f, b);
+    }
+
+    template <typename T, typename F>
+    bool traverse(phylanx::ir::node_data<T> const& data, F && f)
+    {
+        return hpx::util::invoke(f, data);
+    }
+
+    template <typename F>
+    bool traverse(optoken op, F && f)
+    {
+        return hpx::util::invoke(f, op);
+    }
+
+    template <typename F>
+    bool traverse(nil, F && f)
+    {
+        return hpx::util::invoke(f, nil{});
+    }
+
+    template <typename F>
+    bool traverse(identifier const& id, F && f)
+    {
+        return hpx::util::invoke(f, id);
+    }
+
+    template <typename T, typename F>
+    bool traverse(primary_expr<T> const& pe, F && f);
+
+    template <typename T, typename F>
+    bool traverse(operand<T> const& op, F && f);
+
+    template <typename T, typename F>
+    bool traverse(unary_expr<T> const& ue, F && f);
+
+    template <typename T, typename F>
+    bool traverse(operation<T> const& op, F && f);
+
+    template <typename T, typename F>
+    bool traverse(expression<T> const& expr, F && f);
+
+    namespace detail
+    {
+        template <typename F>
+        struct unwrap_visitor
+        {
+            F f_;
+
+            template <typename T>
+            bool operator()(T const& t) const
+            {
+                return traverse(t, f_);
+            }
+
+            template <typename T>
+            bool operator()(phylanx::util::recursive_wrapper<T> const& t) const
+            {
+                return traverse(t.get(), f_);
+            }
+        };
+
+        template <typename F>
+        unwrap_visitor<std::decay_t<F>> make_unwrap_visitor(F && f)
+        {
+            return unwrap_visitor<std::decay_t<F>>{std::forward<F>(f)};
+        }
+    }
+
+    template <typename T, typename F>
+    bool traverse(primary_expr<T> const& pe, F && f)
+    {
+        if (hpx::util::invoke(f, pe))
+        {
+            return phylanx::util::visit(
+                detail::make_unwrap_visitor(std::forward<F>(f)), pe.value);
+        }
+        return false;
+    }
+
+    template <typename T, typename F>
+    bool traverse(operand<T> const& op, F && f)
+    {
+        if (hpx::util::invoke(f, op))
+        {
+            return phylanx::util::visit(
+                detail::make_unwrap_visitor(std::forward<F>(f)), op.value);
+        }
+        return false;
+    }
+
+    template <typename T, typename F>
+    bool traverse(unary_expr<T> const& ue, F && f)
+    {
+        if (hpx::util::invoke(f, ue))
+        {
+            if (!traverse(ue.operand_, std::forward<F>(f)))
+                return false;
+            return traverse(ue.operator_, std::forward<F>(f));
+        }
+        return false;
+    }
+
+    template <typename T, typename F>
+    bool traverse(operation<T> const& op, F && f)
+    {
+        if (hpx::util::invoke(f, op))
+        {
+            if (!traverse(op.operator_, std::forward<F>(f)))
+                return false;
+            return traverse(op.operand_, std::forward<F>(f));
+        }
+        return false;
+    }
+
+    template <typename T, typename F>
+    bool traverse(expression<T> const& expr, F && f)
+    {
+        if (hpx::util::invoke(f, expr))
+        {
+            if (!traverse(expr.first, std::forward<F>(f)))
+                return false;
+
+            for (auto const& op : expr.rest)
+            {
+                if (!traverse(op, std::forward<F>(f)))
+                    return false;
+            }
+        }
+        return true;
+    }
+}}
+
+#endif
+

--- a/phylanx/include/ast.hpp
+++ b/phylanx/include/ast.hpp
@@ -3,14 +3,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_HPP)
-#define PHYLANX_HPP
+#if !defined(PHYLANX_AST_HPP)
+#define PHYLANX_AST_HPP
 
 #include <phylanx/config.hpp>
-
-#include <phylanx/include/ast.hpp>
-#include <phylanx/include/ir.hpp>
-#include <phylanx/include/util.hpp>
-#include <phylanx/include/version.hpp>
+#include <phylanx/ast/node.hpp>
 
 #endif

--- a/phylanx/include/ast.hpp
+++ b/phylanx/include/ast.hpp
@@ -8,5 +8,6 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
+#include <phylanx/ast/traverse.hpp>
 
 #endif

--- a/phylanx/include/util.hpp
+++ b/phylanx/include/util.hpp
@@ -8,6 +8,10 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/util/eigen_range.hpp>
-#include <phylanx/util/eigen_serialization.hpp>
+#include <phylanx/util/serialization/eigen.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+#include <phylanx/util/variant.hpp>
+#include <phylanx/util/serialization/variant.hpp>
 
 #endif

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -184,19 +184,19 @@ namespace phylanx { namespace ir
                 typename node_data_storage_base<T>::dimensions_type;
 
             constexpr node_data_storage()
-              : node_data_storage_base<T>(0, {1, 0})
+              : node_data_storage_base<T>(0, {{1, 0}})
               , data_(0.0)
             {
             }
 
             constexpr node_data_storage(T const& value)
-              : node_data_storage_base<T>(0, {1, 0})
+              : node_data_storage_base<T>(0, {{1, 0}})
               , data_(value)
             {
             }
 
             constexpr node_data_storage(T && value)
-              : node_data_storage_base<T>(0, {1, 0})
+              : node_data_storage_base<T>(0, {{1, 0}})
               , data_(std::move(value))
             {
             }
@@ -262,13 +262,13 @@ namespace phylanx { namespace ir
                 Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
             node_data_storage()
-              : node_data_storage_base(1)
+              : node_data_storage_base<T>(1)
               , data_()
             {
             }
 
             node_data_storage(std::size_t dim)
-              : node_data_storage_base(1)
+              : node_data_storage_base<T>(1)
               , data_(dim)
             {
             }
@@ -305,10 +305,10 @@ namespace phylanx { namespace ir
                 data_ = std::move(data_);
                 return *this;
             }
-            node_data_storage& operator=(std::vector<T> const& data)
+            node_data_storage& operator=(std::vector<T> const& values)
             {
                 this->base_type::set_dimensions(
-                    {static_cast<std::ptrdiff_t>(data.size()), 0});
+                    {static_cast<std::ptrdiff_t>(values.size()), 0});
                 data_ = Eigen::Map<storage1d_type const, Eigen::Unaligned>(
                     values.data(), values.size());
                 return *this;
@@ -362,13 +362,13 @@ namespace phylanx { namespace ir
                 Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
             node_data_storage()
-              : node_data_storage_base(2)
+              : node_data_storage_base<T>(2)
               , data_()
             {
             }
 
             node_data_storage(std::size_t dim1, std::size_t dim2)
-              : node_data_storage_base(2)
+              : node_data_storage_base<T>(2)
               , data_(dim1, dim2)
             {
             }

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/intrusive_ptr.hpp>
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <iterator>
@@ -550,6 +551,26 @@ namespace phylanx { namespace ir
         boost::intrusive_ptr<detail::node_data_storage_base<T>> data_;
         /// \endcond
     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    bool operator==(node_data<T> const& lhs, node_data<T> const& rhs)
+    {
+        if (lhs.num_dimensions() != rhs.num_dimensions() ||
+            lhs.dimensions() != rhs.dimensions())
+        {
+            return false;
+        }
+
+        return std::equal(hpx::util::begin(lhs), hpx::util::end(lhs),
+            hpx::util::begin(rhs), hpx::util::end(rhs));
+    }
+
+    template <typename T>
+    bool operator!=(node_data<T> const& lhs, node_data<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
 }}
 
 #endif

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <cstddef>
+#include <iosfwd>
 #include <iterator>
 #include <vector>
 
@@ -570,6 +571,20 @@ namespace phylanx { namespace ir
     bool operator!=(node_data<T> const& lhs, node_data<T> const& rhs)
     {
         return !(lhs == rhs);
+    }
+
+    template <typename T>
+    inline std::ostream& operator<<(std::ostream& out, node_data<T> const& nd)
+    {
+        out << "node_data<T>: ";
+
+        std::ptrdiff_t dims = nd.num_dimensions();
+        out << std::string(dims, '[');
+        out << nd[0];
+        if (dims)
+            out << ", ...";
+        out << std::string(dims, ']');
+        return out;
     }
 }}
 

--- a/phylanx/util/detail/variant.hpp
+++ b/phylanx/util/detail/variant.hpp
@@ -1,0 +1,2365 @@
+// MPark.Variant
+//
+// Copyright Michael Park, 2015-2017
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#ifndef MPARK_VARIANT_HPP
+#define MPARK_VARIANT_HPP
+
+/*
+   variant synopsis
+
+namespace std {
+
+  // 20.7.2, class template variant
+  template <class... Types>
+  class variant {
+  public:
+
+    // 20.7.2.1, constructors
+    constexpr variant() noexcept(see below);
+    variant(const variant&);
+    variant(variant&&) noexcept(see below);
+
+    template <class T> constexpr variant(T&&) noexcept(see below);
+
+    template <class T, class... Args>
+    constexpr explicit variant(in_place_type_t<T>, Args&&...);
+
+    template <class T, class U, class... Args>
+    constexpr explicit variant(
+        in_place_type_t<T>, initializer_list<U>, Args&&...);
+
+    template <size_t I, class... Args>
+    constexpr explicit variant(in_place_index_t<I>, Args&&...);
+
+    template <size_t I, class U, class... Args>
+    constexpr explicit variant(
+        in_place_index_t<I>, initializer_list<U>, Args&&...);
+
+    // 20.7.2.2, destructor
+    ~variant();
+
+    // 20.7.2.3, assignment
+    variant& operator=(const variant&);
+    variant& operator=(variant&&) noexcept(see below);
+
+    template <class T> variant& operator=(T&&) noexcept(see below);
+
+    // 20.7.2.4, modifiers
+    template <class T, class... Args>
+    T& emplace(Args&&...);
+
+    template <class T, class U, class... Args>
+    T& emplace(initializer_list<U>, Args&&...);
+
+    template <size_t I, class... Args>
+    variant_alternative<I, variant>& emplace(Args&&...);
+
+    template <size_t I, class U, class...  Args>
+    variant_alternative<I, variant>& emplace(initializer_list<U>, Args&&...);
+
+    // 20.7.2.5, value status
+    constexpr bool valueless_by_exception() const noexcept;
+    constexpr size_t index() const noexcept;
+
+    // 20.7.2.6, swap
+    void swap(variant&) noexcept(see below);
+  };
+
+  // 20.7.3, variant helper classes
+  template <class T> struct variant_size; // undefined
+
+  template <class T>
+  constexpr size_t variant_size_v = variant_size<T>::value;
+
+  template <class T> struct variant_size<const T>;
+  template <class T> struct variant_size<volatile T>;
+  template <class T> struct variant_size<const volatile T>;
+
+  template <class... Types>
+  struct variant_size<variant<Types...>>;
+
+  template <size_t I, class T> struct variant_alternative; // undefined
+
+  template <size_t I, class T>
+  using variant_alternative_t = typename variant_alternative<I, T>::type;
+
+  template <size_t I, class T> struct variant_alternative<I, const T>;
+  template <size_t I, class T> struct variant_alternative<I, volatile T>;
+  template <size_t I, class T> struct variant_alternative<I, const volatile T>;
+
+  template <size_t I, class... Types>
+  struct variant_alternative<I, variant<Types...>>;
+
+  constexpr size_t variant_npos = -1;
+
+  // 20.7.4, value access
+  template <class T, class... Types>
+  constexpr bool holds_alternative(const variant<Types...>&) noexcept;
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>>&
+  get(variant<Types...>&);
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>>&&
+  get(variant<Types...>&&);
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>> const&
+  get(const variant<Types...>&);
+
+  template <size_t I, class... Types>
+  constexpr variant_alternative_t<I, variant<Types...>> const&&
+  get(const variant<Types...>&&);
+
+  template <class T, class...  Types>
+  constexpr T& get(variant<Types...>&);
+
+  template <class T, class... Types>
+  constexpr T&& get(variant<Types...>&&);
+
+  template <class T, class... Types>
+  constexpr const T& get(const variant<Types...>&);
+
+  template <class T, class... Types>
+  constexpr const T&& get(const variant<Types...>&&);
+
+  template <size_t I, class... Types>
+  constexpr add_pointer_t<variant_alternative_t<I, variant<Types...>>>
+  get_if(variant<Types...>*) noexcept;
+
+  template <size_t I, class... Types>
+  constexpr add_pointer_t<const variant_alternative_t<I, variant<Types...>>>
+  get_if(const variant<Types...>*) noexcept;
+
+  template <class T, class... Types>
+  constexpr add_pointer_t<T>
+  get_if(variant<Types...>*) noexcept;
+
+  template <class T, class... Types>
+  constexpr add_pointer_t<const T>
+  get_if(const variant<Types...>*) noexcept;
+
+  // 20.7.5, relational operators
+  template <class... Types>
+  constexpr bool operator==(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator!=(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator<(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator>(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator<=(const variant<Types...>&, const variant<Types...>&);
+
+  template <class... Types>
+  constexpr bool operator>=(const variant<Types...>&, const variant<Types...>&);
+
+  // 20.7.6, visitation
+  template <class Visitor, class... Variants>
+  constexpr see below visit(Visitor&&, Variants&&...);
+
+  // 20.7.7, class monostate
+  struct monostate;
+
+  // 20.7.8, monostate relational operators
+  constexpr bool operator<(monostate, monostate) noexcept;
+  constexpr bool operator>(monostate, monostate) noexcept;
+  constexpr bool operator<=(monostate, monostate) noexcept;
+  constexpr bool operator>=(monostate, monostate) noexcept;
+  constexpr bool operator==(monostate, monostate) noexcept;
+  constexpr bool operator!=(monostate, monostate) noexcept;
+
+  // 20.7.9, specialized algorithms
+  template <class... Types>
+  void swap(variant<Types...>&, variant<Types...>&) noexcept(see below);
+
+  // 20.7.10, class bad_variant_access
+  class bad_variant_access;
+
+  // 20.7.11, hash support
+  template <class T> struct hash;
+  template <class... Types> struct hash<variant<Types...>>;
+  template <> struct hash<monostate>;
+
+} // namespace std
+
+*/
+
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <initializer_list>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+// MPark.Variant
+//
+// Copyright Michael Park, 2015-2017
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#ifndef MPARK_CONFIG_HPP
+#define MPARK_CONFIG_HPP
+
+// MSVC 2015 Update 3.
+#if __cplusplus < 201103L && (!defined(_MSC_VER) || _MSC_FULL_VER < 190024215)
+#error "MPark.Variant requires C++11 support."
+#endif
+
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#ifndef __has_feature
+#define __has_feature(x) 0
+#endif
+
+#if __has_builtin(__builtin_addressof) || \
+    (defined(__GNUC__) && __GNUC__ >= 7) || defined(_MSC_VER)
+#define MPARK_BUILTIN_ADDRESSOF
+#endif
+
+#if __has_builtin(__type_pack_element)
+#define MPARK_TYPE_PACK_ELEMENT
+#endif
+
+#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#define MPARK_CPP14_CONSTEXPR
+#endif
+
+#if __has_feature(cxx_exceptions) || defined(__cpp_exceptions)
+#define MPARK_EXCEPTIONS
+#endif
+
+#if defined(__cpp_generic_lambdas) || defined(_MSC_VER)
+#define MPARK_GENERIC_LAMBDAS
+#endif
+
+#if defined(__cpp_lib_integer_sequence)
+#define MPARK_INTEGER_SEQUENCE
+#endif
+
+#if defined(__cpp_return_type_deduction) || defined(_MSC_VER)
+#define MPARK_RETURN_TYPE_DEDUCTION
+#endif
+
+#if defined(__cpp_lib_transparent_operators) || defined(_MSC_VER)
+#define MPARK_TRANSPARENT_OPERATORS
+#endif
+
+#if defined(__cpp_variable_templates) || defined(_MSC_VER)
+#define MPARK_VARIABLE_TEMPLATES
+#endif
+
+#if !defined(__GLIBCXX__)
+#define MPARK_TRIVIALITY_TYPE_TRAITS
+#elif defined(__has_include) && __has_include(<codecvt>)  // >= libstdc++-5
+#define MPARK_TRIVIALITY_TYPE_TRAITS
+#endif
+
+#endif  // MPARK_CONFIG_HPP
+
+// MPark.Variant
+//
+// Copyright Michael Park, 2015-2017
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#ifndef MPARK_IN_PLACE_HPP
+#define MPARK_IN_PLACE_HPP
+
+#include <cstddef>
+
+
+namespace mpark {
+
+  struct in_place_t { explicit in_place_t() = default; };
+
+  template <std::size_t I>
+  struct in_place_index_t { explicit in_place_index_t() = default; };
+
+  template <typename T>
+  struct in_place_type_t { explicit in_place_type_t() = default; };
+
+#ifdef MPARK_VARIABLE_TEMPLATES
+  constexpr in_place_t in_place{};
+
+  template <std::size_t I> constexpr in_place_index_t<I> in_place_index{};
+
+  template <typename T> constexpr in_place_type_t<T> in_place_type{};
+#endif
+
+}  // namespace mpark
+
+#endif  // MPARK_IN_PLACE_HPP
+
+// MPark.Variant
+//
+// Copyright Michael Park, 2015-2017
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
+
+#ifndef MPARK_LIB_HPP
+#define MPARK_LIB_HPP
+
+#include <memory>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+
+#define RETURN(...)                                          \
+  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { \
+    return __VA_ARGS__;                                      \
+  }
+
+namespace mpark {
+  namespace lib {
+    template <typename T>
+    struct identity { using type = T; };
+
+    inline namespace cpp14 {
+      template <typename T, std::size_t N>
+      struct array {
+        constexpr const T &operator[](std::size_t index) const {
+          return data[index];
+        }
+
+        T data[N == 0 ? 1 : N];
+      };
+
+      template <typename T>
+      using add_pointer_t = typename std::add_pointer<T>::type;
+
+      template <typename... Ts>
+      using common_type_t = typename std::common_type<Ts...>::type;
+
+      template <typename T>
+      using decay_t = typename std::decay<T>::type;
+
+      template <bool B, typename T = void>
+      using enable_if_t = typename std::enable_if<B, T>::type;
+
+      template <typename T>
+      using remove_const_t = typename std::remove_const<T>::type;
+
+      template <typename T>
+      using remove_reference_t = typename std::remove_reference<T>::type;
+
+      template <typename T>
+      inline constexpr T &&forward(remove_reference_t<T> &t) noexcept {
+        return static_cast<T &&>(t);
+      }
+
+      template <typename T>
+      inline constexpr T &&forward(remove_reference_t<T> &&t) noexcept {
+        static_assert(!std::is_lvalue_reference<T>::value,
+                      "can not forward an rvalue as an lvalue");
+        return static_cast<T &&>(t);
+      }
+
+      template <typename T>
+      inline constexpr remove_reference_t<T> &&move(T &&t) noexcept {
+        return static_cast<remove_reference_t<T> &&>(t);
+      }
+
+#ifdef MPARK_INTEGER_SEQUENCE
+      template <typename T, T... Is>
+      using integer_sequence = std::integer_sequence<T, Is...>;
+
+      template <std::size_t... Is>
+      using index_sequence = std::index_sequence<Is...>;
+
+      template <std::size_t N>
+      using make_index_sequence = std::make_index_sequence<N>;
+
+      template <typename... Ts>
+      using index_sequence_for = std::index_sequence_for<Ts...>;
+#else
+      template <typename T, T... Is>
+      struct integer_sequence {
+        using value_type = T;
+        static constexpr std::size_t size() noexcept { return sizeof...(Is); }
+      };
+
+      template <std::size_t... Is>
+      using index_sequence = integer_sequence<std::size_t, Is...>;
+
+      template <typename Lhs, typename Rhs>
+      struct make_index_sequence_concat;
+
+      template <std::size_t... Lhs, std::size_t... Rhs>
+      struct make_index_sequence_concat<index_sequence<Lhs...>,
+                                        index_sequence<Rhs...>>
+          : identity<index_sequence<Lhs..., (sizeof...(Lhs) + Rhs)...>> {};
+
+      template <std::size_t N>
+      struct make_index_sequence_impl;
+
+      template <std::size_t N>
+      using make_index_sequence = typename make_index_sequence_impl<N>::type;
+
+      template <std::size_t N>
+      struct make_index_sequence_impl
+          : make_index_sequence_concat<make_index_sequence<N / 2>,
+                                       make_index_sequence<N - (N / 2)>> {};
+
+      template <>
+      struct make_index_sequence_impl<0> : identity<index_sequence<>> {};
+
+      template <>
+      struct make_index_sequence_impl<1> : identity<index_sequence<0>> {};
+
+      template <typename... Ts>
+      using index_sequence_for = make_index_sequence<sizeof...(Ts)>;
+#endif
+
+      // <functional>
+#ifdef MPARK_TRANSPARENT_OPERATORS
+      using equal_to = std::equal_to<>;
+#else
+      struct equal_to {
+        template <typename Lhs, typename Rhs>
+        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+          RETURN(lib::forward<Lhs>(lhs) == lib::forward<Rhs>(rhs))
+      };
+#endif
+
+#ifdef MPARK_TRANSPARENT_OPERATORS
+      using not_equal_to = std::not_equal_to<>;
+#else
+      struct not_equal_to {
+        template <typename Lhs, typename Rhs>
+        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+          RETURN(lib::forward<Lhs>(lhs) != lib::forward<Rhs>(rhs))
+      };
+#endif
+
+#ifdef MPARK_TRANSPARENT_OPERATORS
+      using less = std::less<>;
+#else
+      struct less {
+        template <typename Lhs, typename Rhs>
+        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+          RETURN(lib::forward<Lhs>(lhs) < lib::forward<Rhs>(rhs))
+      };
+#endif
+
+#ifdef MPARK_TRANSPARENT_OPERATORS
+      using greater = std::greater<>;
+#else
+      struct greater {
+        template <typename Lhs, typename Rhs>
+        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+          RETURN(lib::forward<Lhs>(lhs) > lib::forward<Rhs>(rhs))
+      };
+#endif
+
+#ifdef MPARK_TRANSPARENT_OPERATORS
+      using less_equal = std::less_equal<>;
+#else
+      struct less_equal {
+        template <typename Lhs, typename Rhs>
+        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+          RETURN(lib::forward<Lhs>(lhs) <= lib::forward<Rhs>(rhs))
+      };
+#endif
+
+#ifdef MPARK_TRANSPARENT_OPERATORS
+      using greater_equal = std::greater_equal<>;
+#else
+      struct greater_equal {
+        template <typename Lhs, typename Rhs>
+        inline constexpr auto operator()(Lhs &&lhs, Rhs &&rhs) const
+          RETURN(lib::forward<Lhs>(lhs) >= lib::forward<Rhs>(rhs))
+      };
+#endif
+    }  // namespace cpp14
+
+    inline namespace cpp17 {
+
+      // <type_traits>
+      template <bool B>
+      using bool_constant = std::integral_constant<bool, B>;
+
+      template <typename...>
+      struct voider : identity<void> {};
+
+      template <typename... Ts>
+      using void_t = typename voider<Ts...>::type;
+
+      namespace detail {
+        namespace swappable {
+
+          using std::swap;
+
+          template <typename T>
+          struct is_swappable_impl {
+            private:
+            template <typename U,
+                      typename = decltype(swap(std::declval<U &>(),
+                                               std::declval<U &>()))>
+            inline static std::true_type test(int);
+
+            template <typename U>
+            inline static std::false_type test(...);
+
+            public:
+            using type = decltype(test<T>(0));
+          };
+
+          template <typename T>
+          using is_swappable = typename is_swappable_impl<T>::type;
+
+          template <typename T, bool = is_swappable<T>::value>
+          struct is_nothrow_swappable {
+            static constexpr bool value =
+                noexcept(swap(std::declval<T &>(), std::declval<T &>()));
+          };
+
+          template <typename T>
+          struct is_nothrow_swappable<T, false> : std::false_type {};
+
+        }  // namespace swappable
+      }  // namespace detail
+
+      template <typename T>
+      using is_swappable = detail::swappable::is_swappable<T>;
+
+      template <typename T>
+      using is_nothrow_swappable = detail::swappable::is_nothrow_swappable<T>;
+
+      // <functional>
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#endif
+      template <typename F, typename... As>
+      inline constexpr auto invoke(F &&f, As &&... as)
+          RETURN(lib::forward<F>(f)(lib::forward<As>(as)...))
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+      template <typename B, typename T, typename D>
+      inline constexpr auto invoke(T B::*pmv, D &&d)
+          RETURN(lib::forward<D>(d).*pmv)
+
+      template <typename Pmv, typename Ptr>
+      inline constexpr auto invoke(Pmv pmv, Ptr &&ptr)
+          RETURN((*lib::forward<Ptr>(ptr)).*pmv)
+
+      template <typename B, typename T, typename D, typename... As>
+      inline constexpr auto invoke(T B::*pmf, D &&d, As &&... as)
+          RETURN((lib::forward<D>(d).*pmf)(lib::forward<As>(as)...))
+
+      template <typename Pmf, typename Ptr, typename... As>
+      inline constexpr auto invoke(Pmf pmf, Ptr &&ptr, As &&... as)
+          RETURN(((*lib::forward<Ptr>(ptr)).*pmf)(lib::forward<As>(as)...))
+
+      namespace detail {
+
+        template <typename Void, typename, typename...>
+        struct invoke_result {};
+
+        template <typename F, typename... Args>
+        struct invoke_result<void_t<decltype(lib::invoke(
+                                 std::declval<F>(), std::declval<Args>()...))>,
+                             F,
+                             Args...>
+            : identity<decltype(
+                  lib::invoke(std::declval<F>(), std::declval<Args>()...))> {};
+
+      }  // namespace detail
+
+      template <typename F, typename... Args>
+      using invoke_result = detail::invoke_result<void, F, Args...>;
+
+      template <typename F, typename... Args>
+      using invoke_result_t = typename invoke_result<F, Args...>::type;
+
+      namespace detail {
+
+        template <typename Void, typename, typename...>
+        struct is_invocable : std::false_type {};
+
+        template <typename F, typename... Args>
+        struct is_invocable<void_t<invoke_result_t<F, Args...>>, F, Args...>
+            : std::true_type {};
+
+        template <typename Void, typename, typename, typename...>
+        struct is_invocable_r : std::false_type {};
+
+        template <typename R, typename F, typename... Args>
+        struct is_invocable_r<void_t<invoke_result_t<F, Args...>>,
+                              R,
+                              F,
+                              Args...>
+            : std::is_convertible<invoke_result_t<F, Args...>, R> {};
+
+      }  // namespace detail
+
+      template <typename F, typename... Args>
+      using is_invocable = detail::is_invocable<void, F, Args...>;
+
+      template <typename R, typename F, typename... Args>
+      using is_invocable_r = detail::is_invocable_r<void, R, F, Args...>;
+
+      // <memory>
+#ifdef MPARK_BUILTIN_ADDRESSOF
+      template <typename T>
+      inline constexpr T *addressof(T &arg) {
+        return __builtin_addressof(arg);
+      }
+#else
+      namespace detail {
+
+        namespace has_addressof_impl {
+
+          struct fail;
+
+          template <typename T>
+          inline fail operator&(T &&);
+
+          template <typename T>
+          inline static constexpr bool impl() {
+            return (std::is_class<T>::value || std::is_union<T>::value) &&
+                   !std::is_same<decltype(&std::declval<T &>()), fail>::value;
+          }
+
+        }  // namespace has_addressof_impl
+
+        template <typename T>
+        using has_addressof = bool_constant<has_addressof_impl::impl<T>()>;
+
+        template <typename T>
+        inline constexpr T *addressof(T &arg, std::true_type) {
+          return std::addressof(arg);
+        }
+
+        template <typename T>
+        inline constexpr T *addressof(T &arg, std::false_type) {
+          return &arg;
+        }
+
+      }  // namespace detail
+
+      template <typename T>
+      inline constexpr T *addressof(T &arg) {
+        return detail::addressof(arg, detail::has_addressof<T>{});
+      }
+#endif
+
+      template <typename T>
+      inline constexpr T *addressof(const T &&) = delete;
+
+    }  // namespace cpp17
+
+    template <typename T>
+    struct remove_all_extents : identity<T> {};
+
+    template <typename T, std::size_t N>
+    struct remove_all_extents<array<T, N>> : remove_all_extents<T> {};
+
+    template <typename T>
+    using remove_all_extents_t = typename remove_all_extents<T>::type;
+
+    template <std::size_t N>
+    using size_constant = std::integral_constant<std::size_t, N>;
+
+    template <bool... Bs>
+    using bool_sequence = integer_sequence<bool, Bs...>;
+
+    template <std::size_t I, typename T>
+    struct indexed_type : size_constant<I>, identity<T> {};
+
+    template <bool... Bs>
+    using all =
+        std::is_same<bool_sequence<true, Bs...>, bool_sequence<Bs..., true>>;
+
+#ifdef MPARK_TYPE_PACK_ELEMENT
+    template <std::size_t I, typename... Ts>
+    using type_pack_element_t = __type_pack_element<I, Ts...>;
+#else
+    template <std::size_t I, typename... Ts>
+    struct type_pack_element_impl {
+      private:
+      template <typename>
+      struct set;
+
+      template <std::size_t... Is>
+      struct set<index_sequence<Is...>> : indexed_type<Is, Ts>... {};
+
+      template <typename T>
+      inline static std::enable_if<true, T> impl(indexed_type<I, T>);
+
+      inline static std::enable_if<false> impl(...);
+
+      public:
+      using type = decltype(impl(set<index_sequence_for<Ts...>>{}));
+    };
+
+    template <std::size_t I, typename... Ts>
+    using type_pack_element = typename type_pack_element_impl<I, Ts...>::type;
+
+    template <std::size_t I, typename... Ts>
+    using type_pack_element_t = typename type_pack_element<I, Ts...>::type;
+#endif
+
+#ifdef MPARK_TRIVIALITY_TYPE_TRAITS
+    template <typename T>
+    using is_trivially_copy_constructible =
+        std::is_trivially_copy_constructible<T>;
+
+    template <typename T>
+    using is_trivially_move_constructible =
+        std::is_trivially_move_constructible<T>;
+
+    template <typename T>
+    using is_trivially_copy_assignable = std::is_trivially_copy_assignable<T>;
+
+    template <typename T>
+    using is_trivially_move_assignable = std::is_trivially_move_assignable<T>;
+#else
+    template <typename T>
+    struct is_trivially_copy_constructible
+        : bool_constant<
+              std::is_copy_constructible<T>::value && __has_trivial_copy(T)> {};
+
+    template <typename T>
+    struct is_trivially_move_constructible : bool_constant<__is_trivial(T)> {};
+
+    template <typename T>
+    struct is_trivially_copy_assignable
+        : bool_constant<
+              std::is_copy_assignable<T>::value && __has_trivial_assign(T)> {};
+
+    template <typename T>
+    struct is_trivially_move_assignable : bool_constant<__is_trivial(T)> {};
+#endif
+
+  }  // namespace lib
+}  // namespace mpark
+
+#undef RETURN
+
+#endif  // MPARK_LIB_HPP
+
+
+namespace mpark {
+
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+
+#define AUTO auto
+#define AUTO_RETURN(...) { return __VA_ARGS__; }
+
+#define AUTO_REFREF auto &&
+#define AUTO_REFREF_RETURN(...) { return __VA_ARGS__; }
+
+#define DECLTYPE_AUTO decltype(auto)
+#define DECLTYPE_AUTO_RETURN(...) { return __VA_ARGS__; }
+
+#else
+
+#define AUTO auto
+#define AUTO_RETURN(...) \
+  -> lib::decay_t<decltype(__VA_ARGS__)> { return __VA_ARGS__; }
+
+#define AUTO_REFREF auto
+#define AUTO_REFREF_RETURN(...)                                           \
+  -> decltype((__VA_ARGS__)) {                                            \
+    static_assert(std::is_reference<decltype((__VA_ARGS__))>::value, ""); \
+    return __VA_ARGS__;                                                   \
+  }
+
+#define DECLTYPE_AUTO auto
+#define DECLTYPE_AUTO_RETURN(...) \
+  -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
+
+#endif
+
+  class bad_variant_access : public std::exception {
+    public:
+    virtual const char *what() const noexcept { return "bad_variant_access"; }
+  };
+
+  [[noreturn]] inline void throw_bad_variant_access() {
+#ifdef MPARK_EXCEPTIONS
+    throw bad_variant_access{};
+#else
+    std::terminate();
+#endif
+  }
+
+  template <typename... Ts>
+  class variant;
+
+  template <typename T>
+  struct variant_size;
+
+#ifdef MPARK_VARIABLE_TEMPLATES
+  template <typename T>
+  constexpr std::size_t variant_size_v = variant_size<T>::value;
+#endif
+
+  template <typename T>
+  struct variant_size<const T> : variant_size<T> {};
+
+  template <typename T>
+  struct variant_size<volatile T> : variant_size<T> {};
+
+  template <typename T>
+  struct variant_size<const volatile T> : variant_size<T> {};
+
+  template <typename... Ts>
+  struct variant_size<variant<Ts...>> : lib::size_constant<sizeof...(Ts)> {};
+
+  template <std::size_t I, typename T>
+  struct variant_alternative;
+
+  template <std::size_t I, typename T>
+  using variant_alternative_t = typename variant_alternative<I, T>::type;
+
+  template <std::size_t I, typename T>
+  struct variant_alternative<I, const T>
+      : std::add_const<variant_alternative_t<I, T>> {};
+
+  template <std::size_t I, typename T>
+  struct variant_alternative<I, volatile T>
+      : std::add_volatile<variant_alternative_t<I, T>> {};
+
+  template <std::size_t I, typename T>
+  struct variant_alternative<I, const volatile T>
+      : std::add_cv<variant_alternative_t<I, T>> {};
+
+  template <std::size_t I, typename... Ts>
+  struct variant_alternative<I, variant<Ts...>>
+      : lib::identity<lib::type_pack_element_t<I, Ts...>> {
+    static_assert(I < sizeof...(Ts),
+                  "`variant_alternative` index out of range.");
+  };
+
+  constexpr std::size_t variant_npos = static_cast<std::size_t>(-1);
+
+  namespace detail {
+
+    inline constexpr bool all() { return true; }
+
+    template <typename... Bs>
+    inline constexpr bool all(bool b, Bs... bs) {
+      return b && all(bs...);
+    }
+
+    constexpr std::size_t not_found = static_cast<std::size_t>(-1);
+    constexpr std::size_t ambiguous = static_cast<std::size_t>(-2);
+
+#ifdef MPARK_CPP14_CONSTEXPR
+    template <typename T, typename... Ts>
+    inline constexpr std::size_t find_index() {
+      constexpr lib::array<bool, sizeof...(Ts)> matches = {
+          {std::is_same<T, Ts>::value...}
+      };
+      std::size_t result = not_found;
+      for (std::size_t i = 0; i < sizeof...(Ts); ++i) {
+        if (matches[i]) {
+          if (result != not_found) {
+            return ambiguous;
+          }
+          result = i;
+        }
+      }
+      return result;
+    }
+#else
+    inline constexpr std::size_t find_index_impl(std::size_t result,
+                                                 std::size_t) {
+      return result;
+    }
+
+    template <typename... Bs>
+    inline constexpr std::size_t find_index_impl(std::size_t result,
+                                                 std::size_t idx,
+                                                 bool b,
+                                                 Bs... bs) {
+      return b ? (result != not_found ? ambiguous
+                                      : find_index_impl(idx, idx + 1, bs...))
+               : find_index_impl(result, idx + 1, bs...);
+    }
+
+    template <typename T, typename... Ts>
+    inline constexpr std::size_t find_index() {
+      return find_index_impl(not_found, 0, std::is_same<T, Ts>::value...);
+    }
+#endif
+
+    template <std::size_t I>
+    using find_index_sfinae_impl =
+        lib::enable_if_t<I != not_found && I != ambiguous,
+                         lib::size_constant<I>>;
+
+    template <typename T, typename... Ts>
+    using find_index_sfinae = find_index_sfinae_impl<find_index<T, Ts...>()>;
+
+    template <std::size_t I>
+    struct find_index_checked_impl : lib::size_constant<I> {
+      static_assert(I != not_found, "the specified type is not found.");
+      static_assert(I != ambiguous, "the specified type is ambiguous.");
+    };
+
+    template <typename T, typename... Ts>
+    using find_index_checked = find_index_checked_impl<find_index<T, Ts...>()>;
+
+    struct valueless_t {};
+
+    enum class Trait { TriviallyAvailable, Available, Unavailable };
+
+    template <typename T,
+              template <typename> class IsTriviallyAvailable,
+              template <typename> class IsAvailable>
+    inline constexpr Trait trait() {
+      return IsTriviallyAvailable<T>::value
+                 ? Trait::TriviallyAvailable
+                 : IsAvailable<T>::value ? Trait::Available
+                                         : Trait::Unavailable;
+    }
+
+#ifdef MPARK_CPP14_CONSTEXPR
+    template <typename... Traits>
+    inline constexpr Trait common_trait(Traits... traits) {
+      Trait result = Trait::TriviallyAvailable;
+      for (Trait t : {traits...}) {
+        if (static_cast<int>(t) > static_cast<int>(result)) {
+          result = t;
+        }
+      }
+      return result;
+    }
+#else
+    inline constexpr Trait common_trait_impl(Trait result) { return result; }
+
+    template <typename... Traits>
+    inline constexpr Trait common_trait_impl(Trait result,
+                                             Trait t,
+                                             Traits... ts) {
+      return static_cast<int>(t) > static_cast<int>(result)
+                 ? common_trait_impl(t, ts...)
+                 : common_trait_impl(result, ts...);
+    }
+
+    template <typename... Traits>
+    inline constexpr Trait common_trait(Traits... ts) {
+      return common_trait_impl(Trait::TriviallyAvailable, ts...);
+    }
+#endif
+
+    template <typename... Ts>
+    struct traits {
+      static constexpr Trait copy_constructible_trait =
+          common_trait(trait<Ts,
+                             lib::is_trivially_copy_constructible,
+                             std::is_copy_constructible>()...);
+
+      static constexpr Trait move_constructible_trait =
+          common_trait(trait<Ts,
+                             lib::is_trivially_move_constructible,
+                             std::is_move_constructible>()...);
+
+      static constexpr Trait copy_assignable_trait =
+          common_trait(copy_constructible_trait,
+                       trait<Ts,
+                             lib::is_trivially_copy_assignable,
+                             std::is_copy_assignable>()...);
+
+      static constexpr Trait move_assignable_trait =
+          common_trait(move_constructible_trait,
+                       trait<Ts,
+                             lib::is_trivially_move_assignable,
+                             std::is_move_assignable>()...);
+
+      static constexpr Trait destructible_trait =
+          common_trait(trait<Ts,
+                             std::is_trivially_destructible,
+                             std::is_destructible>()...);
+    };
+
+    namespace access {
+
+      struct recursive_union {
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+        template <typename V>
+        inline static constexpr auto &&get_alt(V &&v, in_place_index_t<0>) {
+          return lib::forward<V>(v).head_;
+        }
+
+        template <typename V, std::size_t I>
+        inline static constexpr auto &&get_alt(V &&v, in_place_index_t<I>) {
+          return get_alt(lib::forward<V>(v).tail_, in_place_index_t<I - 1>{});
+        }
+#else
+        template <std::size_t I, bool Dummy = true>
+        struct get_alt_impl {
+          template <typename V>
+          inline constexpr AUTO_REFREF operator()(V &&v) const
+            AUTO_REFREF_RETURN(get_alt_impl<I - 1>{}(lib::forward<V>(v).tail_))
+        };
+
+        template <bool Dummy>
+        struct get_alt_impl<0, Dummy> {
+          template <typename V>
+          inline constexpr AUTO_REFREF operator()(V &&v) const
+            AUTO_REFREF_RETURN(lib::forward<V>(v).head_)
+        };
+
+        template <typename V, std::size_t I>
+        inline static constexpr AUTO_REFREF get_alt(V &&v, in_place_index_t<I>)
+          AUTO_REFREF_RETURN(get_alt_impl<I>{}(lib::forward<V>(v)))
+#endif
+      };
+
+      struct base {
+        template <std::size_t I, typename V>
+        inline static constexpr AUTO_REFREF get_alt(V &&v)
+          AUTO_REFREF_RETURN(recursive_union::get_alt(
+              data(lib::forward<V>(v)), in_place_index_t<I>{}))
+      };
+
+      struct variant {
+        template <std::size_t I, typename V>
+        inline static constexpr AUTO_REFREF get_alt(V &&v)
+          AUTO_REFREF_RETURN(base::get_alt<I>(lib::forward<V>(v).impl_))
+      };
+
+    }  // namespace access
+
+    namespace visitation {
+
+      struct base {
+        private:
+        template <typename T>
+        inline static constexpr const T &at(const T &elem) {
+          return elem;
+        }
+
+        template <typename T, std::size_t N, typename... Is>
+        inline static constexpr const lib::remove_all_extents_t<T> &at(
+            const lib::array<T, N> &elems, std::size_t i, Is... is) {
+          return at(elems[i], is...);
+        }
+
+        template <typename F, typename... Fs>
+        inline static constexpr int visit_visitor_return_type_check() {
+          static_assert(all(std::is_same<F, Fs>::value...),
+                        "`mpark::visit` requires the visitor to have a single "
+                        "return type.");
+          return 0;
+        }
+
+        template <typename... Fs>
+        inline static constexpr lib::array<
+            lib::common_type_t<lib::decay_t<Fs>...>,
+            sizeof...(Fs)>
+        make_farray(Fs &&... fs) {
+          using result = lib::array<lib::common_type_t<lib::decay_t<Fs>...>,
+                                    sizeof...(Fs)>;
+          return visit_visitor_return_type_check<lib::decay_t<Fs>...>(),
+                 result{{lib::forward<Fs>(fs)...}};
+        }
+
+        template <std::size_t... Is>
+        struct dispatcher {
+          template <typename F, typename... Vs>
+          struct impl {
+            inline static constexpr DECLTYPE_AUTO dispatch(F f, Vs... vs)
+              DECLTYPE_AUTO_RETURN(lib::invoke(
+                  static_cast<F>(f),
+                  access::base::get_alt<Is>(static_cast<Vs>(vs))...))
+          };
+        };
+
+        template <typename F, typename... Vs, std::size_t... Is>
+        inline static constexpr AUTO make_dispatch(lib::index_sequence<Is...>)
+          AUTO_RETURN(&dispatcher<Is...>::template impl<F, Vs...>::dispatch)
+
+        template <std::size_t I, typename F, typename... Vs>
+        inline static constexpr AUTO make_fdiagonal_impl()
+          AUTO_RETURN(make_dispatch<F, Vs...>(
+              lib::index_sequence<lib::indexed_type<I, Vs>::value...>{}))
+
+        template <typename F, typename... Vs, std::size_t... Is>
+        inline static constexpr AUTO make_fdiagonal_impl(
+            lib::index_sequence<Is...>)
+          AUTO_RETURN(make_farray(make_fdiagonal_impl<Is, F, Vs...>()...))
+
+        template <typename F, typename V, typename... Vs>
+        inline static constexpr /* auto * */ auto make_fdiagonal()
+            -> decltype(make_fdiagonal_impl<F, V, Vs...>(
+                lib::make_index_sequence<lib::decay_t<V>::size()>{})) {
+          static_assert(
+              all((lib::decay_t<V>::size() == lib::decay_t<Vs>::size())...),
+              "all of the variants must be the same size.");
+          return make_fdiagonal_impl<F, V, Vs...>(
+              lib::make_index_sequence<lib::decay_t<V>::size()>{});
+        }
+
+#ifdef MPARK_RETURN_TYPE_DEDUCTION
+        template <typename F, typename... Vs, std::size_t... Is>
+        inline static constexpr auto make_fmatrix_impl(
+            lib::index_sequence<Is...> is) {
+          return make_dispatch<F, Vs...>(is);
+        }
+
+        template <typename F,
+                  typename... Vs,
+                  std::size_t... Is,
+                  std::size_t... Js,
+                  typename... Ls>
+        inline static constexpr auto make_fmatrix_impl(
+            lib::index_sequence<Is...>, lib::index_sequence<Js...>, Ls... ls) {
+          return make_farray(make_fmatrix_impl<F, Vs...>(
+              lib::index_sequence<Is..., Js>{}, ls...)...);
+        }
+
+        template <typename F, typename... Vs>
+        inline static constexpr auto make_fmatrix() {
+          return make_fmatrix_impl<F, Vs...>(
+              lib::index_sequence<>{},
+              lib::make_index_sequence<lib::decay_t<Vs>::size()>{}...);
+        }
+#else
+        template <typename F, typename... Vs>
+        struct make_fmatrix_impl {
+          template <typename...>
+          struct impl;
+
+          template <std::size_t... Is>
+          struct impl<lib::index_sequence<Is...>> {
+            inline constexpr AUTO operator()() const
+              AUTO_RETURN(
+                  make_dispatch<F, Vs...>(lib::index_sequence<Is...>{}))
+          };
+
+          template <std::size_t... Is, std::size_t... Js, typename... Ls>
+          struct impl<lib::index_sequence<Is...>,
+                      lib::index_sequence<Js...>,
+                      Ls...> {
+            inline constexpr AUTO operator()() const
+              AUTO_RETURN(make_farray(
+                  impl<lib::index_sequence<Is..., Js>, Ls...>{}()...))
+          };
+        };
+
+        template <typename F, typename... Vs>
+        inline static constexpr AUTO make_fmatrix()
+          AUTO_RETURN(
+              typename make_fmatrix_impl<F, Vs...>::template impl<
+                  lib::index_sequence<>,
+                  lib::make_index_sequence<lib::decay_t<Vs>::size()>...>{}())
+#endif
+
+        public:
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
+                                                           Visitor &&visitor,
+                                                           Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(
+              at(make_fdiagonal<Visitor &&,
+                                decltype(as_base(lib::forward<Vs>(vs)))...>(),
+                 index)(lib::forward<Visitor>(visitor),
+                        as_base(lib::forward<Vs>(vs))...))
+
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
+                                                        Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(
+              at(make_fmatrix<Visitor &&,
+                              decltype(as_base(lib::forward<Vs>(vs)))...>(),
+                 vs.index()...)(lib::forward<Visitor>(visitor),
+                                as_base(lib::forward<Vs>(vs))...))
+      };
+
+      struct variant {
+        private:
+        template <typename Visitor, typename... Values>
+        struct visit_exhaustive_visitor_check {
+          static_assert(
+              lib::is_invocable<Visitor, Values...>::value,
+              "`mpark::visit` requires the visitor to be exhaustive.");
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#endif
+          inline constexpr DECLTYPE_AUTO operator()(Visitor &&visitor,
+                                                    Values &&... values) const
+            DECLTYPE_AUTO_RETURN(lib::invoke(lib::forward<Visitor>(visitor),
+                                             lib::forward<Values>(values)...))
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+        };
+
+        template <typename Visitor>
+        struct value_visitor {
+          Visitor &&visitor_;
+
+          template <typename... Alts>
+          inline constexpr DECLTYPE_AUTO operator()(Alts &&... alts) const
+            DECLTYPE_AUTO_RETURN(
+                visit_exhaustive_visitor_check<
+                    Visitor,
+                    decltype((lib::forward<Alts>(alts).value))...>{}(
+                    lib::forward<Visitor>(visitor_),
+                    lib::forward<Alts>(alts).value...))
+        };
+
+        template <typename Visitor>
+        inline static constexpr AUTO make_value_visitor(Visitor &&visitor)
+          AUTO_RETURN(value_visitor<Visitor>{lib::forward<Visitor>(visitor)})
+
+        public:
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt_at(std::size_t index,
+                                                           Visitor &&visitor,
+                                                           Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(
+              base::visit_alt_at(index,
+                                 lib::forward<Visitor>(visitor),
+                                 lib::forward<Vs>(vs).impl_...))
+
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_alt(Visitor &&visitor,
+                                                        Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(base::visit_alt(lib::forward<Visitor>(visitor),
+                                               lib::forward<Vs>(vs).impl_...))
+
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_value_at(std::size_t index,
+                                                             Visitor &&visitor,
+                                                             Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(
+              visit_alt_at(index,
+                           make_value_visitor(lib::forward<Visitor>(visitor)),
+                           lib::forward<Vs>(vs)...))
+
+        template <typename Visitor, typename... Vs>
+        inline static constexpr DECLTYPE_AUTO visit_value(Visitor &&visitor,
+                                                          Vs &&... vs)
+          DECLTYPE_AUTO_RETURN(
+              visit_alt(make_value_visitor(lib::forward<Visitor>(visitor)),
+                        lib::forward<Vs>(vs)...))
+      };
+
+    }  // namespace visitation
+
+    template <std::size_t Index, typename T>
+    struct alt {
+      using value_type = T;
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+      template <typename... Args>
+      inline explicit constexpr alt(in_place_t, Args &&... args)
+          : value(lib::forward<Args>(args)...) {}
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+      T value;
+    };
+
+    template <Trait DestructibleTrait, std::size_t Index, typename... Ts>
+    union recursive_union;
+
+    template <Trait DestructibleTrait, std::size_t Index>
+    union recursive_union<DestructibleTrait, Index> {};
+
+#define MPARK_VARIANT_RECURSIVE_UNION(destructible_trait, destructor)      \
+  template <std::size_t Index, typename T, typename... Ts>                 \
+  union recursive_union<destructible_trait, Index, T, Ts...> {             \
+    public:                                                                \
+    inline explicit constexpr recursive_union(valueless_t) noexcept        \
+        : dummy_{} {}                                                      \
+                                                                           \
+    template <typename... Args>                                            \
+    inline explicit constexpr recursive_union(in_place_index_t<0>,         \
+                                              Args &&... args)             \
+        : head_(in_place_t{}, lib::forward<Args>(args)...) {}              \
+                                                                           \
+    template <std::size_t I, typename... Args>                             \
+    inline explicit constexpr recursive_union(in_place_index_t<I>,         \
+                                              Args &&... args)             \
+        : tail_(in_place_index_t<I - 1>{}, lib::forward<Args>(args)...) {} \
+                                                                           \
+    recursive_union(const recursive_union &) = default;                    \
+    recursive_union(recursive_union &&) = default;                         \
+                                                                           \
+    destructor                                                             \
+                                                                           \
+    recursive_union &operator=(const recursive_union &) = default;         \
+    recursive_union &operator=(recursive_union &&) = default;              \
+                                                                           \
+    private:                                                               \
+    char dummy_;                                                           \
+    alt<Index, T> head_;                                                   \
+    recursive_union<destructible_trait, Index + 1, Ts...> tail_;           \
+                                                                           \
+    friend struct access::recursive_union;                                 \
+  }
+
+    MPARK_VARIANT_RECURSIVE_UNION(Trait::TriviallyAvailable,
+                                  ~recursive_union() = default;);
+    MPARK_VARIANT_RECURSIVE_UNION(Trait::Available,
+                                  ~recursive_union() {});
+    MPARK_VARIANT_RECURSIVE_UNION(Trait::Unavailable,
+                                  ~recursive_union() = delete;);
+
+#undef MPARK_VARIANT_RECURSIVE_UNION
+
+    using index_t = unsigned int;
+
+    template <Trait DestructibleTrait, typename... Ts>
+    class base {
+      public:
+      inline explicit constexpr base(valueless_t tag) noexcept
+          : data_(tag), index_(static_cast<index_t>(-1)) {}
+
+      template <std::size_t I, typename... Args>
+      inline explicit constexpr base(in_place_index_t<I>, Args &&... args)
+          : data_(in_place_index_t<I>{}, lib::forward<Args>(args)...),
+            index_(I) {}
+
+      inline constexpr bool valueless_by_exception() const noexcept {
+        return index_ == static_cast<index_t>(-1);
+      }
+
+      inline constexpr std::size_t index() const noexcept {
+        return valueless_by_exception() ? variant_npos : index_;
+      }
+
+      protected:
+      using data_t = recursive_union<DestructibleTrait, 0, Ts...>;
+
+      friend inline constexpr base &as_base(base &b) { return b; }
+      friend inline constexpr const base &as_base(const base &b) { return b; }
+      friend inline constexpr base &&as_base(base &&b) { return lib::move(b); }
+      friend inline constexpr const base &&as_base(const base &&b) { return lib::move(b); }
+
+      friend inline constexpr data_t &data(base &b) { return b.data_; }
+      friend inline constexpr const data_t &data(const base &b) { return b.data_; }
+      friend inline constexpr data_t &&data(base &&b) { return lib::move(b).data_; }
+      friend inline constexpr const data_t &&data(const base &&b) { return lib::move(b).data_; }
+
+      inline static constexpr std::size_t size() { return sizeof...(Ts); }
+
+      data_t data_;
+      index_t index_;
+
+      friend struct access::base;
+      friend struct visitation::base;
+    };
+
+    struct dtor {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100)
+#endif
+      template <typename Alt>
+      inline void operator()(Alt &alt) const noexcept { alt.~Alt(); }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+    };
+
+#if defined(_MSC_VER) && _MSC_VER < 1910
+#define INHERITING_CTOR(type, base)               \
+  template <typename... Args>                     \
+  inline explicit constexpr type(Args &&... args) \
+      : base(lib::forward<Args>(args)...) {}
+#else
+#define INHERITING_CTOR(type, base) using base::base;
+#endif
+
+    template <typename Traits, Trait = Traits::destructible_trait>
+    class destructor;
+
+#define MPARK_VARIANT_DESTRUCTOR(destructible_trait, definition, destroy) \
+  template <typename... Ts>                                               \
+  class destructor<traits<Ts...>, destructible_trait>                     \
+      : public base<destructible_trait, Ts...> {                          \
+    using super = base<destructible_trait, Ts...>;                        \
+                                                                          \
+    public:                                                               \
+    INHERITING_CTOR(destructor, super)                                    \
+    using super::operator=;                                               \
+                                                                          \
+    destructor(const destructor &) = default;                             \
+    destructor(destructor &&) = default;                                  \
+    definition                                                            \
+    destructor &operator=(const destructor &) = default;                  \
+    destructor &operator=(destructor &&) = default;                       \
+                                                                          \
+    protected:                                                            \
+    destroy                                                               \
+  }
+
+    MPARK_VARIANT_DESTRUCTOR(
+        Trait::TriviallyAvailable,
+        ~destructor() = default;,
+        inline void destroy() noexcept {
+          this->index_ = static_cast<index_t>(-1);
+        });
+
+    MPARK_VARIANT_DESTRUCTOR(
+        Trait::Available,
+        ~destructor() { destroy(); },
+        inline void destroy() noexcept {
+          if (!this->valueless_by_exception()) {
+            visitation::base::visit_alt(dtor{}, *this);
+          }
+          this->index_ = static_cast<index_t>(-1);
+        });
+
+    MPARK_VARIANT_DESTRUCTOR(
+        Trait::Unavailable,
+        ~destructor() = delete;,
+        inline void destroy() noexcept = delete;);
+
+#undef MPARK_VARIANT_DESTRUCTOR
+
+    template <typename Traits>
+    class constructor : public destructor<Traits> {
+      using super = destructor<Traits>;
+
+      public:
+      INHERITING_CTOR(constructor, super)
+      using super::operator=;
+
+      protected:
+#ifndef MPARK_GENERIC_LAMBDAS
+      struct ctor {
+        template <typename LhsAlt, typename RhsAlt>
+        inline void operator()(LhsAlt &lhs_alt, RhsAlt &&rhs_alt) const {
+          constructor::construct_alt(lhs_alt,
+                                     lib::forward<RhsAlt>(rhs_alt).value);
+        }
+      };
+#endif
+
+      template <std::size_t I, typename T, typename... Args>
+      inline static T &construct_alt(alt<I, T> &a, Args &&... args) {
+        ::new (static_cast<void *>(lib::addressof(a)))
+            alt<I, T>(in_place_t{}, lib::forward<Args>(args)...);
+        return a.value;
+      }
+
+      template <typename Rhs>
+      inline static void generic_construct(constructor &lhs, Rhs &&rhs) {
+        lhs.destroy();
+        if (!rhs.valueless_by_exception()) {
+          visitation::base::visit_alt_at(
+              rhs.index(),
+#ifdef MPARK_GENERIC_LAMBDAS
+              [](auto &lhs_alt, auto &&rhs_alt) {
+                constructor::construct_alt(
+                    lhs_alt, lib::forward<decltype(rhs_alt)>(rhs_alt).value);
+              }
+#else
+              ctor{}
+#endif
+              ,
+              lhs,
+              lib::forward<Rhs>(rhs));
+          lhs.index_ = rhs.index_;
+        }
+      }
+    };
+
+    template <typename Traits, Trait = Traits::move_constructible_trait>
+    class move_constructor;
+
+#define MPARK_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, definition) \
+  template <typename... Ts>                                                  \
+  class move_constructor<traits<Ts...>, move_constructible_trait>            \
+      : public constructor<traits<Ts...>> {                                  \
+    using super = constructor<traits<Ts...>>;                                \
+                                                                             \
+    public:                                                                  \
+    INHERITING_CTOR(move_constructor, super)                                 \
+    using super::operator=;                                                  \
+                                                                             \
+    move_constructor(const move_constructor &) = default;                    \
+    definition                                                               \
+    ~move_constructor() = default;                                           \
+    move_constructor &operator=(const move_constructor &) = default;         \
+    move_constructor &operator=(move_constructor &&) = default;              \
+  }
+
+    MPARK_VARIANT_MOVE_CONSTRUCTOR(
+        Trait::TriviallyAvailable,
+        move_constructor(move_constructor &&that) = default;);
+
+    MPARK_VARIANT_MOVE_CONSTRUCTOR(
+        Trait::Available,
+        move_constructor(move_constructor &&that) noexcept(
+            all(std::is_nothrow_move_constructible<Ts>::value...))
+            : move_constructor(valueless_t{}) {
+          this->generic_construct(*this, lib::move(that));
+        });
+
+    MPARK_VARIANT_MOVE_CONSTRUCTOR(
+        Trait::Unavailable,
+        move_constructor(move_constructor &&) = delete;);
+
+#undef MPARK_VARIANT_MOVE_CONSTRUCTOR
+
+    template <typename Traits, Trait = Traits::copy_constructible_trait>
+    class copy_constructor;
+
+#define MPARK_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait, definition) \
+  template <typename... Ts>                                                  \
+  class copy_constructor<traits<Ts...>, copy_constructible_trait>            \
+      : public move_constructor<traits<Ts...>> {                             \
+    using super = move_constructor<traits<Ts...>>;                           \
+                                                                             \
+    public:                                                                  \
+    INHERITING_CTOR(copy_constructor, super)                                 \
+    using super::operator=;                                                  \
+                                                                             \
+    definition                                                               \
+    copy_constructor(copy_constructor &&) = default;                         \
+    ~copy_constructor() = default;                                           \
+    copy_constructor &operator=(const copy_constructor &) = default;         \
+    copy_constructor &operator=(copy_constructor &&) = default;              \
+  }
+
+    MPARK_VARIANT_COPY_CONSTRUCTOR(
+        Trait::TriviallyAvailable,
+        copy_constructor(const copy_constructor &that) = default;);
+
+    MPARK_VARIANT_COPY_CONSTRUCTOR(
+        Trait::Available,
+        copy_constructor(const copy_constructor &that)
+            : copy_constructor(valueless_t{}) {
+          this->generic_construct(*this, that);
+        });
+
+    MPARK_VARIANT_COPY_CONSTRUCTOR(
+        Trait::Unavailable,
+        copy_constructor(const copy_constructor &) = delete;);
+
+#undef MPARK_VARIANT_COPY_CONSTRUCTOR
+
+    template <typename Traits>
+    class assignment : public copy_constructor<Traits> {
+      using super = copy_constructor<Traits>;
+
+      public:
+      INHERITING_CTOR(assignment, super)
+      using super::operator=;
+
+      template <std::size_t I, typename... Args>
+      inline /* auto & */ auto emplace(Args &&... args)
+          -> decltype(this->construct_alt(access::base::get_alt<I>(*this),
+                                          lib::forward<Args>(args)...)) {
+        this->destroy();
+        auto &result = this->construct_alt(access::base::get_alt<I>(*this),
+                                           lib::forward<Args>(args)...);
+        this->index_ = I;
+        return result;
+      }
+
+      protected:
+#ifndef MPARK_GENERIC_LAMBDAS
+      template <typename That>
+      struct assigner {
+        template <typename ThisAlt, typename ThatAlt>
+        inline void operator()(ThisAlt &this_alt, ThatAlt &&that_alt) const {
+          self->assign_alt(this_alt, lib::forward<ThatAlt>(that_alt).value);
+        }
+        assignment *self;
+      };
+#endif
+
+      template <std::size_t I, typename T, typename Arg>
+      inline void assign_alt(alt<I, T> &a, Arg &&arg) {
+        if (this->index() == I) {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
+          a.value = lib::forward<Arg>(arg);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+        } else {
+          struct {
+            void operator()(std::true_type) const {
+              this_->emplace<I>(lib::forward<Arg>(arg_));
+            }
+            void operator()(std::false_type) const {
+              this_->emplace<I>(T(lib::forward<Arg>(arg_)));
+            }
+            assignment *this_;
+            Arg &&arg_;
+          } impl{this, lib::forward<Arg>(arg)};
+          impl(lib::bool_constant<
+                   std::is_nothrow_constructible<T, Arg>::value ||
+                   !std::is_nothrow_move_constructible<T>::value>{});
+        }
+      }
+
+      template <typename That>
+      inline void generic_assign(That &&that) {
+        if (this->valueless_by_exception() && that.valueless_by_exception()) {
+          // do nothing.
+        } else if (that.valueless_by_exception()) {
+          this->destroy();
+        } else {
+          visitation::base::visit_alt_at(
+              that.index(),
+#ifdef MPARK_GENERIC_LAMBDAS
+              [this](auto &this_alt, auto &&that_alt) {
+                this->assign_alt(
+                    this_alt, lib::forward<decltype(that_alt)>(that_alt).value);
+              }
+#else
+              assigner<That>{this}
+#endif
+              ,
+              *this,
+              lib::forward<That>(that));
+        }
+      }
+    };
+
+    template <typename Traits, Trait = Traits::move_assignable_trait>
+    class move_assignment;
+
+#define MPARK_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, definition) \
+  template <typename... Ts>                                              \
+  class move_assignment<traits<Ts...>, move_assignable_trait>            \
+      : public assignment<traits<Ts...>> {                               \
+    using super = assignment<traits<Ts...>>;                             \
+                                                                         \
+    public:                                                              \
+    INHERITING_CTOR(move_assignment, super)                              \
+    using super::operator=;                                              \
+                                                                         \
+    move_assignment(const move_assignment &) = default;                  \
+    move_assignment(move_assignment &&) = default;                       \
+    ~move_assignment() = default;                                        \
+    move_assignment &operator=(const move_assignment &) = default;       \
+    definition                                                           \
+  }
+
+    MPARK_VARIANT_MOVE_ASSIGNMENT(
+        Trait::TriviallyAvailable,
+        move_assignment &operator=(move_assignment &&that) = default;);
+
+    MPARK_VARIANT_MOVE_ASSIGNMENT(
+        Trait::Available,
+        move_assignment &
+        operator=(move_assignment &&that) noexcept(
+            all((std::is_nothrow_move_constructible<Ts>::value &&
+                 std::is_nothrow_move_assignable<Ts>::value)...)) {
+          this->generic_assign(lib::move(that));
+          return *this;
+        });
+
+    MPARK_VARIANT_MOVE_ASSIGNMENT(
+        Trait::Unavailable,
+        move_assignment &operator=(move_assignment &&) = delete;);
+
+#undef MPARK_VARIANT_MOVE_ASSIGNMENT
+
+    template <typename Traits, Trait = Traits::copy_assignable_trait>
+    class copy_assignment;
+
+#define MPARK_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, definition) \
+  template <typename... Ts>                                              \
+  class copy_assignment<traits<Ts...>, copy_assignable_trait>            \
+      : public move_assignment<traits<Ts...>> {                          \
+    using super = move_assignment<traits<Ts...>>;                        \
+                                                                         \
+    public:                                                              \
+    INHERITING_CTOR(copy_assignment, super)                              \
+    using super::operator=;                                              \
+                                                                         \
+    copy_assignment(const copy_assignment &) = default;                  \
+    copy_assignment(copy_assignment &&) = default;                       \
+    ~copy_assignment() = default;                                        \
+    definition                                                           \
+    copy_assignment &operator=(copy_assignment &&) = default;            \
+  }
+
+    MPARK_VARIANT_COPY_ASSIGNMENT(
+        Trait::TriviallyAvailable,
+        copy_assignment &operator=(const copy_assignment &that) = default;);
+
+    MPARK_VARIANT_COPY_ASSIGNMENT(
+        Trait::Available,
+        copy_assignment &operator=(const copy_assignment &that) {
+          this->generic_assign(that);
+          return *this;
+        });
+
+    MPARK_VARIANT_COPY_ASSIGNMENT(
+        Trait::Unavailable,
+        copy_assignment &operator=(const copy_assignment &) = delete;);
+
+#undef MPARK_VARIANT_COPY_ASSIGNMENT
+
+    template <typename... Ts>
+    class impl : public copy_assignment<traits<Ts...>> {
+      using super = copy_assignment<traits<Ts...>>;
+
+      public:
+      INHERITING_CTOR(impl, super)
+      using super::operator=;
+
+      template <std::size_t I, typename Arg>
+      inline void assign(Arg &&arg) {
+        this->assign_alt(access::base::get_alt<I>(*this),
+                         lib::forward<Arg>(arg));
+      }
+
+      inline void swap(impl &that) {
+        if (this->valueless_by_exception() && that.valueless_by_exception()) {
+          // do nothing.
+        } else if (this->index() == that.index()) {
+          visitation::base::visit_alt_at(this->index(),
+#ifdef MPARK_GENERIC_LAMBDAS
+                                         [](auto &this_alt, auto &that_alt) {
+                                           using std::swap;
+                                           swap(this_alt.value,
+                                                that_alt.value);
+                                         }
+#else
+                                         swapper{}
+#endif
+                                         ,
+                                         *this,
+                                         that);
+        } else {
+          impl *lhs = this;
+          impl *rhs = lib::addressof(that);
+          if (lhs->move_nothrow() && !rhs->move_nothrow()) {
+            std::swap(lhs, rhs);
+          }
+          impl tmp(lib::move(*rhs));
+#ifdef MPARK_EXCEPTIONS
+          // EXTENSION: When the move construction of `lhs` into `rhs` throws
+          // and `tmp` is nothrow move constructible then we move `tmp` back
+          // into `rhs` and provide the strong exception safety guarantee.
+          try {
+            this->generic_construct(*rhs, lib::move(*lhs));
+          } catch (...) {
+            if (tmp.move_nothrow()) {
+              this->generic_construct(*rhs, lib::move(tmp));
+            }
+            throw;
+          }
+#else
+          this->generic_construct(*rhs, lib::move(*lhs));
+#endif
+          this->generic_construct(*lhs, lib::move(tmp));
+        }
+      }
+
+      private:
+#ifndef MPARK_GENERIC_LAMBDAS
+      struct swapper {
+        template <typename ThisAlt, typename ThatAlt>
+        inline void operator()(ThisAlt &this_alt, ThatAlt &that_alt) const {
+          using std::swap;
+          swap(this_alt.value, that_alt.value);
+        }
+      };
+#endif
+
+      inline constexpr bool move_nothrow() const {
+        return this->valueless_by_exception() ||
+               lib::array<bool, sizeof...(Ts)>{
+                   {std::is_nothrow_move_constructible<Ts>::value...}
+               }[this->index()];
+      }
+    };
+
+    template <typename... Ts>
+    struct overload;
+
+    template <>
+    struct overload<> { void operator()() const {} };
+
+    template <typename T, typename... Ts>
+    struct overload<T, Ts...> : overload<Ts...> {
+      using overload<Ts...>::operator();
+      lib::identity<T> operator()(T) const { return {}; }
+    };
+
+    template <typename T, typename... Ts>
+    using best_match_t =
+        typename lib::invoke_result_t<overload<Ts...>, T &&>::type;
+
+  }  // detail
+
+  template <typename... Ts>
+  class variant {
+    static_assert(0 < sizeof...(Ts),
+                  "variant must consist of at least one alternative.");
+
+    static_assert(lib::all<!std::is_array<Ts>::value...>::value,
+                  "variant can not have an array type as an alternative.");
+
+    static_assert(lib::all<!std::is_reference<Ts>::value...>::value,
+                  "variant can not have a reference type as an alternative.");
+
+    static_assert(lib::all<!std::is_void<Ts>::value...>::value,
+                  "variant can not have a void type as an alternative.");
+
+    public:
+    template <
+        typename Front = lib::type_pack_element_t<0, Ts...>,
+        lib::enable_if_t<std::is_default_constructible<Front>::value, int> = 0>
+    inline constexpr variant() noexcept(
+        std::is_nothrow_default_constructible<Front>::value)
+        : impl_(in_place_index_t<0>{}) {}
+
+    variant(const variant &) = default;
+    variant(variant &&) = default;
+
+    template <typename Arg,
+              lib::enable_if_t<!std::is_same<lib::decay_t<Arg>, variant>::value,
+                               int> = 0,
+              typename T = detail::best_match_t<Arg, Ts...>,
+              std::size_t I = detail::find_index_sfinae<T, Ts...>::value,
+              lib::enable_if_t<std::is_constructible<T, Arg>::value, int> = 0>
+    inline constexpr variant(Arg &&arg) noexcept(
+        std::is_nothrow_constructible<T, Arg>::value)
+        : impl_(in_place_index_t<I>{}, lib::forward<Arg>(arg)) {}
+
+    template <
+        std::size_t I,
+        typename... Args,
+        typename T = lib::type_pack_element_t<I, Ts...>,
+        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+    inline explicit constexpr variant(
+        in_place_index_t<I>,
+        Args &&... args) noexcept(std::is_nothrow_constructible<T,
+                                                                Args...>::value)
+        : impl_(in_place_index_t<I>{}, lib::forward<Args>(args)...) {}
+
+    template <
+        std::size_t I,
+        typename Up,
+        typename... Args,
+        typename T = lib::type_pack_element_t<I, Ts...>,
+        lib::enable_if_t<std::is_constructible<T,
+                                               std::initializer_list<Up> &,
+                                               Args...>::value,
+                         int> = 0>
+    inline explicit constexpr variant(
+        in_place_index_t<I>,
+        std::initializer_list<Up> il,
+        Args &&... args) noexcept(std::
+                                      is_nothrow_constructible<
+                                          T,
+                                          std::initializer_list<Up> &,
+                                          Args...>::value)
+        : impl_(in_place_index_t<I>{}, il, lib::forward<Args>(args)...) {}
+
+    template <
+        typename T,
+        typename... Args,
+        std::size_t I = detail::find_index_sfinae<T, Ts...>::value,
+        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+    inline explicit constexpr variant(
+        in_place_type_t<T>,
+        Args &&... args) noexcept(std::is_nothrow_constructible<T,
+                                                                Args...>::value)
+        : impl_(in_place_index_t<I>{}, lib::forward<Args>(args)...) {}
+
+    template <
+        typename T,
+        typename Up,
+        typename... Args,
+        std::size_t I = detail::find_index_sfinae<T, Ts...>::value,
+        lib::enable_if_t<std::is_constructible<T,
+                                               std::initializer_list<Up> &,
+                                               Args...>::value,
+                         int> = 0>
+    inline explicit constexpr variant(
+        in_place_type_t<T>,
+        std::initializer_list<Up> il,
+        Args &&... args) noexcept(std::
+                                      is_nothrow_constructible<
+                                          T,
+                                          std::initializer_list<Up> &,
+                                          Args...>::value)
+        : impl_(in_place_index_t<I>{}, il, lib::forward<Args>(args)...) {}
+
+    ~variant() = default;
+
+    variant &operator=(const variant &) = default;
+    variant &operator=(variant &&) = default;
+
+    template <typename Arg,
+              lib::enable_if_t<!std::is_same<lib::decay_t<Arg>, variant>::value,
+                               int> = 0,
+              typename T = detail::best_match_t<Arg, Ts...>,
+              std::size_t I = detail::find_index_sfinae<T, Ts...>::value,
+              lib::enable_if_t<(std::is_assignable<T &, Arg>::value &&
+                                std::is_constructible<T, Arg>::value),
+                               int> = 0>
+    inline variant &operator=(Arg &&arg) noexcept(
+        (std::is_nothrow_assignable<T &, Arg>::value &&
+         std::is_nothrow_constructible<T, Arg>::value)) {
+      impl_.template assign<I>(lib::forward<Arg>(arg));
+      return *this;
+    }
+
+    template <
+        std::size_t I,
+        typename... Args,
+        typename T = lib::type_pack_element_t<I, Ts...>,
+        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+    inline T &emplace(Args &&... args) {
+      return impl_.template emplace<I>(lib::forward<Args>(args)...);
+    }
+
+    template <
+        std::size_t I,
+        typename Up,
+        typename... Args,
+        typename T = lib::type_pack_element_t<I, Ts...>,
+        lib::enable_if_t<std::is_constructible<T,
+                                               std::initializer_list<Up> &,
+                                               Args...>::value,
+                         int> = 0>
+    inline T &emplace(std::initializer_list<Up> il, Args &&... args) {
+      return impl_.template emplace<I>(il, lib::forward<Args>(args)...);
+    }
+
+    template <
+        typename T,
+        typename... Args,
+        std::size_t I = detail::find_index_sfinae<T, Ts...>::value,
+        lib::enable_if_t<std::is_constructible<T, Args...>::value, int> = 0>
+    inline T &emplace(Args &&... args) {
+      return impl_.template emplace<I>(lib::forward<Args>(args)...);
+    }
+
+    template <
+        typename T,
+        typename Up,
+        typename... Args,
+        std::size_t I = detail::find_index_sfinae<T, Ts...>::value,
+        lib::enable_if_t<std::is_constructible<T,
+                                               std::initializer_list<Up> &,
+                                               Args...>::value,
+                         int> = 0>
+    inline T &emplace(std::initializer_list<Up> il, Args &&... args) {
+      return impl_.template emplace<I>(il, lib::forward<Args>(args)...);
+    }
+
+    inline constexpr bool valueless_by_exception() const noexcept {
+      return impl_.valueless_by_exception();
+    }
+
+    inline constexpr std::size_t index() const noexcept {
+      return impl_.index();
+    }
+
+    template <
+        bool Dummy = true,
+        lib::enable_if_t<lib::all<Dummy,
+                                  (std::is_move_constructible<Ts>::value &&
+                                   lib::is_swappable<Ts>::value)...>::value,
+                         int> = 0>
+    inline void swap(variant &that) noexcept(
+        lib::all<(std::is_nothrow_move_constructible<Ts>::value &&
+                  lib::is_nothrow_swappable<Ts>::value)...>::value) {
+      impl_.swap(that.impl_);
+    }
+
+    private:
+    detail::impl<Ts...> impl_;
+
+    friend struct detail::access::variant;
+    friend struct detail::visitation::variant;
+  };
+
+  template <std::size_t I, typename... Ts>
+  inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
+    return v.index() == I;
+  }
+
+  template <typename T, typename... Ts>
+  inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
+    return holds_alternative<detail::find_index_checked<T, Ts...>::value>(v);
+  }
+
+  namespace detail {
+    template <std::size_t I, typename V>
+    struct generic_get_impl {
+      constexpr generic_get_impl(int) {}
+
+      constexpr AUTO_REFREF operator()(V &&v) const
+        AUTO_REFREF_RETURN(
+            access::variant::get_alt<I>(lib::forward<V>(v)).value)
+    };
+
+    template <std::size_t I, typename V>
+    inline constexpr AUTO_REFREF generic_get(V &&v)
+      AUTO_REFREF_RETURN(generic_get_impl<I, V>(
+          holds_alternative<I>(v) ? 0 : (throw_bad_variant_access(), 0))(
+          lib::forward<V>(v)))
+  }  // namespace detail
+
+  template <std::size_t I, typename... Ts>
+  inline constexpr variant_alternative_t<I, variant<Ts...>> &get(
+      variant<Ts...> &v) {
+    return detail::generic_get<I>(v);
+  }
+
+  template <std::size_t I, typename... Ts>
+  inline constexpr variant_alternative_t<I, variant<Ts...>> &&get(
+      variant<Ts...> &&v) {
+    return detail::generic_get<I>(lib::move(v));
+  }
+
+  template <std::size_t I, typename... Ts>
+  inline constexpr const variant_alternative_t<I, variant<Ts...>> &get(
+      const variant<Ts...> &v) {
+    return detail::generic_get<I>(v);
+  }
+
+  template <std::size_t I, typename... Ts>
+  inline constexpr const variant_alternative_t<I, variant<Ts...>> &&get(
+      const variant<Ts...> &&v) {
+    return detail::generic_get<I>(lib::move(v));
+  }
+
+  template <typename T, typename... Ts>
+  inline constexpr T &get(variant<Ts...> &v) {
+    return get<detail::find_index_checked<T, Ts...>::value>(v);
+  }
+
+  template <typename T, typename... Ts>
+  inline constexpr T &&get(variant<Ts...> &&v) {
+    return get<detail::find_index_checked<T, Ts...>::value>(lib::move(v));
+  }
+
+  template <typename T, typename... Ts>
+  inline constexpr const T &get(const variant<Ts...> &v) {
+    return get<detail::find_index_checked<T, Ts...>::value>(v);
+  }
+
+  template <typename T, typename... Ts>
+  inline constexpr const T &&get(const variant<Ts...> &&v) {
+    return get<detail::find_index_checked<T, Ts...>::value>(lib::move(v));
+  }
+
+  namespace detail {
+
+    template <std::size_t I, typename V>
+    inline constexpr /* auto * */ AUTO generic_get_if(V *v) noexcept
+      AUTO_RETURN(v && holds_alternative<I>(*v)
+                      ? lib::addressof(access::variant::get_alt<I>(*v).value)
+                      : nullptr)
+
+  }  // namespace detail
+
+  template <std::size_t I, typename... Ts>
+  inline constexpr lib::add_pointer_t<variant_alternative_t<I, variant<Ts...>>>
+  get_if(variant<Ts...> *v) noexcept {
+    return detail::generic_get_if<I>(v);
+  }
+
+  template <std::size_t I, typename... Ts>
+  inline constexpr lib::add_pointer_t<
+      const variant_alternative_t<I, variant<Ts...>>>
+  get_if(const variant<Ts...> *v) noexcept {
+    return detail::generic_get_if<I>(v);
+  }
+
+  template <typename T, typename... Ts>
+  inline constexpr lib::add_pointer_t<T>
+  get_if(variant<Ts...> *v) noexcept {
+    return get_if<detail::find_index_checked<T, Ts...>::value>(v);
+  }
+
+  template <typename T, typename... Ts>
+  inline constexpr lib::add_pointer_t<const T>
+  get_if(const variant<Ts...> *v) noexcept {
+    return get_if<detail::find_index_checked<T, Ts...>::value>(v);
+  }
+
+  template <typename... Ts>
+  inline constexpr bool operator==(const variant<Ts...> &lhs,
+                                   const variant<Ts...> &rhs) {
+    using detail::visitation::variant;
+    using lib::equal_to;
+#ifdef MPARK_CPP14_CONSTEXPR
+    if (lhs.index() != rhs.index()) return false;
+    if (lhs.valueless_by_exception()) return true;
+    return variant::visit_value_at(lhs.index(), equal_to{}, lhs, rhs);
+#else
+    return lhs.index() == rhs.index() &&
+           (lhs.valueless_by_exception() ||
+            variant::visit_value_at(lhs.index(), equal_to{}, lhs, rhs));
+#endif
+  }
+
+  template <typename... Ts>
+  inline constexpr bool operator!=(const variant<Ts...> &lhs,
+                                   const variant<Ts...> &rhs) {
+    using detail::visitation::variant;
+    using lib::not_equal_to;
+#ifdef MPARK_CPP14_CONSTEXPR
+    if (lhs.index() != rhs.index()) return true;
+    if (lhs.valueless_by_exception()) return false;
+    return variant::visit_value_at(lhs.index(), not_equal_to{}, lhs, rhs);
+#else
+    return lhs.index() != rhs.index() ||
+           (!lhs.valueless_by_exception() &&
+            variant::visit_value_at(lhs.index(), not_equal_to{}, lhs, rhs));
+#endif
+  }
+
+  template <typename... Ts>
+  inline constexpr bool operator<(const variant<Ts...> &lhs,
+                                  const variant<Ts...> &rhs) {
+    using detail::visitation::variant;
+    using lib::less;
+#ifdef MPARK_CPP14_CONSTEXPR
+    if (rhs.valueless_by_exception()) return false;
+    if (lhs.valueless_by_exception()) return true;
+    if (lhs.index() < rhs.index()) return true;
+    if (lhs.index() > rhs.index()) return false;
+    return variant::visit_value_at(lhs.index(), less{}, lhs, rhs);
+#else
+    return !rhs.valueless_by_exception() &&
+           (lhs.valueless_by_exception() || lhs.index() < rhs.index() ||
+            (lhs.index() == rhs.index() &&
+             variant::visit_value_at(lhs.index(), less{}, lhs, rhs)));
+#endif
+  }
+
+  template <typename... Ts>
+  inline constexpr bool operator>(const variant<Ts...> &lhs,
+                                  const variant<Ts...> &rhs) {
+    using detail::visitation::variant;
+    using lib::greater;
+#ifdef MPARK_CPP14_CONSTEXPR
+    if (lhs.valueless_by_exception()) return false;
+    if (rhs.valueless_by_exception()) return true;
+    if (lhs.index() > rhs.index()) return true;
+    if (lhs.index() < rhs.index()) return false;
+    return variant::visit_value_at(lhs.index(), greater{}, lhs, rhs);
+#else
+    return !lhs.valueless_by_exception() &&
+           (rhs.valueless_by_exception() || lhs.index() > rhs.index() ||
+            (lhs.index() == rhs.index() &&
+             variant::visit_value_at(lhs.index(), greater{}, lhs, rhs)));
+#endif
+  }
+
+  template <typename... Ts>
+  inline constexpr bool operator<=(const variant<Ts...> &lhs,
+                                   const variant<Ts...> &rhs) {
+    using detail::visitation::variant;
+    using lib::less_equal;
+#ifdef MPARK_CPP14_CONSTEXPR
+    if (lhs.valueless_by_exception()) return true;
+    if (rhs.valueless_by_exception()) return false;
+    if (lhs.index() < rhs.index()) return true;
+    if (lhs.index() > rhs.index()) return false;
+    return variant::visit_value_at(lhs.index(), less_equal{}, lhs, rhs);
+#else
+    return lhs.valueless_by_exception() ||
+           (!rhs.valueless_by_exception() &&
+            (lhs.index() < rhs.index() ||
+             (lhs.index() == rhs.index() &&
+              variant::visit_value_at(lhs.index(), less_equal{}, lhs, rhs))));
+#endif
+  }
+
+  template <typename... Ts>
+  inline constexpr bool operator>=(const variant<Ts...> &lhs,
+                                   const variant<Ts...> &rhs) {
+    using detail::visitation::variant;
+    using lib::greater_equal;
+#ifdef MPARK_CPP14_CONSTEXPR
+    if (rhs.valueless_by_exception()) return true;
+    if (lhs.valueless_by_exception()) return false;
+    if (lhs.index() > rhs.index()) return true;
+    if (lhs.index() < rhs.index()) return false;
+    return variant::visit_value_at(lhs.index(), greater_equal{}, lhs, rhs);
+#else
+    return rhs.valueless_by_exception() ||
+           (!lhs.valueless_by_exception() &&
+            (lhs.index() > rhs.index() ||
+             (lhs.index() == rhs.index() &&
+              variant::visit_value_at(
+                  lhs.index(), greater_equal{}, lhs, rhs))));
+#endif
+  }
+
+  template <typename Visitor, typename... Vs>
+  inline constexpr DECLTYPE_AUTO visit(Visitor &&visitor, Vs &&... vs)
+    DECLTYPE_AUTO_RETURN(
+        (detail::all(!vs.valueless_by_exception()...)
+             ? (void)0
+             : throw_bad_variant_access()),
+        detail::visitation::variant::visit_value(lib::forward<Visitor>(visitor),
+                                                 lib::forward<Vs>(vs)...))
+
+  struct monostate {};
+
+  inline constexpr bool operator<(monostate, monostate) noexcept {
+    return false;
+  }
+
+  inline constexpr bool operator>(monostate, monostate) noexcept {
+    return false;
+  }
+
+  inline constexpr bool operator<=(monostate, monostate) noexcept {
+    return true;
+  }
+
+  inline constexpr bool operator>=(monostate, monostate) noexcept {
+    return true;
+  }
+
+  inline constexpr bool operator==(monostate, monostate) noexcept {
+    return true;
+  }
+
+  inline constexpr bool operator!=(monostate, monostate) noexcept {
+    return false;
+  }
+
+  template <typename... Ts>
+  inline auto swap(variant<Ts...> &lhs,
+                   variant<Ts...> &rhs) noexcept(noexcept(lhs.swap(rhs)))
+      -> decltype(lhs.swap(rhs)) {
+    lhs.swap(rhs);
+  }
+
+  namespace detail {
+
+    template <typename T, typename...>
+    using enabled_type = T;
+
+    namespace hash {
+
+      template <typename H, typename K>
+      constexpr bool meets_requirements() {
+        return std::is_copy_constructible<H>::value &&
+               std::is_move_constructible<H>::value &&
+               lib::is_invocable_r<std::size_t, H, const K &>::value;
+      }
+
+      template <typename K>
+      constexpr bool is_enabled() {
+        using H = std::hash<K>;
+        return meets_requirements<H, K>() &&
+               std::is_default_constructible<H>::value &&
+               std::is_copy_assignable<H>::value &&
+               std::is_move_assignable<H>::value;
+      }
+
+    }  // namespace hash
+
+  }  // namespace detail
+
+#undef AUTO
+#undef AUTO_RETURN
+
+#undef AUTO_REFREF
+#undef AUTO_REFREF_RETURN
+
+#undef DECLTYPE_AUTO
+#undef DECLTYPE_AUTO_RETURN
+
+}  // namespace mpark
+
+namespace std {
+
+  template <typename... Ts>
+  struct hash<mpark::detail::enabled_type<
+      mpark::variant<Ts...>,
+      mpark::lib::enable_if_t<mpark::lib::all<mpark::detail::hash::is_enabled<
+          mpark::lib::remove_const_t<Ts>>()...>::value>>> {
+    using argument_type = mpark::variant<Ts...>;
+    using result_type = std::size_t;
+
+    inline result_type operator()(const argument_type &v) const {
+      using mpark::detail::visitation::variant;
+      std::size_t result =
+          v.valueless_by_exception()
+              ? 299792458  // Random value chosen by the universe upon creation
+              : variant::visit_alt(
+#ifdef MPARK_GENERIC_LAMBDAS
+                    [](const auto &alt) {
+                      using alt_type = mpark::lib::decay_t<decltype(alt)>;
+                      using value_type = mpark::lib::remove_const_t<
+                          typename alt_type::value_type>;
+                      return hash<value_type>{}(alt.value);
+                    }
+#else
+                    hasher{}
+#endif
+                    ,
+                    v);
+      return hash_combine(result, hash<std::size_t>{}(v.index()));
+    }
+
+    private:
+#ifndef MPARK_GENERIC_LAMBDAS
+    struct hasher {
+      template <typename Alt>
+      inline std::size_t operator()(const Alt &alt) const {
+        using alt_type = mpark::lib::decay_t<Alt>;
+        using value_type =
+            mpark::lib::remove_const_t<typename alt_type::value_type>;
+        return hash<value_type>{}(alt.value);
+      }
+    };
+#endif
+
+    static std::size_t hash_combine(std::size_t lhs, std::size_t rhs) {
+      return lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
+    }
+  };
+
+  template <>
+  struct hash<mpark::monostate> {
+    using argument_type = mpark::monostate;
+    using result_type = std::size_t;
+
+    inline result_type operator()(const argument_type &) const noexcept {
+      return 66740831;  // return a fundamentally attractive random value.
+    }
+  };
+
+}  // namespace std
+
+#endif  // MPARK_VARIANT_HPP

--- a/phylanx/util/optional.hpp
+++ b/phylanx/util/optional.hpp
@@ -1,0 +1,541 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_OPTIONAL_HPP)
+#define PHYLANX_UTIL_OPTIONAL_HPP
+
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace phylanx { namespace util
+{
+    struct nullopt_t
+    {
+        struct init
+        {
+        };
+        constexpr explicit nullopt_t(nullopt_t::init) {}
+    };
+    constexpr nullopt_t nullopt{nullopt_t::init()};
+
+    struct in_place_t
+    {
+    };
+    constexpr struct in_place_t in_place{};
+
+    class bad_optional_access : public std::logic_error
+    {
+    public:
+        explicit bad_optional_access(std::string const& what_arg)
+          : logic_error(what_arg)
+        {
+        }
+
+        explicit bad_optional_access(char const* what_arg)
+          : logic_error(what_arg)
+        {
+        }
+    };
+
+    template <typename T>
+    class optional
+    {
+    public:
+        using value_type = T;
+
+        constexpr optional() noexcept
+          : empty_(true)
+        {
+        }
+
+        constexpr optional(nullopt_t) noexcept
+          : empty_(true)
+        {
+        }
+
+        optional(optional const& other)
+          : empty_(true)
+        {
+            if (!other.empty_)
+            {
+                new (&storage_) T(other.value());
+                empty_ = false;
+            }
+        }
+        optional(optional && other)
+                noexcept(std::is_nothrow_move_constructible<T>::value)
+          : empty_(true)
+        {
+            if (!other.empty_)
+            {
+                new (&storage_) T(std::move(other.value()));
+                empty_ = false;
+            }
+        }
+
+        optional(T const& val)
+          : empty_(true)
+        {
+            new (&storage_) T(val);
+            empty_ = false;
+        }
+        optional(T && val)
+                noexcept(std::is_nothrow_move_constructible<T>::value)
+          : empty_(true)
+        {
+            new (&storage_) T(std::move(val));
+            empty_ = false;
+        }
+
+        template <typename ... Ts>
+        explicit optional(in_place_t, Ts &&... ts)
+          : empty_(true)
+        {
+            new (&storage_) T(std::forward<Ts>(ts)...);
+            empty_ = false;
+        }
+
+        template <typename U, typename ... Ts>
+        explicit optional(in_place_t, std::initializer_list<U> il, Ts &&... ts)
+          : empty_(true)
+        {
+            new (&storage_) T(il, std::forward<Ts>(ts)...);
+            empty_ = false;
+        }
+
+        ~optional()
+        {
+            reset();
+        }
+
+        optional &operator=(optional const& other)
+        {
+            optional tmp(other);
+            swap(tmp);
+
+            return *this;
+        }
+        optional &operator=(optional && other)
+            noexcept(std::is_nothrow_move_assignable<T>::value &&
+                std::is_nothrow_move_constructible<T>::value)
+        {
+            if (empty_)
+            {
+                if (!other.empty_)
+                {
+                    new (&storage_) T(std::move(other.value()));
+                    empty_ = false;
+                }
+            }
+            else
+            {
+                if (other.empty_)
+                {
+                    reinterpret_cast<T*>(&storage_)->~T();
+                    empty_ = true;
+                }
+                else
+                {
+                    **this = std::move(other.value());
+                }
+            }
+            return *this;
+        }
+
+        optional &operator=(T const& other)
+        {
+            optional tmp(other);
+            swap(tmp);
+
+            return *this;
+        }
+        optional &operator=(T && other)
+        {
+            if (!empty_)
+            {
+                reinterpret_cast<T*>(&storage_)->~T();
+                empty_ = true;
+            }
+
+            new (&storage_) T(std::move(other));
+            empty_ = false;
+
+            return *this;
+        }
+
+        optional &operator=(nullopt_t) noexcept
+        {
+            if (!empty_)
+            {
+                reinterpret_cast<T*>(&storage_)->~T();
+                empty_ = true;
+            }
+            return *this;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        constexpr T const * operator->() const noexcept
+        {
+            return reinterpret_cast<T const*>(&storage_);
+        }
+
+        T* operator->() noexcept
+        {
+            return reinterpret_cast<T*>(&storage_);
+        }
+
+        constexpr T const& operator*() const noexcept
+        {
+            return *reinterpret_cast<T const*>(&storage_);
+        }
+
+        T& operator*() noexcept
+        {
+            return *reinterpret_cast<T*>(&storage_);
+        }
+
+        constexpr explicit operator bool() const noexcept
+        {
+            return !empty_;
+        }
+
+        constexpr bool has_value() const
+        {
+            return !empty_;
+        }
+
+        T& value()
+        {
+            if (empty_)
+            {
+                throw bad_optional_access(
+                    "object is empty during call to 'value()'");
+            }
+            return **this;
+        }
+
+        T const& value() const
+        {
+            if (empty_)
+            {
+                throw bad_optional_access(
+                    "object is empty during call to 'value()'");
+            }
+            return **this;
+        }
+
+        template <typename U>
+        constexpr T value_or(U && value) const
+        {
+            if (empty_)
+                return std::forward<U>(value);
+            return **this;
+        }
+
+        template <typename ... Ts>
+        void emplace(Ts &&... ts)
+        {
+            if (!empty_)
+            {
+                reinterpret_cast<T*>(&storage_)->~T();
+                empty_ = true;
+            }
+            new (&storage_) T(std::forward<Ts>(ts)...);
+            empty_ = false;
+        }
+
+        void swap(optional& other)
+            noexcept(std::is_nothrow_move_constructible<T>::value &&
+                noexcept(swap(std::declval<T&>(), std::declval<T&>())))
+        {
+            // do nothing if both are empty
+            if (empty_ && other.empty_)
+            {
+                return;
+            }
+            // swap content if both are non-empty
+            if (!empty_ && !other.empty_)
+            {
+                swap(**this, *other);
+                return;
+            }
+
+            // move the non-empty one into the empty one and make remains empty
+            optional* empty = empty_ ? this : &other;
+            optional* non_empty = empty_ ? &other : this;
+
+            new (&empty->storage_) T(std::move(**non_empty));
+            reinterpret_cast<T*>(&non_empty->storage_)->~T();
+
+            empty->empty_ = false;
+            non_empty->empty_ = true;
+        }
+
+        void reset()
+        {
+            if (!empty_)
+            {
+                reinterpret_cast<T*>(&storage_)->~T();
+            }
+        }
+
+    private:
+        typename std::aligned_storage<sizeof(T), alignof(T)>::type storage_;
+        bool empty_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    constexpr bool operator==(optional<T> const& lhs, optional<T> const& rhs)
+    {
+        if (bool(lhs) != bool(rhs))
+        {
+            return false;
+        }
+        if (!bool(lhs) && !bool(rhs))
+        {
+            return true;
+        }
+        return *lhs == *rhs;
+    }
+
+    template <typename T>
+    constexpr bool operator!=(optional<T> const& lhs, optional<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    template <typename T>
+    constexpr bool operator<(optional<T> const& lhs, optional<T> const& rhs)
+    {
+        if (!bool(rhs))
+        {
+            return false;
+        }
+        if (!bool(lhs))
+        {
+            return true;
+        }
+        return *rhs < *lhs;
+    }
+
+    template <typename T>
+    constexpr bool operator>=(optional<T> const& lhs, optional<T> const& rhs)
+    {
+        return !(lhs < rhs);
+    }
+
+    template <typename T>
+    constexpr bool operator>(optional<T> const& lhs, optional<T> const& rhs)
+    {
+        if (!bool(lhs))
+        {
+            return false;
+        }
+        if (!bool(rhs))
+        {
+            return true;
+        }
+        return *rhs > *lhs;
+    }
+
+    template <typename T>
+    constexpr bool operator<=(optional<T> const& lhs, optional<T> const& rhs)
+    {
+        return !(lhs > rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    constexpr bool operator==(optional<T> const& opt, nullopt_t) noexcept
+    {
+        return !bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator==(nullopt_t, optional<T> const& opt) noexcept
+    {
+        return !bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator!=(optional<T> const& opt, nullopt_t) noexcept
+    {
+        return bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator!=(nullopt_t, optional<T> const& opt) noexcept
+    {
+        return bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator<(optional<T> const& opt, nullopt_t) noexcept
+    {
+        return false;
+    }
+
+    template <typename T>
+    constexpr bool operator<(nullopt_t, optional<T> const& opt) noexcept
+    {
+        return bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator>=(optional<T> const& opt, nullopt_t) noexcept
+    {
+        return true;
+    }
+
+    template <typename T>
+    constexpr bool operator>=(nullopt_t, optional<T> const& opt) noexcept
+    {
+        return !bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator>(optional<T> const& opt, nullopt_t) noexcept
+    {
+        return bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator>(nullopt_t, optional<T> const& opt) noexcept
+    {
+        return false;
+    }
+
+    template <typename T>
+    constexpr bool operator<=(optional<T> const& opt, nullopt_t) noexcept
+    {
+        return !bool(opt);
+    }
+
+    template <typename T>
+    constexpr bool operator<=(nullopt_t, optional<T> const& opt) noexcept
+    {
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    constexpr bool operator==(optional<T> const& opt, T const& value)
+    {
+        return bool(opt) ? (*opt == value) : false;
+    }
+
+    template <typename T>
+    constexpr bool operator==(T const& value, optional<T> const& opt)
+    {
+        return bool(opt) ? (value == *opt) : false;
+    }
+
+    template <typename T>
+    constexpr bool operator!=(optional<T> const& opt, T const& value)
+    {
+        return !(opt == value);
+    }
+
+    template <typename T>
+    constexpr bool operator!=(T const& value, optional<T> const& opt)
+    {
+        return !(value == *opt);
+    }
+
+    template <typename T>
+    constexpr bool operator<(optional<T> const& opt, T const& value)
+    {
+        return bool(opt) ? (*opt < value) : true;
+    }
+
+    template <typename T>
+    constexpr bool operator<(T const& value, optional<T> const& opt)
+    {
+        return bool(opt) ? (value < *opt) : false;
+    }
+
+    template <typename T>
+    constexpr bool operator>=(optional<T> const& opt, T const& value)
+    {
+        return !(*opt < value);
+    }
+
+    template <typename T>
+    constexpr bool operator>=(T const& value, optional<T> const& opt)
+    {
+        return !(value < *opt);
+    }
+
+    template <typename T>
+    constexpr bool operator>(optional<T> const& opt, T const& value)
+    {
+        return bool(opt) ? (*opt > value) : false;
+    }
+
+    template <typename T>
+    constexpr bool operator>(T const& value, optional<T> const& opt)
+    {
+        return bool(opt) ? (value > *opt) : true;
+    }
+
+    template <typename T>
+    constexpr bool operator<=(optional<T> const& opt, T const& value)
+    {
+        return !(*opt > value);
+    }
+
+    template <typename T>
+    constexpr bool operator<=(T const& value, optional<T> const& opt)
+    {
+        return !(value > *opt);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void swap(optional<T>& x, optional<T>& y) noexcept(noexcept(x.swap(y)))
+    {
+        x.swap(y);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    constexpr optional<std::decay_t<T>> make_optional(T && v)
+    {
+        return optional<std::decay_t<T>>(std::forward<T>(v));
+    }
+
+    template <typename T, typename ... Ts>
+    constexpr optional<T> make_optional(Ts &&... ts)
+    {
+        return optional<T>(in_place, std::forward<Ts>(ts)...);
+    }
+
+    template <typename T, typename U, typename ... Ts>
+    constexpr optional<T> make_optional(std::initializer_list<U> il, Ts &&... ts)
+    {
+        return optional<T>(in_place, il, std::forward<Ts>(ts)...);
+    }
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+namespace std
+{
+    template <typename T>
+    struct hash<phylanx::util::optional<T>>
+    {
+        typedef typename hash<T>::result_type result_type;
+        typedef phylanx::util::optional<T> argument_type;
+
+        constexpr result_type operator()(argument_type const& arg) const
+        {
+            return arg ? std::hash<T>{}(*arg) : result_type{};
+        }
+    };
+}
+
+#endif

--- a/phylanx/util/serialization/eigen.hpp
+++ b/phylanx/util/serialization/eigen.hpp
@@ -10,6 +10,8 @@
 
 #include <hpx/include/serialization.hpp>
 
+#include <cstddef>
+
 #include <Eigen/Dense>
 
 namespace hpx { namespace serialization

--- a/phylanx/util/serialization/optional.hpp
+++ b/phylanx/util/serialization/optional.hpp
@@ -1,0 +1,48 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_OPTIONAL_SERIALIZATION_HPP)
+#define PHYLANX_UTIL_OPTIONAL_SERIALIZATION_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/optional.hpp>
+
+#include <hpx/include/serialization.hpp>
+
+namespace hpx { namespace serialization
+{
+    template <typename T>
+    void save(
+        output_archive& ar, phylanx::util::optional<T> const& o, unsigned)
+    {
+        bool const valid = bool(o);
+        ar << valid;
+        if (valid)
+        {
+            ar << *o;
+        }
+    }
+
+    template <typename T>
+    void load(input_archive& ar, phylanx::util::optional<T>& o, unsigned)
+    {
+        bool valid = false;
+        ar >> valid;
+        if (!valid)
+        {
+            o.reset();
+            return;
+        }
+
+        T value;
+        ar >> value;
+        o.emplace(std::move(value));
+    }
+
+    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
+        (template <typename T>), (phylanx::util::optional<T>));
+}}
+
+#endif //HPX_SERIALIZATION_VARIANT_HPP

--- a/phylanx/util/serialization/variant.hpp
+++ b/phylanx/util/serialization/variant.hpp
@@ -1,0 +1,123 @@
+//  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_VARIANT_SERIALIZATION_HPP)
+#define PHYLANX_UTIL_VARIANT_SERIALIZATION_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <hpx/include/serialization.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <cstddef>
+
+namespace hpx { namespace serialization
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        struct variant_save_visitor
+        {
+            variant_save_visitor(output_archive& ar)
+              : ar_(ar)
+            {}
+
+            template <typename T>
+            void operator()(T const& value) const
+            {
+                ar_ << value;
+            }
+
+        private:
+            output_archive& ar_;
+        };
+
+        template <typename ... Ts>
+        struct variant_impl;
+
+        template <typename T, typename ... Ts>
+        struct variant_impl<T, Ts...>
+        {
+            template <typename V>
+            static void load(input_archive& ar, std::size_t which, V& v)
+            {
+                // note: A non-intrusive implementation (such as this one)
+                // necessary has to copy the value.  This wouldn't be necessary
+                // with an implementation that de-serialized to the address of
+                // the aligned storage included in the variant.
+                if (which == 0)
+                {
+                    T value;
+                    ar >> value;
+                    v.template emplace<T>(std::move(value));
+                    return;
+                }
+                variant_impl<Ts...>::load(ar, which - 1, v);
+            }
+        };
+
+        template <>
+        struct variant_impl<>
+        {
+            template <typename V>
+            static void load(
+                input_archive& /*ar*/, std::size_t /*which*/, V& /*v*/)
+            {
+            }
+        };
+    }
+
+    template <typename ... Ts>
+    void save(output_archive& ar, phylanx::util::variant<Ts...> const& v, unsigned)
+    {
+        std::size_t which = v.index();
+        ar << which;
+        detail::variant_save_visitor visitor(ar);
+        phylanx::util::visit(visitor, v);
+    }
+
+    template <typename ... Ts>
+    void load(input_archive& ar, phylanx::util::variant<Ts...>& v, unsigned)
+    {
+        std::size_t which;
+        ar >> which;
+        if (which >= sizeof...(Ts))
+        {
+            // this might happen if a type was removed from the list of variant
+            // types
+            HPX_THROW_EXCEPTION(serialization_error
+              , "load<Archive, Variant, version>"
+              , "type was removed from the list of variant types");
+        }
+        detail::variant_impl<Ts...>::load(ar, which, v);
+    }
+
+    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
+        (template <typename ... Ts>), (phylanx::util::variant<Ts...>));
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void save(output_archive& ar, phylanx::util::recursive_wrapper<T> const& rw,
+        unsigned)
+    {
+        ar << rw.get();
+    }
+
+    template <typename T>
+    void load(
+        input_archive& ar, phylanx::util::recursive_wrapper<T>& rw, unsigned)
+    {
+        T value;
+        ar >> value;
+        rw = std::move(value);
+    }
+
+    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
+        (template <typename T>), (phylanx::util::recursive_wrapper<T>));
+}}
+
+#endif

--- a/phylanx/util/variant.hpp
+++ b/phylanx/util/variant.hpp
@@ -1,0 +1,145 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2002-2003 Eric Friedman, Itay Maman
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_VARIANT_HPP)
+#define PHYLANX_UTIL_VARIANT_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/detail/variant.hpp>
+
+namespace phylanx { namespace util
+{
+    using mpark::variant;
+    using mpark::monostate;
+
+    using mpark::holds_alternative;
+    using mpark::get;
+    using mpark::get_if;
+    using mpark::visit;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // class template recursive_wrapper
+    template <typename T>
+    class recursive_wrapper
+    {
+    public:    // typedefs
+        using type = T;
+
+    private:    // representation
+        T* p_;
+
+    public:
+        ~recursive_wrapper()
+        {
+            delete p_;
+        }
+
+        recursive_wrapper()
+          : p_(new T)
+        {
+        }
+
+        recursive_wrapper(recursive_wrapper const& operand)
+          : p_(new T(operand.get()))
+        {
+        }
+
+        recursive_wrapper(T const& operand)
+          : p_(new T(operand))
+        {
+        }
+
+        recursive_wrapper(recursive_wrapper && operand)
+          : p_(new T(std::move(operand.get())))
+        {
+        }
+
+        recursive_wrapper(T && operand)
+          : p_(new T(std::move(operand)))
+        {
+        }
+
+    private: // helpers, for modifiers (below)
+        void assign(T const& rhs)
+        {
+            this->get() = rhs;
+        }
+
+    public: // modifiers
+        recursive_wrapper& operator=(recursive_wrapper const& rhs)
+        {
+            assign(rhs.get());
+            return *this;
+        }
+        recursive_wrapper& operator=(recursive_wrapper && rhs) noexcept
+        {
+            swap(rhs);
+            return *this;
+        }
+
+        recursive_wrapper& operator=(T const& rhs)
+        {
+            assign(rhs);
+            return *this;
+        }
+        recursive_wrapper& operator=(T && rhs)
+        {
+            get() = std::move(rhs);
+            return *this;
+        }
+
+        void swap(recursive_wrapper& operand) noexcept
+        {
+            T* temp = operand.p_;
+            operand.p_ = p_;
+            p_ = temp;
+        }
+
+    public:    // queries
+        T& get()
+        {
+            return *get_pointer();
+        }
+        T const& get() const
+        {
+            return *get_pointer();
+        }
+
+        T* get_pointer()
+        {
+            return p_;
+        }
+        T const* get_pointer() const
+        {
+            return p_;
+        }
+    };
+
+    // Swaps two recursive_wrapper<T> objects of the same type T.
+    template <typename T>
+    inline void swap(
+        recursive_wrapper<T>& lhs, recursive_wrapper<T>& rhs) noexcept
+    {
+        lhs.swap(rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    bool operator==(
+        recursive_wrapper<T> const& lhs, recursive_wrapper<T> const& rhs)
+    {
+        return lhs.get() == rhs.get();
+    }
+
+    template <typename T>
+    bool operator!=(
+        recursive_wrapper<T> const& lhs, recursive_wrapper<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+}}
+
+#endif

--- a/phylanx/util/variant.hpp
+++ b/phylanx/util/variant.hpp
@@ -53,8 +53,9 @@ namespace phylanx { namespace util
         }
 
         recursive_wrapper(recursive_wrapper && operand)
-          : p_(new T(std::move(operand.get())))
+          : p_(new T)
         {
+            swap(operand);
         }
 
         recursive_wrapper(T && operand)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,10 +33,13 @@ if(MSVC)
     GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/config/*.hpp"
     APPEND)
   add_phylanx_library_headers(phylanx
+    GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/ast/*.hpp"
+    APPEND)
+  add_phylanx_library_headers(phylanx
     GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/ir/*.hpp"
     APPEND)
   add_phylanx_library_headers(phylanx
-    GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/util/*.hpp"
+    GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/phylanx/util/*.hpp"
     APPEND)
   add_phylanx_library_headers(phylanx
     GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/include/*.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ endif()
 add_phylanx_library_sources(phylanx
   GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/*.cpp")
 add_phylanx_library_sources(phylanx
-  GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/ir/*.cpp"
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/ast/*.cpp"
   APPEND)
 
 add_phylanx_source_group(
@@ -33,7 +33,7 @@ if(MSVC)
     GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/config/*.hpp"
     APPEND)
   add_phylanx_library_headers(phylanx
-    GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/ast/*.hpp"
+    GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/phylanx/ast/*.hpp"
     APPEND)
   add_phylanx_library_headers(phylanx
     GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/ir/*.hpp"

--- a/src/ast/generate_ast.cpp
+++ b/src/ast/generate_ast.cpp
@@ -1,0 +1,54 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/generate_ast.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ast/parser/expression.hpp>
+#include <phylanx/ast/parser/skipper.hpp>
+
+#include <hpx/throw_exception.hpp>
+
+#include <boost/spirit/include/qi.hpp>
+
+#include <strstream>
+#include <string>
+
+namespace phylanx { namespace ast
+{
+    ast::expression generate_ast(std::string const& input)
+    {
+        using iterator = std::string::const_iterator;
+
+        iterator first = input.begin();
+        iterator last = input.end();
+
+        std::stringstream strm;
+        ast::parser::error_handler<iterator> error_handler(first, last, strm);
+
+        ast::parser::expression<iterator> expr(error_handler);
+        ast::parser::skipper<iterator> skipper;
+
+        ast::expression ast;
+
+        if (!boost::spirit::qi::phrase_parse(first, last, expr, skipper, ast))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::ast::generate_ast", strm.str());
+        }
+
+        if (first != last)
+        {
+            error_handler("Error! ", "Incomplete parse:", first);
+
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::ast::generate_ast", strm.str());
+        }
+
+        return ast;
+    }
+}}
+
+

--- a/src/ast/node.cpp
+++ b/src/ast/node.cpp
@@ -1,0 +1,372 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+
+#include <hpx/include/serialization.hpp>
+
+#include <iosfwd>
+
+namespace phylanx { namespace ast
+{
+    ///////////////////////////////////////////////////////////////////////////
+    void serialize(hpx::serialization::input_archive& ar, optoken& id, unsigned)
+    {
+        int val;
+        ar >> val;
+        id = static_cast<optoken>(val);
+    }
+
+    void serialize(
+        hpx::serialization::output_archive& ar, optoken const& id, unsigned)
+    {
+        int val = static_cast<int>(id);
+        ar << val;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void identifier::serialize(hpx::serialization::output_archive& ar, unsigned)
+    {
+        ar << name;
+    }
+
+    void identifier::serialize(hpx::serialization::input_archive& ar, unsigned)
+    {
+        ar >> name;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void primary_expr::serialize(
+        hpx::serialization::output_archive& ar, unsigned)
+    {
+        ar << *static_cast<expr_node_type*>(this);
+    }
+
+    void primary_expr::serialize(
+        hpx::serialization::input_archive& ar, unsigned)
+    {
+        ar >> *static_cast<expr_node_type*>(this);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void operand::serialize(hpx::serialization::output_archive& ar, unsigned)
+    {
+        ar << *static_cast<operand_node_type*>(this);
+    }
+
+    void operand::serialize(hpx::serialization::input_archive& ar, unsigned)
+    {
+        ar >> *static_cast<operand_node_type*>(this);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void unary_expr::serialize(hpx::serialization::output_archive& ar, unsigned)
+    {
+        ar << operator_ << operand_;
+    }
+
+    void unary_expr::serialize(hpx::serialization::input_archive& ar, unsigned)
+    {
+        ar >> operator_ >> operand_;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void operation::serialize(hpx::serialization::output_archive& ar, unsigned)
+    {
+        ar << operator_ << operand_;
+    }
+
+    void operation::serialize(hpx::serialization::input_archive& ar, unsigned)
+    {
+        ar >> operator_ >> operand_;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void expression::serialize(hpx::serialization::output_archive& ar, unsigned)
+    {
+        ar << first << rest;
+    }
+
+    void expression::serialize(hpx::serialization::input_archive& ar, unsigned)
+    {
+        ar >> first >> rest;
+    }
+
+//     ///////////////////////////////////////////////////////////////////////////
+//     void function_call::serialize(
+//         hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << function_name << args;
+//     }
+//
+//     void function_call::serialize(
+//         hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> function_name >> args;
+//     }
+//
+//     ///////////////////////////////////////////////////////////////////////////
+//     void assignment::serialize(hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << lhs << operator_ << rhs;
+//     }
+//
+//     void assignment::serialize(hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> lhs >> operator_ >> rhs;
+//     }
+//
+//     ///////////////////////////////////////////////////////////////////////////
+//     void variable_declaration::serialize(
+//         hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << lhs << rhs;
+//     }
+//
+//     void variable_declaration::serialize(
+//         hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> lhs >> rhs;
+//     }
+//
+//     ///////////////////////////////////////////////////////////////////////////
+//     void statement::serialize(hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << *static_cast<statement_node_type*>(this);
+//     }
+//
+//     void statement::serialize(hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> *static_cast<statement_node_type*>(this);
+//     }
+//
+//     ///////////////////////////////////////////////////////////////////////////
+//     void if_statement::serialize(
+//         hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << condition << then << else_;
+//     }
+//
+//     void if_statement::serialize(
+//         hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> condition >> then >> else_;
+//     }
+//
+//     ///////////////////////////////////////////////////////////////////////////
+//     void while_statement::serialize(
+//         hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << condition << body;
+//     }
+//
+//     void while_statement::serialize(
+//         hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> condition >> body;
+//     }
+//
+//     ///////////////////////////////////////////////////////////////////////////
+//     void return_statement::serialize(
+//         hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << expr;
+//     }
+//
+//     void return_statement::serialize(
+//         hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> expr;
+//     }
+//
+//     ///////////////////////////////////////////////////////////////////////////
+//     void function::serialize(hpx::serialization::output_archive& ar, unsigned)
+//     {
+//         ar << return_type << function_name << args << body;
+//     }
+//
+//     void function::serialize(hpx::serialization::input_archive& ar, unsigned)
+//     {
+//         ar >> return_type >> function_name >> args >> body;
+//     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        char const* const optoken_names[] =
+        {
+            "op_unknown",
+
+            // precedence 1
+            "op_comma",
+
+            // precedence 2
+            "op_assign",
+            "op_plus_assign",
+            "op_minus_assign",
+            "op_times_assign",
+            "op_divide_assign",
+            "op_mod_assign",
+            "op_bit_and_assign",
+            "op_bit_xor_assign",
+            "op_bitor_assign",
+            "op_shift_left_assign",
+            "op_shift_right_assign",
+
+            // precedence 3
+            "op_logical_or",
+
+            // precedence 4
+            "op_logical_and",
+
+            // precedence 5
+            "op_bit_or",
+
+            // precedence 6
+            "op_bit_xor",
+
+            // precedence 7
+            "op_bit_and",
+
+            // precedence 8
+            "op_equal",
+            "op_not_equal",
+
+            // precedence 9
+            "op_less",
+            "op_less_equal",
+            "op_greater",
+            "op_greater_equal",
+
+            // precedence 10
+            "op_shift_left",
+            "op_shift_right",
+
+            // precedence 11
+            "op_plus",
+            "op_minus",
+
+            // precedence 12
+            "op_times",
+            "op_divide",
+            "op_mod",
+
+            // precedence 13
+            "op_positive",
+            "op_negative",
+            "op_pre_incr",
+            "op_pre_decr",
+            "op_compl",
+            "op_not",
+
+            // precedence 14
+            "op_post_incr",
+            "op_post_decr",
+        };
+    }
+
+    std::ostream& operator<<(std::ostream& out, nil)
+    {
+        out << "nil";
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, optoken op)
+    {
+        out << detail::optoken_names[static_cast<int>(op)];
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, identifier const& id)
+    {
+        out << "identifier: " << id.name;
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, primary_expr const& pe)
+    {
+        out << "primary_expr";
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, operand const& op)
+    {
+        out << "operand";
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, unary_expr const& ue)
+    {
+        out << "unary_expr";
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, operation const& op)
+    {
+        out << "operation";
+        return out;
+    }
+
+    std::ostream& operator<<(std::ostream& out, expression const& expr)
+    {
+        out << "expression";
+        return out;
+    }
+
+//     std::ostream& operator<<(std::ostream& out, function_call const& f)
+//     {
+//         out << "function_call";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, assignment const& a)
+//     {
+//         out << "assignment";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, variable_declaration const& vd)
+//     {
+//         out << "variable_declaration";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, statement const& stmt)
+//     {
+//         out << "statement";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, if_statement const& if_)
+//     {
+//         out << "if_statement";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, while_statement const& while_)
+//     {
+//         out << "while_statement";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, return_statement const& ret)
+//     {
+//         out << "return_statement";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, function const& func)
+//     {
+//         out << "function";
+//         return out;
+//     }
+//
+//     std::ostream& operator<<(std::ostream& out, function_list const& fl)
+//     {
+//         out << "function_list";
+//         return out;
+//     }
+}}

--- a/src/ast/parser/expression.cpp
+++ b/src/ast/parser/expression.cpp
@@ -1,0 +1,13 @@
+//  Copyright (c) 2001-2010 Joel de Guzman
+//  Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+#include <phylanx/ast/parser/expression_def.hpp>
+
+#include <string>
+
+using iterator_type = std::string::const_iterator;
+template struct phylanx::ast::parser::expression<iterator_type>;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,8 +4,10 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(subdirs
+    ast
     config
     ir
+    util
    )
 
 foreach(subdir ${subdirs})

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -11,8 +11,8 @@ set(subdirs
    )
 
 foreach(subdir ${subdirs})
-  add_hpx_pseudo_target(tests.unit.${subdir})
+  add_phylanx_pseudo_target(tests.unit.${subdir})
   add_subdirectory(${subdir})
-  add_hpx_pseudo_dependencies(tests.unit tests.unit.${subdir})
+  add_phylanx_pseudo_dependencies(tests.unit tests.unit.${subdir})
 endforeach()
 

--- a/tests/unit/ast/CMakeLists.txt
+++ b/tests/unit/ast/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) 2017 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    node
+   )
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add executable
+  add_phylanx_executable(${test}_test
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Unit/AST/")
+
+  add_phylanx_unit_test("ast" ${test} ${${test}_PARAMETERS})
+
+  add_hpx_pseudo_target(tests.unit.ast.${test})
+  add_hpx_pseudo_dependencies(tests.unit.ast tests.unit.ast.${test})
+  add_hpx_pseudo_dependencies(tests.unit.ast.${test} ${test}_test_exe)
+
+endforeach()
+

--- a/tests/unit/ast/CMakeLists.txt
+++ b/tests/unit/ast/CMakeLists.txt
@@ -21,9 +21,9 @@ foreach(test ${tests})
 
   add_phylanx_unit_test("ast" ${test} ${${test}_PARAMETERS})
 
-  add_hpx_pseudo_target(tests.unit.ast.${test})
-  add_hpx_pseudo_dependencies(tests.unit.ast tests.unit.ast.${test})
-  add_hpx_pseudo_dependencies(tests.unit.ast.${test} ${test}_test_exe)
+  add_phylanx_pseudo_target(tests.unit.ast.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.ast tests.unit.ast.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.ast.${test} ${test}_test_exe)
 
 endforeach()
 

--- a/tests/unit/ast/CMakeLists.txt
+++ b/tests/unit/ast/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    generate_ast
     node
    )
 

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -12,16 +12,21 @@
 #include <iostream>
 #include <strstream>
 
-struct traverse_ast
+struct traverse_ast : phylanx::ast::static_visitor
 {
+    traverse_ast(std::stringstream& strm)
+      : strm_(strm)
+    {
+    }
+
     template <typename T>
     bool operator()(T const& val) const
     {
-        strm << val << '\n';
+        strm_ << val << '\n';
         return true;
     }
 
-    std::stringstream& strm;
+    std::stringstream& strm_;
 };
 
 void test_expression(std::string const& expr, std::string const& expected)

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -1,0 +1,72 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/serialization.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <iostream>
+#include <strstream>
+
+struct traverse_ast
+{
+    template <typename T>
+    bool operator()(T const& val) const
+    {
+        strm << val << '\n';
+        return true;
+    }
+
+    std::stringstream& strm;
+};
+
+void test_expression(std::string const& expr, std::string const& expected)
+{
+    phylanx::ast::expression ast = phylanx::ast::generate_ast(expr);
+    std::stringstream strm;
+    phylanx::ast::traverse(ast, traverse_ast{strm});
+    HPX_TEST_EQ(strm.str(), expected);
+}
+
+int main(int argc, char* argv[])
+{
+    test_expression(
+        "A + B",
+        "expression\n"
+            "operand\n"
+                "primary_expr\n"
+                    "identifier: A\n"
+            "operation\n"
+                "op_plus\n"
+            "operand\n"
+                "primary_expr\n"
+                    "identifier: B\n"
+    );
+
+    test_expression(
+        "A + B + -C",
+        "expression\n"
+            "operand\n"
+                "primary_expr\n"
+                    "identifier: A\n"
+            "operation\n"
+                "op_plus\n"
+            "operand\n"
+                "primary_expr\n"
+                    "identifier: B\n"
+            "operation\n"
+                "op_plus\n"
+            "operand\n"
+                "unary_expr\n"
+                    "op_negative\n"
+                    "operand\n"
+                        "primary_expr\n"
+                            "identifier: C\n"
+    );
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -1,4 +1,4 @@
-//   Copyright (c) 2001-2017 Hartmut Kaiser
+//   Copyright (c) 2017 Hartmut Kaiser
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -5,6 +5,7 @@
 
 #include <phylanx/phylanx.hpp>
 
+#include <hpx/hpx_main.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
@@ -47,15 +48,15 @@ void test_identifier()
 ///////////////////////////////////////////////////////////////////////////////
 void test_primary_expr()
 {
-    phylanx::ast::primary_expr<double> p1(true);
+    phylanx::ast::primary_expr p1(true);
     test_serialization(p1);
 
-    phylanx::ast::primary_expr<double> p2(
+    phylanx::ast::primary_expr p2(
         phylanx::ast::identifier("some_name"));
     test_serialization(p2);
 
     Eigen::VectorXd v = Eigen::VectorXd::Random(1007);
-    phylanx::ast::primary_expr<double> p3{
+    phylanx::ast::primary_expr p3{
         phylanx::ir::node_data<double>{v}};
     test_serialization(p3);
 }
@@ -63,28 +64,28 @@ void test_primary_expr()
 ///////////////////////////////////////////////////////////////////////////////
 void test_operand()
 {
-    phylanx::ast::primary_expr<double> p1(true);
-    phylanx::ast::operand<double> op1(p1);
+    phylanx::ast::primary_expr p1(true);
+    phylanx::ast::operand op1(p1);
     test_serialization(op1);
 
-    phylanx::ast::primary_expr<double> p2(
+    phylanx::ast::primary_expr p2(
         phylanx::ast::identifier{"some_name"});
-    phylanx::ast::operand<double> op2(std::move(p2));
+    phylanx::ast::operand op2(std::move(p2));
     test_serialization(op2);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 void test_unary_expr()
 {
-    phylanx::ast::primary_expr<double> p1(true);
-    phylanx::ast::operand<double> op1(p1);
-    phylanx::ast::unary_expr<double> u1(phylanx::ast::optoken::op_not, op1);
+    phylanx::ast::primary_expr p1(true);
+    phylanx::ast::operand op1(p1);
+    phylanx::ast::unary_expr u1(phylanx::ast::optoken::op_not, op1);
     test_serialization(u1);
 
-    phylanx::ast::primary_expr<double> p2(
+    phylanx::ast::primary_expr p2(
         phylanx::ast::identifier{"some_name"});
-    phylanx::ast::operand<double> op2(p2);
-    phylanx::ast::unary_expr<double> u2(
+    phylanx::ast::operand op2(p2);
+    phylanx::ast::unary_expr u2(
         phylanx::ast::optoken::op_negative, std::move(op2));
     test_serialization(u2);
 }
@@ -92,15 +93,15 @@ void test_unary_expr()
 ///////////////////////////////////////////////////////////////////////////////
 void test_operation()
 {
-    phylanx::ast::primary_expr<double> p1(true);
-    phylanx::ast::operand<double> op1(p1);
-    phylanx::ast::operation<double> u1(phylanx::ast::optoken::op_plus, op1);
+    phylanx::ast::primary_expr p1(true);
+    phylanx::ast::operand op1(p1);
+    phylanx::ast::operation u1(phylanx::ast::optoken::op_plus, op1);
     test_serialization(u1);
 
-    phylanx::ast::primary_expr<double> p2(
+    phylanx::ast::primary_expr p2(
         phylanx::ast::identifier{"some_name"});
-    phylanx::ast::operand<double> op2(p2);
-    phylanx::ast::operation<double> u2(
+    phylanx::ast::operand op2(p2);
+    phylanx::ast::operation u2(
         phylanx::ast::optoken::op_minus, std::move(op2));
     test_serialization(u2);
 }
@@ -108,19 +109,19 @@ void test_operation()
 ///////////////////////////////////////////////////////////////////////////////
 void test_expression()
 {
-    phylanx::ast::primary_expr<double> p1(true);
-    phylanx::ast::operand<double> op1(p1);
-    phylanx::ast::expression<double> e1(std::move(op1));
+    phylanx::ast::primary_expr p1(true);
+    phylanx::ast::operand op1(p1);
+    phylanx::ast::expression e1(std::move(op1));
 
-    phylanx::ast::operation<double> u1(phylanx::ast::optoken::op_plus, op1);
+    phylanx::ast::operation u1(phylanx::ast::optoken::op_plus, op1);
     e1.append(u1);
 
-    std::list<phylanx::ast::operation<double>> ops = {u1, u1};
+    std::list<phylanx::ast::operation> ops = {u1, u1};
     e1.append(ops);
 
     test_serialization(e1);
 
-    phylanx::ast::primary_expr<double> p2(std::move(e1));
+    phylanx::ast::primary_expr p2(std::move(e1));
     test_serialization(p2);
 }
 

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -1,0 +1,139 @@
+//   Copyright (c) 2001-2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/include/serialization.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <vector>
+
+#include <Eigen/Dense>
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Ast>
+void test_serialization(Ast const& in)
+{
+    std::vector<char> out_buffer;
+    std::size_t archive_size = 0;
+
+    {
+        hpx::serialization::output_archive archive(out_buffer);
+        archive << in;
+        archive_size = archive.bytes_written();
+    }
+
+    Ast out;
+
+    {
+        hpx::serialization::input_archive archive(
+            out_buffer, archive_size);
+
+        archive >> out;
+    }
+
+    HPX_TEST(in == out);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_identifier()
+{
+    phylanx::ast::identifier id("some_name");
+    test_serialization(id);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_primary_expr()
+{
+    phylanx::ast::primary_expr<double> p1(true);
+    test_serialization(p1);
+
+    phylanx::ast::primary_expr<double> p2(
+        phylanx::ast::identifier("some_name"));
+    test_serialization(p2);
+
+    Eigen::VectorXd v = Eigen::VectorXd::Random(1007);
+    phylanx::ast::primary_expr<double> p3{
+        phylanx::ir::node_data<double>{v}};
+    test_serialization(p3);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_operand()
+{
+    phylanx::ast::primary_expr<double> p1(true);
+    phylanx::ast::operand<double> op1(p1);
+    test_serialization(op1);
+
+    phylanx::ast::primary_expr<double> p2(
+        phylanx::ast::identifier{"some_name"});
+    phylanx::ast::operand<double> op2(std::move(p2));
+    test_serialization(op2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_unary_expr()
+{
+    phylanx::ast::primary_expr<double> p1(true);
+    phylanx::ast::operand<double> op1(p1);
+    phylanx::ast::unary_expr<double> u1(phylanx::ast::optoken::op_not, op1);
+    test_serialization(u1);
+
+    phylanx::ast::primary_expr<double> p2(
+        phylanx::ast::identifier{"some_name"});
+    phylanx::ast::operand<double> op2(p2);
+    phylanx::ast::unary_expr<double> u2(
+        phylanx::ast::optoken::op_negative, std::move(op2));
+    test_serialization(u2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_operation()
+{
+    phylanx::ast::primary_expr<double> p1(true);
+    phylanx::ast::operand<double> op1(p1);
+    phylanx::ast::operation<double> u1(phylanx::ast::optoken::op_plus, op1);
+    test_serialization(u1);
+
+    phylanx::ast::primary_expr<double> p2(
+        phylanx::ast::identifier{"some_name"});
+    phylanx::ast::operand<double> op2(p2);
+    phylanx::ast::operation<double> u2(
+        phylanx::ast::optoken::op_minus, std::move(op2));
+    test_serialization(u2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_expression()
+{
+    phylanx::ast::primary_expr<double> p1(true);
+    phylanx::ast::operand<double> op1(p1);
+    phylanx::ast::expression<double> e1(std::move(op1));
+
+    phylanx::ast::operation<double> u1(phylanx::ast::optoken::op_plus, op1);
+    e1.append(u1);
+
+    std::list<phylanx::ast::operation<double>> ops = {u1, u1};
+    e1.append(ops);
+
+    test_serialization(e1);
+
+    phylanx::ast::primary_expr<double> p2(std::move(e1));
+    test_serialization(p2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_identifier();
+    test_primary_expr();
+    test_operand();
+    test_unary_expr();
+    test_operation();
+    test_expression();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/config/CMakeLists.txt
+++ b/tests/unit/config/CMakeLists.txt
@@ -21,9 +21,9 @@ foreach(test ${tests})
 
   add_phylanx_unit_test("config" ${test} ${${test}_PARAMETERS})
 
-  add_hpx_pseudo_target(tests.unit.config.${test})
-  add_hpx_pseudo_dependencies(tests.unit.config tests.unit.config.${test})
-  add_hpx_pseudo_dependencies(tests.unit.config.${test} ${test}_test_exe)
+  add_phylanx_pseudo_target(tests.unit.config.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.config tests.unit.config.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.config.${test} ${test}_test_exe)
 
 endforeach()
 

--- a/tests/unit/config/version.cpp
+++ b/tests/unit/config/version.cpp
@@ -4,6 +4,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstdint>

--- a/tests/unit/ir/CMakeLists.txt
+++ b/tests/unit/ir/CMakeLists.txt
@@ -21,9 +21,9 @@ foreach(test ${tests})
 
   add_phylanx_unit_test("ir" ${test} ${${test}_PARAMETERS})
 
-  add_hpx_pseudo_target(tests.unit.ir.${test})
-  add_hpx_pseudo_dependencies(tests.unit.ir tests.unit.ir.${test})
-  add_hpx_pseudo_dependencies(tests.unit.ir.${test} ${test}_test_exe)
+  add_phylanx_pseudo_target(tests.unit.ir.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.ir tests.unit.ir.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.ir.${test} ${test}_test_exe)
 
 endforeach()
 

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -8,9 +8,6 @@
 
 #include <Eigen/Dense>
 
-#include <algorithm>
-#include <cstdint>
-
 void test_serialization(phylanx::ir::node_data<double> const& array_value1)
 {
     std::vector<char> out_buffer;
@@ -31,13 +28,7 @@ void test_serialization(phylanx::ir::node_data<double> const& array_value1)
         archive >> array_value2;
     }
 
-    HPX_TEST_EQ(array_value1.num_dimensions(), array_value2.num_dimensions());
-    HPX_TEST(array_value1.dimensions() == array_value2.dimensions());
-
-    HPX_TEST(
-        std::equal(
-            hpx::util::begin(array_value1), hpx::util::end(array_value1),
-            hpx::util::begin(array_value2), hpx::util::end(array_value2)));
+    HPX_TEST(array_value1 == array_value2);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -4,6 +4,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <Eigen/Dense>

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -22,9 +22,9 @@ foreach(test ${tests})
 
   add_phylanx_unit_test("util" ${test} ${${test}_PARAMETERS})
 
-  add_hpx_pseudo_target(tests.unit.util.${test})
-  add_hpx_pseudo_dependencies(tests.unit.util tests.unit.util.${test})
-  add_hpx_pseudo_dependencies(tests.unit.util.${test} ${test}_test_exe)
+  add_phylanx_pseudo_target(tests.unit.util.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.util tests.unit.util.${test})
+  add_phylanx_pseudo_dependencies(tests.unit.util.${test} ${test}_test_exe)
 
 endforeach()
 

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2017 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    serialization_optional
+    serialization_variant
+   )
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add executable
+  add_phylanx_executable(${test}_test
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Unit/Util/")
+
+  add_phylanx_unit_test("util" ${test} ${${test}_PARAMETERS})
+
+  add_hpx_pseudo_target(tests.unit.util.${test})
+  add_hpx_pseudo_dependencies(tests.unit.util tests.unit.util.${test})
+  add_hpx_pseudo_dependencies(tests.unit.util.${test} ${test}_test_exe)
+
+endforeach()
+

--- a/tests/unit/util/serialization_optional.cpp
+++ b/tests/unit/util/serialization_optional.cpp
@@ -1,0 +1,87 @@
+//  Copyright (c) 2015 Anton Bikineev
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/string.hpp>
+
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <vector>
+
+template <typename T>
+struct A
+{
+    A() {}
+
+    A(T t) : t_(t) {}
+    T t_;
+
+    A & operator=(T t) { t_ = t; return *this; }
+
+    friend bool operator==(A a, A b)
+    {
+        return a.t_ == b.t_;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, A a)
+    {
+        os << a.t_;
+        return os;
+    }
+
+    template <typename Archive>
+    void serialize(Archive & ar, unsigned)
+    {
+        ar & t_;
+    }
+};
+
+template <typename T>
+void test_serialization(T value)
+{
+    std::vector<char> buf;
+    hpx::serialization::output_archive oar(buf);
+    hpx::serialization::input_archive iar(buf);
+
+    phylanx::util::optional<T> oo = value;
+    phylanx::util::optional<T> io;
+    oar << oo;
+    iar >> io;
+
+    HPX_TEST(io.has_value());
+    HPX_TEST(*io == *oo);
+    HPX_TEST(*io == value);
+}
+
+int main()
+{
+    {
+        std::vector<char> buf;
+        hpx::serialization::output_archive oar(buf);
+        hpx::serialization::input_archive iar(buf);
+
+        phylanx::util::optional<std::string> oo;
+        phylanx::util::optional<std::string> io;
+        oar << oo;
+        iar >> io;
+
+        HPX_TEST(!io.has_value());
+    }
+
+    test_serialization(std::string("dfsdf"));
+    test_serialization(2.5);
+    test_serialization(42);
+    test_serialization(A<int>(2));
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/util/serialization_optional.cpp
+++ b/tests/unit/util/serialization_optional.cpp
@@ -7,12 +7,8 @@
 #include <phylanx/config.hpp>
 #include <phylanx/util/serialization/optional.hpp>
 
-#include <hpx/runtime/serialization/serialize.hpp>
-#include <hpx/runtime/serialization/string.hpp>
-
-#include <hpx/runtime/serialization/input_archive.hpp>
-#include <hpx/runtime/serialization/output_archive.hpp>
-
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/serialization.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <string>

--- a/tests/unit/util/serialization_variant.cpp
+++ b/tests/unit/util/serialization_variant.cpp
@@ -1,0 +1,93 @@
+//  Copyright (c) 2015 Anton Bikineev
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/serialization/variant.hpp>
+
+#include <hpx/runtime/serialization/serialize.hpp>
+#include <hpx/runtime/serialization/string.hpp>
+
+#include <hpx/runtime/serialization/input_archive.hpp>
+#include <hpx/runtime/serialization/output_archive.hpp>
+
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <vector>
+
+template <typename T>
+struct A
+{
+    A() {}
+
+    A(T t) : t_(t) {}
+    T t_;
+
+    A & operator=(T t) { t_ = t; return *this; }
+
+    friend bool operator==(A a, A b)
+    {
+        return a.t_ == b.t_;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, A a)
+    {
+        os << a.t_;
+        return os;
+    }
+
+    template <typename Archive>
+    void serialize(Archive & ar, unsigned)
+    {
+        ar & t_;
+    }
+};
+
+int main()
+{
+    std::vector<char> buf;
+    hpx::serialization::output_archive oar(buf);
+    hpx::serialization::input_archive iar(buf);
+
+    phylanx::util::variant<int, std::string, double, A<int> > ovar =
+        std::string("dfsdf");
+    phylanx::util::variant<int, std::string, double, A<int> > ivar;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.index(), ovar.index());
+    HPX_TEST(ivar == ovar);
+
+    ovar = 2.5;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.index(), ovar.index());
+    HPX_TEST(ivar == ovar);
+
+    ovar = 1;
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.index(), ovar.index());
+    HPX_TEST(ivar == ovar);
+
+    ovar = A<int>(2);
+    oar << ovar;
+    iar >> ivar;
+
+    HPX_TEST_EQ(ivar.index(), ovar.index());
+    HPX_TEST(ivar == ovar);
+
+    const phylanx::util::variant<std::string> sovar = std::string("string");
+    phylanx::util::variant<std::string> sivar;
+    oar << sovar;
+    iar >> sivar;
+
+    HPX_TEST_EQ(sivar.index(), sovar.index());
+    HPX_TEST(sivar == sovar);
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/util/serialization_variant.cpp
+++ b/tests/unit/util/serialization_variant.cpp
@@ -6,12 +6,8 @@
 #include <phylanx/config.hpp>
 #include <phylanx/util/serialization/variant.hpp>
 
-#include <hpx/runtime/serialization/serialize.hpp>
-#include <hpx/runtime/serialization/string.hpp>
-
-#include <hpx/runtime/serialization/input_archive.hpp>
-#include <hpx/runtime/serialization/output_archive.hpp>
-
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/serialization.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <string>


### PR DESCRIPTION
This adds the beginnings of possible types and an API for an abstract syntax tree (AST) representation. This also adds `util::variant` and `util::optional` utility types with tests and an example.