### PR TITLE
Adding file_read and file_write primitives

### DIFF
--- a/phylanx/ast/detail/is_literal_value.hpp
+++ b/phylanx/ast/detail/is_literal_value.hpp
@@ -1,0 +1,104 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_AST_DETAIL_IS_LITERAL_VALUE_HPP)
+#define PHYLANX_AST_DETAIL_IS_LITERAL_VALUE_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <string>
+
+namespace phylanx { namespace ast { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Ast>
+    bool is_literal_value(Ast const&)
+    {
+        return false;
+    }
+
+    template <typename Ast>
+    literal_value_type literal_value(Ast const&)
+    {
+        return nil{};
+    }
+
+    inline bool is_literal_value(identifier const& id);
+    inline literal_value_type literal_value(identifier const& id);
+
+    PHYLANX_EXPORT bool is_literal_value(primary_expr const& pe);
+    PHYLANX_EXPORT literal_value_type literal_value(primary_expr const& pe);
+
+    PHYLANX_EXPORT bool is_literal_value(operand const& op);
+    PHYLANX_EXPORT literal_value_type literal_value(operand const& op);
+
+    inline bool is_literal_value(unary_expr const& ue);
+    inline literal_value_type literal_value(unary_expr const& ue);
+
+    inline bool is_literal_value(operation const& op);
+    inline literal_value_type literal_value(operation const& op);
+
+    inline bool is_literal_value(expression const& expr);
+    inline literal_value_type literal_value(expression const& expr);
+
+    template <typename Ast>
+    bool is_literal_value(util::recursive_wrapper<Ast> const& ast)
+    {
+        return is_literal_value(ast.get());
+    }
+
+    template <typename Ast>
+    literal_value_type literal_value(util::recursive_wrapper<Ast> const& ast)
+    {
+        return literal_value(ast.get());
+    }
+
+    inline bool is_literal_value(unary_expr const& ue)
+    {
+        return is_literal_value(ue.operand_);
+    }
+
+    inline literal_value_type literal_value(unary_expr const& ue)
+    {
+        return literal_value(ue.operand_);
+    }
+
+    inline bool is_literal_value(operation const& op)
+    {
+        return is_literal_value(op.operand_);
+    }
+
+    inline literal_value_type literal_value(operation const& op)
+    {
+        return literal_value(op.operand_);
+    }
+
+    inline bool is_literal_value(expression const& expr)
+    {
+        if (!expr.rest.empty())
+        {
+            return false;
+        }
+        return is_literal_value(expr.first);
+    }
+
+    inline literal_value_type literal_value(expression const& expr)
+    {
+        if (!expr.rest.empty())
+        {
+            return "";
+        }
+        return literal_value(expr.first);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    PHYLANX_EXPORT ir::node_data<double> literal_value(
+        literal_value_type const&);
+}}}
+
+#endif
+

--- a/phylanx/ast/match_ast.hpp
+++ b/phylanx/ast/match_ast.hpp
@@ -265,9 +265,9 @@ namespace phylanx { namespace ast
             std::list<operation>::const_iterator end)
         {
             // primary expression refers to an expression itself
-            if (pe.index() == 4)
+            if (pe.index() == 6)
             {
-                return extract_subexpression(util::get<4>(pe.get()).get(),
+                return extract_subexpression(util::get<6>(pe.get()).get(),
                     prec, it, end);
             }
 
@@ -311,8 +311,8 @@ namespace phylanx { namespace ast
 
         inline bool is_expression(primary_expr const& pe)
         {
-            return pe.index() == 4 &&
-                is_expression(util::get<4>(pe.get()).get());
+            return pe.index() == 6 &&
+                is_expression(util::get<6>(pe.get()).get());
         }
 
         inline bool is_expression(operand const& op)
@@ -332,8 +332,8 @@ namespace phylanx { namespace ast
 
         inline expression const& extract_expression(primary_expr const& pe)
         {
-            HPX_ASSERT(pe.index() == 4);
-            return extract_expression(util::get<4>(pe.get()).get());
+            HPX_ASSERT(pe.index() == 6);
+            return extract_expression(util::get<6>(pe.get()).get());
         }
 
         inline expression const& extract_expression(operand const& op)

--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -182,9 +182,25 @@ namespace phylanx { namespace ast
           , bool
           , phylanx::ir::node_data<double>
           , identifier
+          , std::string
+          , std::int64_t
           , phylanx::util::recursive_wrapper<expression>
           , phylanx::util::recursive_wrapper<function_call>
         >;
+
+    using literal_value_type = phylanx::util::variant<
+            nil
+          , bool
+          , std::int64_t
+          , std::string
+          , phylanx::ir::node_data<double>
+        >;
+
+    // a literal value is valid of its not nil{}
+    inline bool valid(literal_value_type const& val)
+    {
+        return val.index() != 0;
+    }
 
     struct primary_expr : tagged, expr_node_type
     {
@@ -205,6 +221,24 @@ namespace phylanx { namespace ast
         {
         }
 
+        primary_expr(std::uint64_t val)
+          : expr_node_type(std::int64_t(val))
+        {
+        }
+        primary_expr(std::int64_t val)
+          : expr_node_type(val)
+        {
+        }
+
+        primary_expr(std::string const& val)
+          : expr_node_type(val)
+        {
+        }
+        primary_expr(std::string && val)
+          : expr_node_type(std::move(val))
+        {
+        }
+
         primary_expr(phylanx::ir::node_data<double> const& val)
           : expr_node_type(val)
         {
@@ -220,14 +254,6 @@ namespace phylanx { namespace ast
         }
         primary_expr(identifier && val)
           : expr_node_type(std::move(val))
-        {
-        }
-        primary_expr(std::string const& val)
-          : expr_node_type(identifier(val))
-        {
-        }
-        primary_expr(std::string && val)
-          : expr_node_type(identifier(std::move(val)))
         {
         }
 
@@ -269,19 +295,34 @@ namespace phylanx { namespace ast
     {
         operand() = default;
 
-        explicit operand(double val)
+        operand(bool const val)
           : operand_node_type(
                 phylanx::util::recursive_wrapper<primary_expr>(val))
         {
         }
-        explicit operand(std::string const& val)
+        operand(double const val)
           : operand_node_type(
                 phylanx::util::recursive_wrapper<primary_expr>(val))
         {
         }
-        explicit operand(std::string && val)
+        operand(std::string const& val)
+          : operand_node_type(
+                phylanx::util::recursive_wrapper<primary_expr>(val))
+        {
+        }
+        operand(std::string && val)
           : operand_node_type(
                 phylanx::util::recursive_wrapper<primary_expr>(std::move(val)))
+        {
+        }
+        operand(std::int64_t const val)
+          : operand_node_type(
+                phylanx::util::recursive_wrapper<primary_expr>(val))
+        {
+        }
+        operand(std::uint64_t const val)
+          : operand_node_type(
+                phylanx::util::recursive_wrapper<primary_expr>(val))
         {
         }
 
@@ -401,10 +442,10 @@ namespace phylanx { namespace ast
         {}
 
         explicit expression(identifier const& id)
-          : first(operand(id.name))
+          : first(operand(id))
         {}
         explicit expression(identifier && id)
-          : first(operand(std::move(id.name)))
+          : first(operand(std::move(id)))
         {}
 
         explicit expression(primary_expr const& pe)

--- a/phylanx/ast/parser/expression.hpp
+++ b/phylanx/ast/parser/expression.hpp
@@ -49,6 +49,7 @@ namespace phylanx { namespace ast { namespace parser
             argument_list;
 
         qi::rule<Iterator, std::string(), skipper<Iterator>> identifier;
+        qi::rule<Iterator, std::string(), skipper<Iterator>> string;
 
         qi::symbols<char, ast::optoken> unary_op;
         qi::symbols<char, ast::optoken> binary_op;

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -40,6 +40,7 @@ namespace phylanx { namespace ast { namespace parser
         qi::alpha_type alpha;
         qi::alnum_type alnum;
         qi::bool_type bool_;
+        qi::uint_parser<std::uint64_t> ulong_long;
 
         using qi::on_error;
         using qi::on_success;
@@ -100,8 +101,10 @@ namespace phylanx { namespace ast { namespace parser
         primary_expr =
                 double_
             |   function_call
-            |   identifier
+            |   as<ast::identifier>()[identifier]
             |   bool_
+            |   ulong_long
+            |   string
             |   '(' > expr > ')'
             ;
 
@@ -116,6 +119,9 @@ namespace phylanx { namespace ast { namespace parser
         identifier =
                 !lexeme[keywords >> !(alnum | '_')]
             >>  raw[lexeme[(alpha | '_') >> *(alnum | '_')]]
+            ;
+
+        string = '"' > raw[lexeme[+(char_ - '"')]] > '"'
             ;
 
         ///////////////////////////////////////////////////////////////////////

--- a/phylanx/ast/parser/extended_variant.hpp
+++ b/phylanx/ast/parser/extended_variant.hpp
@@ -38,16 +38,16 @@ namespace phylanx { namespace ast { namespace parser
 
         template <typename F>
         auto apply_visitor(F && v) -> decltype(
-            util::visit(std::declval<variant_type>(), std::forward<F>(v)))
+            util::visit(std::forward<F>(v), std::declval<variant_type>()))
         {
-            return util::visit(var, std::forward<F>(v));
+            return util::visit(std::forward<F>(v), var);
         }
 
         template <typename F>
         auto apply_visitor(F && v) const -> decltype(
-            util::visit(std::declval<variant_type>(), std::forward<F>(v)))
+            util::visit(std::forward<F>(v), std::declval<variant_type>()))
         {
-            return util::visit(var, std::forward<F>(v));
+            return util::visit(std::forward<F>(v), var);
         }
 
         variant_type const& get() const

--- a/phylanx/ast/traverse.hpp
+++ b/phylanx/ast/traverse.hpp
@@ -124,6 +124,28 @@ namespace phylanx { namespace ast
             b, std::forward<F>(f), ts...);
     }
 
+    template <typename F, typename ... Ts>
+    bool traverse(std::string const& str, F && f, Ts const&... ts)
+    {
+        return detail::on_visit(
+            [](std::string const& str, F && f, Ts const&... ts)
+            {
+                detail::on_enter::call(f, str, ts...);
+            },
+            str, std::forward<F>(f), ts...);
+    }
+
+    template <typename F, typename ... Ts>
+    bool traverse(std::int64_t val, F && f, Ts const&... ts)
+    {
+        return detail::on_visit(
+            [](std::int64_t val, F && f, Ts const&... ts)
+            {
+                detail::on_enter::call(f, val, ts...);
+            },
+            val, std::forward<F>(f), ts...);
+    }
+
     template <typename F, typename... Ts>
     bool traverse(
         phylanx::ir::node_data<double> const& data, F&& f, Ts const&... ts)

--- a/phylanx/execution_tree/primitives/add_operation.hpp
+++ b/phylanx/execution_tree/primitives/add_operation.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_PRIMITIVES_ADD_OPERATION_SEP_05_2017_1202PM
 
 #include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 
@@ -27,8 +28,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     public:
         add_operation() = default;
 
-        add_operation(std::vector<primitive> && operands);
-        add_operation(std::vector<primitive> const& operands);
+        add_operation(std::vector<ast::literal_value_type>&& literals,
+            std::vector<primitive>&& operands);
 
         hpx::future<ir::node_data<double>> eval() const override;
 
@@ -41,6 +42,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ir::node_data<double> add2d2d(operands_type const& ops) const;
 
     private:
+        std::vector<ast::literal_value_type> literals_;
         std::vector<primitive> operands_;
     };
 }}}

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_PRIMITIVES_BASE_PRIMITIVE_SEP_05_2017_1102AM
 
 #include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
 
 #include <hpx/include/components.hpp>
@@ -76,14 +77,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // Factory functions
     using factory_function_type =
-        hpx::util::function_nonser<primitive(
-            hpx::id_type, std::vector<primitive>&&)>;
+        hpx::util::function_nonser<primitive(hpx::id_type,
+            std::vector<ast::literal_value_type>&&, std::vector<primitive>&&)>;
 
     template <typename Primitive>
-    primitive create(
-        hpx::id_type locality, std::vector<primitive>&& operands)
+    primitive create(hpx::id_type locality,
+        std::vector<ast::literal_value_type>&& literals,
+        std::vector<primitive>&& operands)
     {
-        return primitive(hpx::new_<Primitive>(locality, std::move(operands)));
+        return primitive(hpx::new_<Primitive>(
+            locality, std::move(literals), std::move(operands)));
     }
 }}}
 

--- a/phylanx/execution_tree/primitives/file_read.hpp
+++ b/phylanx/execution_tree/primitives/file_read.hpp
@@ -1,0 +1,42 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_FILE_READ_SEP_17_2017_1016AM)
+#define PHYLANX_PRIMITIVES_FILE_READ_SEP_17_2017_1016AM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <array>
+#include <fstream>
+#include <utility>
+#include <string>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT file_read
+      : public base_primitive
+      , public hpx::components::component_base<file_read>
+    {
+    public:
+        file_read() = default;
+
+        file_read(std::vector<ast::literal_value_type>&& literals,
+            std::vector<primitive>&& operands);
+
+        hpx::future<ir::node_data<double>> eval() const override;
+
+    private:
+        std::string filename_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/file_write.hpp
+++ b/phylanx/execution_tree/primitives/file_write.hpp
@@ -1,0 +1,44 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_FILE_WRITE_SEP_17_2017_0111PM)
+#define PHYLANX_PRIMITIVES_FILE_WRITE_SEP_17_2017_0111PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <array>
+#include <fstream>
+#include <utility>
+#include <string>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT file_write
+      : public base_primitive
+      , public hpx::components::component_base<file_write>
+    {
+    public:
+        file_write() = default;
+
+        file_write(std::vector<ast::literal_value_type>&& literals,
+            std::vector<primitive>&& operands);
+
+        hpx::future<ir::node_data<double>> eval() const override;
+
+    private:
+        std::string filename_;
+        std::vector<ast::literal_value_type> literals_;
+        std::vector<primitive> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/include/primitives.hpp
+++ b/phylanx/include/primitives.hpp
@@ -8,6 +8,8 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
+#include <phylanx/execution_tree/primitives/file_read.hpp>
+#include <phylanx/execution_tree/primitives/file_write.hpp>
 #include <phylanx/execution_tree/primitives/literal_value.hpp>
 
 #endif

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_IR_NODE_DATA_AUG_26_2017_0924AM
 
 #include <phylanx/config.hpp>
+#include <phylanx/util/serialization/eigen.hpp>
 
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/util.hpp>
@@ -91,423 +92,22 @@ namespace phylanx { namespace ir
             T const* p_;
         };
 
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T> class node_data_storage_base;
-
-        template <typename T>
-        void intrusive_ptr_add_ref(node_data_storage_base<T>* p);
-        template <typename T>
-        void intrusive_ptr_release(node_data_storage_base<T>* p);
-
-        template <typename T>
-        class node_data_storage_base
-        {
-        public:
-            constexpr static std::size_t const max_dimensions = 2;
-
-            using dimensions_type = std::array<std::ptrdiff_t, max_dimensions>;
-
-        public:
-            constexpr node_data_storage_base(std::size_t num_dims,
-                    dimensions_type const& dims = {0, 0})
-              : num_dimensions_(num_dims)
-              , dimensions_(dims)
-              , count_(0)
-            {
-            }
-            virtual ~node_data_storage_base() = default;
-
-            constexpr std::size_t num_dimensions() const
-            {
-                return num_dimensions_;
-            }
-            constexpr std::size_t dimension(std::size_t dim) const
-            {
-                return dimensions_[dim];
-            }
-            constexpr dimensions_type const& dimensions() const
-            {
-                return dimensions_;
-            }
-
-            void set_dimensions(dimensions_type const& dims)
-            {
-                dimensions_ = dims;
-            }
-
-            virtual T const& operator[](std::ptrdiff_t index) const = 0;
-            virtual T const& operator[](dimensions_type const& indicies) const = 0;
-
-            using iterator = node_data_iterator<T>;
-
-            virtual iterator begin() const = 0;
-            virtual iterator end() const = 0;
-
-            virtual T const* data() const = 0;
-            virtual std::size_t size() const = 0;
-
-        private:
-            friend class hpx::serialization::access;
-
-            template <typename Archive>
-            void serialize(Archive& ar, unsigned)
-            {
-                ar & num_dimensions_ & dimensions_;
-            }
-            HPX_SERIALIZATION_POLYMORPHIC_ABSTRACT(node_data_storage_base);
-
-            std::size_t num_dimensions_;
-            dimensions_type dimensions_;
-
-            // support for intrusive_ptr
-            template <typename T_>
-            friend void intrusive_ptr_add_ref(node_data_storage_base<T_>* p)
-            {
-                ++p->count_;
-            }
-            template <typename T_>
-            friend void intrusive_ptr_release(node_data_storage_base<T_>* p)
-            {
-                if (--p->count_ == 0)
-                    delete p;
-            }
-
-            hpx::util::atomic_count count_;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <std::size_t N, typename T>
-        class node_data_storage;
-
-        template <typename T>
-        class node_data_storage<0, T> : public node_data_storage_base<T>
-        {
-        public:
-            using dimensions_type =
-                typename node_data_storage_base<T>::dimensions_type;
-            using base_type = node_data_storage_base<T>;
-
-            constexpr node_data_storage()
-              : node_data_storage_base<T>(0, {{1, 0}})
-              , data_(0.0)
-            {
-            }
-
-            constexpr node_data_storage(T const& value)
-              : node_data_storage_base<T>(0, {{1, 0}})
-              , data_(value)
-            {
-            }
-
-            constexpr node_data_storage(T && value)
-              : node_data_storage_base<T>(0, {{1, 0}})
-              , data_(std::move(value))
-            {
-            }
-
-            T const& operator[](std::ptrdiff_t index) const override
-            {
-                HPX_ASSERT(index == 0);
-                return data_;
-            }
-            T const& operator[](dimensions_type const& indicies) const override
-            {
-                HPX_ASSERT(indicies[0] == 0 && indicies[1] == 0);
-                return data_;
-            }
-
-            node_data_storage& operator=(T const& data)
-            {
-                this->base_type::set_dimensions({0, 0});
-                data_ = data;
-                return *this;
-            }
-            node_data_storage& operator=(T && data)
-            {
-                this->base_type::set_dimensions({0, 0});
-                data_ = std::move(data_);
-                return *this;
-            }
-
-            using iterator = typename node_data_storage_base<T>::iterator;
-
-            iterator begin() const override
-            {
-                return iterator(&data_);
-            }
-            iterator end() const override
-            {
-                return iterator(&data_ + 1);
-            }
-
-            T const* data() const override
-            {
-                return &data_;
-            }
-            std::size_t size() const override
-            {
-                return 1;
-            }
-
-        private:
-            friend class hpx::serialization::access;
-
-            template <typename Archive>
-            void serialize(Archive& ar, unsigned)
-            {
-                ar & hpx::serialization::template base_object<base_type>(*this);
-                ar & data_;
-            }
-            HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(node_data_storage);
-
-            T data_;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T>
-        class node_data_storage<1, T> : public node_data_storage_base<T>
-        {
-        public:
-            using dimensions_type =
-                typename node_data_storage_base<T>::dimensions_type;
-            using storage1d_type =
-                Eigen::Matrix<T, Eigen::Dynamic, 1>;
-            using base_type = node_data_storage_base<T>;
-            using constant_type =
-                typename Eigen::DenseBase<storage1d_type>;
-
-            node_data_storage()
-              : node_data_storage_base<T>(1)
-              , data_()
-            {
-            }
-
-            node_data_storage(std::size_t dim)
-              : node_data_storage_base<T>(1)
-              , data_(dim)
-            {
-            }
-            node_data_storage(std::size_t dim, T default_value)
-              : node_data_storage_base<T>(1)
-              , data_(constant_type::Constant(dim, default_value))
-            {
-            }
-
-            node_data_storage(storage1d_type const& values)
-              : node_data_storage_base<T>(1,
-                    {static_cast<std::ptrdiff_t>(values.size()), 0})
-              , data_(values)
-            {
-            }
-            node_data_storage(storage1d_type && values)
-              : node_data_storage_base<T>(1,
-                    {static_cast<std::ptrdiff_t>(values.size()), 0})
-              , data_(std::move(values))
-            {
-            }
-            node_data_storage(std::vector<T> const& values)
-              : node_data_storage_base<T>(1,
-                    {static_cast<std::ptrdiff_t>(values.size()), 0})
-              , data_(Eigen::Map<storage1d_type const, Eigen::Unaligned>(
-                    values.data(), values.size()))
-            {
-            }
-
-            node_data_storage& operator=(storage1d_type const& data)
-            {
-                this->base_type::set_dimensions({data.rows(), 0});
-                data_ = data;
-                return *this;
-            }
-            node_data_storage& operator=(storage1d_type && data)
-            {
-                this->base_type::set_dimensions({data.rows(), 0});
-                data_ = std::move(data_);
-                return *this;
-            }
-            node_data_storage& operator=(std::vector<T> const& values)
-            {
-                this->base_type::set_dimensions(
-                    {static_cast<std::ptrdiff_t>(values.size()), 0});
-                data_ = Eigen::Map<storage1d_type const, Eigen::Unaligned>(
-                    values.data(), values.size());
-                return *this;
-            }
-
-            T const& operator[](std::ptrdiff_t index) const override
-            {
-                HPX_ASSERT(index < data_.size());
-                return data_[index];
-            }
-            T const& operator[](dimensions_type const& indicies) const override
-            {
-                HPX_ASSERT(indicies[0] < data_.size() && indicies[1] == 0);
-                return data_[indicies[0]];
-            }
-
-            using iterator = typename node_data_storage_base<T>::iterator;
-
-            iterator begin() const override
-            {
-                return iterator(data_.data());
-            }
-            iterator end() const override
-            {
-                return iterator(data_.data() + data_.size());
-            }
-
-            T const* data() const override
-            {
-                return data_.data();
-            }
-            std::size_t size() const override
-            {
-                return data_.size();
-            }
-
-        private:
-            friend class hpx::serialization::access;
-
-            template <typename Archive>
-            void serialize(Archive& ar, unsigned)
-            {
-                ar & hpx::serialization::template base_object<base_type>(*this);
-                ar & data_;
-            }
-            HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(node_data_storage);
-
-            storage1d_type data_;
-        };
-
-        ///////////////////////////////////////////////////////////////////////
-        template <typename T>
-        class node_data_storage<2, T> : public node_data_storage_base<T>
-        {
-        public:
-            using base_type = node_data_storage_base<T>;
-            using dimensions_type =
-                typename node_data_storage_base<T>::dimensions_type;
-            using storage2d_type =
-                Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
-            using constant_type =
-                typename Eigen::DenseBase<storage2d_type>;
-
-            node_data_storage()
-              : node_data_storage_base<T>(2)
-              , data_()
-            {
-            }
-
-            node_data_storage(std::size_t dim1, std::size_t dim2)
-              : node_data_storage_base<T>(2)
-              , data_(constant_type::Constant(dim1, dim2))
-            {
-            }
-            node_data_storage(
-                std::size_t dim1, std::size_t dim2, T default_value)
-              : node_data_storage_base<T>(2)
-              , data_(constant_type::Constant(dim1, dim2, default_value))
-            {
-            }
-
-            node_data_storage(storage2d_type const& values)
-              : node_data_storage_base<T>(2, {values.rows(), values.cols()})
-              , data_(values)
-            {
-            }
-            node_data_storage(storage2d_type && values)
-              : node_data_storage_base<T>(2, {values.rows(), values.cols()})
-              , data_(std::move(values))
-            {
-            }
-
-            node_data_storage& operator=(storage2d_type const& data)
-            {
-                this->base_type::set_dimensions({data.rows(), data.cols()});
-                data_ = data;
-                return *this;
-            }
-            node_data_storage& operator=(storage2d_type && data)
-            {
-                this->base_type::set_dimensions({data.rows(), data.cols()});
-                data_ = std::move(data);
-                return *this;
-            }
-
-            T const& operator[](std::ptrdiff_t index) const override
-            {
-                HPX_ASSERT(index < data_.size());
-                return data_(index);
-            }
-            T const& operator[](dimensions_type const& indicies) const override
-            {
-                HPX_ASSERT(indicies[0] < data_.rows() && indicies[1] != data_.cols());
-                return data_(indicies[0], indicies[1]);
-            }
-
-            using iterator = typename node_data_storage_base<T>::iterator;
-
-            iterator begin() const override
-            {
-                return iterator(data_.data());
-            }
-            iterator end() const override
-            {
-                return iterator(data_.data() + data_.size());
-            }
-
-            T const* data() const override
-            {
-                return data_.data();
-            }
-            std::size_t size() const override
-            {
-                return data_.size();
-            }
-
-        private:
-            friend class hpx::serialization::access;
-
-            template <typename Archive>
-            void serialize(Archive& ar, unsigned)
-            {
-                ar & hpx::serialization::template base_object<base_type>(*this);
-                ar & data_;
-            }
-            HPX_SERIALIZATION_POLYMORPHIC_TEMPLATE(node_data_storage);
-
-            storage2d_type data_;
-        };
-
         /// \endcond
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename Enable = void>
-    struct node_data_traits
-    {
-        using type = T;
-    };
-
-    template <typename T, int Rows, int Cols, int Options, int MaxRows,
-        int MaxCols>
-    struct node_data_traits<
-        Eigen::Matrix<T, Rows, Cols, Options, MaxRows, MaxCols>>
-    {
-        using type = T;
-    };
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     class node_data
     {
     public:
-        using dimensions_type =
-            typename detail::node_data_storage_base<T>::dimensions_type;
-        using storage1d_type =
-            Eigen::Matrix<T, Eigen::Dynamic, 1>;
-        using storage2d_type =
-            Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+        constexpr static std::size_t const max_dimensions = 2;
+
+        using dimensions_type = std::array<std::ptrdiff_t, max_dimensions>;
+        using storage_type = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
+        using array_storage_type = Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>;
+        using constant_type = Eigen::DenseBase<storage_type>;
+
+        using storage1d_type = Eigen::Matrix<T, Eigen::Dynamic, 1>;
 
         node_data() = default;
 
@@ -515,16 +115,15 @@ namespace phylanx { namespace ir
         {
             if (dims[1] != 0)
             {
-                data_ =
-                    (new detail::node_data_storage<2, T>(dims[0], dims[1]));
+                data_ = constant_type::Constant(dims[0], dims[1]);
             }
             else if (dims[0] != 0)
             {
-                data_ = (new detail::node_data_storage<1, T>(dims[0]));
+                data_ = constant_type::Constant(dims[0], 1);
             }
             else
             {
-                data_ = (new detail::node_data_storage<0, T>());
+                data_ = constant_type::Constant(1, 1);
             }
         }
 
@@ -532,100 +131,123 @@ namespace phylanx { namespace ir
         {
             if (dims[1] != 0)
             {
-                data_ = (new detail::node_data_storage<2, T>(
-                    dims[0], dims[1], default_value));
+                data_ = constant_type::Constant(dims[0], dims[1], default_value);
             }
             else if (dims[0] != 0)
             {
-                data_ = (new detail::node_data_storage<1, T>(
-                    dims[0], default_value));
+                data_ = constant_type::Constant(dims[0], 1, default_value);
             }
             else
             {
-                data_ = (new detail::node_data_storage<0, T>(default_value));
+                data_ = constant_type::Constant(1, 1, default_value);
             }
         }
 
         /// Create node data for a 0-dimensional value
         node_data(T const& value)
-          : data_(new detail::node_data_storage<0, T>(value))
+          : data_(constant_type::Constant(1, 1, value))
         {
         }
         node_data(T && value)
-          : data_(new detail::node_data_storage<0, T>(std::move(value)))
+          : data_(constant_type::Constant(1, 1, std::move(value)))
         {
         }
 
         /// Create node data for a 1-dimensional value
-        node_data(storage1d_type const& value)
-          : data_(new detail::node_data_storage<1, T>(value))
+        node_data(storage1d_type const& values)
+          : data_(values)
         {
         }
-        node_data(storage1d_type && value)
-          : data_(new detail::node_data_storage<1, T>(std::move(value)))
+        node_data(storage1d_type && values)
+          : data_(std::move(values))
         {
         }
-        node_data(std::vector<T> const& value)
-          : data_(new detail::node_data_storage<1, T>(value))
+        node_data(std::vector<T> const& values)
+          : data_(Eigen::Map<storage1d_type const, Eigen::Unaligned>(
+                values.data(), values.size()))
         {
         }
 
         /// Create node data for a 2-dimensional value
-        node_data(storage2d_type const& value)
-          : data_(new detail::node_data_storage<2, T>(value))
+        node_data(storage_type const& values)
+          : data_(values)
         {
         }
-        node_data(storage2d_type && value)
-          : data_(new detail::node_data_storage<2, T>(std::move(value)))
+        node_data(storage_type && values)
+          : data_(std::move(values))
         {
         }
 
         /// Access a specific element of the underlying N-dimensional array
         T const& operator[](std::ptrdiff_t index) const
         {
-            return (*data_)[index];
+            return data_.data()[index];
         }
         T const& operator[](dimensions_type const& indicies) const
         {
-            return (*data_)[indicies];
+            return data_(indicies[0], indicies[1]);
         }
 
-        using iterator = typename detail::node_data_storage_base<T>::iterator;
+        using iterator = detail::node_data_iterator<T>;
+        using const_iterator = detail::node_data_iterator<T>;
 
         /// Get iterator referring to the beginning of the underlying data
         iterator begin() const
         {
-            return data_->begin();
+            return iterator{data_.data()};
         }
         /// Get iterator referring to the end of the underlying data
         iterator end() const
         {
-            return data_->end();
+            return iterator{data_.data() + data_.size()};
         }
 
-        T const* data() const
+        iterator cbegin() const
         {
-            return data_->data();
+            return begin();
         }
+        /// Get iterator referring to the end of the underlying data
+        iterator cend() const
+        {
+            return end();
+        }
+
+//         T const* data() const
+//         {
+//             return data_.data();
+//         }
         std::size_t size() const
         {
-            return data_->size();
+            return data_.size();
+        }
+
+        storage_type const& matrix() const
+        {
+            return data_;
         }
 
         /// Extract the dimensionality of the underlying data array.
         std::size_t num_dimensions() const
         {
-            return data_->num_dimensions();
+            if (data_.cols() != 1)
+            {
+                return 2;
+            }
+            if (data_.rows() != 1)
+            {
+                return 1;
+            }
+            return 0;
         }
 
         /// Extract the dimensional extends of the underlying data array.
-        dimensions_type const& dimensions() const
+        dimensions_type dimensions() const
         {
-            return data_->dimensions();
+            return dimensions_type{data_.rows(), data_.cols()};
         }
         std::size_t dimension(std::size_t dim) const
         {
-            return data_->dimension(dim);
+            return (dim == 0) ? data_.rows() : data_.cols();
         }
 
     private:
@@ -638,7 +260,7 @@ namespace phylanx { namespace ir
             ar & data_;
         }
 
-        boost::intrusive_ptr<detail::node_data_storage_base<T>> data_;
+        storage_type data_;
         /// \endcond
     };
 

--- a/phylanx/util/variant.hpp
+++ b/phylanx/util/variant.hpp
@@ -119,6 +119,7 @@ namespace phylanx { namespace util
         }
     };
 
+    ///////////////////////////////////////////////////////////////////////////
     // Swaps two recursive_wrapper<T> objects of the same type T.
     template <typename T>
     inline void swap(
@@ -140,6 +141,13 @@ namespace phylanx { namespace util
         recursive_wrapper<T> const& lhs, recursive_wrapper<T> const& rhs)
     {
         return !(lhs == rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    std::ostream& operator<<(std::ostream& os, recursive_wrapper<T> const& val)
+    {
+        return os << val.get();
     }
 }}
 

--- a/src/ast/detail/is_literal_value.cpp
+++ b/src/ast/detail/is_literal_value.cpp
@@ -1,0 +1,107 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <hpx/throw_exception.hpp>
+
+#include <string>
+
+namespace phylanx { namespace ast { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////
+    struct is_literal_value_helper
+    {
+        template <typename Ast>
+        bool operator()(Ast const& ast) const
+        {
+            return is_literal_value(ast);
+        }
+    };
+
+    bool is_literal_value(primary_expr const& pe)
+    {
+        switch (pe.index())
+        {
+        case 1: HPX_FALLTHROUGH;    // bool
+        case 2: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 4: HPX_FALLTHROUGH;    // std::string
+        case 5:                     // std::uint64_t
+            return true;
+
+        default:
+            break;
+        }
+        return false;
+    }
+
+    bool is_literal_value(operand const& op)
+    {
+        return visit(is_literal_value_helper(), op);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct literal_value_helper
+    {
+        template <typename Ast>
+        literal_value_type operator()(Ast const& ast) const
+        {
+            return literal_value(ast);
+        }
+    };
+
+    literal_value_type literal_value(primary_expr const& pe)
+    {
+        switch (pe.index())
+        {
+        case 1:     // bool
+            return util::get<1>(pe.get());
+
+        case 2:     // phylanx::ir::node_data<double>
+            return util::get<2>(pe.get());
+
+        case 4:     // std::string
+            return util::get<4>(pe.get());
+
+        case 5:     // std::uint64_t
+            return util::get<5>(pe.get());
+
+        default:
+            break;
+        }
+        return nil{};
+    }
+
+    literal_value_type literal_value(operand const& op)
+    {
+        return visit(literal_value_helper(), op);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> literal_value(literal_value_type const& val)
+    {
+        switch (val.index())
+        {
+        case 4:     // phylanx::ir::node_data<double>
+            return util::get<4>(val);
+
+        case 1:     // bool
+            return ir::node_data<double>{double(util::get<1>(val))};
+
+        case 2:     // std::uint64_t
+            return ir::node_data<double>{double(util::get<2>(val))};
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::ast::detail::literal_value",
+            "unsupported literal_value_type");
+    }
+}}}
+

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -118,14 +118,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         using array_type = Eigen::Array<double, Eigen::Dynamic, 1>;
 
+        array_type first_term = ops.begin()->matrix().array();
         Eigen::Matrix<double, Eigen::Dynamic, 1> result =
-            std::accumulate(ops.begin(), ops.end(),
-                array_type::Zero(lhs_size).eval(),
-                [&](array_type const& result, ir::node_data<double> const& curr)
+            std::accumulate(
+                ops.begin() + 1, ops.end(), first_term,
+                [&](array_type& result, ir::node_data<double> const& curr)
                 ->  array_type
                 {
-                    Eigen::Map<array_type const> lhs(curr.data(), lhs_size);
-                    return result + lhs;
+                    return result += curr.matrix().array();
                 });
 
         return ir::node_data<double>(std::move(result));
@@ -162,17 +162,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         using array_type = Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>;
-        using array_map_type = Eigen::Map<array_type const>;
 
+        array_type first_term = ops.begin()->matrix().array();
         Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
             std::accumulate(
-                ops.begin(), ops.end(),
-                array_type::Zero(lhs_size[0], lhs_size[1]).eval(),
-                [&](array_type const& result, ir::node_data<double> const& curr)
+                ops.begin() + 1, ops.end(), first_term,
+                [&](array_type& result, ir::node_data<double> const& curr)
                 ->  array_type
                 {
-                    return result +
-                        array_map_type{curr.data(), lhs_size[0], lhs_size[1]};
+                    return result += curr.matrix().array();
                 });
 
         return ir::node_data<double>(std::move(result));

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -7,31 +7,14 @@
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
 #include <phylanx/execution_tree/primitives/literal_value.hpp>
 
-#include <hpx/hpx.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
 
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 // Add factory registration functionality
 HPX_REGISTER_COMPONENT_MODULE()
-
-///////////////////////////////////////////////////////////////////////////////
-typedef hpx::components::component<
-    phylanx::execution_tree::primitives::literal_value>
-    literal_type;
-HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
-    literal_type, phylanx_literal_component,
-    "phylanx_primitive_component", hpx::components::factory_enabled)
-HPX_DEFINE_GET_COMPONENT_TYPE(literal_type::wrapped_type)
-
-///////////////////////////////////////////////////////////////////////////////
-typedef hpx::components::component<
-    phylanx::execution_tree::primitives::add_operation>
-    add_operation_type;
-HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
-    add_operation_type, phylanx_add_operation_component,
-    "phylanx_primitive_component", hpx::components::factory_enabled)
-HPX_DEFINE_GET_COMPONENT_TYPE(add_operation_type::wrapped_type)
 
 ///////////////////////////////////////////////////////////////////////////////
 // Serialization support for the base_file actions

--- a/src/execution_tree/primitives/file_read.cpp
+++ b/src/execution_tree/primitives/file_read.cpp
@@ -1,0 +1,105 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/file_read.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/serialization/ast.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+
+#include <cstddef>
+#include <fstream>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::file_read>
+    file_read_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    file_read_type, phylanx_file_read_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(file_read_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    file_read::file_read(std::vector<ast::literal_value_type>&& literals,
+        std::vector<primitive>&& operands)
+    {
+        if (literals.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_read::file_read",
+                "the file_read primitive requires exactly one literal "
+                    "argument");
+        }
+
+        // Verify that argument arrays are filled properly (this could be
+        // converted to asserts).
+        if (operands.size() != literals.size())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_read::file_read",
+                "the file_read primitive requires that the size of the "
+                    "literals and operands arrays is the same");
+        }
+
+        if (!valid(literals[0]) || operands[0].valid())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_read::file_read",
+                "the file_read primitive requires that the "
+                    "exactly one element of the literals and operands "
+                    "arrays is valid");
+        }
+
+        std::string* name = util::get_if<std::string>(&literals[0]);
+        if (name == nullptr)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_read::file_read",
+                "the first literal argument must be a string representing a "
+                    "valid file name");
+        }
+
+        filename_ = std::move(*name);
+    }
+
+    // read data from given file and return content
+    hpx::future<ir::node_data<double>> file_read::eval() const
+    {
+        std::ifstream infile(filename_.c_str(),
+            std::ios::binary | std::ios::in | std::ios::ate);
+
+        if (!infile.is_open())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_read::eval",
+                "couldn't open file: " + filename_);
+        }
+
+        std::streamsize count = infile.tellg();
+        infile.seekg(0);
+
+        std::vector<char> data;
+        data.resize(count);
+
+        if (!infile.read(data.data(), count))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_read::eval",
+                "couldn't read expected number of bytes from file: " +
+                    filename_);
+        }
+
+        // assume data in file is result of a serialized ir::node_data
+        ir::node_data<double> nd;
+        phylanx::util::detail::unserialize(data, nd);
+
+        return hpx::make_ready_future(std::move(nd));
+    }
+}}}

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -1,0 +1,142 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/file_write.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/serialization/ast.hpp>
+#include <phylanx/util/variant.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <fstream>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::file_write>
+    file_write_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    file_write_type, phylanx_file_write_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(file_write_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    file_write::file_write(std::vector<ast::literal_value_type>&& literals,
+            std::vector<primitive>&& operands)
+      : literals_(literals)
+      , operands_(operands)
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::file_write",
+                "the file_write primitive requires exactly two operands");
+        }
+
+        // Verify that argument arrays are filled properly (this could be
+        // converted to asserts).
+        if (operands_.size() != literals.size())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::file_write",
+                "the file_write primitive requires that the size of the "
+                    "literals and operands arrays is the same");
+        }
+
+        bool arguments_valid = true;
+        if (!valid(literals[0]))
+        {
+            arguments_valid = false;
+        }
+
+        if (valid(literals[1]))
+        {
+            if (operands_[1].valid())
+            {
+                arguments_valid = false;
+            }
+        }
+        else if (!operands_[1].valid())
+        {
+            arguments_valid = false;
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::file_write",
+                "the file_write primitive requires that the "
+                    "exactly one element of the literals and operands "
+                    "arrays is valid");
+        }
+
+        std::string* name = util::get_if<std::string>(&literals[0]);
+        if (name == nullptr)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::file_write",
+                "the first literal argument must be a string representing a "
+                    "valid file name");
+        }
+
+        filename_ = std::move(*name);
+    }
+
+    void write_to_file(
+        std::string const& filename, ir::node_data<double> const& nd)
+    {
+        std::ofstream outfile(filename.c_str(),
+            std::ios::binary | std::ios::out | std::ios::trunc);
+        if (!outfile.is_open())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::eval",
+                "couldn't open file: " + filename);
+        }
+
+        std::vector<char> data = phylanx::util::serialize(nd);
+        if (!outfile.write(data.data(), data.size()))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::eval",
+                "couldn't read expected number of bytes from file: " +
+                    filename);
+        }
+    }
+
+    // read data from given file and return content
+    hpx::future<ir::node_data<double>> file_write::eval() const
+    {
+        if (valid(literals_[1]))
+        {
+            ir::node_data<double> const* nd =
+                util::get_if<ir::node_data<double>>(&literals_[1]);
+
+            if (nd == nullptr)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::file_write::eval",
+                    "second argument must be a literator of type "
+                        "ir::node_data<double> or another primitive");
+            }
+
+            write_to_file(filename_, *nd);
+            return hpx::make_ready_future(*nd);
+        }
+
+        return operands_[1].eval().then(hpx::util::unwrapping(
+            [this](ir::node_data<double> && nd) -> ir::node_data<double>
+            {
+                write_to_file(filename_, nd);
+                return std::move(nd);
+            }));
+    }
+}}}

--- a/src/execution_tree/primitives/literal_value.cpp
+++ b/src/execution_tree/primitives/literal_value.cpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/literal_value.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::literal_value>
+    literal_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    literal_type, phylanx_literal_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(literal_type::wrapped_type)
+

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -39,13 +39,13 @@ void test_expression(std::string const& expr, std::string const& expected)
 
 int main(int argc, char* argv[])
 {
-//     test_expression(
-//         "A + B",
-//         "expression\n"
-//             "identifier: A\n"
-//             "identifier: B\n"
-//             "op_plus\n"
-//     );
+    test_expression(
+        "A + B",
+        "expression\n"
+            "identifier: A\n"
+            "identifier: B\n"
+            "op_plus\n"
+    );
 
     test_expression(
         "A + B + -C",
@@ -88,6 +88,11 @@ int main(int argc, char* argv[])
                 "expression\n"
                     "identifier: B\n"
     );
+
+    test_expression(
+        "\"test\"",
+        "expression\n"
+            "test\n");
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -45,6 +45,12 @@ void test_primary_expr()
     phylanx::ast::primary_expr p3{
         phylanx::ir::node_data<double>{v}};
     test_serialization(p3);
+
+    phylanx::ast::primary_expr p4{"some string"};
+    test_serialization(p4);
+
+    phylanx::ast::primary_expr p5{std::uint64_t(42)};
+    test_serialization(p5);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -58,6 +64,14 @@ void test_operand()
         phylanx::ast::identifier{"some_name"});
     phylanx::ast::operand op2(std::move(p2));
     test_serialization(op2);
+
+    phylanx::ast::primary_expr p3{"some string"};
+    phylanx::ast::operand op3(std::move(p3));
+    test_serialization(op3);
+
+    phylanx::ast::primary_expr p4{std::uint64_t(42)};
+    phylanx::ast::operand op4(std::move(p4));
+    test_serialization(op4);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/execution_tree/generate_tree.cpp
+++ b/tests/unit/execution_tree/generate_tree.cpp
@@ -26,7 +26,7 @@ phylanx::execution_tree::primitive create_literal_value(double value)
             hpx::find_here(), phylanx::ir::node_data<double>(value)));
 }
 
-int main(int argc, char* argv[])
+void test_add_primitive()
 {
     phylanx::execution_tree::pattern_list patterns = {
         { "_1 + _2", &phylanx::execution_tree::primitives::create<
@@ -43,6 +43,31 @@ int main(int argc, char* argv[])
     test_generate_tree("A + (B + C)", patterns, variables, 55.0);
     test_generate_tree("A + (B + A)", patterns, variables, 83.0);
     test_generate_tree("(A + B) + C", patterns, variables, 55.0);
+}
+
+void test_file_io_primitives()
+{
+    phylanx::execution_tree::variables variables = {
+        {"A", create_literal_value(41.0)},
+        {"B", create_literal_value(1.0)},
+        {"C", create_literal_value(13.0)}
+    };
+
+    phylanx::execution_tree::pattern_list patterns = {
+        { "file_write(_1, _2)", &phylanx::execution_tree::primitives::create<
+                phylanx::execution_tree::primitives::file_write>},
+        { "file_read(_1)", &phylanx::execution_tree::primitives::create<
+                phylanx::execution_tree::primitives::file_read>}
+    };
+
+    test_generate_tree("file_write(\"test_file\", A)", patterns, variables, 41.0);
+    test_generate_tree("file_read(\"test_file\")", patterns, variables, 41.0);
+}
+
+int main(int argc, char* argv[])
+{
+//     test_add_primitive();
+    test_file_io_primitives();
 
     return 0;
 }

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 set(tests
     add_operation
+    file_primitives
+    literal_value
    )
 
 foreach(test ${tests})
@@ -24,7 +26,7 @@ foreach(test ${tests})
   add_phylanx_pseudo_target(tests.unit.execution_tree.primitives.${test})
   add_phylanx_pseudo_dependencies(tests.unit.execution_tree.primitives
     tests.unit.execution_tree.primitives.${test})
-  add_phylanx_pseudo_dependencies(tests.unit.execution_tree.primitives.${test} 
+  add_phylanx_pseudo_dependencies(tests.unit.execution_tree.primitives.${test}
     ${test}_test_exe)
 
 endforeach()

--- a/tests/unit/execution_tree/primitives/add_operation.cpp
+++ b/tests/unit/execution_tree/primitives/add_operation.cpp
@@ -6,6 +6,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <Eigen/Dense>
@@ -27,8 +28,31 @@ void test_add_operation_0d()
     phylanx::execution_tree::primitive add =
         hpx::new_<phylanx::execution_tree::primitives::add_operation>(
             hpx::find_here(),
+            std::vector<phylanx::ast::literal_value_type>(2),
             std::vector<phylanx::execution_tree::primitive>{
                 std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
+    HPX_TEST_EQ(42.0, f.get()[0]);
+}
+
+void test_add_operation_0d_lit()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive add =
+        hpx::new_<phylanx::execution_tree::primitives::add_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::ast::literal_value_type>{
+                std::move(lhs), {}
+            },
+            std::vector<phylanx::execution_tree::primitive>{
+                {}, std::move(rhs)
             });
 
     hpx::future<phylanx::ir::node_data<double>> f = add.eval();
@@ -51,8 +75,36 @@ void test_add_operation_1d()
     phylanx::execution_tree::primitive add =
         hpx::new_<phylanx::execution_tree::primitives::add_operation>(
             hpx::find_here(),
+            std::vector<phylanx::ast::literal_value_type>(2),
             std::vector<phylanx::execution_tree::primitive>{
                 std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
+
+    Eigen::VectorXd expected = v1 + v2;
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+}
+
+void test_add_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive add =
+        hpx::new_<phylanx::execution_tree::primitives::add_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::ast::literal_value_type>{
+                std::move(lhs), {}
+            },
+            std::vector<phylanx::execution_tree::primitive>{
+                {}, std::move(rhs)
             });
 
     hpx::future<phylanx::ir::node_data<double>> f = add.eval();
@@ -77,8 +129,36 @@ void test_add_operation_2d()
     phylanx::execution_tree::primitive add =
         hpx::new_<phylanx::execution_tree::primitives::add_operation>(
             hpx::find_here(),
+            std::vector<phylanx::ast::literal_value_type>(2),
             std::vector<phylanx::execution_tree::primitive>{
                 std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
+
+    Eigen::MatrixXd expected = m1.array() + m2.array();
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+}
+
+void test_add_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive add =
+        hpx::new_<phylanx::execution_tree::primitives::add_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::ast::literal_value_type>{
+                std::move(lhs), {}
+            },
+            std::vector<phylanx::execution_tree::primitive>{
+                {}, std::move(rhs)
             });
 
     hpx::future<phylanx::ir::node_data<double>> f = add.eval();
@@ -90,8 +170,13 @@ void test_add_operation_2d()
 int main(int argc, char* argv[])
 {
     test_add_operation_0d();
+    test_add_operation_0d_lit();
+
     test_add_operation_1d();
+    test_add_operation_1d_lit();
+
     test_add_operation_2d();
+    test_add_operation_2d_lit();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/file_primitives.cpp
+++ b/tests/unit/execution_tree/primitives/file_primitives.cpp
@@ -1,0 +1,128 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+void test_file_io_lit(phylanx::ir::node_data<double> const& in)
+{
+    std::string filename = std::tmpnam(nullptr);
+
+    // write to file
+    {
+        phylanx::execution_tree::primitive litval =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), in);
+
+        phylanx::execution_tree::primitive outfile =
+            hpx::new_<phylanx::execution_tree::primitives::file_write>(
+                hpx::find_here(),
+                std::vector<phylanx::ast::literal_value_type>{
+                    {filename}, {}
+                },
+                std::vector<phylanx::execution_tree::primitive>{
+                    {}, litval
+                });
+
+        auto f = outfile.eval();
+        f.get();
+    }
+
+    // read back the file
+    hpx::future<phylanx::ir::node_data<double>> f;
+    {
+        phylanx::execution_tree::primitive infile =
+            hpx::new_<phylanx::execution_tree::primitives::file_read>(
+                hpx::find_here(),
+                std::vector<phylanx::ast::literal_value_type>{
+                    {filename}
+                },
+                std::vector<phylanx::execution_tree::primitive>{
+                    {}
+                });
+
+
+        f = infile.eval();
+    }
+
+    HPX_TEST(in == f.get());
+
+    std::remove(filename.c_str());
+}
+
+void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
+{
+    std::string filename = std::tmpnam(nullptr);
+
+    // write to file
+    {
+        phylanx::execution_tree::primitive outfile =
+            hpx::new_<phylanx::execution_tree::primitives::file_write>(
+                hpx::find_here(),
+                std::vector<phylanx::ast::literal_value_type>{
+                    {filename}, in
+                },
+                std::vector<phylanx::execution_tree::primitive>{
+                    {}, {}
+                });
+
+        auto f = outfile.eval();
+        f.get();
+    }
+
+    // read back the file
+    hpx::future<phylanx::ir::node_data<double>> f;
+    {
+        phylanx::execution_tree::primitive infile =
+            hpx::new_<phylanx::execution_tree::primitives::file_read>(
+                hpx::find_here(),
+                std::vector<phylanx::ast::literal_value_type>{
+                    {filename}
+                },
+                std::vector<phylanx::execution_tree::primitive>{
+                    {}
+                });
+
+
+        f = infile.eval();
+    }
+
+    HPX_TEST(in == f.get());
+
+    std::remove(filename.c_str());
+}
+
+void test_file_io(phylanx::ir::node_data<double> const& in)
+{
+    test_file_io_lit(in);
+    test_file_io_primitive(in);
+}
+
+int main(int argc, char* argv[])
+{
+    test_file_io(phylanx::ir::node_data<double>(42.0));
+
+    Eigen::VectorXd ev = Eigen::VectorXd::Random(1007);
+    test_file_io(phylanx::ir::node_data<double>(std::move(ev)));
+
+    std::vector<double> v(1007);
+    std::generate(v.begin(), v.end(), std::rand);
+    test_file_io(phylanx::ir::node_data<double>(std::move(v)));
+
+    Eigen::MatrixXd m = Eigen::MatrixXd::Random(101, 101);
+    test_file_io(phylanx::ir::node_data<double>(std::move(m)));
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/literal_value.cpp
+++ b/tests/unit/execution_tree/primitives/literal_value.cpp
@@ -1,0 +1,29 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+void test_literal_value()
+{
+    phylanx::execution_tree::primitive val =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+
+    hpx::future<phylanx::ir::node_data<double>> f = val.eval();
+
+    HPX_TEST_EQ(42.0, f.get()[0]);
+}
+
+int main(int argc, char* argv[])
+{
+    test_literal_value();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -10,6 +10,8 @@
 
 #include <Eigen/Dense>
 
+#include <algorithm>
+
 void test_serialization(phylanx::ir::node_data<double> const& array_value1)
 {
     phylanx::ir::node_data<double> array_value2;

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[])
 
         HPX_TEST_EQ(single_value.num_dimensions(), std::ptrdiff_t(0));
         HPX_TEST(single_value.dimensions() ==
-            phylanx::ir::node_data<double>::dimensions_type({1, 0}));
+            phylanx::ir::node_data<double>::dimensions_type({1, 1}));
 
         test_serialization(single_value);
     }
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
 
         HPX_TEST_EQ(array_value.num_dimensions(), std::ptrdiff_t(1));
         HPX_TEST(array_value.dimensions() ==
-            phylanx::ir::node_data<double>::dimensions_type({v.rows(), 0}));
+            phylanx::ir::node_data<double>::dimensions_type({v.rows(), 1}));
 
         test_serialization(array_value);
     }
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
         HPX_TEST_EQ(array_value.num_dimensions(), std::ptrdiff_t(1));
         HPX_TEST(array_value.dimensions() ==
             phylanx::ir::node_data<double>::dimensions_type(
-                {static_cast<std::ptrdiff_t>(v.size()), 0}));
+                {static_cast<std::ptrdiff_t>(v.size()), 1}));
 
         test_serialization(array_value);
     }

--- a/tools/VS/ast.natvis
+++ b/tools/VS/ast.natvis
@@ -27,14 +27,18 @@
         <DisplayString Condition="(var.impl_.index_ == 3)">identifier ({var.impl_.data_.tail_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 4)">expression ({var.impl_.data_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 5)">function_call ({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
+        <DisplayString Condition="(var.impl_.index_ == 6)">function_call ({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
+        <DisplayString Condition="(var.impl_.index_ == 7)">function_call ({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <Expand>
             <Item Name="[tagged]" Condition="(id != 0)">id</Item>
             <Item Name="[nil]" Condition="(var.impl_.index_ == 0)">"nil"</Item>
             <Item Name="[bool]" Condition="(var.impl_.index_ == 1)">var.impl_.data_.tail_.head_.value</Item>
             <Item Name="[node_data]" Condition="(var.impl_.index_ == 2)">var.impl_.data_.tail_.tail_.head_.value</Item>
             <Item Name="[identifier]" Condition="(var.impl_.index_ == 3)">var.impl_.data_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[expression]" Condition="(var.impl_.index_ == 4)">var.impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[function_call]" Condition="(var.impl_.index_ == 5)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[string]" Condition="(var.impl_.index_ == 4)">var.impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[std::int64_t]" Condition="(var.impl_.index_ == 5)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[expression]" Condition="(var.impl_.index_ == 6)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[function_call]" Condition="(var.impl_.index_ == 7)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 

--- a/tools/VS/variant.natvis
+++ b/tools/VS/variant.natvis
@@ -11,7 +11,7 @@
     <Type Name="mpark::variant&lt;*&gt;">
         <DisplayString Condition="(impl_.index_ ==  0)">{_impl.data_.head_.value}"</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -19,8 +19,8 @@
         <DisplayString Condition="(impl_.index_ ==  0)">{impl_.data_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  1)">{impl_.data_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -29,9 +29,9 @@
         <DisplayString Condition="(impl_.index_ ==  1)">{impl_.data_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  2)">{impl_.data_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -41,10 +41,10 @@
         <DisplayString Condition="(impl_.index_ ==  2)">{impl_.data_.tail_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  3)">{impl_.data_.tail_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[3]]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -55,11 +55,11 @@
         <DisplayString Condition="(impl_.index_ ==  3)">{impl_.data_.tail_.tail_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  4)">{impl_.data_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[3]]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[4]]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -71,12 +71,12 @@
         <DisplayString Condition="(impl_.index_ ==  4)">{impl_.data_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  5)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[3]]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[4]]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[5]]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -89,13 +89,13 @@
         <DisplayString Condition="(impl_.index_ ==  5)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  6)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[3]]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[4]]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[5]]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[6]]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -109,14 +109,14 @@
         <DisplayString Condition="(impl_.index_ ==  6)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  7)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  7)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[3]]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[4]]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[5]]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[6]]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[7]]" Condition="(impl_.index_ ==  7)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -131,15 +131,15 @@
         <DisplayString Condition="(impl_.index_ ==  7)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  8)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  7)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  8)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[3]]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[4]]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[5]]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[6]]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[7]]" Condition="(impl_.index_ ==  7)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[8]]" Condition="(impl_.index_ ==  8)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 
@@ -155,16 +155,16 @@
         <DisplayString Condition="(impl_.index_ ==  8)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <DisplayString Condition="(impl_.index_ ==  9)">{impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value}</DisplayString>
         <Expand>
-            <Item Name="[data]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  7)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  8)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
-            <Item Name="[data]" Condition="(impl_.index_ ==  9)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[0]]" Condition="(impl_.index_ ==  0)">impl_.data_.head_.value</Item>
+            <Item Name="[data[1]]" Condition="(impl_.index_ ==  1)">impl_.data_.tail_.head_.value</Item>
+            <Item Name="[data[2]]" Condition="(impl_.index_ ==  2)">impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[3]]" Condition="(impl_.index_ ==  3)">impl_.data_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[4]]" Condition="(impl_.index_ ==  4)">impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[5]]" Condition="(impl_.index_ ==  5)">impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[6]]" Condition="(impl_.index_ ==  6)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[7]]" Condition="(impl_.index_ ==  7)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[8]]" Condition="(impl_.index_ ==  8)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[data[9]]" Condition="(impl_.index_ ==  9)">impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 


### PR DESCRIPTION
- the file_read pattern is `file_read(_1)`, where `_1` is representing the
  file name to read data from
- the file_write pattern is `file_write(_1, _2)`, where `_1` is 
  representing the file name to write the data to that is represented
  by `_2`

- both facilities operate on serialized `ir::node_data<double>` byte streams

- adding corresponding tests
- introduced literal values in AST (bool, double, uint64, string)
- this changes construction API for primitives, those now expect to take two
  arguments: a vector of literal values and a vector of other primitives
- updated add_primitive to be able to handle literal values in addition
  to other primitives

- flyby: adding literal_value test