### PR TITLE
Fix typos in python scripts.

### DIFF
--- a/tests/unit/py/ast/generate_ast.py
+++ b/tests/unit/py/ast/generate_ast.py
@@ -53,6 +53,17 @@ test_expression(
     '\n')
 
 test_expression(
+    'A + B + -C',
+    'expression\n' +
+        'identifier: A\n' +
+        'identifier: B\n' +
+        'op_plus\n' +
+        'identifier: C\n' +
+        'op_negative\n' +
+        'op_plus\n',
+    '\n')
+
+test_expression(
     'A + B * C',
     'expression\n' +
         'identifier: A\n' +

--- a/tests/unit/py/ast/generate_ast.py
+++ b/tests/unit/py/ast/generate_ast.py
@@ -49,18 +49,7 @@ test_expression(
     'expression\n' +
         'identifier: A\n' +
         'identifier: B\n' +
-        'op_plus\n'
-    '\n')
-
-test_expression(
-    'A + B + -C',
-    'expression\n' +
-        'identifier: A\n' +
-        'identifier: B\n' +
-        'op_plus\n' +
-        'identifier: C\n' +
-        'op_negative\n' +
-        'op_plus\n'
+        'op_plus\n',
     '\n')
 
 test_expression(
@@ -70,7 +59,7 @@ test_expression(
         'identifier: B\n' +
         'identifier: C\n' +
         'op_times\n' +
-        'op_plus\n'
+        'op_plus\n',
     '\n')
 
 test_expression(
@@ -80,7 +69,7 @@ test_expression(
         'identifier: B\n' +
         'op_times\n' +
         'identifier: C\n' +
-        'op_plus\n'
+        'op_plus\n',
     '\n')
 
 test_expression(

--- a/tests/unit/py/lu_algo.py
+++ b/tests/unit/py/lu_algo.py
@@ -40,7 +40,7 @@ def lu_decomp(A, B):
     def compute_piv(A, n, p, j, k, piv):
       for k in range(n):
         t = A[p,k]
-        A[p, k] = A[j, k)
+        A[p, k] = A[j, k]
         A[j, k] = t
 
       k = piv[p]
@@ -87,10 +87,10 @@ def get_l(LU):
       L[i,j] = LU[i,j]
     elif i == j:
       L[i,j] = 1.0
-    else
+    else:
       L[i,j] = 0.0
 
-   return c, L
+  return c, L
 
 def get_u(LU):
   m = LU.shape[0] # row

--- a/tests/unit/py/qr_algo.py
+++ b/tests/unit/py/qr_algo.py
@@ -83,7 +83,7 @@ def get_q(QR, Rdiag):
          
 
    for k in range(n, -1, -1):
-      Q[k,k = 1.0
+      Q[k,k] = 1.0
       for j in range(k,n):
          QR.conditional(QR[k,k] != 0.0, Qcompute(j, k, n, QR, Q))
 


### PR DESCRIPTION
There were some obvious typos in the python scripts. Only one of them is actually made runnable by these changes, however, all obviously need fixing.