### PR TITLE
Optional eval return type

### DIFF
--- a/phylanx/execution_tree/primitives/add_operation.hpp
+++ b/phylanx/execution_tree/primitives/add_operation.hpp
@@ -8,8 +8,10 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
-#include <phylanx/ir/node_data.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 
@@ -23,14 +25,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<add_operation>
     {
     private:
-        using operands_type = std::vector<ir::node_data<double>>;
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
 
     public:
         add_operation() = default;
 
         add_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<ir::node_data<double>> eval() const override;
+        hpx::future<operand_type> eval() const override;
 
     protected:
         ir::node_data<double> add0d(operands_type const& ops) const;

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -84,7 +84,7 @@ namespace phylanx { namespace execution_tree
           , primitive
         >;
 
-
+    ///////////////////////////////////////////////////////////////////////////
     // a literal value is valid of its not nil{}
     inline bool valid(primitive_argument_type const& val)
     {
@@ -117,6 +117,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     namespace detail
     {
+        // Invoke the given function on all items in the input vector, while
+        // returning another vector holding the respective results.
         template <typename T, typename F>
         auto map_operands(std::vector<T> const& in, F && f)
         ->  std::vector<decltype(hpx::util::invoke(f, std::declval<T>()))>
@@ -129,6 +131,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 out.push_back(hpx::util::invoke(f, d));
             }
             return out;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // check if one of the optionals in the list of operands is empty
+        inline bool verify_argument_values(
+            std::vector<util::optional<ir::node_data<double>>> const& ops)
+        {
+            for (auto const& op : ops)
+            {
+                if (!op)
+                    return false;
+            }
+            return true;
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        // Extract a node_data<double> from a primitive_argument_type (that
+        // could be a primitive or a literal value).
+        inline hpx::future<util::optional<ir::node_data<double>>>
+            extract_node_data(primitive_argument_type const& val)
+        {
+            primitive const* p = util::get_if<primitive>(&val);
+            if (p != nullptr)
+                return p->eval();
+
+            HPX_ASSERT(valid(val));
+            return hpx::make_ready_future(util::optional<ir::node_data<double>>(
+                extract_literal_value(val)));
         }
     }
 }}}

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -9,6 +9,8 @@
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/util.hpp>
@@ -26,11 +28,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         base_primitive() = default;
         virtual ~base_primitive() = default;
 
-        hpx::future<ir::node_data<double>> eval_nonvirtual()
+        hpx::future<util::optional<ir::node_data<double>>> eval_nonvirtual()
         {
             return eval();
         }
-        virtual hpx::future<ir::node_data<double>> eval() const = 0;
+        virtual hpx::future<util::optional<ir::node_data<double>>> eval() const = 0;
 
     public:
         HPX_DEFINE_COMPONENT_ACTION(base_primitive,
@@ -69,7 +71,7 @@ namespace phylanx { namespace execution_tree
         {
         }
 
-        hpx::future<ir::node_data<double>> eval() const;
+        hpx::future<util::optional<ir::node_data<double>>> eval() const;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/phylanx/execution_tree/primitives/file_read.hpp
+++ b/phylanx/execution_tree/primitives/file_read.hpp
@@ -10,6 +10,8 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 
@@ -24,12 +26,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public base_primitive
       , public hpx::components::component_base<file_read>
     {
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
     public:
         file_read() = default;
 
         file_read(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<ir::node_data<double>> eval() const override;
+        hpx::future<operand_type> eval() const override;
 
     private:
         std::string filename_;

--- a/phylanx/execution_tree/primitives/file_write.hpp
+++ b/phylanx/execution_tree/primitives/file_write.hpp
@@ -24,12 +24,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public base_primitive
       , public hpx::components::component_base<file_write>
     {
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
     public:
         file_write() = default;
 
         file_write(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<ir::node_data<double>> eval() const override;
+        hpx::future<operand_type> eval() const override;
 
     private:
         std::string filename_;

--- a/phylanx/execution_tree/primitives/literal_value.hpp
+++ b/phylanx/execution_tree/primitives/literal_value.hpp
@@ -9,6 +9,8 @@
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 
@@ -30,9 +32,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
             : data_(std::move(data))
         {}
 
-        hpx::future<ir::node_data<double>> eval() const override
+        hpx::future<util::optional<ir::node_data<double>>> eval() const override
         {
-            return hpx::make_ready_future(data_);
+            return hpx::make_ready_future(
+                util::optional<ir::node_data<double>>(data_));
         }
 
     private:

--- a/phylanx/execution_tree/primitives/mul_operation.hpp
+++ b/phylanx/execution_tree/primitives/mul_operation.hpp
@@ -11,6 +11,8 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 
@@ -24,14 +26,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public hpx::components::component_base<mul_operation>
     {
     private:
-        using operands_type = std::vector<ir::node_data<double>>;
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
 
     public:
         mul_operation() = default;
 
         mul_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<ir::node_data<double>> eval() const override;
+        hpx::future<operand_type> eval() const override;
 
     protected:
         ir::node_data<double> mul0d(operands_type const& ops) const;

--- a/phylanx/execution_tree/primitives/sub_operation.hpp
+++ b/phylanx/execution_tree/primitives/sub_operation.hpp
@@ -10,6 +10,8 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 
@@ -23,14 +25,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<sub_operation>
     {
     private:
-        using operands_type = std::vector<ir::node_data<double>>;
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
 
     public:
         sub_operation() = default;
 
         sub_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<ir::node_data<double>> eval() const override;
+        hpx::future<operand_type> eval() const override;
 
     protected:
         ir::node_data<double> sub0d(operands_type const& ops) const;

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -7,7 +7,9 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
 #include <phylanx/util/serialization/eigen.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -62,21 +64,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> add_operation::add0d(operands_type const& ops) const
     {
-        std::size_t rhs_dims = ops[1].num_dimensions();
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 0:
             {
                 if (ops.size() == 2)
                 {
-                    return ops[0][0] + ops[1][0];
+                    return lhs[0] + rhs[0];
                 }
 
                 return ir::node_data<double>(
-                    std::accumulate(ops.begin() + 1, ops.end(), ops[0][0],
-                        [](double result, ir::node_data<double> const& curr)
+                    std::accumulate(ops.begin() + 1, ops.end(), lhs[0],
+                        [](double result, operand_type const& curr)
                         {
-                            return result + curr[0];
+                            return result + curr.value()[0];
                         }));
             }
             break;
@@ -93,8 +98,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> add_operation::add1d1d(operands_type const& ops) const
     {
-        std::size_t lhs_size = ops[0].dimension(0);
-        std::size_t rhs_size = ops[1].dimension(0);
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
 
         if(lhs_size  != rhs_size)
         {
@@ -108,18 +116,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (ops.size() == 2)
         {
-            matrix_type result = ops[0].matrix().array() + ops[1].matrix().array();
+            matrix_type result = lhs.matrix().array() + rhs.matrix().array();
             return ir::node_data<double>(std::move(result));
         }
 
-        array_type first_term = ops.begin()->matrix().array();
+        array_type first_term = ops.begin()->value().matrix().array();
         matrix_type result =
             std::accumulate(
                 ops.begin() + 1, ops.end(), first_term,
-                [](array_type& result, ir::node_data<double> const& curr)
+                [](array_type& result, operand_type const& curr)
                 ->  array_type
                 {
-                    return result += curr.matrix().array();
+                    return result += curr.value().matrix().array();
                 });
 
         return ir::node_data<double>(std::move(result));
@@ -127,7 +135,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ir::node_data<double> add_operation::add1d(operands_type const& ops) const
     {
-        std::size_t rhs_dims = ops[1].num_dimensions();
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+
         switch(rhs_dims)
         {
         case 1:
@@ -145,8 +154,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> add_operation::add2d2d(operands_type const& ops) const
     {
-        auto lhs_size = ops[0].dimensions();
-        auto rhs_size = ops[1].dimensions();
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
 
         if (lhs_size != rhs_size)
         {
@@ -160,18 +172,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (ops.size() == 2)
         {
-            matrix_type result = ops[0].matrix().array() + ops[1].matrix().array();
+            matrix_type result = lhs.matrix().array() + rhs.matrix().array();
             return ir::node_data<double>(std::move(result));
         }
 
-        array_type first_term = ops.begin()->matrix().array();
+        array_type first_term = ops.begin()->value().matrix().array();
         matrix_type result =
             std::accumulate(
                 ops.begin() + 1, ops.end(), first_term,
-                [](array_type& result, ir::node_data<double> const& curr)
+                [](array_type& result, operand_type const& curr)
                 ->  array_type
                 {
-                    return result += curr.matrix().array();
+                    return result += curr.value().matrix().array();
                 });
 
         return ir::node_data<double>(std::move(result));
@@ -179,7 +191,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ir::node_data<double> add_operation::add2d(operands_type const& ops) const
     {
-        std::size_t rhs_dims = ops[1].num_dimensions();
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
         switch(rhs_dims)
         {
         case 2:
@@ -195,22 +207,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     // implement '+' for all possible combinations of lhs and rhs
-    hpx::future<ir::node_data<double>> add_operation::eval() const
+    hpx::future<util::optional<ir::node_data<double>>> add_operation::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
-            [this](std::vector<ir::node_data<double>> && ops)
+            [this](operands_type && ops)
             {
-                std::size_t lhs_dims = ops[0].num_dimensions();
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
                 switch (lhs_dims)
                 {
                 case 0:
-                    return add0d(ops);
+                    return operand_type(add0d(ops));
 
                 case 1:
-                    return add1d(ops);
+                    return operand_type(add1d(ops));
 
                 case 2:
-                    return add2d(ops);
+                    return operand_type(add2d(ops));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -221,14 +233,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }),
             detail::map_operands(operands_,
                 [](primitive_argument_type const& val)
-                ->  hpx::future<ir::node_data<double>>
+                ->  hpx::future<operand_type>
                 {
                     primitive const* p = util::get_if<primitive>(&val);
                     if (p != nullptr)
                         return p->eval();
 
                     HPX_ASSERT(valid(val));
-                    return hpx::make_ready_future(extract_literal_value(val));
+                    return hpx::make_ready_future(
+                        operand_type(extract_literal_value(val)));
                 })
         );
     }

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -4,9 +4,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
-#include <phylanx/execution_tree/primitives/add_operation.hpp>
-#include <phylanx/execution_tree/primitives/sub_operation.hpp>
-#include <phylanx/execution_tree/primitives/literal_value.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/actions.hpp>
 #include <hpx/include/components.hpp>
@@ -28,26 +29,26 @@ HPX_DEFINE_GET_COMPONENT_TYPE(base_primitive_type)
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree
 {
-    hpx::future<ir::node_data<double>> primitive::eval() const
+    hpx::future<util::optional<ir::node_data<double>>> primitive::eval() const
     {
         using action_type = primitives::base_primitive::eval_action;
         return hpx::async(action_type(), this->base_type::get_id());
     }
 
-    ///////////////////////////////////////////////////////////////////////
+    ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> extract_literal_value(
         primitive_argument_type const& val)
     {
         switch (val.index())
         {
-        case 4:     // phylanx::ir::node_data<double>
-            return util::get<4>(val);
-
         case 1:     // bool
             return ir::node_data<double>{double(util::get<1>(val))};
 
         case 2:     // std::uint64_t
             return ir::node_data<double>{double(util::get<2>(val))};
+
+        case 4:     // phylanx::ir::node_data<double>
+            return util::get<4>(val);
 
         default:
             break;

--- a/src/execution_tree/primitives/file_read.cpp
+++ b/src/execution_tree/primitives/file_read.cpp
@@ -6,7 +6,9 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/file_read.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
 #include <phylanx/util/serialization/ast.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -59,7 +61,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     // read data from given file and return content
-    hpx::future<ir::node_data<double>> file_read::eval() const
+    hpx::future<util::optional<ir::node_data<double>>> file_read::eval() const
     {
         std::ifstream infile(filename_.c_str(),
             std::ios::binary | std::ios::in | std::ios::ate);
@@ -89,6 +91,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ir::node_data<double> nd;
         phylanx::util::detail::unserialize(data, nd);
 
-        return hpx::make_ready_future(std::move(nd));
+        return hpx::make_ready_future(operand_type(std::move(nd)));
     }
 }}}

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -94,6 +94,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [this](util::optional<ir::node_data<double>> && nd)
                 ->  operand_type
                 {
+                    if (!nd)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "file_write::eval",
+                            "the file_write primitive requires that the argument"
+                                " value given by the operand is non-empty");
+                    }
+
                     write_to_file(filename_, nd.value());
                     return operand_type(std::move(nd));
                 }));

--- a/src/execution_tree/primitives/literal_value.cpp
+++ b/src/execution_tree/primitives/literal_value.cpp
@@ -5,7 +5,6 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/literal_value.hpp>
-#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -153,6 +153,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type&& ops)
             {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "mul_operation::eval",
+                        "the mul_operation primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
                 std::size_t lhs_dims = ops[0].value().num_dimensions();
                 switch (lhs_dims)
                 {
@@ -170,17 +178,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "dimensions");
                 }
             }),
-            detail::map_operands(operands_,
-                [](primitive_argument_type const& val)
-                ->  hpx::future<operand_type>
-                {
-                    primitive const* p = util::get_if<primitive>(&val);
-                    if (p != nullptr)
-                        return p->eval();
-
-                    HPX_ASSERT(valid(val));
-                    return hpx::make_ready_future(
-                        operand_type(extract_literal_value(val)));
-                }));
+            detail::map_operands(operands_, detail::extract_node_data)
+        );
     }
 }}}

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -8,7 +8,9 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/mul_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
 #include <phylanx/util/serialization/eigen.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -66,21 +68,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
 
-        std::size_t rhs_dims = ops[1].num_dimensions();
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch (rhs_dims)
         {
         case 0:
             {
                 if (ops.size() == 2)
                 {
-                    return ops[0][0] * ops[1][0];
+                    return lhs[0] * rhs[0];
                 }
 
                 return ir::node_data<double>(
-                    std::accumulate(ops.begin() + 1, ops.end(), ops[0][0],
-                        [](double result, ir::node_data<double> const& curr)
+                    std::accumulate(ops.begin() + 1, ops.end(), lhs[0],
+                        [](double result, operand_type const& curr)
                         {
-                            return result * curr[0];
+                            return result * curr.value()[0];
                         }));
             }
             break;
@@ -96,7 +101,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "is not a matrix");
                 }
 
-                matrix_type result = ops[0][0] * ops[1].matrix();
+                matrix_type result = lhs[0] * rhs.matrix();
                 return ir::node_data<double>(std::move(result));
             }
 
@@ -112,47 +117,51 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
 
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
         if (ops.size() == 2)
         {
-            if (ops[1].num_dimensions() == 0)
+            if (rhs.num_dimensions() == 0)
             {
-                matrix_type result = ops[0].matrix() * ops[1][0];
+                matrix_type result = lhs.matrix() * rhs[0];
                 return ir::node_data<double>(std::move(result));
             }
 
-            matrix_type result = ops[0].matrix() * ops[1].matrix();
+            matrix_type result = lhs.matrix() * rhs.matrix();
             return ir::node_data<double>(std::move(result));
         }
 
-        matrix_type first_term = ops.begin()->matrix();
+        matrix_type first_term = ops.begin()->value().matrix();
         matrix_type result =
             std::accumulate(ops.begin() + 1, ops.end(), first_term,
-                [](matrix_type& result, ir::node_data<double> const& curr)
+                [](matrix_type& result, operand_type const& curr)
                 ->  matrix_type
                 {
-                    if (curr.num_dimensions() == 0)
-                        return result *= curr[0];
-                    return result *= curr.matrix();
+                    auto const& val = curr.value();
+                    if (val.num_dimensions() == 0)
+                        return result *= val[0];
+                    return result *= val.matrix();
                 });
 
         return ir::node_data<double>(std::move(result));
     }
 
     // implement '*' for all possible combinations of lhs and rhs
-    hpx::future<ir::node_data<double>> mul_operation::eval() const
+    hpx::future<util::optional<ir::node_data<double>>> mul_operation::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
-            [this](std::vector<ir::node_data<double>>&& ops)
+            [this](operands_type&& ops)
             {
-                std::size_t lhs_dims = ops[0].num_dimensions();
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
                 switch (lhs_dims)
                 {
                 case 0:
-                    return mul0d(ops);
+                    return operand_type(mul0d(ops));
 
                 case 1:
                 case 2:
-                    return mulxd(ops);
+                    return operand_type(mulxd(ops));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -163,14 +172,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }),
             detail::map_operands(operands_,
                 [](primitive_argument_type const& val)
-                ->  hpx::future<ir::node_data<double>>
+                ->  hpx::future<operand_type>
                 {
                     primitive const* p = util::get_if<primitive>(&val);
                     if (p != nullptr)
                         return p->eval();
 
                     HPX_ASSERT(valid(val));
-                    return hpx::make_ready_future(extract_literal_value(val));
+                    return hpx::make_ready_future(
+                        operand_type(extract_literal_value(val)));
                 }));
     }
 }}}

--- a/src/execution_tree/primitives/sub_operation.cpp
+++ b/src/execution_tree/primitives/sub_operation.cpp
@@ -211,6 +211,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type&& ops)
             {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "sub_operation::eval",
+                        "the sub_operation primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
                 std::size_t lhs_dims = ops[0].value().num_dimensions();
                 switch (lhs_dims)
                 {
@@ -230,17 +238,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "dimensions");
                 }
             }),
-            detail::map_operands(operands_,
-                [](primitive_argument_type const& val)
-                ->  hpx::future<operand_type>
-                {
-                    primitive const* p = util::get_if<primitive>(&val);
-                    if (p != nullptr)
-                        return p->eval();
-
-                    HPX_ASSERT(valid(val));
-                    return hpx::make_ready_future(
-                        operand_type(extract_literal_value(val)));
-                }));
+            detail::map_operands(operands_, detail::extract_node_data)
+        );
     }
 }}}

--- a/src/execution_tree/primitives/sub_operation.cpp
+++ b/src/execution_tree/primitives/sub_operation.cpp
@@ -7,7 +7,9 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/sub_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
 #include <phylanx/util/serialization/eigen.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -63,21 +65,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> sub_operation::sub0d(operands_type const& ops) const
     {
-        std::size_t rhs_dims = ops[1].num_dimensions();
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch (rhs_dims)
         {
         case 0:
             {
                 if (ops.size() == 2)
                 {
-                    return ops[0][0] - ops[1][0];
+                    return lhs[0] - rhs[0];
                 }
 
                 return ir::node_data<double>(
-                    std::accumulate(ops.begin() + 1, ops.end(), ops[0][0],
-                        [](double result, ir::node_data<double> const& curr)
+                    std::accumulate(ops.begin() + 1, ops.end(), lhs[0],
+                        [](double result, operand_type const& curr)
                         {
-                            return result - curr[0];
+                            return result - curr.value()[0];
                         }));
             }
             break;
@@ -94,8 +99,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> sub_operation::sub1d1d(operands_type const& ops) const
     {
-        std::size_t lhs_size = ops[0].dimension(0);
-        std::size_t rhs_size = ops[1].dimension(0);
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
 
         if (lhs_size != rhs_size)
         {
@@ -109,17 +117,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (ops.size() == 2)
         {
-            matrix_type result = ops[0].matrix().array() - ops[1].matrix().array();
+            matrix_type result = lhs.matrix().array() - rhs.matrix().array();
             return ir::node_data<double>(std::move(result));
         }
 
-        array_type first = ops.begin()->matrix().array();
+        array_type first_term = ops.begin()->value().matrix().array();
         matrix_type result =
-            std::accumulate(ops.begin() + 1, ops.end(), first,
-                [](array_type& result, ir::node_data<double> const& curr)
+            std::accumulate(ops.begin() + 1, ops.end(), first_term,
+                [](array_type& result, operand_type const& curr)
                 ->  array_type
                 {
-                    return result -= curr.matrix().array();
+                    return result -= curr.value().matrix().array();
                 });
 
         return ir::node_data<double>(std::move(result));
@@ -127,7 +135,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ir::node_data<double> sub_operation::sub1d(operands_type const& ops) const
     {
-        std::size_t rhs_dims = ops[1].num_dimensions();
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
         switch (rhs_dims)
         {
         case 1:
@@ -145,8 +153,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> sub_operation::sub2d2d(operands_type const& ops) const
     {
-        auto lhs_size = ops[0].dimensions();
-        auto rhs_size = ops[1].dimensions();
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
 
         if (lhs_size != rhs_size)
         {
@@ -160,17 +171,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (ops.size() == 2)
         {
-            matrix_type result = ops[0].matrix().array() - ops[1].matrix().array();
+            matrix_type result = lhs.matrix().array() - rhs.matrix().array();
             return ir::node_data<double>(std::move(result));
         }
 
-        array_type first = ops.begin()->matrix().array();
+        array_type first_term = ops.begin()->value().matrix().array();
         matrix_type result =
-            std::accumulate(ops.begin() + 1, ops.end(), first,
-                [](array_type& result, ir::node_data<double> const& curr)
+            std::accumulate(ops.begin() + 1, ops.end(), first_term,
+                [](array_type& result, operand_type const& curr)
                 ->  array_type
                 {
-                    return result -= curr.matrix().array();
+                    return result -= curr.value().matrix().array();
                 });
 
         return ir::node_data<double>(std::move(result));
@@ -179,7 +190,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ir::node_data<double> sub_operation::sub2d(
         operands_type const& ops) const
     {
-        std::size_t rhs_dims = ops[1].num_dimensions();
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
         switch (rhs_dims)
         {
         case 2:
@@ -195,23 +206,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     // implement '-' for all possible combinations of lhs and rhs
-    hpx::future<ir::node_data<double>> sub_operation::eval() const
+    hpx::future<util::optional<ir::node_data<double>>> sub_operation::eval() const
     {
-        return hpx::dataflow(
-            hpx::util::unwrapping([this](
-                                        std::vector<ir::node_data<double>>&&
-                                            ops) {
-                std::size_t lhs_dims = ops[0].num_dimensions();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type&& ops)
+            {
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
                 switch (lhs_dims)
                 {
                 case 0:
-                    return sub0d(ops);
+                    return operand_type(sub0d(ops));
 
                 case 1:
-                    return sub1d(ops);
+                    return operand_type(sub1d(ops));
 
                 case 2:
-                    return sub2d(ops);
+                    return operand_type(sub2d(ops));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -222,14 +232,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }),
             detail::map_operands(operands_,
                 [](primitive_argument_type const& val)
-                ->  hpx::future<ir::node_data<double>>
+                ->  hpx::future<operand_type>
                 {
                     primitive const* p = util::get_if<primitive>(&val);
                     if (p != nullptr)
                         return p->eval();
 
                     HPX_ASSERT(valid(val));
-                    return hpx::make_ready_future(extract_literal_value(val));
+                    return hpx::make_ready_future(
+                        operand_type(extract_literal_value(val)));
                 }));
     }
 }}}

--- a/tests/unit/execution_tree/generate_tree.cpp
+++ b/tests/unit/execution_tree/generate_tree.cpp
@@ -17,7 +17,7 @@ void test_generate_tree(std::string const& exprstr,
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::generate_tree(exprstr, patterns, variables);
 
-    HPX_TEST_EQ(p.eval().get()[0], expected_result);
+    HPX_TEST_EQ(p.eval().get().value()[0], expected_result);
 }
 
 phylanx::execution_tree::primitive create_literal_value(double value)

--- a/tests/unit/execution_tree/primitives/add_operation.cpp
+++ b/tests/unit/execution_tree/primitives/add_operation.cpp
@@ -32,8 +32,9 @@ void test_add_operation_0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
-    HPX_TEST_EQ(42.0, f.get()[0]);
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        add.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
 }
 
 void test_add_operation_0d_lit()
@@ -51,8 +52,9 @@ void test_add_operation_0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
-    HPX_TEST_EQ(42.0, f.get()[0]);
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        add.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
 }
 
 void test_add_operation_1d()
@@ -75,10 +77,12 @@ void test_add_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        add.eval();
 
     Eigen::VectorXd expected = v1 + v2;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_add_operation_1d_lit()
@@ -99,10 +103,12 @@ void test_add_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        add.eval();
 
     Eigen::VectorXd expected = v1 + v2;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_add_operation_2d()
@@ -125,10 +131,12 @@ void test_add_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        add.eval();
 
     Eigen::MatrixXd expected = m1.array() + m2.array();
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_add_operation_2d_lit()
@@ -149,10 +157,12 @@ void test_add_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = add.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        add.eval();
 
     Eigen::MatrixXd expected = m1.array() + m2.array();
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/file_primitives.cpp
+++ b/tests/unit/execution_tree/primitives/file_primitives.cpp
@@ -37,7 +37,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
     }
 
     // read back the file
-    hpx::future<phylanx::ir::node_data<double>> f;
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f;
     {
         phylanx::execution_tree::primitive infile =
             hpx::new_<phylanx::execution_tree::primitives::file_read>(
@@ -50,7 +50,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         f = infile.eval();
     }
 
-    HPX_TEST(in == f.get());
+    HPX_TEST(in == f.get().value());
 
     std::remove(filename.c_str());
 }
@@ -73,7 +73,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
     }
 
     // read back the file
-    hpx::future<phylanx::ir::node_data<double>> f;
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f;
     {
         phylanx::execution_tree::primitive infile =
             hpx::new_<phylanx::execution_tree::primitives::file_read>(
@@ -86,7 +86,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         f = infile.eval();
     }
 
-    HPX_TEST(in == f.get());
+    HPX_TEST(in == f.get().value());
 
     std::remove(filename.c_str());
 }

--- a/tests/unit/execution_tree/primitives/literal_value.cpp
+++ b/tests/unit/execution_tree/primitives/literal_value.cpp
@@ -15,9 +15,10 @@ void test_literal_value()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(42.0));
 
-    hpx::future<phylanx::ir::node_data<double>> f = val.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        val.eval();
 
-    HPX_TEST_EQ(42.0, f.get()[0]);
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/mul_operation.cpp
+++ b/tests/unit/execution_tree/primitives/mul_operation.cpp
@@ -33,8 +33,9 @@ void test_mul_operation_0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
-    HPX_TEST_EQ(42.0, f.get()[0]);
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
 }
 
 void test_mul_operation_0d_lit()
@@ -52,8 +53,9 @@ void test_mul_operation_0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
-    HPX_TEST_EQ(42.0, f.get()[0]);
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
 }
 
 void test_mul_operation_0d1d()
@@ -75,10 +77,12 @@ void test_mul_operation_0d1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::VectorXd expected = 6.0 * v;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_0d1d_lit()
@@ -98,10 +102,12 @@ void test_mul_operation_0d1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::VectorXd expected = 6.0 * v;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_0d2d()
@@ -123,10 +129,12 @@ void test_mul_operation_0d2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::MatrixXd expected = 6.0 * m;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_0d2d_lit()
@@ -146,10 +154,12 @@ void test_mul_operation_0d2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::MatrixXd expected = 6.0 * m;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_1d0d()
@@ -171,10 +181,12 @@ void test_mul_operation_1d0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::VectorXd expected = v * 6.0;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_1d0d_lit()
@@ -194,10 +206,12 @@ void test_mul_operation_1d0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::VectorXd expected = v * 6.0;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_2d0d()
@@ -219,10 +233,12 @@ void test_mul_operation_2d0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::MatrixXd expected = m * 6.0;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_2d0d_lit()
@@ -242,10 +258,12 @@ void test_mul_operation_2d0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::MatrixXd expected = m * 6.0;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_2d()
@@ -268,10 +286,12 @@ void test_mul_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::MatrixXd expected = m1 * m2;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_mul_operation_2d_lit()
@@ -292,10 +312,12 @@ void test_mul_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::ir::node_data<double>> f = mul.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        mul.eval();
 
     Eigen::MatrixXd expected = m1 * m2;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/sub_operation.cpp
+++ b/tests/unit/execution_tree/primitives/sub_operation.cpp
@@ -31,8 +31,9 @@ void test_sub_operation_0d()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::ir::node_data<double>> f = sub.eval();
-    HPX_TEST_EQ(42.0, f.get()[0]);
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        sub.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
 }
 
 void test_sub_operation_0d_lit()
@@ -49,8 +50,9 @@ void test_sub_operation_0d_lit()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::ir::node_data<double>> f = sub.eval();
-    HPX_TEST_EQ(42.0, f.get()[0]);
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        sub.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
 }
 
 void test_sub_operation_1d()
@@ -72,10 +74,12 @@ void test_sub_operation_1d()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::ir::node_data<double>> f = sub.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        sub.eval();
 
     Eigen::VectorXd expected = v1 - v2;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_sub_operation_1d_lit()
@@ -95,10 +99,12 @@ void test_sub_operation_1d_lit()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::ir::node_data<double>> f = sub.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        sub.eval();
 
     Eigen::VectorXd expected = v1 - v2;
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_sub_operation_2d()
@@ -120,10 +126,12 @@ void test_sub_operation_2d()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::ir::node_data<double>> f = sub.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        sub.eval();
 
     Eigen::MatrixXd expected = m1.array() - m2.array();
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 void test_sub_operation_2d_lit()
@@ -143,10 +151,12 @@ void test_sub_operation_2d_lit()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::ir::node_data<double>> f = sub.eval();
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        sub.eval();
 
     Eigen::MatrixXd expected = m1.array() - m2.array();
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), f.get());
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This replaces the return type for `primitive::eval()` to be an optional. This will be needed for implementing primitives like `if(cond, expr)` which will return an 'empty' optional if the condition evaluates to false.