### PR TITLE
Python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,13 @@ endif()
 include_directories(${Eigen3_INCLUDE_DIRS})
 phylanx_info("Eigen3 version: " ${EIGEN3_VERSION_STRING})
 
+find_package(pybind11 REQUIRED NO_CMAKE_PACKAGE_REGISTRY)
+if(NOT pybind11_FOUND)
+  phylanx_error("pybind11 could not be found, please set pybind11_DIR to help locating it.")
+endif()
+phylanx_info("Python library version: " ${PYTHON_VERSION_STRING})
+phylanx_info("Pybind11 library version: " ${pybind11_VERSION})
+
 ################################################################################
 # Special compiler flags
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,10 @@ find_package(pybind11 REQUIRED NO_CMAKE_PACKAGE_REGISTRY)
 if(NOT pybind11_FOUND)
   phylanx_error("pybind11 could not be found, please set pybind11_DIR to help locating it.")
 endif()
+if(${pybind11_VERSION} VERSION_LESS 2.2.0)
+  phylanx_error("pybind11 too old, should be of version 2.2.0 or newer.")
+endif()
+
 phylanx_info("Python library version: " ${PYTHON_VERSION_STRING})
 phylanx_info("Pybind11 library version: " ${pybind11_VERSION})
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,9 @@ version: '{branch}-{build}'
 image:
   - Visual Studio 2017
 
+environment:
+  PYTHON: 36-x64
+
 configuration:
   - Debug
 
@@ -25,6 +28,7 @@ install:
   - ps: Start-FileDownload 'http://stellar-group.org/files/hpx-master-redist-VS2017-Debug.7z' -FileName 'C:\projects\hpx-master-redist-VS2017-Debug.7z' -Timeout 60000
   - cmd: 7z x "C:\projects\vcpkg-export-hpx-dependencies.7z" -y -oC:\projects\vcpkg >NUL
   - cmd: 7z x "C:\projects\hpx-master-redist-VS2017-Debug.7z" -y -oC:\projects\hpx >NUL
+  - ps: $env:PATH = "C:\Python$env:PYTHON\;C:\Python$env:PYTHON\Scripts\;$env:PATH"
 
 before_build:
   - cmd: cmake -H. -Bbuild -G"Visual Studio 15 2017" -A%PLATFORM% -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_TOOLCHAIN_FILE=C:/projects/vcpkg/scripts/buildsystems/vcpkg.cmake -DHPX_DIR=C:/projects/hpx/build/lib/cmake/HPX -DPHYLANX_WITH_PSEUDO_DEPENDENCIES=On

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ before_build:
 
 build_script:
   - cmd: cmake --build build --config %CONFIGURATION% --target core -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal /maxcpucount:2 /nologo
+  - cmd: cmake --build build --config %CONFIGURATION% --target examples -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal /maxcpucount:2 /nologo
   - cmd: cmake --build build --config %CONFIGURATION% --target tests -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal /maxcpucount:2 /nologo
 
 #test_script:

--- a/cmake/Phylanx_SetupTarget.cmake
+++ b/cmake/Phylanx_SetupTarget.cmake
@@ -127,9 +127,9 @@ function(phylanx_setup_target target)
         VERSION ${PHYLANX_LIBRARY_VERSION}
         SOVERSION ${PHYLANX_SOVERSION})
     endif()
-    if(NOT target_NONAMEPREFIX)
-      phylanx_set_lib_name(${target} ${name})
-    endif()
+#    if(NOT target_NONAMEPREFIX)
+#      phylanx_set_lib_name(${target} ${name})
+#    endif()
     set_target_properties(${target}
       PROPERTIES
       # create *nix style library versions + symbolic links

--- a/phylanx/ast/generate_ast.hpp
+++ b/phylanx/ast/generate_ast.hpp
@@ -3,6 +3,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#if !defined(PHYLANX_AST_GENERATE_AST_HPP)
+#define PHYLANX_AST_GENERATE_AST_HPP
+
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
 
@@ -13,4 +16,4 @@ namespace phylanx { namespace ast
     PHYLANX_EXPORT ast::expression generate_ast(std::string const& input);
 }}
 
-
+#endif

--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -135,6 +135,9 @@ namespace phylanx { namespace ast
 
         std::string name;
 
+    private:
+        friend class hpx::serialization::access;
+
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);
         PHYLANX_EXPORT void serialize(
@@ -224,8 +227,8 @@ namespace phylanx { namespace ast
         {
         }
 
-        // this is only for usage in the Python bindings
-        expr_node_type const& value() const { return *this; }
+    private:
+        friend class hpx::serialization::access;
 
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);
@@ -288,8 +291,8 @@ namespace phylanx { namespace ast
 //         {
 //         }
 
-        // this is only for usage in the Python bindings
-        operand_node_type const& value() const { return *this; }
+    private:
+        friend class hpx::serialization::access;
 
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);
@@ -325,6 +328,9 @@ namespace phylanx { namespace ast
         optoken operator_;
         operand operand_;
 
+    private:
+        friend class hpx::serialization::access;
+
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);
         PHYLANX_EXPORT void serialize(
@@ -359,6 +365,9 @@ namespace phylanx { namespace ast
 
         optoken operator_;
         operand operand_;
+
+    private:
+        friend class hpx::serialization::access;
 
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);
@@ -407,6 +416,9 @@ namespace phylanx { namespace ast
 
         operand first;
         std::list<operation> rest;
+
+    private:
+        friend class hpx::serialization::access;
 
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);

--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -185,17 +185,16 @@ namespace phylanx { namespace ast
         {
         }
 
-        primary_expr(double val)
-          : expr_node_type(phylanx::ir::node_data<double>(val))
-        {
-        }
-
         primary_expr(phylanx::ir::node_data<double> const& val)
           : expr_node_type(val)
         {
         }
         primary_expr(phylanx::ir::node_data<double> && val)
           : expr_node_type(std::move(val))
+        {
+        }
+        primary_expr(double val)
+          : expr_node_type(phylanx::ir::node_data<double>(val))
         {
         }
 
@@ -207,8 +206,12 @@ namespace phylanx { namespace ast
           : expr_node_type(std::move(val))
         {
         }
-        primary_expr(std::string const&val)
+        primary_expr(std::string const& val)
           : expr_node_type(identifier(val))
+        {
+        }
+        primary_expr(std::string && val)
+          : expr_node_type(identifier(std::move(val)))
         {
         }
 
@@ -220,6 +223,9 @@ namespace phylanx { namespace ast
           : expr_node_type(std::move(val))
         {
         }
+
+        // this is only for usage in the Python bindings
+        expr_node_type const& value() const { return *this; }
 
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);
@@ -249,6 +255,11 @@ namespace phylanx { namespace ast
                 phylanx::util::recursive_wrapper<primary_expr>(val))
         {
         }
+        operand(std::string && val)
+          : operand_node_type(
+                phylanx::util::recursive_wrapper<primary_expr>(std::move(val)))
+        {
+        }
 
         operand(primary_expr const& val)
           : operand_node_type(val)
@@ -276,6 +287,9 @@ namespace phylanx { namespace ast
 //            : operand_node_type(std::move(val))
 //         {
 //         }
+
+        // this is only for usage in the Python bindings
+        operand_node_type const& value() const { return *this; }
 
         PHYLANX_EXPORT void serialize(
             hpx::serialization::input_archive& ar, unsigned);

--- a/phylanx/include/ast.hpp
+++ b/phylanx/include/ast.hpp
@@ -7,8 +7,8 @@
 #define PHYLANX_AST_HPP
 
 #include <phylanx/config.hpp>
+#include <phylanx/ast/generate_ast.hpp>
 #include <phylanx/ast/node.hpp>
 #include <phylanx/ast/traverse.hpp>
-#include <phylanx/ast/generate_ast.hpp>
 
 #endif

--- a/phylanx/include/util.hpp
+++ b/phylanx/include/util.hpp
@@ -8,10 +8,11 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/util/eigen_range.hpp>
-#include <phylanx/util/serialization/eigen.hpp>
 #include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/ast.hpp>
+#include <phylanx/util/serialization/eigen.hpp>
 #include <phylanx/util/serialization/optional.hpp>
-#include <phylanx/util/variant.hpp>
 #include <phylanx/util/serialization/variant.hpp>
+#include <phylanx/util/variant.hpp>
 
 #endif

--- a/phylanx/util/serialization/ast.hpp
+++ b/phylanx/util/serialization/ast.hpp
@@ -1,0 +1,48 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_SERIALIZE_HPP)
+#define PHYLANX_SERIALIZE_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <vector>
+
+namespace phylanx { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    PHYLANX_EXPORT std::vector<char> serialize(ir::node_data<double> const&);
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ir::node_data<double>&);
+
+    ///////////////////////////////////////////////////////////////////////////
+    PHYLANX_EXPORT std::vector<char> serialize(ast::optoken);
+    PHYLANX_EXPORT std::vector<char> serialize(ast::identifier const&);
+    PHYLANX_EXPORT std::vector<char> serialize(ast::primary_expr const&);
+    PHYLANX_EXPORT std::vector<char> serialize(ast::operand const&);
+    PHYLANX_EXPORT std::vector<char> serialize(ast::unary_expr const&);
+    PHYLANX_EXPORT std::vector<char> serialize(ast::operation const&);
+    PHYLANX_EXPORT std::vector<char> serialize(ast::expression const&);
+
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ast::optoken&);
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ast::identifier&);
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ast::primary_expr&);
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ast::operand&);
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ast::unary_expr&);
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ast::operation&);
+    PHYLANX_EXPORT void unserialize(
+        std::vector<char> const&, ast::expression&);
+}}
+
+#endif
+

--- a/phylanx/util/serialization/ast.hpp
+++ b/phylanx/util/serialization/ast.hpp
@@ -16,8 +16,12 @@ namespace phylanx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT std::vector<char> serialize(ir::node_data<double> const&);
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ir::node_data<double>&);
+
+    namespace detail
+    {
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ir::node_data<double>&);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT std::vector<char> serialize(ast::optoken);
@@ -28,20 +32,25 @@ namespace phylanx { namespace util
     PHYLANX_EXPORT std::vector<char> serialize(ast::operation const&);
     PHYLANX_EXPORT std::vector<char> serialize(ast::expression const&);
 
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ast::optoken&);
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ast::identifier&);
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ast::primary_expr&);
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ast::operand&);
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ast::unary_expr&);
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ast::operation&);
-    PHYLANX_EXPORT void unserialize(
-        std::vector<char> const&, ast::expression&);
+    namespace detail
+    {
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::optoken&);
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::identifier&);
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::primary_expr&);
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::operand&);
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::unary_expr&);
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::operation&);
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::expression&);
+    }
+
+    PHYLANX_EXPORT ast::expression unserialize(std::vector<char> const&);
 }}
 
 #endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,9 @@ add_phylanx_library_sources(phylanx
 add_phylanx_library_sources(phylanx
   GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/ast/*.cpp"
   APPEND)
+add_phylanx_library_sources(phylanx
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/util/*.cpp"
+  APPEND)
 
 add_phylanx_source_group(
   NAME phylanx

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,9 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 ################################################################################
+add_subdirectory(python)
+
+################################################################################
 set(phylanx_SOURCES "" CACHE INTERNAL "Sources for libphylanx." FORCE)
 if(MSVC)
   set(phylanx_HEADERS "" CACHE INTERNAL "Headers for libphylanx." FORCE)
@@ -63,7 +66,7 @@ set_target_properties(
     VERSION ${PHYLANX_VERSION}
     SOVERSION ${PHYLANX_SOVERSION}
     CLEAN_DIRECT_OUTPUT 1
-    OUTPUT_NAME phylanx
+    OUTPUT_NAME phylanx_core
     FOLDER "Core")
 
 set_property(TARGET phylanx APPEND

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (c) 2014-2017 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+find_package(pybind11 REQUIRED)
+phylanx_info("Python library version: " ${PYTHON_VERSION_STRING})
+phylanx_info("Pybind11 library version: " ${pybind11_VERSION})
+
+if(NOT PYTHONLIBS_FOUND)
+  phylanx_fatal(boo)
+endif()
+
+###############################################################################
+set(phylanx_py_SOURCES "" CACHE INTERNAL "Sources for libphylanx_py." FORCE)
+if(MSVC)
+  set(phylanx_py_HEADERS "" CACHE INTERNAL "Headers for libphylanx_py." FORCE)
+endif()
+
+add_phylanx_library_sources(phylanx_py
+  GLOB GLOBS "${PROJECT_SOURCE_DIR}/src/python/*.cpp")
+
+add_phylanx_source_group(
+  NAME phylanx_py
+  CLASS "Source Files"
+  ROOT "${PROJECT_SOURCE_DIR}/src/python"
+  TARGETS ${phylanx_SOURCES})
+
+if(MSVC)
+  # libphylanx_py headers
+  add_phylanx_library_headers(phylanx_py
+    GLOB GLOBS "${PROJECT_SOURCE_DIR}/phylanx/python/*.hpp")
+
+  add_phylanx_source_group(
+    NAME phylanx_py
+    CLASS "Header Files"
+    ROOT "${PROJECT_SOURCE_DIR}/phylanx/python"
+    TARGETS ${phylanx_HEADERS})
+endif()
+
+###############################################################################
+pybind11_add_module(phylanx_py ${phylanx_py_SOURCES} ${phylanx_py_HEADERS})
+
+include_directories(${pybind11_INCLUDE_DIR}})
+
+target_link_libraries(phylanx_py PRIVATE phylanx ${pybind11_LIBRARIES})
+target_compile_definitions(phylanx_py PRIVATE NOMINMAX)
+
+set_target_properties(
+  phylanx_py PROPERTIES
+    VERSION ${PHYLANX_VERSION}
+    SOVERSION ${PHYLANX_SOVERSION}
+    CLEAN_DIRECT_OUTPUT 1
+    OUTPUT_NAME phylanx
+    FOLDER "Core")
+
+set(phylanx_targets ${phylanx_targets} phylanx_py)
+

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -3,14 +3,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-find_package(pybind11 REQUIRED)
-phylanx_info("Python library version: " ${PYTHON_VERSION_STRING})
-phylanx_info("Pybind11 library version: " ${pybind11_VERSION})
-
-if(NOT PYTHONLIBS_FOUND)
-  phylanx_fatal(boo)
-endif()
-
 ###############################################################################
 set(phylanx_py_SOURCES "" CACHE INTERNAL "Sources for libphylanx_py." FORCE)
 if(MSVC)
@@ -53,6 +45,19 @@ set_target_properties(
     CLEAN_DIRECT_OUTPUT 1
     OUTPUT_NAME phylanx
     FOLDER "Core")
+
+if(MSVC)
+  set_target_properties(
+    phylanx_py PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/Release/bin"
+      LIBRARY_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/Debug/bin"
+      LIBRARY_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_BINARY_DIR}/MinSizeRel/bin"
+      LIBRARY_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}/RelWithDebInfo/bin")
+else()
+  set_target_properties(
+    phylanx_py PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+endif()
 
 set(phylanx_targets ${phylanx_targets} phylanx_py)
 

--- a/src/python/phylanx.cpp
+++ b/src/python/phylanx.cpp
@@ -4,7 +4,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
+
 #include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
 
 #include <hpx/util/detail/pp/stringize.hpp>
 
@@ -14,6 +17,110 @@
 #define PHYLANX_MODULE_NAME phylanx
 #endif
 
+// older versions of pybind11 don't support variant-like types
+#if !defined(PYBIND11_HAS_VARIANT)
+namespace pybind11 { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // Expose phylanx::util::variant -- can be any `std::variant`-like container
+
+    // Visit a variant and cast any found type to Python
+    struct variant_caster_visitor
+    {
+        return_value_policy policy;
+        handle parent;
+
+        using result_type = handle; // required by boost::variant in C++11
+
+        template <typename T>
+        result_type operator()(T &&src) const
+        {
+            return make_caster<T>::cast(std::forward<T>(src), policy, parent);
+        }
+    };
+
+    // Helper class which abstracts away variant's `visit` function.
+    // `std::variant` and similar `namespace::variant` types which provide a
+    // `namespace::visit()` function are handled here automatically using
+    // argument-dependent lookup. Users can provide specializations for other
+    // variant-like classes, e.g. `boost::variant` and `boost::apply_visitor`.
+    template <template<typename...> class Variant>
+    struct visit_helper
+    {
+        template <typename... Args>
+        static auto call(Args &&...args)
+        ->  decltype(visit(std::forward<Args>(args)...))
+        {
+            return visit(std::forward<Args>(args)...);
+        }
+    };
+
+    // Generic variant caster
+    template <typename Variant> struct variant_caster;
+
+    template <template <typename...> class V, typename... Ts>
+    struct variant_caster<V<Ts...>>
+    {
+        static_assert(sizeof...(Ts) > 0,
+            "Variant must consist of at least one alternative.");
+
+        template <typename U, typename... Us>
+        bool load_alternative(handle src, bool convert, type_list<U, Us...>)
+        {
+            auto caster = make_caster<U>();
+            if (caster.load(src, convert))
+            {
+                value = cast_op<U>(caster);
+                return true;
+            }
+            return load_alternative(src, convert, type_list<Us...>{});
+        }
+
+        bool load_alternative(handle, bool, type_list<>) { return false; }
+
+        bool load(handle src, bool convert)
+        {
+            // Do a first pass without conversions to improve constructor
+            // resolution.
+            // E.g. `py::int_(1).cast<variant<double, int>>()` needs to fill
+            // the `int` slot of the variant. Without two-pass loading `double`
+            // would be filled because it appears first and a conversion is
+            // possible.
+            if (convert && load_alternative(src, false, type_list<Ts...>{}))
+                return true;
+            return load_alternative(src, convert, type_list<Ts...>{});
+        }
+
+        template <typename Variant>
+        static handle cast(
+            Variant&& src, return_value_policy policy, handle parent)
+        {
+            return visit_helper<V>::call(
+                variant_caster_visitor{policy, parent},
+                std::forward<Variant>(src));
+        }
+
+        using Type = V<Ts...>;
+
+        PYBIND11_TYPE_CASTER(Type,
+            _("Union[") + detail::concat(make_caster<Ts>::name()...) + _("]"));
+    };
+
+    template <typename... Ts>
+    struct type_caster<phylanx::util::variant<Ts...>>
+      : variant_caster<phylanx::util::variant<Ts...>>
+    {
+    };
+
+    template <typename... Ts>
+    struct type_caster<phylanx::ast::parser::extended_variant<Ts...>>
+      : variant_caster<phylanx::ast::parser::extended_variant<Ts...>>
+    {
+    };
+}}
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 PYBIND11_PLUGIN(PHYLANX_MODULE_NAME)
 {
     pybind11::module m(
@@ -26,6 +133,134 @@ PYBIND11_PLUGIN(PHYLANX_MODULE_NAME)
     m.def("subminor_version", &phylanx::subminor_version);
     m.def("full_version", &phylanx::full_version);
     m.def("full_version_as_string", &phylanx::full_version_as_string);
+
+    // expose AST submodule
+    auto ast = m.def_submodule("ast");
+
+    pybind11::enum_<phylanx::ast::optoken>(
+            ast, "optoken", pybind11::arithmetic(),
+            "an enumerator type representing possible operations with operands")
+        .value("op_comma", phylanx::ast::optoken::op_comma)
+        .value("op_assign", phylanx::ast::optoken::op_assign)
+        .value("op_plus_assign", phylanx::ast::optoken::op_plus_assign)
+        .value("op_minus_assign", phylanx::ast::optoken::op_minus_assign)
+        .value("op_times_assign", phylanx::ast::optoken::op_times_assign)
+        .value("op_divide_assign", phylanx::ast::optoken::op_divide_assign)
+        .value("op_mod_assign", phylanx::ast::optoken::op_mod_assign)
+        .value("op_bit_and_assign", phylanx::ast::optoken::op_bit_and_assign)
+        .value("op_bit_xor_assign", phylanx::ast::optoken::op_bit_xor_assign)
+        .value("op_bitor_assign", phylanx::ast::optoken::op_bitor_assign)
+        .value("op_shift_left_assign", phylanx::ast::optoken::op_shift_left_assign)
+        .value("op_shift_right_assign", phylanx::ast::optoken::op_shift_right_assign)
+        .value("op_logical_or", phylanx::ast::optoken::op_logical_or)
+        .value("op_logical_and", phylanx::ast::optoken::op_logical_and)
+        .value("op_bit_or", phylanx::ast::optoken::op_bit_or)
+        .value("op_bit_xor", phylanx::ast::optoken::op_bit_xor)
+        .value("op_bit_and", phylanx::ast::optoken::op_bit_and)
+        .value("op_equal", phylanx::ast::optoken::op_equal)
+        .value("op_not_equal", phylanx::ast::optoken::op_not_equal)
+        .value("op_less", phylanx::ast::optoken::op_less)
+        .value("op_less_equal", phylanx::ast::optoken::op_less_equal)
+        .value("op_greater", phylanx::ast::optoken::op_greater)
+        .value("op_greater_equal", phylanx::ast::optoken::op_greater_equal)
+        .value("op_shift_left", phylanx::ast::optoken::op_shift_left)
+        .value("op_shift_right", phylanx::ast::optoken::op_shift_right)
+        .value("op_plus", phylanx::ast::optoken::op_plus)
+        .value("op_minus", phylanx::ast::optoken::op_minus)
+        .value("op_times", phylanx::ast::optoken::op_times)
+        .value("op_divide", phylanx::ast::optoken::op_divide)
+        .value("op_mod", phylanx::ast::optoken::op_mod)
+        .value("op_positive", phylanx::ast::optoken::op_positive)
+        .value("op_negative", phylanx::ast::optoken::op_negative)
+        .value("op_pre_incr", phylanx::ast::optoken::op_pre_incr)
+        .value("op_pre_decr", phylanx::ast::optoken::op_pre_decr)
+        .value("op_compl", phylanx::ast::optoken::op_compl)
+        .value("op_not", phylanx::ast::optoken::op_not)
+        .value("op_post_incr", phylanx::ast::optoken::op_post_incr)
+        .value("op_post_decr", phylanx::ast::optoken::op_post_decr);
+
+    // phylanx::ast::identifier
+    pybind11::class_<phylanx::ast::identifier>(
+            ast, "identifier", "AST node representing an identifier")
+        .def(pybind11::init<std::string const&>(),
+            "initialize identifier instance with a name")
+        .def_readonly("name", &phylanx::ast::identifier::name,
+            "the name of the identifier")
+        .def(pybind11::self == pybind11::self)
+        .def(pybind11::self != pybind11::self);
+
+    // phylanx::ast::primary_expr
+    pybind11::class_<phylanx::ast::primary_expr>(
+            ast, "primary_expr", "AST node representing a primary_expr")
+        .def(pybind11::init<bool>(),
+            "initialize primary_expr instance with a boolean value")
+        .def(pybind11::init<double>(),
+            "initialize primary_expr instance with a floating point value")
+        .def(pybind11::init<std::string const&>(),
+            "initialize primary_expr instance with an identifier name")
+        .def(pybind11::init<phylanx::ast::identifier>(),
+            "initialize primary_expr instance with an value")
+        .def(pybind11::init<phylanx::ast::expression>(),
+            "initialize primary_expr instance with an expression value")
+        .def_property_readonly("value", &phylanx::ast::primary_expr::value,
+            "access the current primary_expr's value")
+        .def(pybind11::self == pybind11::self)
+        .def(pybind11::self != pybind11::self);
+
+    // phylanx::ast::operand
+    pybind11::class_<phylanx::ast::operand>(
+            ast, "operand", "AST node representing an operand")
+        .def(pybind11::init<double>(),
+            "initialize operand instance with a floating point value")
+        .def(pybind11::init<std::string const&>(),
+            "initialize operand instance with a primary_expr (identifier) name")
+        .def(pybind11::init<phylanx::ast::primary_expr>(),
+            "initialize operand instance with a primary_expr value")
+        .def(pybind11::init<phylanx::ast::unary_expr>(),
+            "initialize operand instance with a unary_expr value")
+        .def_property_readonly("value", &phylanx::ast::operand::value,
+            "access the current operand's value")
+        .def(pybind11::self == pybind11::self)
+        .def(pybind11::self != pybind11::self);
+
+    // phylanx::ast::unary_expr
+    pybind11::class_<phylanx::ast::unary_expr>(
+            ast, "unary_expr", "AST node representing an unary_expr")
+        .def(pybind11::init<phylanx::ast::optoken, phylanx::ast::operand>(),
+            "initialize unary_expr instance with an operator and an operand")
+        .def_readonly("operator", &phylanx::ast::unary_expr::operator_,
+            "the operator of the unary_expr")
+        .def_readonly("operand", &phylanx::ast::unary_expr::operand_,
+            "the operand of the unary_expr")
+        .def(pybind11::self == pybind11::self)
+        .def(pybind11::self != pybind11::self);
+
+    // phylanx::ast::operation
+    pybind11::class_<phylanx::ast::operation>(
+            ast, "operation", "AST node representing an operation")
+        .def(pybind11::init<phylanx::ast::optoken, phylanx::ast::operand>(),
+            "initialize operation instance with an operator and an operand")
+        .def_readonly("operator", &phylanx::ast::operation::operator_,
+            "the operator of the operation")
+        .def_readonly("operand", &phylanx::ast::operation::operand_,
+            "the operand of the operation")
+        .def(pybind11::self == pybind11::self)
+        .def(pybind11::self != pybind11::self);
+
+    // phylanx::ast::expression
+    pybind11::class_<phylanx::ast::expression>(
+            ast, "expression", "AST node representing an expression")
+        .def(pybind11::init<phylanx::ast::operand>(),
+            "initialize operation instance with an operand")
+        .def_readonly("first", &phylanx::ast::expression::first,
+            "the first operand of the expression")
+        .def_readwrite("rest", &phylanx::ast::expression::rest,
+            "the (optional) list of operations of the expression")
+        .def(pybind11::self == pybind11::self)
+        .def(pybind11::self != pybind11::self);
+
+    ast.def("generate_ast", &phylanx::ast::generate_ast,
+        "generate an AST from the given expression string)");
 
     return m.ptr();
 }

--- a/src/python/phylanx.cpp
+++ b/src/python/phylanx.cpp
@@ -61,10 +61,30 @@ namespace phylanx { namespace bindings
     struct traverse_helper
     {
         template <typename Ast>
-        bool operator()(Ast const& ast) const
+        bool on_enter(Ast const& ast) const
         {
+            pybind11::dict d = func_.attr("__class__").attr("__dict__");
+            if (d.contains("on_enter"))
+            {
+                pybind11::object ret =
+                    d["on_enter"](func_, ast, *args_, **kwargs_);
+                return ret.cast<bool>();
+            }
             pybind11::object ret = func_(ast, *args_, **kwargs_);
             return ret.cast<bool>();
+        }
+
+        template <typename Ast>
+        bool on_exit(Ast const& ast) const
+        {
+            pybind11::dict d = func_.attr("__class__").attr("__dict__");
+            if (d.contains("on_exit"))
+            {
+                pybind11::object ret =
+                    d["on_exit"](func_, ast, *args_, **kwargs_);
+                return ret.cast<bool>();
+            }
+            return true;
         }
 
         pybind11::object& func_;

--- a/src/python/phylanx.cpp
+++ b/src/python/phylanx.cpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+#include <pybind11/pybind11.h>
+
+#include <hpx/util/detail/pp/stringize.hpp>
+
+#if defined(_DEBUG)
+#define PHYLANX_MODULE_NAME phylanxd
+#else
+#define PHYLANX_MODULE_NAME phylanx
+#endif
+
+PYBIND11_PLUGIN(PHYLANX_MODULE_NAME)
+{
+    pybind11::module m(
+        HPX_PP_STRINGIZE(PHYLANX_MODULE_NAME),
+        "Phylanx plugin module");
+
+    // expose version functions
+    m.def("major_version", &phylanx::major_version);
+    m.def("minor_version", &phylanx::minor_version);
+    m.def("subminor_version", &phylanx::subminor_version);
+    m.def("full_version", &phylanx::full_version);
+    m.def("full_version_as_string", &phylanx::full_version_as_string);
+
+    return m.ptr();
+}

--- a/src/python/phylanx.cpp
+++ b/src/python/phylanx.cpp
@@ -56,6 +56,8 @@ namespace pybind11 { namespace detail
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace bindings
 {
+    ///////////////////////////////////////////////////////////////////////////
+    // support for the traverse API
     struct traverse_helper
     {
         template <typename Ast>
@@ -77,18 +79,37 @@ namespace phylanx { namespace bindings
         return phylanx::ast::traverse(ast, traverse_helper{func, args, kwargs});
     }
 
+    // serialization support
     template <typename Ast>
     std::vector<char> serialize(Ast const& ast)
     {
         return phylanx::util::serialize(ast);
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    // support for __str__
     template <typename Ast>
     std::string as_string(Ast const& ast)
     {
         std::stringstream strm;
         strm << ast;
         return strm.str();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // pickle support
+    template <typename Ast>
+    std::vector<char> pickle_helper(Ast const& ast)
+    {
+        return phylanx::util::serialize(ast);
+    }
+
+    template <typename Ast>
+    Ast unpickle_helper(std::vector<char> data)
+    {
+        Ast ast;
+        phylanx::util::detail::unserialize(data, ast);
+        return ast;
     }
 }}
 
@@ -154,7 +175,10 @@ PYBIND11_MODULE(phylanx, m)
         .value("op_not", phylanx::ast::optoken::op_not)
         .value("op_post_incr", phylanx::ast::optoken::op_post_incr)
         .value("op_post_decr", phylanx::ast::optoken::op_post_decr)
-        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::optoken>);
+        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::optoken>)
+        .def(pybind11::pickle(
+            &phylanx::bindings::pickle_helper<phylanx::ast::optoken>,
+            &phylanx::bindings::unpickle_helper<phylanx::ast::optoken>));
 
     // phylanx::ast::identifier
     pybind11::class_<phylanx::ast::identifier>(
@@ -165,7 +189,10 @@ PYBIND11_MODULE(phylanx, m)
             "the name of the identifier")
         .def(pybind11::self == pybind11::self)
         .def(pybind11::self != pybind11::self)
-        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::identifier>);
+        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::identifier>)
+        .def(pybind11::pickle(
+            &phylanx::bindings::pickle_helper<phylanx::ast::identifier>,
+            &phylanx::bindings::unpickle_helper<phylanx::ast::identifier>));
 
     // phylanx::ast::primary_expr
     pybind11::class_<phylanx::ast::primary_expr>(
@@ -189,7 +216,10 @@ PYBIND11_MODULE(phylanx, m)
             "access the current primary_expr's value")
         .def(pybind11::self == pybind11::self)
         .def(pybind11::self != pybind11::self)
-        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::primary_expr>);
+        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::primary_expr>)
+        .def(pybind11::pickle(
+            &phylanx::bindings::pickle_helper<phylanx::ast::primary_expr>,
+            &phylanx::bindings::unpickle_helper<phylanx::ast::primary_expr>));
 
     // phylanx::ast::operand
     pybind11::class_<phylanx::ast::operand>(
@@ -211,7 +241,10 @@ PYBIND11_MODULE(phylanx, m)
             "access the current operand's value")
         .def(pybind11::self == pybind11::self)
         .def(pybind11::self != pybind11::self)
-        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::operand>);
+        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::operand>)
+        .def(pybind11::pickle(
+            &phylanx::bindings::pickle_helper<phylanx::ast::operand>,
+            &phylanx::bindings::unpickle_helper<phylanx::ast::operand>));
 
     // phylanx::ast::unary_expr
     pybind11::class_<phylanx::ast::unary_expr>(
@@ -224,7 +257,10 @@ PYBIND11_MODULE(phylanx, m)
             "the operand of the unary_expr")
         .def(pybind11::self == pybind11::self)
         .def(pybind11::self != pybind11::self)
-        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::unary_expr>);
+        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::unary_expr>)
+        .def(pybind11::pickle(
+            &phylanx::bindings::pickle_helper<phylanx::ast::unary_expr>,
+            &phylanx::bindings::unpickle_helper<phylanx::ast::unary_expr>));
 
     // phylanx::ast::operation
     pybind11::class_<phylanx::ast::operation>(
@@ -237,7 +273,10 @@ PYBIND11_MODULE(phylanx, m)
             "the operand of the operation")
         .def(pybind11::self == pybind11::self)
         .def(pybind11::self != pybind11::self)
-        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::operation>);
+        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::operation>)
+        .def(pybind11::pickle(
+            &phylanx::bindings::pickle_helper<phylanx::ast::operation>,
+            &phylanx::bindings::unpickle_helper<phylanx::ast::operation>));
 
     // phylanx::ast::expression
     pybind11::class_<phylanx::ast::expression>(
@@ -250,7 +289,10 @@ PYBIND11_MODULE(phylanx, m)
             "the (optional) list of operations of the expression")
         .def(pybind11::self == pybind11::self)
         .def(pybind11::self != pybind11::self)
-        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::expression>);
+        .def("__str__", &phylanx::bindings::as_string<phylanx::ast::expression>)
+        .def(pybind11::pickle(
+            &phylanx::bindings::pickle_helper<phylanx::ast::expression>,
+            &phylanx::bindings::unpickle_helper<phylanx::ast::expression>));
 
     // phylanx::ast::generate_ast()
     ast.def("generate_ast", &phylanx::ast::generate_ast,

--- a/src/util/serialization/ast.cpp
+++ b/src/util/serialization/ast.cpp
@@ -39,7 +39,7 @@ namespace phylanx { namespace util
         return detail::serialize(ast);
     }
 
-    std::vector<char> serialize(ast::optoken const& ast)
+    std::vector<char> serialize(ast::optoken ast)
     {
         return detail::serialize(ast);
     }
@@ -78,54 +78,60 @@ namespace phylanx { namespace util
     namespace detail
     {
         template <typename Ast>
-        void unserialize(std::vector<char> const& input, Ast& ast)
+        void unserialize_helper(std::vector<char> const& input, Ast& ast)
         {
             hpx::serialization::input_archive archive(input, input.size());
             archive >> ast;
         }
+
+        void unserialize(
+            std::vector<char> const& input, ir::node_data<double>& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::optoken& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::identifier& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::primary_expr& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::operand& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::unary_expr& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::operation& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::expression& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
     }
 
-    void unserialize(
-        std::vector<char> const& input, ir::node_data<double>& ast)
+    ast::expression unserialize(std::vector<char> const& input)
     {
-        detail::unserialize(input, ast);
+        ast::expression expr;
+        detail::unserialize_helper(input, expr);
+        return expr;
     }
-
-    void unserialize(std::vector<char> const& input, ast::optoken& ast)
-    {
-        detail::unserialize(input, ast);
-    }
-
-    void unserialize(std::vector<char> const& input, ast::identifier& ast)
-    {
-        detail::unserialize(input, ast);
-    }
-
-    void unserialize(std::vector<char> const& input, ast::primary_expr& ast)
-    {
-        detail::unserialize(input, ast);
-    }
-
-    void unserialize(std::vector<char> const& input, ast::operand& ast)
-    {
-        detail::unserialize(input, ast);
-    }
-
-    void unserialize(std::vector<char> const& input, ast::unary_expr& ast)
-    {
-        detail::unserialize(input, ast);
-    }
-
-    void unserialize(std::vector<char> const& input, ast::operation& ast)
-    {
-        detail::unserialize(input, ast);
-    }
-
-    void unserialize(std::vector<char> const& input, ast::expression& ast)
-    {
-        detail::unserialize(input, ast);
-    }
-
 }}
 
 

--- a/src/util/serialization/ast.cpp
+++ b/src/util/serialization/ast.cpp
@@ -1,0 +1,131 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/util/serialization/ast.hpp>
+
+#include <hpx/include/serialization.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace phylanx { namespace util
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Ast>
+        std::vector<char> serialize(Ast const& input)
+        {
+            std::vector<char> data;
+            std::size_t archive_size = 0;
+
+            {
+                hpx::serialization::output_archive archive(data);
+                archive << input;
+                archive_size = archive.bytes_written();
+            }
+
+            data.resize(archive_size);
+            return data;
+        }
+    }
+
+    std::vector<char> serialize(ir::node_data<double> const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::optoken const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::identifier const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::primary_expr const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::operand const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::unary_expr const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::operation const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::expression const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename Ast>
+        void unserialize(std::vector<char> const& input, Ast& ast)
+        {
+            hpx::serialization::input_archive archive(input, input.size());
+            archive >> ast;
+        }
+    }
+
+    void unserialize(
+        std::vector<char> const& input, ir::node_data<double>& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+    void unserialize(std::vector<char> const& input, ast::optoken& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+    void unserialize(std::vector<char> const& input, ast::identifier& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+    void unserialize(std::vector<char> const& input, ast::primary_expr& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+    void unserialize(std::vector<char> const& input, ast::operand& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+    void unserialize(std::vector<char> const& input, ast::unary_expr& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+    void unserialize(std::vector<char> const& input, ast::operation& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+    void unserialize(std::vector<char> const& input, ast::expression& ast)
+    {
+        detail::unserialize(input, ast);
+    }
+
+}}
+
+

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -37,11 +37,11 @@ namespace phylanx
 
     std::string full_version_as_string()
     {
-        std::string result(HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_VERSION_MAJOR)));
+        std::string result(HPX_PP_STRINGIZE(HPX_PP_EXPAND(PHYLANX_VERSION_MAJOR)));
         result += ".";
-        result += HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_VERSION_MINOR));
+        result += HPX_PP_STRINGIZE(HPX_PP_EXPAND(PHYLANX_VERSION_MINOR));
         result += ".";
-        result += HPX_PP_STRINGIZE(HPX_PP_EXPAND(HPX_VERSION_SUBMINOR));
+        result += HPX_PP_STRINGIZE(HPX_PP_EXPAND(PHYLANX_VERSION_SUBMINOR));
         return result;
     }
 

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -19,7 +19,7 @@ void test_serialization(Ast const& in)
     Ast out;
 
     std::vector<char> buffer = phylanx::util::serialize(in);
-    phylanx::util::unserialize(buffer, out);
+    phylanx::util::detail::unserialize(buffer, out);
 
     HPX_TEST(in == out);
 }

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -6,7 +6,6 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/serialization.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <vector>
@@ -17,23 +16,10 @@
 template <typename Ast>
 void test_serialization(Ast const& in)
 {
-    std::vector<char> out_buffer;
-    std::size_t archive_size = 0;
-
-    {
-        hpx::serialization::output_archive archive(out_buffer);
-        archive << in;
-        archive_size = archive.bytes_written();
-    }
-
     Ast out;
 
-    {
-        hpx::serialization::input_archive archive(
-            out_buffer, archive_size);
-
-        archive >> out;
-    }
+    std::vector<char> buffer = phylanx::util::serialize(in);
+    phylanx::util::unserialize(buffer, out);
 
     HPX_TEST(in == out);
 }

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -12,23 +12,10 @@
 
 void test_serialization(phylanx::ir::node_data<double> const& array_value1)
 {
-    std::vector<char> out_buffer;
-    std::size_t archive_size = 0;
-
-    {
-        hpx::serialization::output_archive archive(out_buffer);
-        archive << array_value1;
-        archive_size = archive.bytes_written();
-    }
-
     phylanx::ir::node_data<double> array_value2;
 
-    {
-        hpx::serialization::input_archive archive(
-            out_buffer, archive_size);
-
-        archive >> array_value2;
-    }
+    std::vector<char> buffer = phylanx::util::serialize(array_value1);
+    phylanx::util::unserialize(buffer, array_value2);
 
     HPX_TEST(array_value1 == array_value2);
 }

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -15,7 +15,7 @@ void test_serialization(phylanx::ir::node_data<double> const& array_value1)
     phylanx::ir::node_data<double> array_value2;
 
     std::vector<char> buffer = phylanx::util::serialize(array_value1);
-    phylanx::util::unserialize(buffer, array_value2);
+    phylanx::util::detail::unserialize(buffer, array_value2);
 
     HPX_TEST(array_value1 == array_value2);
 }

--- a/tests/unit/py/ast/generate_ast.py
+++ b/tests/unit/py/ast/generate_ast.py
@@ -1,0 +1,62 @@
+#  Copyright (c) 2017 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+try:
+    # first try release version
+    import phylanx
+except Exception:
+    # then try debug version
+    import phylanxd as phylanx
+
+###############################################################################
+class traverse_ast:
+    def __init__(self):
+        self.result = ''
+
+    def __call__(self, ast, delimiter = ''):
+        self.result += str(ast) + delimiter
+        return True
+
+def test_expression(expr, expected, delimier):
+    ast = phylanx.ast.generate_ast(expr)
+    visitor = traverse_ast()
+    phylanx.ast.traverse(ast, visitor, delimier)
+    assert(visitor.result == expected)
+
+
+###############################################################################
+test_expression(
+    'A + B',
+    'expression\n' +
+        'operand\n' +
+            'primary_expr\n' +
+                'identifier: A\n' +
+        'operation\n' +
+            'op_plus\n' +
+        'operand\n' +
+            'primary_expr\n' +
+                'identifier: B\n',
+    '\n')
+
+test_expression(
+    'A + B + -C',
+    'expression\n' +
+        'operand\n' +
+            'primary_expr\n' +
+                'identifier: A\n' +
+        'operation\n' +
+            'op_plus\n' +
+        'operand\n' +
+            'primary_expr\n' +
+                'identifier: B\n' +
+        'operation\n' +
+            'op_plus\n' +
+        'operand\n' +
+            'unary_expr\n' +
+                'op_negative\n' +
+                'operand\n' +
+                    'primary_expr\n' +
+                        'identifier: C\n',
+    '\n')

--- a/tests/unit/py/ast/generate_ast.py
+++ b/tests/unit/py/ast/generate_ast.py
@@ -19,9 +19,26 @@ class traverse_ast:
         self.result += str(ast) + delimiter
         return True
 
+class traverse_ast_enter_exit:
+    def __init__(self):
+        self.result = ''
+
+    def on_enter(self, ast, delimiter = ''):
+        self.result += str(ast) + delimiter
+        return True
+
+    # optional, can be ommitted
+    def on_exit(self, ast, *args):
+        return True
+
 def test_expression(expr, expected, delimier):
     ast = phylanx.ast.generate_ast(expr)
+
     visitor = traverse_ast()
+    phylanx.ast.traverse(ast, visitor, delimier)
+    assert(visitor.result == expected)
+
+    visitor = traverse_ast_enter_exit()
     phylanx.ast.traverse(ast, visitor, delimier)
     assert(visitor.result == expected)
 

--- a/tests/unit/py/ast/node.py
+++ b/tests/unit/py/ast/node.py
@@ -4,11 +4,21 @@
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 try:
+    # first try release version
     import phylanx
     import phylanx.ast as ast
+    import phylanx.util as util
 except Exception:
+    # then try debug version
     import phylanxd as phylanx
     import phylanxd.ast as ast
+    import phylanxd.util as util
+
+###############################################################################
+def test_serialization(in_ast):
+    data = util.serialize(in_ast)
+    out_ast = util.unserialize(data)
+    assert(in_ast == out_ast)
 
 ###############################################################################
 def test_identifier():
@@ -35,9 +45,59 @@ def test_operand():
     pe1 = ast.primary_expr(True)
     op1 = ast.operand(pe1)
     assert(op1.value == pe1)
+    assert(op1.value.value == True)
+
+    id2 = ast.identifier('ident')
+    pe2 = ast.primary_expr(id2)
+    op2 = ast.operand(pe2)
+    assert(op2.value == pe2)
+    assert(op2.value.value.name == 'ident')
+
+def test_unary_expr():
+    pe1 = ast.primary_expr(True)
+    op1 = ast.operand(pe1)
+    ue1 = ast.unary_expr(ast.optoken.op_not, op1)
+    assert(ue1.operator == ast.optoken.op_not)
+    assert(ue1.operand == op1)
+
+    id2 = ast.identifier('ident')
+    pe2 = ast.primary_expr(id2)
+    op2 = ast.operand(pe2)
+    ue2 = ast.unary_expr(ast.optoken.op_negative, op2)
+    assert(ue2.operator == ast.optoken.op_negative)
+    assert(ue2.operand == op2)
+
+def test_operation():
+    pe1 = ast.primary_expr(True)
+    op1 = ast.operand(pe1)
+    op2 = ast.operation(ast.optoken.op_plus, op1)
+    assert(op2.operator == ast.optoken.op_plus)
+    assert(op2.operand == op1)
+
+    id2 = ast.identifier('ident')
+    pe2 = ast.primary_expr(id2)
+    op3 = ast.operand(pe2)
+    op4 = ast.unary_expr(ast.optoken.op_minus, op3)
+    assert(op4.operator == ast.optoken.op_minus)
+    assert(op4.operand == op3)
+
+def test_expression():
+    pe1 = ast.primary_expr(True)
+    op1 = ast.operand(pe1)
+    e1 = ast.expression(op1);
+
+    op2 = ast.operation(ast.optoken.op_plus, op1);
+    e1.rest.append(op2);
+    test_serialization(e1)
+
+    e1.rest.append([op2, op2]);
+    test_serialization(e1)
 
 ###############################################################################
 test_identifier()
 test_primary_expr()
 test_operand()
+test_unary_expr()
+test_operation()
+test_expression()
 

--- a/tests/unit/py/ast/node.py
+++ b/tests/unit/py/ast/node.py
@@ -1,0 +1,43 @@
+#  Copyright (c) 2017 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+try:
+    import phylanx
+    import phylanx.ast as ast
+except Exception:
+    import phylanxd as phylanx
+    import phylanxd.ast as ast
+
+###############################################################################
+def test_identifier():
+    ident1 = ast.identifier('ident1')
+    assert(ident1.name == 'ident1')
+
+    ident2 = ast.identifier('ident1')
+    assert(ident2.name == 'ident1')
+    assert(ident1 == ident2)
+
+    ident3 = ast.identifier('ident3')
+    assert(ident3.name == 'ident3')
+    assert(ident1 != ident3)
+
+def test_primary_expr():
+    pe1 = ast.primary_expr(False)
+    assert(pe1.value == False)
+
+    ident1 = ast.identifier('ident1')
+    pe2 = ast.primary_expr(ident1)
+    assert(pe2.value == ident1)
+
+def test_operand():
+    pe1 = ast.primary_expr(True)
+    op1 = ast.operand(pe1)
+    assert(op1.value == pe1)
+
+###############################################################################
+test_identifier()
+test_primary_expr()
+test_operand()
+

--- a/tests/unit/py/ast/node.py
+++ b/tests/unit/py/ast/node.py
@@ -20,6 +20,11 @@ def test_serialization(in_ast):
     out_ast = util.unserialize(data)
     assert(in_ast == out_ast)
 
+    import pickle
+    pickled_data = pickle.dumps(in_ast, pickle.DEFAULT_PROTOCOL)
+    out_ast = pickle.loads(pickled_data)
+    assert(in_ast == out_ast)
+
 ###############################################################################
 def test_identifier():
     ident1 = ast.identifier('ident1')

--- a/tests/unit/py/version.py
+++ b/tests/unit/py/version.py
@@ -1,0 +1,14 @@
+#  Copyright (c) 2017 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+try:
+    import phylanx
+except Exception:
+    import phylanxd as phylanx
+
+assert(phylanx.major_version() == 0)
+assert(phylanx.minor_version() == 0)
+assert(phylanx.subminor_version() == 1)
+assert(phylanx.full_version_as_string() == '0.0.1')

--- a/tests/unit/py/version.py
+++ b/tests/unit/py/version.py
@@ -4,8 +4,10 @@
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 try:
+    # first try release version
     import phylanx
 except Exception:
+    # then try debug version
     import phylanxd as phylanx
 
 assert(phylanx.major_version() == 0)


### PR DESCRIPTION
This adds the beginnings of python bindings for the functionalities in the phylanx core C++ library.

- this renames the main module into phylanx_core to avoid name clashes with the Python bindings