### PR TITLE
More primitives

### DIFF
--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -141,6 +141,22 @@ namespace phylanx { namespace ast
     {
         return false;
     }
+    constexpr inline bool operator>(nil const&, nil const&)
+    {
+        return false;
+    }
+    constexpr inline bool operator<(nil const&, nil const&)
+    {
+        return false;
+    }
+    constexpr inline bool operator>=(nil const&, nil const&)
+    {
+        return true;
+    }
+    constexpr inline bool operator<=(nil const&, nil const&)
+    {
+        return true;
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     struct identifier : tagged

--- a/phylanx/execution_tree/primitives/add_operation.hpp
+++ b/phylanx/execution_tree/primitives/add_operation.hpp
@@ -25,7 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<add_operation>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<operand_type>;
 
     public:
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         add_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
         ir::node_data<double> add0d(operands_type const& ops) const;

--- a/phylanx/execution_tree/primitives/add_operation.hpp
+++ b/phylanx/execution_tree/primitives/add_operation.hpp
@@ -39,10 +39,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     protected:
         ir::node_data<double> add0d(operands_type const& ops) const;
-        ir::node_data<double> add1d(operands_type const& ops) const;
-        ir::node_data<double> add2d(operands_type const& ops) const;
+        ir::node_data<double> add0d0d(operands_type const& ops) const;
+        ir::node_data<double> add0d1d(operands_type const& ops) const;
+        ir::node_data<double> add0d2d(operands_type const& ops) const;
 
+        ir::node_data<double> add1d(operands_type const& ops) const;
+        ir::node_data<double> add1d0d(operands_type const& ops) const;
         ir::node_data<double> add1d1d(operands_type const& ops) const;
+
+        ir::node_data<double> add2d(operands_type const& ops) const;
+        ir::node_data<double> add2d0d(operands_type const& ops) const;
         ir::node_data<double> add2d2d(operands_type const& ops) const;
 
     private:

--- a/phylanx/execution_tree/primitives/and_operation.hpp
+++ b/phylanx/execution_tree/primitives/and_operation.hpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_AND_OPERATION_OCT_06_2017_0522PM)
+#define PHYLANX_PRIMITIVES_AND_OPERATION_OCT_06_2017_0522PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT and_operation
+        : public base_primitive
+        , public hpx::components::component_base<and_operation>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        and_operation() = default;
+
+        and_operation(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/and_operation.hpp
+++ b/phylanx/execution_tree/primitives/and_operation.hpp
@@ -29,6 +29,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         and_operation() = default;
 
         and_operation(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/and_operation.hpp
+++ b/phylanx/execution_tree/primitives/and_operation.hpp
@@ -25,8 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<and_operation>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<std::uint8_t>;
 
     public:
         static match_pattern_type const match_data;
@@ -35,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         and_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/div_operation.hpp
+++ b/phylanx/execution_tree/primitives/div_operation.hpp
@@ -1,0 +1,61 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_DIV_OPERATION_OCT_07_2017_0631PM)
+#define PHYLANX_PRIMITIVES_DIV_OPERATION_OCT_07_2017_0631PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT div_operation
+        : public base_primitive
+        , public hpx::components::component_base<div_operation>
+    {
+    private:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        static match_pattern_type const match_data;
+
+        div_operation() = default;
+
+        div_operation(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<primitive_result_type> eval() const override;
+
+    protected:
+        ir::node_data<double> div0d(operands_type const& ops) const;
+        ir::node_data<double> div0d0d(operands_type const& ops) const;
+        ir::node_data<double> div0d1d(operands_type const& ops) const;
+        ir::node_data<double> div0d2d(operands_type const& ops) const;
+
+        ir::node_data<double> div1d(operands_type const& ops) const;
+        ir::node_data<double> div1d0d(operands_type const& ops) const;
+        ir::node_data<double> div1d1d(operands_type const& ops) const;
+
+        ir::node_data<double> div2d(operands_type const& ops) const;
+        ir::node_data<double> div2d0d(operands_type const& ops) const;
+        ir::node_data<double> div2d2d(operands_type const& ops) const;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/equal.hpp
+++ b/phylanx/execution_tree/primitives/equal.hpp
@@ -23,8 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<equal>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<primitive_result_type>;
 
     public:
         static match_pattern_type const match_data;
@@ -33,15 +32,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         equal(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> equal0d(operands_type const& ops) const;
-        ir::node_data<double> equal1d(operands_type const& ops) const;
-        ir::node_data<double> equal2d(operands_type const& ops) const;
+        bool equal0d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool equal1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool equal2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
-        ir::node_data<double> equal1d1d(operands_type const& ops) const;
-        ir::node_data<double> equal2d2d(operands_type const& ops) const;
+        bool equal1d1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool equal2d2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+
+    public:
+        bool equal_all(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/equal.hpp
+++ b/phylanx/execution_tree/primitives/equal.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_EQUAL_OCT_07_2017_0212PM)
+#define PHYLANX_PRIMITIVES_EQUAL_OCT_07_2017_0212PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT equal
+        : public base_primitive
+        , public hpx::components::component_base<equal>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        equal() = default;
+
+        equal(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    protected:
+        ir::node_data<double> equal0d(operands_type const& ops) const;
+        ir::node_data<double> equal1d(operands_type const& ops) const;
+        ir::node_data<double> equal2d(operands_type const& ops) const;
+
+        ir::node_data<double> equal1d1d(operands_type const& ops) const;
+        ir::node_data<double> equal2d2d(operands_type const& ops) const;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/equal.hpp
+++ b/phylanx/execution_tree/primitives/equal.hpp
@@ -27,6 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         equal() = default;
 
         equal(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/file_read.hpp
+++ b/phylanx/execution_tree/primitives/file_read.hpp
@@ -15,9 +15,6 @@
 
 #include <hpx/include/components.hpp>
 
-#include <array>
-#include <fstream>
-#include <utility>
 #include <string>
 
 namespace phylanx { namespace execution_tree { namespace primitives

--- a/phylanx/execution_tree/primitives/file_read.hpp
+++ b/phylanx/execution_tree/primitives/file_read.hpp
@@ -23,9 +23,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public base_primitive
       , public hpx::components::component_base<file_read>
     {
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -33,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         file_read(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     private:
         std::string filename_;

--- a/phylanx/execution_tree/primitives/file_write.hpp
+++ b/phylanx/execution_tree/primitives/file_write.hpp
@@ -21,9 +21,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public base_primitive
       , public hpx::components::component_base<file_write>
     {
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -31,7 +28,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         file_write(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     private:
         std::string filename_;

--- a/phylanx/execution_tree/primitives/greater.hpp
+++ b/phylanx/execution_tree/primitives/greater.hpp
@@ -27,6 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         greater() = default;
 
         greater(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/greater.hpp
+++ b/phylanx/execution_tree/primitives/greater.hpp
@@ -23,8 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<greater>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<primitive_result_type>;
 
     public:
         static match_pattern_type const match_data;
@@ -33,15 +32,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         greater(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> greater0d(operands_type const& ops) const;
-        ir::node_data<double> greater1d(operands_type const& ops) const;
-        ir::node_data<double> greater2d(operands_type const& ops) const;
+        bool greater0d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool greater1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool greater2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
-        ir::node_data<double> greater1d1d(operands_type const& ops) const;
-        ir::node_data<double> greater2d2d(operands_type const& ops) const;
+        bool greater1d1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool greater2d2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+
+    public:
+        bool greater_all(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/greater.hpp
+++ b/phylanx/execution_tree/primitives/greater.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_GREATER_OCT_07_2017_0223PM)
+#define PHYLANX_PRIMITIVES_GREATER_OCT_07_2017_0223PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT greater
+        : public base_primitive
+        , public hpx::components::component_base<greater>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        greater() = default;
+
+        greater(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    protected:
+        ir::node_data<double> greater0d(operands_type const& ops) const;
+        ir::node_data<double> greater1d(operands_type const& ops) const;
+        ir::node_data<double> greater2d(operands_type const& ops) const;
+
+        ir::node_data<double> greater1d1d(operands_type const& ops) const;
+        ir::node_data<double> greater2d2d(operands_type const& ops) const;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/greater_equal.hpp
+++ b/phylanx/execution_tree/primitives/greater_equal.hpp
@@ -27,6 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         greater_equal() = default;
 
         greater_equal(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/greater_equal.hpp
+++ b/phylanx/execution_tree/primitives/greater_equal.hpp
@@ -3,8 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_PRIMITIVES_GREATER_EQUAL_OCT_07_2017_0212PM)
-#define PHYLANX_PRIMITIVES_GREATER_EQUAL_OCT_07_2017_0212PM
+#if !defined(PHYLANX_PRIMITIVES_greater_equal_OCT_07_2017_0212PM)
+#define PHYLANX_PRIMITIVES_greater_equal_OCT_07_2017_0212PM
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
@@ -23,8 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<greater_equal>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<primitive_result_type>;
 
     public:
         static match_pattern_type const match_data;
@@ -33,15 +32,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         greater_equal(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> greater_equal0d(operands_type const& ops) const;
-        ir::node_data<double> greater_equal1d(operands_type const& ops) const;
-        ir::node_data<double> greater_equal2d(operands_type const& ops) const;
+        bool greater_equal0d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool greater_equal1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool greater_equal2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
-        ir::node_data<double> greater_equal1d1d(operands_type const& ops) const;
-        ir::node_data<double> greater_equal2d2d(operands_type const& ops) const;
+        bool greater_equal1d1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool greater_equal2d2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+
+    public:
+        bool greater_equal_all(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/greater_equal.hpp
+++ b/phylanx/execution_tree/primitives/greater_equal.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_GREATER_EQUAL_OCT_07_2017_0212PM)
+#define PHYLANX_PRIMITIVES_GREATER_EQUAL_OCT_07_2017_0212PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT greater_equal
+        : public base_primitive
+        , public hpx::components::component_base<greater_equal>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        greater_equal() = default;
+
+        greater_equal(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    protected:
+        ir::node_data<double> greater_equal0d(operands_type const& ops) const;
+        ir::node_data<double> greater_equal1d(operands_type const& ops) const;
+        ir::node_data<double> greater_equal2d(operands_type const& ops) const;
+
+        ir::node_data<double> greater_equal1d1d(operands_type const& ops) const;
+        ir::node_data<double> greater_equal2d2d(operands_type const& ops) const;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/less.hpp
+++ b/phylanx/execution_tree/primitives/less.hpp
@@ -23,8 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<less>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<primitive_result_type>;
 
     public:
         static match_pattern_type const match_data;
@@ -33,15 +32,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         less(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> less0d(operands_type const& ops) const;
-        ir::node_data<double> less1d(operands_type const& ops) const;
-        ir::node_data<double> less2d(operands_type const& ops) const;
+        bool less0d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool less1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool less2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
-        ir::node_data<double> less1d1d(operands_type const& ops) const;
-        ir::node_data<double> less2d2d(operands_type const& ops) const;
+        bool less1d1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool less2d2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+
+    public:
+        bool less_all(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/less.hpp
+++ b/phylanx/execution_tree/primitives/less.hpp
@@ -27,6 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         less() = default;
 
         less(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/less.hpp
+++ b/phylanx/execution_tree/primitives/less.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_LESS_OCT_07_2017_0225PM)
+#define PHYLANX_PRIMITIVES_LESS_OCT_07_2017_0225PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT less
+        : public base_primitive
+        , public hpx::components::component_base<less>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        less() = default;
+
+        less(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    protected:
+        ir::node_data<double> less0d(operands_type const& ops) const;
+        ir::node_data<double> less1d(operands_type const& ops) const;
+        ir::node_data<double> less2d(operands_type const& ops) const;
+
+        ir::node_data<double> less1d1d(operands_type const& ops) const;
+        ir::node_data<double> less2d2d(operands_type const& ops) const;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/less_equal.hpp
+++ b/phylanx/execution_tree/primitives/less_equal.hpp
@@ -3,8 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_PRIMITIVES_LESS_EQUAL_OCT_07_2017_0226PM)
-#define PHYLANX_PRIMITIVES_LESS_EQUAL_OCT_07_2017_0226PM
+#if !defined(PHYLANX_PRIMITIVES_less_equal_OCT_07_2017_0226PM)
+#define PHYLANX_PRIMITIVES_less_equal_OCT_07_2017_0226PM
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
@@ -23,8 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<less_equal>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<primitive_result_type>;
 
     public:
         static match_pattern_type const match_data;
@@ -33,15 +32,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         less_equal(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> less_equal0d(operands_type const& ops) const;
-        ir::node_data<double> less_equal1d(operands_type const& ops) const;
-        ir::node_data<double> less_equal2d(operands_type const& ops) const;
+        bool less_equal0d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool less_equal1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool less_equal2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
-        ir::node_data<double> less_equal1d1d(operands_type const& ops) const;
-        ir::node_data<double> less_equal2d2d(operands_type const& ops) const;
+        bool less_equal1d1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool less_equal2d2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+
+    public:
+        bool less_equal_all(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/less_equal.hpp
+++ b/phylanx/execution_tree/primitives/less_equal.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_LESS_EQUAL_OCT_07_2017_0226PM)
+#define PHYLANX_PRIMITIVES_LESS_EQUAL_OCT_07_2017_0226PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT less_equal
+        : public base_primitive
+        , public hpx::components::component_base<less_equal>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        less_equal() = default;
+
+        less_equal(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    protected:
+        ir::node_data<double> less_equal0d(operands_type const& ops) const;
+        ir::node_data<double> less_equal1d(operands_type const& ops) const;
+        ir::node_data<double> less_equal2d(operands_type const& ops) const;
+
+        ir::node_data<double> less_equal1d1d(operands_type const& ops) const;
+        ir::node_data<double> less_equal2d2d(operands_type const& ops) const;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/less_equal.hpp
+++ b/phylanx/execution_tree/primitives/less_equal.hpp
@@ -27,6 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         less_equal() = default;
 
         less_equal(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/literal_value.hpp
+++ b/phylanx/execution_tree/primitives/literal_value.hpp
@@ -32,10 +32,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
             : data_(std::move(data))
         {}
 
-        hpx::future<util::optional<ir::node_data<double>>> eval() const override
+        hpx::future<primitive_result_type> eval() const override
         {
-            return hpx::make_ready_future(
-                util::optional<ir::node_data<double>>(data_));
+            return hpx::make_ready_future(primitive_result_type(data_));
         }
 
     private:

--- a/phylanx/execution_tree/primitives/mul_operation.hpp
+++ b/phylanx/execution_tree/primitives/mul_operation.hpp
@@ -26,7 +26,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public hpx::components::component_base<mul_operation>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<operand_type>;
 
     public:
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         mul_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
         ir::node_data<double> mul0d(operands_type const& ops) const;

--- a/phylanx/execution_tree/primitives/not_equal.hpp
+++ b/phylanx/execution_tree/primitives/not_equal.hpp
@@ -27,6 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         not_equal() = default;
 
         not_equal(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/not_equal.hpp
+++ b/phylanx/execution_tree/primitives/not_equal.hpp
@@ -23,8 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<not_equal>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<primitive_result_type>;
 
     public:
         static match_pattern_type const match_data;
@@ -33,15 +32,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         not_equal(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> not_equal0d(operands_type const& ops) const;
-        ir::node_data<double> not_equal1d(operands_type const& ops) const;
-        ir::node_data<double> not_equal2d(operands_type const& ops) const;
+        bool not_equal0d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool not_equal1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool not_equal2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
-        ir::node_data<double> not_equal1d1d(operands_type const& ops) const;
-        ir::node_data<double> not_equal2d2d(operands_type const& ops) const;
+        bool not_equal1d1d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+        bool not_equal2d2d(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
+
+    public:
+        bool not_equal_all(ir::node_data<double> const& lhs,
+            ir::node_data<double> const& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/not_equal.hpp
+++ b/phylanx/execution_tree/primitives/not_equal.hpp
@@ -1,0 +1,51 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_NOT_EQUAL_OCT_07_2017_0212PM)
+#define PHYLANX_PRIMITIVES_NOT_EQUAL_OCT_07_2017_0212PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT not_equal
+        : public base_primitive
+        , public hpx::components::component_base<not_equal>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        not_equal() = default;
+
+        not_equal(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    protected:
+        ir::node_data<double> not_equal0d(operands_type const& ops) const;
+        ir::node_data<double> not_equal1d(operands_type const& ops) const;
+        ir::node_data<double> not_equal2d(operands_type const& ops) const;
+
+        ir::node_data<double> not_equal1d1d(operands_type const& ops) const;
+        ir::node_data<double> not_equal2d2d(operands_type const& ops) const;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/or_operation.hpp
+++ b/phylanx/execution_tree/primitives/or_operation.hpp
@@ -25,8 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<or_operation>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<std::uint8_t>;
 
     public:
         static match_pattern_type const match_data;
@@ -35,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         or_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/or_operation.hpp
+++ b/phylanx/execution_tree/primitives/or_operation.hpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_OR_OPERATION_OCT_06_2017_0522PM)
+#define PHYLANX_PRIMITIVES_OR_OPERATION_OCT_06_2017_0522PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class HPX_COMPONENT_EXPORT or_operation
+        : public base_primitive
+        , public hpx::components::component_base<or_operation>
+    {
+    private:
+        using operand_type = util::optional<ir::node_data<double>>;
+        using operands_type = std::vector<operand_type>;
+
+    public:
+        or_operation() = default;
+
+        or_operation(std::vector<primitive_argument_type>&& operands);
+
+        hpx::future<operand_type> eval() const override;
+
+    private:
+        std::vector<primitive_argument_type> operands_;
+    };
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives/or_operation.hpp
+++ b/phylanx/execution_tree/primitives/or_operation.hpp
@@ -29,6 +29,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         or_operation() = default;
 
         or_operation(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/execution_tree/primitives/sub_operation.hpp
+++ b/phylanx/execution_tree/primitives/sub_operation.hpp
@@ -25,7 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<sub_operation>
     {
     private:
-        using operand_type = util::optional<ir::node_data<double>>;
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<operand_type>;
 
     public:
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         sub_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     protected:
         ir::node_data<double> sub0d(operands_type const& ops) const;

--- a/phylanx/execution_tree/primitives/sub_operation.hpp
+++ b/phylanx/execution_tree/primitives/sub_operation.hpp
@@ -39,10 +39,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     protected:
         ir::node_data<double> sub0d(operands_type const& ops) const;
-        ir::node_data<double> sub1d(operands_type const& ops) const;
-        ir::node_data<double> sub2d(operands_type const& ops) const;
+        ir::node_data<double> sub0d0d(operands_type const& ops) const;
+        ir::node_data<double> sub0d1d(operands_type const& ops) const;
+        ir::node_data<double> sub0d2d(operands_type const& ops) const;
 
+        ir::node_data<double> sub1d(operands_type const& ops) const;
+        ir::node_data<double> sub1d0d(operands_type const& ops) const;
         ir::node_data<double> sub1d1d(operands_type const& ops) const;
+
+        ir::node_data<double> sub2d(operands_type const& ops) const;
+        ir::node_data<double> sub2d0d(operands_type const& ops) const;
         ir::node_data<double> sub2d2d(operands_type const& ops) const;
 
     private:

--- a/phylanx/execution_tree/primitives/while_operation.hpp
+++ b/phylanx/execution_tree/primitives/while_operation.hpp
@@ -25,8 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public base_primitive
       , public hpx::components::component_base<while_operation>
     {
-        using operand_type = util::optional<ir::node_data<double>>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type = std::vector<primitive_result_type>;
 
     public:
         static match_pattern_type const match_data;
@@ -35,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         while_operation(std::vector<primitive_argument_type>&& operands);
 
-        hpx::future<operand_type> eval() const override;
+        hpx::future<primitive_result_type> eval() const override;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/while_operation.hpp
+++ b/phylanx/execution_tree/primitives/while_operation.hpp
@@ -3,37 +3,40 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_PRIMITIVES_FILE_WRITE_SEP_17_2017_0111PM)
-#define PHYLANX_PRIMITIVES_FILE_WRITE_SEP_17_2017_0111PM
+#if !defined(PHYLANX_PRIMITIVES_WHILE_OPERATION_OCT_06_2017_1127AM)
+#define PHYLANX_PRIMITIVES_WHILE_OPERATION_OCT_06_2017_1127AM
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
 
 #include <hpx/include/components.hpp>
 
-#include <string>
+#include <array>
+#include <utility>
+#include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class HPX_COMPONENT_EXPORT file_write
+    class HPX_COMPONENT_EXPORT while_operation
       : public base_primitive
-      , public hpx::components::component_base<file_write>
+      , public hpx::components::component_base<while_operation>
     {
         using operand_type = util::optional<ir::node_data<double>>;
         using operands_type = std::vector<operand_type>;
 
     public:
-        file_write() = default;
+        while_operation() = default;
 
-        file_write(std::vector<primitive_argument_type>&& operands);
+        while_operation(std::vector<primitive_argument_type>&& operands);
 
         hpx::future<operand_type> eval() const override;
 
     private:
-        std::string filename_;
-        primitive_argument_type operand_;
+        std::vector<primitive_argument_type> operands_;
     };
 }}}
 

--- a/phylanx/execution_tree/primitives/while_operation.hpp
+++ b/phylanx/execution_tree/primitives/while_operation.hpp
@@ -29,6 +29,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
+        static match_pattern_type const match_data;
+
         while_operation() = default;
 
         while_operation(std::vector<primitive_argument_type>&& operands);

--- a/phylanx/include/primitives.hpp
+++ b/phylanx/include/primitives.hpp
@@ -8,6 +8,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
+#include <phylanx/execution_tree/primitives/and_operation.hpp>
 #include <phylanx/execution_tree/primitives/equal.hpp>
 #include <phylanx/execution_tree/primitives/file_read.hpp>
 #include <phylanx/execution_tree/primitives/file_write.hpp>
@@ -18,6 +19,7 @@
 #include <phylanx/execution_tree/primitives/literal_value.hpp>
 #include <phylanx/execution_tree/primitives/mul_operation.hpp>
 #include <phylanx/execution_tree/primitives/not_equal.hpp>
+#include <phylanx/execution_tree/primitives/or_operation.hpp>
 #include <phylanx/execution_tree/primitives/sub_operation.hpp>
 #include <phylanx/execution_tree/primitives/while_operation.hpp>
 

--- a/phylanx/include/primitives.hpp
+++ b/phylanx/include/primitives.hpp
@@ -8,9 +8,10 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
-#include <phylanx/execution_tree/primitives/exponential_operation.hpp>
 #include <phylanx/execution_tree/primitives/and_operation.hpp>
+#include <phylanx/execution_tree/primitives/div_operation.hpp>
 #include <phylanx/execution_tree/primitives/equal.hpp>
+#include <phylanx/execution_tree/primitives/exponential_operation.hpp>
 #include <phylanx/execution_tree/primitives/file_read.hpp>
 #include <phylanx/execution_tree/primitives/file_write.hpp>
 #include <phylanx/execution_tree/primitives/greater.hpp>

--- a/phylanx/include/primitives.hpp
+++ b/phylanx/include/primitives.hpp
@@ -8,10 +8,11 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
-#include <phylanx/execution_tree/primitives/sub_operation.hpp>
-#include <phylanx/execution_tree/primitives/mul_operation.hpp>
 #include <phylanx/execution_tree/primitives/file_read.hpp>
 #include <phylanx/execution_tree/primitives/file_write.hpp>
 #include <phylanx/execution_tree/primitives/literal_value.hpp>
+#include <phylanx/execution_tree/primitives/mul_operation.hpp>
+#include <phylanx/execution_tree/primitives/sub_operation.hpp>
+#include <phylanx/execution_tree/primitives/while_operation.hpp>
 
 #endif

--- a/phylanx/include/primitives.hpp
+++ b/phylanx/include/primitives.hpp
@@ -8,10 +8,16 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
+#include <phylanx/execution_tree/primitives/equal.hpp>
 #include <phylanx/execution_tree/primitives/file_read.hpp>
 #include <phylanx/execution_tree/primitives/file_write.hpp>
+#include <phylanx/execution_tree/primitives/greater.hpp>
+#include <phylanx/execution_tree/primitives/greater_equal.hpp>
+#include <phylanx/execution_tree/primitives/less.hpp>
+#include <phylanx/execution_tree/primitives/less_equal.hpp>
 #include <phylanx/execution_tree/primitives/literal_value.hpp>
 #include <phylanx/execution_tree/primitives/mul_operation.hpp>
+#include <phylanx/execution_tree/primitives/not_equal.hpp>
 #include <phylanx/execution_tree/primitives/sub_operation.hpp>
 #include <phylanx/execution_tree/primitives/while_operation.hpp>
 

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -249,6 +249,12 @@ namespace phylanx { namespace ir
             return (dim == 0) ? data_.rows() : data_.cols();
         }
 
+        explicit operator bool() const;
+        bool operator!() const
+        {
+            return !bool(*this);
+        }
+
     private:
         /// \cond NOINTERNAL
         friend class hpx::serialization::access;

--- a/phylanx/util/serialization/ast.hpp
+++ b/phylanx/util/serialization/ast.hpp
@@ -33,6 +33,8 @@ namespace phylanx { namespace util
     PHYLANX_EXPORT std::vector<char> serialize(ast::expression const&);
     PHYLANX_EXPORT std::vector<char> serialize(ast::function_call const&);
 
+    PHYLANX_EXPORT std::vector<char> serialize(ast::literal_value_type const&);
+
     PHYLANX_EXPORT void append_operation(ast::expression &,ast::operation const &);
 
     namespace detail
@@ -53,6 +55,9 @@ namespace phylanx { namespace util
             std::vector<char> const&, ast::expression&);
         PHYLANX_EXPORT void unserialize(
             std::vector<char> const&, ast::function_call&);
+
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::literal_value_type&);
     }
 
     PHYLANX_EXPORT ast::expression unserialize(std::vector<char> const&);

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -68,32 +68,68 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> add_operation::add0d(operands_type const& ops) const
+    ir::node_data<double> add_operation::add0d0d(operands_type const& ops) const
     {
         auto const& lhs = ops[0];
         auto const& rhs = ops[1];
 
-        std::size_t rhs_dims = rhs.num_dimensions();
+        if (ops.size() == 2)
+        {
+            return lhs[0] + rhs[0];
+        }
+
+        return ir::node_data<double>(
+            std::accumulate(ops.begin() + 1, ops.end(), lhs[0],
+                [](double result, operand_type const& curr)
+                {
+                    return result + curr[0];
+                }));
+    }
+
+    ir::node_data<double> add_operation::add0d1d(operands_type const& ops) const
+    {
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "add_operation::add0d1d",
+                "the add_operation primitive can add a single value to a "
+                    "vector only if there are exectly 2 operands");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+        matrix_type result = ops[0][0] + ops[1].matrix().array();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> add_operation::add0d2d(operands_type const& ops) const
+    {
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "add_operation::add0d2d",
+                "the add_operation primitive can add a single value to a "
+                    "matrix only if there are exectly 2 operands");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+        matrix_type result = ops[0][0] + ops[1].matrix().array();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> add_operation::add0d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].num_dimensions();
         switch(rhs_dims)
         {
         case 0:
-            {
-                if (ops.size() == 2)
-                {
-                    return lhs[0] + rhs[0];
-                }
+            return add0d0d(ops);
 
-                return ir::node_data<double>(
-                    std::accumulate(ops.begin() + 1, ops.end(), lhs[0],
-                        [](double result, operand_type const& curr)
-                        {
-                            return result + curr[0];
-                        }));
-            }
-            break;
+        case 1:
+            return add0d1d(ops);
 
-        case 1: HPX_FALLTHROUGH;
-        case 2: HPX_FALLTHROUGH;
+        case 2:
+            return add0d2d(ops);
+
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "add_operation::add0d",
@@ -102,6 +138,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> add_operation::add1d0d(operands_type const& ops) const
+    {
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "add_operation::add0d1d",
+                "the add_operation primitive can add a single value to a "
+                    "vector only if there are exactly 2 operands");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+        matrix_type result = ops[0].matrix().array() + ops[1][0];
+        return ir::node_data<double>(std::move(result));
+    }
+
     ir::node_data<double> add_operation::add1d1d(operands_type const& ops) const
     {
         auto const& lhs = ops[0];
@@ -110,7 +161,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
-        if(lhs_size  != rhs_size)
+        if (lhs_size  != rhs_size)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "add_operation::add1d1d",
@@ -145,10 +196,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         switch(rhs_dims)
         {
+        case 0:
+            return add1d0d(ops);
+
         case 1:
             return add1d1d(ops);
 
-        case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -158,6 +211,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> add_operation::add2d0d(operands_type const& ops) const
+    {
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "add_operation::add0d2d",
+                "the add_operation primitive can add a single value to a "
+                    "matrix only if there are exactly 2 operands");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+        matrix_type result = ops[0].matrix().array() + ops[1][0];
+        return ir::node_data<double>(std::move(result));
+    }
+
     ir::node_data<double> add_operation::add2d2d(operands_type const& ops) const
     {
         auto const& lhs = ops[0];
@@ -200,10 +268,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::size_t rhs_dims = ops[1].num_dimensions();
         switch(rhs_dims)
         {
+        case 0:
+            return add2d0d(ops);
+
         case 2:
             return add2d2d(ops);
 
-        case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -212,7 +212,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "add_operation::eval",

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -180,7 +180,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         array_type first_term = ops.begin()->matrix().array();
         matrix_type result =
             std::accumulate(
-                ops.begin() + 1, ops.end(), first_term,
+                ops.begin() + 1, ops.end(), std::move(first_term),
                 [](array_type& result, operand_type const& curr)
                 ->  array_type
                 {
@@ -253,7 +253,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         array_type first_term = ops.begin()->matrix().array();
         matrix_type result =
             std::accumulate(
-                ops.begin() + 1, ops.end(), first_term,
+                ops.begin() + 1, ops.end(), std::move(first_term),
                 [](array_type& result, operand_type const& curr)
                 ->  array_type
                 {

--- a/src/execution_tree/primitives/and_operation.cpp
+++ b/src/execution_tree/primitives/and_operation.cpp
@@ -33,6 +33,12 @@ HPX_DEFINE_GET_COMPONENT_TYPE(and_operation_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const and_operation::match_data =
+    {
+        "_1 && __2", &create<and_operation>
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     and_operation::and_operation(std::vector<primitive_argument_type>&& operands)
       : operands_(std::move(operands))
     {

--- a/src/execution_tree/primitives/and_operation.cpp
+++ b/src/execution_tree/primitives/and_operation.cpp
@@ -69,35 +69,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     // implement '&&' for all possible combinations of lhs and rhs
-    hpx::future<util::optional<ir::node_data<double>>> and_operation::eval() const
+    hpx::future<primitive_result_type> and_operation::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (!detail::verify_argument_values(ops))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "and_operation::eval",
-                        "the and_operation primitive requires that the argument"
-                            " values given by the operands array are non-empty");
-                }
-
                 if (ops.size() == 2)
                 {
-                    return operand_type(ir::node_data<double>(
-                            bool(ops[0].value()) && bool(ops[1].value()) ?
-                                1.0 : 0.0
-                        ));
+                    return primitive_result_type(ops[0] && ops[1]);
                 }
 
-                return operand_type(ir::node_data<double>(
+                return primitive_result_type(
                     std::all_of(ops.begin(), ops.end(),
-                        [](operand_type const& curr)
-                        {
-                            return bool(curr.value());
-                        }) ? 1.0 : 0.0));
+                        [](std::uint8_t curr) { return curr; }));
             }),
-            detail::map_operands(operands_, evaluate_operand)
+            detail::map_operands(operands_, boolean_operand)
         );
     }
 }}}

--- a/src/execution_tree/primitives/and_operation.cpp
+++ b/src/execution_tree/primitives/and_operation.cpp
@@ -1,0 +1,97 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/and_operation.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/eigen.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::and_operation>
+    and_operation_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    and_operation_type, phylanx_and_operation_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(and_operation_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    and_operation::and_operation(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() < 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "and_operation::and_operation",
+                "the and_operation primitive requires at least two operands");
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands_.size(); ++i)
+        {
+            if (!valid(operands_[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "and_operation::and_operation",
+                "the and_operation primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // implement '&&' for all possible combinations of lhs and rhs
+    hpx::future<util::optional<ir::node_data<double>>> and_operation::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (!detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "and_operation::eval",
+                        "the and_operation primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
+                if (ops.size() == 2)
+                {
+                    return operand_type(ir::node_data<double>(
+                            bool(ops[0].value()) && bool(ops[1].value()) ?
+                                1.0 : 0.0
+                        ));
+                }
+
+                return operand_type(ir::node_data<double>(
+                    std::all_of(ops.begin(), ops.end(),
+                        [](operand_type const& curr)
+                        {
+                            return bool(curr.value());
+                        }) ? 1.0 : 0.0));
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -29,14 +29,74 @@ HPX_DEFINE_GET_COMPONENT_TYPE(base_primitive_type)
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree
 {
-    hpx::future<util::optional<ir::node_data<double>>> primitive::eval() const
+    hpx::future<primitive_result_type> primitive::eval() const
     {
         using action_type = primitives::base_primitive::eval_action;
         return hpx::async(action_type(), this->base_type::get_id());
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> extract_literal_value(
+    primitive_result_type extract_literal_value(
+        primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+            return ast::nil{};
+
+        case 1:     // bool
+            return util::get<1>(val);
+
+        case 2:     // std::uint64_t
+            return util::get<2>(val);
+
+        case 3:     // std::string
+            return util::get<3>(val);
+
+        case 4:     // phylanx::ir::node_data<double>
+            return util::get<4>(val);
+
+        case 5: HPX_FALLTHROUGH;    // primitive
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_literal_value",
+            "primitive_argument_type does not hold a literal value type");
+    }
+
+    primitive_result_type extract_literal_value(
+        primitive_result_type && val)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+            return ast::nil{};
+
+        case 1:     // bool
+            return util::get<1>(val);
+
+        case 2:     // std::uint64_t
+            return util::get<2>(val);
+
+        case 3:     // std::string
+            return util::get<3>(std::move(val));
+
+        case 4:     // phylanx::ir::node_data<double>
+            return util::get<4>(std::move(val));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_literal_value",
+            "primitive_result_type does not hold a literal value type");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> extract_numeric_value(
         primitive_argument_type const& val)
     {
         switch (val.index())
@@ -50,17 +110,95 @@ namespace phylanx { namespace execution_tree
         case 4:     // phylanx::ir::node_data<double>
             return util::get<4>(val);
 
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        case 5: HPX_FALLTHROUGH;    // primitive
         default:
             break;
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "phylanx::execution_tree::extract_literal_value",
-            "primitive_value_type does not hold a literal value type");
+            "phylanx::execution_tree::extract_numeric_value",
+            "primitive_argument_type does not hold a literal value type");
+    }
+
+    ir::node_data<double> extract_numeric_value(
+        primitive_result_type && val)
+    {
+        switch (val.index())
+        {
+        case 1:     // bool
+            return ir::node_data<double>{double(util::get<1>(val))};
+
+        case 2:     // std::uint64_t
+            return ir::node_data<double>{double(util::get<2>(val))};
+
+        case 4:     // phylanx::ir::node_data<double>
+            return util::get<4>(std::move(val));
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_numeric_value",
+            "primitive_result_type does not hold a literal value type");
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive extract_primitive(primitive_argument_type const& val)
+    std::uint8_t extract_boolean_value(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 1:     // bool
+            return util::get<1>(val);
+
+        case 2:     // std::uint64_t
+            return util::get<2>(val) != 0;
+
+        case 4:     // phylanx::ir::node_data<double>
+            return bool(util::get<4>(val));
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        case 5: HPX_FALLTHROUGH;    // primitive
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_numeric_value",
+            "primitive_argument_type does not hold a literal value type");
+    }
+
+    std::uint8_t extract_boolean_value(primitive_result_type const& val)
+    {
+        switch (val.index())
+        {
+        case 1:     // bool
+            return util::get<1>(val);
+
+        case 2:     // std::uint64_t
+            return util::get<2>(val) != 0;
+
+        case 4:     // phylanx::ir::node_data<double>
+            return bool(util::get<4>(val));
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_numeric_value",
+            "primitive_result_type does not hold a literal value type");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive primitive_operand(primitive_argument_type const& val)
     {
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
@@ -72,21 +210,58 @@ namespace phylanx { namespace execution_tree
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<util::optional<ir::node_data<double>>> evaluate_operand(
+    hpx::future<primitive_result_type> literal_operand(
         primitive_argument_type const& val)
     {
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
-            return p->eval();
+        {
+            return p->eval().then(
+                [](hpx::future<primitive_result_type> && f)
+                {
+                    return extract_literal_value(f.get());
+                });
+        }
 
         HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(util::optional<ir::node_data<double>>(
-            extract_literal_value(val)));
+        return hpx::make_ready_future(extract_literal_value(val));
+    }
+
+    hpx::future<ir::node_data<double>> numeric_operand(
+        primitive_argument_type const& val)
+    {
+        primitive const* p = util::get_if<primitive>(&val);
+        if (p != nullptr)
+        {
+            return p->eval().then(
+                [](hpx::future<primitive_result_type> && f)
+                {
+                    return extract_numeric_value(f.get());
+                });
+        }
+
+        HPX_ASSERT(valid(val));
+        return hpx::make_ready_future(extract_numeric_value(val));
+    }
+
+    hpx::future<std::uint8_t> boolean_operand(primitive_argument_type const& val)
+    {
+        primitive const* p = util::get_if<primitive>(&val);
+        if (p != nullptr)
+        {
+            return p->eval().then(
+                [](hpx::future<primitive_result_type> && f)
+                {
+                    return extract_boolean_value(f.get());
+                });
+        }
+
+        HPX_ASSERT(valid(val));
+        return hpx::make_ready_future(extract_boolean_value(val));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive_argument_type to_primitive_value_type(
-        ast::literal_value_type && val)
+    primitive_argument_type to_primitive_value_type(primitive_result_type&& val)
     {
         switch (val.index())
         {

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -163,7 +163,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "equal::eval",

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -30,10 +30,10 @@ HPX_DEFINE_GET_COMPONENT_TYPE(equal_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-//     match_pattern_type const equal::match_data =
-//     {
-//         "_1 == _2", &create<equal>
-//     };
+    match_pattern_type const equal::match_data =
+    {
+        "_1 == _2", &create<equal>
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     equal::equal(std::vector<primitive_argument_type>&& operands)

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -56,11 +56,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> equal::equal0d(operands_type const& ops) const
+    bool equal::equal0d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
@@ -77,11 +75,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> equal::equal1d1d(operands_type const& ops) const
+    bool equal::equal1d1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
@@ -92,21 +88,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
             (lhs.matrix().array() == rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> equal::equal1d(operands_type const& ops) const
+    bool equal::equal1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
-
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return equal1d1d(ops);
+            return equal1d1d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -118,11 +113,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> equal::equal2d2d(operands_type const& ops) const
+    bool equal::equal2d2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
 
@@ -133,20 +126,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
             (lhs.matrix().array() == rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> equal::equal2d(operands_type const& ops) const
+    bool equal::equal2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return equal2d2d(ops);
+            return equal2d2d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -157,40 +150,72 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    // implement '<' for all possible combinations of lhs and rhs
-    hpx::future<util::optional<ir::node_data<double>>> equal::eval() const
+    bool equal::equal_all(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return equal0d(lhs, rhs);
+
+        case 1:
+            return equal1d(lhs, rhs);
+
+        case 2:
+            return equal2d(lhs, rhs);
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal_all",
+                "left hand side operand has unsupported number of "
+                "dimensions");
+        }
+    }
+
+    namespace detail
+    {
+        struct visit_equal
+        {
+            visit_equal(equal const& this_)
+              : equal_(this_)
+            {}
+
+            template <typename T1, typename T2>
+            bool operator()(T1, T2) const
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "equal::eval",
+                    "left hand side and right hand side are incompatible and "
+                        "can't be compared");
+            }
+
+            template <typename T>
+            bool operator()(T const& lhs, T const& rhs) const
+            {
+                return lhs == rhs;
+            }
+
+            bool operator()(ir::node_data<double> const& lhs,
+                ir::node_data<double> const& rhs) const
+            {
+                return equal_.equal_all(lhs, rhs);
+            }
+
+            equal const& equal_;
+        };
+    }
+
+    // implement '==' for all possible combinations of lhs and rhs
+    hpx::future<primitive_result_type> equal::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (!detail::verify_argument_values(ops))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::eval",
-                        "the equal primitive requires that the argument"
-                            " values given by the operands array are non-empty");
-                }
-
-                std::size_t lhs_dims = ops[0].value().num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return operand_type(equal0d(ops));
-
-                case 1:
-                    return operand_type(equal1d(ops));
-
-                case 2:
-                    return operand_type(equal2d(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::eval",
-                        "left hand side operand has unsupported number of "
-                        "dimensions");
-                }
+                return primitive_result_type(
+                    util::visit(detail::visit_equal(*this), ops[0], ops[1]));
             }),
-            detail::map_operands(operands_, evaluate_operand)
+            detail::map_operands(operands_, literal_operand)
         );
     }
 }}}

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -1,0 +1,196 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/equal.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::equal>
+    equal_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    equal_type, phylanx_equal_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(equal_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+//     match_pattern_type const equal::match_data =
+//     {
+//         "_1 == _2", &create<equal>
+//     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    equal::equal(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal",
+                "the equal primitive requires exactly two operands");
+        }
+
+        if (!valid(operands_[0]) || !valid(operands_[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal",
+                "the equal primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> equal::equal0d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return lhs[0] == rhs[0];
+
+        case 1: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> equal::equal1d1d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size  != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal1d1d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+        matrix_type result =
+            (lhs.matrix().array() == rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> equal::equal1d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+
+        switch(rhs_dims)
+        {
+        case 1:
+            return equal1d1d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal1d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> equal::equal2d2d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal2d2d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+
+        matrix_type result =
+            (lhs.matrix().array() == rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> equal::equal2d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        switch(rhs_dims)
+        {
+        case 2:
+            return equal2d2d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 1: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal2d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    // implement '<' for all possible combinations of lhs and rhs
+    hpx::future<util::optional<ir::node_data<double>>> equal::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "equal::eval",
+                        "the equal primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return operand_type(equal0d(ops));
+
+                case 1:
+                    return operand_type(equal1d(ops));
+
+                case 2:
+                    return operand_type(equal2d(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "equal::eval",
+                        "left hand side operand has unsupported number of "
+                        "dimensions");
+                }
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/file_read.cpp
+++ b/src/execution_tree/primitives/file_read.cpp
@@ -68,7 +68,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     // read data from given file and return content
-    hpx::future<util::optional<ir::node_data<double>>> file_read::eval() const
+    hpx::future<primitive_result_type> file_read::eval() const
     {
         std::ifstream infile(filename_.c_str(),
             std::ios::binary | std::ios::in | std::ios::ate);
@@ -94,10 +94,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     filename_);
         }
 
-        // assume data in file is result of a serialized ir::node_data
-        ir::node_data<double> nd;
-        phylanx::util::detail::unserialize(data, nd);
+        // assume data in file is result of a serialized primitive_result_type
+        primitive_result_type val;
+        phylanx::util::detail::unserialize(data, val);
 
-        return hpx::make_ready_future(operand_type(std::move(nd)));
+        return hpx::make_ready_future(std::move(val));
     }
 }}}

--- a/src/execution_tree/primitives/file_read.cpp
+++ b/src/execution_tree/primitives/file_read.cpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <fstream>
 #include <vector>
+#include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
 typedef hpx::components::component<
@@ -43,9 +44,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::primitives::file_read::file_read",
-                "the file_read primitive requires that the "
-                    "exactly one element of the literals and operands "
-                    "arrays is valid");
+                "the file_read primitive requires that the given operand is "
+                    "valid");
         }
 
         std::string* name = util::get_if<std::string>(&operands[0]);

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <fstream>
 #include <vector>
+#include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
 typedef hpx::components::component<
@@ -44,9 +45,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::primitives::file_write::file_write",
-                "the file_write primitive requires that the "
-                    "exactly one element of the literals and operands "
-                    "arrays is valid");
+                "the file_write primitive requires that the given operands "
+                    "are valid");
         }
 
         std::string* name = util::get_if<std::string>(&operands[0]);

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -70,7 +70,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     void write_to_file(
-        std::string const& filename, ir::node_data<double> const& nd)
+        std::string const& filename, primitive_result_type const& val)
     {
         std::ofstream outfile(filename.c_str(),
             std::ios::binary | std::ios::out | std::ios::trunc);
@@ -81,7 +81,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "couldn't open file: " + filename);
         }
 
-        std::vector<char> data = phylanx::util::serialize(nd);
+        std::vector<char> data = phylanx::util::serialize(val);
         if (!outfile.write(data.data(), data.size()))
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -92,40 +92,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     // read data from given file and return content
-    hpx::future<util::optional<ir::node_data<double>>> file_write::eval() const
+    hpx::future<primitive_result_type> file_write::eval() const
     {
-        primitive const* p = util::get_if<primitive>(&operand_);
-        if (p != nullptr)
-        {
-            return p->eval().then(hpx::util::unwrapping(
-                [this](util::optional<ir::node_data<double>> && nd)
-                ->  operand_type
+        return literal_operand(operand_).then(hpx::util::unwrapping(
+            [this](primitive_result_type && val) -> primitive_result_type
+            {
+                if (!valid(val))
                 {
-                    if (!nd)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "file_write::eval",
-                            "the file_write primitive requires that the argument"
-                                " value given by the operand is non-empty");
-                    }
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "file_write::eval",
+                        "the file_write primitive requires that the argument"
+                            " value given by the operand is non-empty");
+                }
 
-                    write_to_file(filename_, nd.value());
-                    return operand_type(std::move(nd));
-                }));
-        }
-
-        ir::node_data<double> const* nd =
-            util::get_if<ir::node_data<double>>(&operand_);
-
-        if (nd == nullptr)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "phylanx::execution_tree::primitives::file_write::eval",
-                "second argument must be a literator of type "
-                    "ir::node_data<double> or another primitive");
-        }
-
-        write_to_file(filename_, *nd);
-        return hpx::make_ready_future(operand_type(*nd));
+                write_to_file(filename_, val);
+                return primitive_result_type(std::move(val));
+            }));
     }
 }}}

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -54,12 +54,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "by the operands array are valid");
         }
     }
-    ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> greater::greater0d(operands_type const& ops) const
-    {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
 
+    ///////////////////////////////////////////////////////////////////////////
+    bool greater::greater0d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
+    {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
@@ -76,11 +75,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> greater::greater1d1d(operands_type const& ops) const
+    bool greater::greater1d1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
@@ -91,21 +88,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
             (lhs.matrix().array() > rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> greater::greater1d(operands_type const& ops) const
+    bool greater::greater1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
-
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return greater1d1d(ops);
+            return greater1d1d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -117,11 +113,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> greater::greater2d2d(operands_type const& ops) const
+    bool greater::greater2d2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
 
@@ -132,20 +126,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
             (lhs.matrix().array() > rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> greater::greater2d(operands_type const& ops) const
+    bool greater::greater2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return greater2d2d(ops);
+            return greater2d2d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -156,40 +150,72 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    bool greater::greater_all(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return greater0d(lhs, rhs);
+
+        case 1:
+            return greater1d(lhs, rhs);
+
+        case 2:
+            return greater2d(lhs, rhs);
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater_all",
+                "left hand side operand has unsupported number of "
+                "dimensions");
+        }
+    }
+
+    namespace detail
+    {
+        struct visit_greater
+        {
+            visit_greater(greater const& this_)
+              : greater_(this_)
+            {}
+
+            template <typename T1, typename T2>
+            bool operator()(T1, T2) const
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "greater::eval",
+                    "left hand side and right hand side are incompatible and "
+                        "can't be compared");
+            }
+
+            template <typename T>
+            bool operator()(T const& lhs, T const& rhs) const
+            {
+                return lhs > rhs;
+            }
+
+            bool operator()(ir::node_data<double> const& lhs,
+                ir::node_data<double> const& rhs) const
+            {
+                return greater_.greater_all(lhs, rhs);
+            }
+
+            greater const& greater_;
+        };
+    }
+
     // implement '>' for all possible combinations of lhs and rhs
-    hpx::future<util::optional<ir::node_data<double>>> greater::eval() const
+    hpx::future<primitive_result_type> greater::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (!detail::verify_argument_values(ops))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        "the greater primitive requires that the argument"
-                            " values given by the operands array are non-empty");
-                }
-
-                std::size_t lhs_dims = ops[0].value().num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return operand_type(greater0d(ops));
-
-                case 1:
-                    return operand_type(greater1d(ops));
-
-                case 2:
-                    return operand_type(greater2d(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        "left hand side operand has unsupported number of "
-                        "dimensions");
-                }
+                return primitive_result_type(
+                    util::visit(detail::visit_greater(*this), ops[0], ops[1]));
             }),
-            detail::map_operands(operands_, evaluate_operand)
+            detail::map_operands(operands_, literal_operand)
         );
     }
 }}}

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -162,7 +162,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater::eval",

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -30,10 +30,10 @@ HPX_DEFINE_GET_COMPONENT_TYPE(greater_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-//     match_pattern_type const greater::match_data =
-//     {
-//         "_1 > _2", &create<greater>
-//     };
+    match_pattern_type const greater::match_data =
+    {
+        "_1 > _2", &create<greater>
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     greater::greater(std::vector<primitive_argument_type>&& operands)

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -1,0 +1,195 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/greater.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::greater>
+    greater_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    greater_type, phylanx_greater_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(greater_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+//     match_pattern_type const greater::match_data =
+//     {
+//         "_1 > _2", &create<greater>
+//     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    greater::greater(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater",
+                "the greater primitive requires exactly two operands");
+        }
+
+        if (!valid(operands_[0]) || !valid(operands_[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater",
+                "the greater primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> greater::greater0d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return lhs[0] > rhs[0];
+
+        case 1: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> greater::greater1d1d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size  != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater1d1d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+        matrix_type result =
+            (lhs.matrix().array() > rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> greater::greater1d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+
+        switch(rhs_dims)
+        {
+        case 1:
+            return greater1d1d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater1d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> greater::greater2d2d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater2d2d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+
+        matrix_type result =
+            (lhs.matrix().array() > rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> greater::greater2d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        switch(rhs_dims)
+        {
+        case 2:
+            return greater2d2d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 1: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater2d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    // implement '>' for all possible combinations of lhs and rhs
+    hpx::future<util::optional<ir::node_data<double>>> greater::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "greater::eval",
+                        "the greater primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return operand_type(greater0d(ops));
+
+                case 1:
+                    return operand_type(greater1d(ops));
+
+                case 2:
+                    return operand_type(greater2d(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "greater::eval",
+                        "left hand side operand has unsupported number of "
+                        "dimensions");
+                }
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -1,0 +1,196 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/greater_equal.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::greater_equal>
+    greater_equal_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    greater_equal_type, phylanx_greater_equal_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(greater_equal_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+//     match_pattern_type const greater_equal::match_data =
+//     {
+//         "_1 >= _2", &create<greater_equal>
+//     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    greater_equal::greater_equal(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal",
+                "the greater_equal primitive requires exactly two operands");
+        }
+
+        if (!valid(operands_[0]) || !valid(operands_[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal",
+                "the greater_equal primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> greater_equal::greater_equal0d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return lhs[0] >= rhs[0];
+
+        case 1: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> greater_equal::greater_equal1d1d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size  != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal1d1d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+        matrix_type result =
+            (lhs.matrix().array() >= rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> greater_equal::greater_equal1d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+
+        switch(rhs_dims)
+        {
+        case 1:
+            return greater_equal1d1d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal1d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> greater_equal::greater_equal2d2d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal2d2d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+
+        matrix_type result =
+            (lhs.matrix().array() >= rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> greater_equal::greater_equal2d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        switch(rhs_dims)
+        {
+        case 2:
+            return greater_equal2d2d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 1: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal2d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    // implement '>=' for all possible combinations of lhs and rhs
+    hpx::future<util::optional<ir::node_data<double>>> greater_equal::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "greater_equal::eval",
+                        "the greater_equal primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return operand_type(greater_equal0d(ops));
+
+                case 1:
+                    return operand_type(greater_equal1d(ops));
+
+                case 2:
+                    return operand_type(greater_equal2d(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "greater_equal::eval",
+                        "left hand side operand has unsupported number of "
+                        "dimensions");
+                }
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -30,10 +30,10 @@ HPX_DEFINE_GET_COMPONENT_TYPE(greater_equal_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-//     match_pattern_type const greater_equal::match_data =
-//     {
-//         "_1 >= _2", &create<greater_equal>
-//     };
+    match_pattern_type const greater_equal::match_data =
+    {
+        "_1 >= _2", &create<greater_equal>
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     greater_equal::greater_equal(std::vector<primitive_argument_type>&& operands)

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -163,7 +163,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::eval",

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -56,11 +56,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> greater_equal::greater_equal0d(operands_type const& ops) const
+    bool greater_equal::greater_equal0d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
@@ -77,11 +75,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> greater_equal::greater_equal1d1d(operands_type const& ops) const
+    bool greater_equal::greater_equal1d1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
@@ -92,21 +88,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
             (lhs.matrix().array() >= rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> greater_equal::greater_equal1d(operands_type const& ops) const
+    bool greater_equal::greater_equal1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
-
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return greater_equal1d1d(ops);
+            return greater_equal1d1d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -118,11 +113,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> greater_equal::greater_equal2d2d(operands_type const& ops) const
+    bool greater_equal::greater_equal2d2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
 
@@ -133,20 +126,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
             (lhs.matrix().array() >= rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> greater_equal::greater_equal2d(operands_type const& ops) const
+    bool greater_equal::greater_equal2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return greater_equal2d2d(ops);
+            return greater_equal2d2d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -157,40 +150,72 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    bool greater_equal::greater_equal_all(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return greater_equal0d(lhs, rhs);
+
+        case 1:
+            return greater_equal1d(lhs, rhs);
+
+        case 2:
+            return greater_equal2d(lhs, rhs);
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal_all",
+                "left hand side operand has unsupported number of "
+                "dimensions");
+        }
+    }
+
+    namespace detail
+    {
+        struct visit_greater_equal
+        {
+            visit_greater_equal(greater_equal const& this_)
+              : greater_equal_(this_)
+            {}
+
+            template <typename T1, typename T2>
+            bool operator()(T1, T2) const
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "greater_equal::eval",
+                    "left hand side and right hand side are incompatible and "
+                        "can't be compared");
+            }
+
+            template <typename T>
+            bool operator()(T const& lhs, T const& rhs) const
+            {
+                return lhs >= rhs;
+            }
+
+            bool operator()(ir::node_data<double> const& lhs,
+                ir::node_data<double> const& rhs) const
+            {
+                return greater_equal_.greater_equal_all(lhs, rhs);
+            }
+
+            greater_equal const& greater_equal_;
+        };
+    }
+
     // implement '>=' for all possible combinations of lhs and rhs
-    hpx::future<util::optional<ir::node_data<double>>> greater_equal::eval() const
+    hpx::future<primitive_result_type> greater_equal::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (!detail::verify_argument_values(ops))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        "the greater_equal primitive requires that the argument"
-                            " values given by the operands array are non-empty");
-                }
-
-                std::size_t lhs_dims = ops[0].value().num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return operand_type(greater_equal0d(ops));
-
-                case 1:
-                    return operand_type(greater_equal1d(ops));
-
-                case 2:
-                    return operand_type(greater_equal2d(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        "left hand side operand has unsupported number of "
-                        "dimensions");
-                }
+                return primitive_result_type(
+                    util::visit(detail::visit_greater_equal(*this), ops[0], ops[1]));
             }),
-            detail::map_operands(operands_, evaluate_operand)
+            detail::map_operands(operands_, literal_operand)
         );
     }
 }}}

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -1,0 +1,196 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/less.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::less>
+    less_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    less_type, phylanx_less_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(less_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+//     match_pattern_type const less::match_data =
+//     {
+//         "_1 < _2", &create<less>
+//     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    less::less(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less",
+                "the less primitive requires exactly two operands");
+        }
+
+        if (!valid(operands_[0]) || !valid(operands_[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less",
+                "the less primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> less::less0d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return lhs[0] < rhs[0];
+
+        case 1: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> less::less1d1d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size  != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less1d1d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+        matrix_type result =
+            (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> less::less1d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+
+        switch(rhs_dims)
+        {
+        case 1:
+            return less1d1d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less1d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> less::less2d2d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less2d2d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+
+        matrix_type result =
+            (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> less::less2d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        switch(rhs_dims)
+        {
+        case 2:
+            return less2d2d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 1: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less2d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    // implement '<' for all possible combinations of lhs and rhs
+    hpx::future<util::optional<ir::node_data<double>>> less::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "less::eval",
+                        "the less primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return operand_type(less0d(ops));
+
+                case 1:
+                    return operand_type(less1d(ops));
+
+                case 2:
+                    return operand_type(less2d(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "less::eval",
+                        "left hand side operand has unsupported number of "
+                        "dimensions");
+                }
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -163,7 +163,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "less::eval",

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -56,11 +56,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> less::less0d(operands_type const& ops) const
+    bool less::less0d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
@@ -77,11 +75,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> less::less1d1d(operands_type const& ops) const
+    bool less::less1d1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
@@ -92,21 +88,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
             (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> less::less1d(operands_type const& ops) const
+    bool less::less1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
-
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return less1d1d(ops);
+            return less1d1d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -118,11 +113,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> less::less2d2d(operands_type const& ops) const
+    bool less::less2d2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
 
@@ -133,20 +126,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-
-        matrix_type result =
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
             (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> less::less2d(operands_type const& ops) const
+    bool less::less2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return less2d2d(ops);
+            return less2d2d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -157,40 +150,72 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    bool less::less_all(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return less0d(lhs, rhs);
+
+        case 1:
+            return less1d(lhs, rhs);
+
+        case 2:
+            return less2d(lhs, rhs);
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less_all",
+                "left hand side operand has unsupported number of "
+                "dimensions");
+        }
+    }
+
+    namespace detail
+    {
+        struct visit_less
+        {
+            visit_less(less const& this_)
+              : less_(this_)
+            {}
+
+            template <typename T1, typename T2>
+            bool operator()(T1, T2) const
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "less::eval",
+                    "left hand side and right hand side are incompatible and "
+                        "can't be compared");
+            }
+
+            template <typename T>
+            bool operator()(T const& lhs, T const& rhs) const
+            {
+                return lhs < rhs;
+            }
+
+            bool operator()(ir::node_data<double> const& lhs,
+                ir::node_data<double> const& rhs) const
+            {
+                return less_.less_all(lhs, rhs);
+            }
+
+            less const& less_;
+        };
+    }
+
     // implement '<' for all possible combinations of lhs and rhs
-    hpx::future<util::optional<ir::node_data<double>>> less::eval() const
+    hpx::future<primitive_result_type> less::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (!detail::verify_argument_values(ops))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        "the less primitive requires that the argument"
-                            " values given by the operands array are non-empty");
-                }
-
-                std::size_t lhs_dims = ops[0].value().num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return operand_type(less0d(ops));
-
-                case 1:
-                    return operand_type(less1d(ops));
-
-                case 2:
-                    return operand_type(less2d(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        "left hand side operand has unsupported number of "
-                        "dimensions");
-                }
+                return primitive_result_type(
+                    util::visit(detail::visit_less(*this), ops[0], ops[1]));
             }),
-            detail::map_operands(operands_, evaluate_operand)
+            detail::map_operands(operands_, literal_operand)
         );
     }
 }}}

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -30,10 +30,10 @@ HPX_DEFINE_GET_COMPONENT_TYPE(less_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-//     match_pattern_type const less::match_data =
-//     {
-//         "_1 < _2", &create<less>
-//     };
+    match_pattern_type const less::match_data =
+    {
+        "_1 < _2", &create<less>
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     less::less(std::vector<primitive_argument_type>&& operands)

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -167,7 +167,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "less_equal::eval",

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -30,10 +30,10 @@ HPX_DEFINE_GET_COMPONENT_TYPE(less_equal_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-//     match_pattern_type const less_equal::match_data =
-//     {
-//         "_1 <= _2", &create<less_equal>
-//     };
+    match_pattern_type const less_equal::match_data =
+    {
+        "_1 <= _2", &create<less_equal>
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     less_equal::less_equal(std::vector<primitive_argument_type>&& operands)

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -1,0 +1,200 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/less_equal.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::less_equal>
+    less_equal_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    less_equal_type, phylanx_less_equal_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(less_equal_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+//     match_pattern_type const less_equal::match_data =
+//     {
+//         "_1 <= _2", &create<less_equal>
+//     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    less_equal::less_equal(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal",
+                "the less_equal primitive requires exactly two operands");
+        }
+
+        if (!valid(operands_[0]) || !valid(operands_[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal",
+                "the less_equal primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> less_equal::less_equal0d(
+        operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return lhs[0] <= rhs[0];
+
+        case 1: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> less_equal::less_equal1d1d(
+        operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size  != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal1d1d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+        matrix_type result =
+            (lhs.matrix().array() <= rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> less_equal::less_equal1d(
+        operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+
+        switch(rhs_dims)
+        {
+        case 1:
+            return less_equal1d1d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less1d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> less_equal::less_equal2d2d(
+        operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal2d2d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+
+        matrix_type result =
+            (lhs.matrix().array() <= rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> less_equal::less_equal2d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        switch(rhs_dims)
+        {
+        case 2:
+            return less_equal2d2d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 1: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal2d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    // implement '<=' for all possible combinations of lhs and rhs
+    hpx::future<util::optional<ir::node_data<double>>> less_equal::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "less_equal::eval",
+                        "the less_equal primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return operand_type(less_equal0d(ops));
+
+                case 1:
+                    return operand_type(less_equal1d(ops));
+
+                case 2:
+                    return operand_type(less_equal2d(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "less_equal::eval",
+                        "left hand side operand has unsupported number of "
+                        "dimensions");
+                }
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -153,7 +153,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type&& ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "mul_operation::eval",

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -140,7 +140,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         matrix_type first_term = ops.begin()->matrix();
         matrix_type result =
-            std::accumulate(ops.begin() + 1, ops.end(), first_term,
+            std::accumulate(ops.begin() + 1, ops.end(), std::move(first_term),
                 [](matrix_type& result, operand_type const& curr)
                 ->  matrix_type
                 {

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -59,7 +59,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "mul_operation::mul_operation",
                 "the mul_operation primitive requires that the arguments given "
-                    "by the operands array is valid");
+                    "by the operands array are valid");
         }
     }
 

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -56,16 +56,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> not_equal::not_equal0d(operands_type const& ops) const
+    bool not_equal::not_equal0d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 0:
-            return lhs[0] < rhs[0];
+            return lhs[0] != rhs[0];
 
         case 1: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -77,11 +75,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> not_equal::not_equal1d1d(operands_type const& ops) const
+    bool not_equal::not_equal1d1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
@@ -92,21 +88,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
+            (lhs.matrix().array() != rhs.matrix().array()).cast<double>();
 
-        matrix_type result =
-            (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> not_equal::not_equal1d(operands_type const& ops) const
+    bool not_equal::not_equal1d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
-
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return not_equal1d1d(ops);
+            return not_equal1d1d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -118,11 +113,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> not_equal::not_equal2d2d(operands_type const& ops) const
+    bool not_equal::not_equal2d2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        auto const& lhs = ops[0].value();
-        auto const& rhs = ops[1].value();
-
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
 
@@ -133,20 +126,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
+            (lhs.matrix().array() != rhs.matrix().array()).cast<double>();
 
-        matrix_type result =
-            (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
-        return ir::node_data<double>(std::move(result));
+        return result.norm() != 0.0;
     }
 
-    ir::node_data<double> not_equal::not_equal2d(operands_type const& ops) const
+    bool not_equal::not_equal2d(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
     {
-        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return not_equal2d2d(ops);
+            return not_equal2d2d(lhs, rhs);
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -157,40 +150,72 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    // implement '<' for all possible combinations of lhs and rhs
-    hpx::future<util::optional<ir::node_data<double>>> not_equal::eval() const
+    bool not_equal::not_equal_all(ir::node_data<double> const& lhs,
+        ir::node_data<double> const& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return not_equal0d(lhs, rhs);
+
+        case 1:
+            return not_equal1d(lhs, rhs);
+
+        case 2:
+            return not_equal2d(lhs, rhs);
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal_all",
+                "left hand side operand has unsupported number of "
+                "dimensions");
+        }
+    }
+
+    namespace detail
+    {
+        struct visit_not_equal
+        {
+            visit_not_equal(not_equal const& this_)
+              : not_equal_(this_)
+            {}
+
+            template <typename T1, typename T2>
+            bool operator()(T1, T2) const
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "not_equal::eval",
+                    "left hand side and right hand side are incompatible and "
+                        "can't be compared");
+            }
+
+            template <typename T>
+            bool operator()(T const& lhs, T const& rhs) const
+            {
+                return lhs != rhs;
+            }
+
+            bool operator()(ir::node_data<double> const& lhs,
+                ir::node_data<double> const& rhs) const
+            {
+                return not_equal_.not_equal_all(lhs, rhs);
+            }
+
+            not_equal const& not_equal_;
+        };
+    }
+
+    // implement '!=' for all possible combinations of lhs and rhs
+    hpx::future<primitive_result_type> not_equal::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (!detail::verify_argument_values(ops))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::eval",
-                        "the not_equal primitive requires that the argument"
-                            " values given by the operands array are non-empty");
-                }
-
-                std::size_t lhs_dims = ops[0].value().num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return operand_type(not_equal0d(ops));
-
-                case 1:
-                    return operand_type(not_equal1d(ops));
-
-                case 2:
-                    return operand_type(not_equal2d(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::eval",
-                        "left hand side operand has unsupported number of "
-                        "dimensions");
-                }
+                return primitive_result_type(
+                    util::visit(detail::visit_not_equal(*this), ops[0], ops[1]));
             }),
-            detail::map_operands(operands_, evaluate_operand)
+            detail::map_operands(operands_, literal_operand)
         );
     }
 }}}

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -163,7 +163,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "not_equal::eval",

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -30,10 +30,10 @@ HPX_DEFINE_GET_COMPONENT_TYPE(not_equal_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-//     match_pattern_type const not_equal::match_data =
-//     {
-//         "_1 != _2", &create<not_equal>
-//     };
+    match_pattern_type const not_equal::match_data =
+    {
+        "_1 != _2", &create<not_equal>
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     not_equal::not_equal(std::vector<primitive_argument_type>&& operands)

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -1,0 +1,196 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/not_equal.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::not_equal>
+    not_equal_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    not_equal_type, phylanx_not_equal_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(not_equal_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+//     match_pattern_type const not_equal::match_data =
+//     {
+//         "_1 != _2", &create<not_equal>
+//     };
+
+    ///////////////////////////////////////////////////////////////////////////
+    not_equal::not_equal(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal",
+                "the not_equal primitive requires exactly two operands");
+        }
+
+        if (!valid(operands_[0]) || !valid(operands_[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal",
+                "the not_equal primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> not_equal::not_equal0d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return lhs[0] < rhs[0];
+
+        case 1: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> not_equal::not_equal1d1d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size  != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal1d1d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
+        matrix_type result =
+            (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> not_equal::not_equal1d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+
+        switch(rhs_dims)
+        {
+        case 1:
+            return not_equal1d1d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 2: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal1d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> not_equal::not_equal2d2d(operands_type const& ops) const
+    {
+        auto const& lhs = ops[0].value();
+        auto const& rhs = ops[1].value();
+
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal2d2d",
+                "the dimensions of the operands do not match");
+        }
+
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
+
+        matrix_type result =
+            (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
+        return ir::node_data<double>(std::move(result));
+    }
+
+    ir::node_data<double> not_equal::not_equal2d(operands_type const& ops) const
+    {
+        std::size_t rhs_dims = ops[1].value().num_dimensions();
+        switch(rhs_dims)
+        {
+        case 2:
+            return not_equal2d2d(ops);
+
+        case 0: HPX_FALLTHROUGH;
+        case 1: HPX_FALLTHROUGH;
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal2d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    // implement '<' for all possible combinations of lhs and rhs
+    hpx::future<util::optional<ir::node_data<double>>> not_equal::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "not_equal::eval",
+                        "the not_equal primitive requires that the argument"
+                            " values given by the operands array are non-empty");
+                }
+
+                std::size_t lhs_dims = ops[0].value().num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return operand_type(not_equal0d(ops));
+
+                case 1:
+                    return operand_type(not_equal1d(ops));
+
+                case 2:
+                    return operand_type(not_equal2d(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "not_equal::eval",
+                        "left hand side operand has unsupported number of "
+                        "dimensions");
+                }
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/or_operation.cpp
+++ b/src/execution_tree/primitives/or_operation.cpp
@@ -1,0 +1,97 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_literal_value.hpp>
+#include <phylanx/execution_tree/primitives/or_operation.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/eigen.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::or_operation>
+    or_operation_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    or_operation_type, phylanx_or_operation_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(or_operation_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    or_operation::or_operation(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() < 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::or_operation",
+                "the or_operation primitive requires at least two operors");
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands_.size(); ++i)
+        {
+            if (!valid(operands_[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::or_operation",
+                "the or_operation primitive requires that the arguments given "
+                    "by the operands array are valid");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // implement '||' for all possible combinations of lhs or rhs
+    hpx::future<util::optional<ir::node_data<double>>> or_operation::eval() const
+    {
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this](operands_type && ops)
+            {
+                if (!detail::verify_argument_values(ops))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "or_operation::eval",
+                        "the or_operation primitive requires that the argument"
+                            " values given by the operors array are non-empty");
+                }
+
+                if (ops.size() == 2)
+                {
+                    return operand_type(ir::node_data<double>(
+                            bool(ops[0].value()) || bool(ops[1].value()) ?
+                                1.0 : 0.0
+                        ));
+                }
+
+                return operand_type(ir::node_data<double>(
+                    std::any_of(ops.begin(), ops.end(),
+                        [](operand_type const& curr)
+                        {
+                            return bool(curr.value());
+                        }) ? 1.0 : 0.0));
+            }),
+            detail::map_operands(operands_, evaluate_operand)
+        );
+    }
+}}}

--- a/src/execution_tree/primitives/or_operation.cpp
+++ b/src/execution_tree/primitives/or_operation.cpp
@@ -69,35 +69,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     // implement '||' for all possible combinations of lhs or rhs
-    hpx::future<util::optional<ir::node_data<double>>> or_operation::eval() const
+    hpx::future<primitive_result_type> or_operation::eval() const
     {
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type && ops)
             {
-                if (!detail::verify_argument_values(ops))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        "the or_operation primitive requires that the argument"
-                            " values given by the operors array are non-empty");
-                }
-
                 if (ops.size() == 2)
                 {
-                    return operand_type(ir::node_data<double>(
-                            bool(ops[0].value()) || bool(ops[1].value()) ?
-                                1.0 : 0.0
-                        ));
+                    return primitive_result_type(ops[0] || ops[1]);
                 }
 
-                return operand_type(ir::node_data<double>(
+                return primitive_result_type(
                     std::any_of(ops.begin(), ops.end(),
-                        [](operand_type const& curr)
-                        {
-                            return bool(curr.value());
-                        }) ? 1.0 : 0.0));
+                        [](std::uint8_t curr) { return curr; }));
             }),
-            detail::map_operands(operands_, evaluate_operand)
+            detail::map_operands(operands_, boolean_operand)
         );
     }
 }}}

--- a/src/execution_tree/primitives/or_operation.cpp
+++ b/src/execution_tree/primitives/or_operation.cpp
@@ -33,6 +33,12 @@ HPX_DEFINE_GET_COMPONENT_TYPE(or_operation_type::wrapped_type)
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const or_operation::match_data =
+    {
+        "_1 || __2", &create<or_operation>
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     or_operation::or_operation(std::vector<primitive_argument_type>&& operands)
       : operands_(std::move(operands))
     {

--- a/src/execution_tree/primitives/sub_operation.cpp
+++ b/src/execution_tree/primitives/sub_operation.cpp
@@ -58,7 +58,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "sub_operation::sub_operation",
                 "the sub_operation primitive requires that the arguments given "
-                    "by the operands array is valid");
+                    "by the operands array are valid");
         }
     }
 

--- a/src/execution_tree/primitives/sub_operation.cpp
+++ b/src/execution_tree/primitives/sub_operation.cpp
@@ -211,7 +211,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(hpx::util::unwrapping(
             [this](operands_type&& ops)
             {
-                if (detail::verify_argument_values(ops))
+                if (!detail::verify_argument_values(ops))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "sub_operation::eval",

--- a/src/execution_tree/primitives/while_operation.cpp
+++ b/src/execution_tree/primitives/while_operation.cpp
@@ -30,6 +30,13 @@ HPX_DEFINE_GET_COMPONENT_TYPE(while_operation_type::wrapped_type)
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree { namespace primitives
 {
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const while_operation::match_data =
+    {
+        "while(_1, _2)", &create<while_operation>
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     while_operation::while_operation(
             std::vector<primitive_argument_type>&& operands)
       : operands_(std::move(operands))

--- a/src/execution_tree/primitives/while_operation.cpp
+++ b/src/execution_tree/primitives/while_operation.cpp
@@ -1,0 +1,107 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/while_operation.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/ast.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+    phylanx::execution_tree::primitives::while_operation>
+    while_operation_type;
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    while_operation_type, phylanx_while_operation_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(while_operation_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    while_operation::while_operation(std::vector<primitive_argument_type>&& operands)
+      : operands_(std::move(operands))
+    {
+        if (operands_.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::while_operation::"
+                    "while_operation",
+                "the while_operation primitive requires exactly two arguments");
+        }
+
+        if (!valid(operands_[0]) || !valid(operands_[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::while_operation::"
+                    "while_operation",
+                "the while_operation primitive requires that the arguments "
+                    "given by the operands array are valid");
+        }
+    }
+
+    namespace detail
+    {
+        struct iteration : std::enable_shared_from_this<iteration>
+        {
+            using operand_type = util::optional<ir::node_data<double>>;
+
+            iteration(std::vector<primitive_argument_type> const& operands)
+              : operands_(operands)
+              , result_(hpx::make_ready_future(operand_type{}))
+            {}
+
+            hpx::future<operand_type> recurse(hpx::future<operand_type> && cond)
+            {
+                if (bool(cond.get()))
+                {
+                    // evaluate body of while statement
+                    result_ = evaluate_operand(operands_[1]);
+
+                    auto this_ = this->shared_from_this();
+                    return result_.then(
+                        [this_](hpx::future<operand_type> && result)
+                        {
+                            return this_->loop();
+                        });
+                }
+                return std::move(result_);
+            }
+
+            hpx::future<operand_type> loop()
+            {
+                // evaluate condition of while statement
+                hpx::future<operand_type> cond = evaluate_operand(operands_[0]);
+
+                auto this_ = this->shared_from_this();
+                return cond.then(
+                    [this_](hpx::future<operand_type> && cond)
+                    {
+                        return this_->recurse(std::move(cond));
+                    });
+            }
+
+        private:
+            std::vector<primitive_argument_type> operands_;
+            hpx::future<operand_type> result_;
+        };
+    }
+
+    // start iteration over given while statement
+    hpx::future<util::optional<ir::node_data<double>>>
+        while_operation::eval() const
+    {
+        return std::make_shared<detail::iteration>(operands_)->loop();
+    }
+}}}

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -67,6 +67,7 @@ namespace phylanx { namespace ir
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    template <>
     node_data<double>::operator bool() const
     {
         std::size_t dims = num_dimensions();

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -8,7 +8,6 @@
 
 #include <hpx/exception.hpp>
 
-#include <algorithm>
 #include <cstddef>
 #include <iosfwd>
 #include <string>
@@ -74,12 +73,11 @@ namespace phylanx { namespace ir
         switch (dims)
         {
         case 0:
-            return data_.data()[0] != 0.0;
-
-        case 1: HPX_FALLTHROUGH;
+            HPX_FALLTHROUGH;
+        case 1:
+            HPX_FALLTHROUGH;
         case 2:
-            return std::any_of(
-                begin(), end(), [](double d) { return d != 0.0; });
+            return matrix().norm() != 0;
 
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,

--- a/src/util/serialization/ast.cpp
+++ b/src/util/serialization/ast.cpp
@@ -13,8 +13,8 @@
 #include <sstream>
 #include <vector>
 
-namespace phylanx {
-namespace util {
+namespace phylanx { namespace util
+{
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         template <typename Ast>
@@ -79,10 +79,16 @@ namespace util {
         return detail::serialize(ast);
     }
 
+    std::vector<char> serialize(ast::literal_value_type const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
+    namespace detail
+    {
         template <typename Ast>
-        void unserialize_helper(std::vector<char> const& input, Ast& ast)
+        inline void unserialize_helper(std::vector<char> const& input, Ast& ast)
         {
             hpx::serialization::input_archive archive(input, input.size());
             archive >> ast;
@@ -131,6 +137,12 @@ namespace util {
 
         void unserialize(
             std::vector<char> const& input, ast::function_call& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(
+            std::vector<char> const& input, ast::literal_value_type& ast)
         {
             detail::unserialize_helper(input, ast);
         }

--- a/tests/unit/execution_tree/generate_tree.cpp
+++ b/tests/unit/execution_tree/generate_tree.cpp
@@ -17,7 +17,9 @@ void test_generate_tree(std::string const& exprstr,
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::generate_tree(exprstr, patterns, variables);
 
-    HPX_TEST_EQ(p.eval().get().value()[0], expected_result);
+    HPX_TEST_EQ(
+        phylanx::execution_tree::extract_numeric_value(p.eval().get())[0],
+        expected_result);
 }
 
 phylanx::execution_tree::primitive create_literal_value(double value)

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -5,11 +5,18 @@
 
 set(tests
     add_operation
+    and_operation
     equal_operation
-    sub_operation
-    mul_operation
     file_primitives
+    greater_operation
+    greater_equal_operation
+    less_operation
+    less_equal_operation
     literal_value
+    mul_operation
+    not_equal_operation
+    or_operation
+    sub_operation
    )
 
 foreach(test ${tests})

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 set(tests
     add_operation
+    equal_operation
     sub_operation
     mul_operation
     file_primitives

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(tests
     add_operation
     and_operation
+    div_operation
     equal_operation
     exponential_operation
     file_primitives

--- a/tests/unit/execution_tree/primitives/add_operation.cpp
+++ b/tests/unit/execution_tree/primitives/add_operation.cpp
@@ -32,9 +32,11 @@ void test_add_operation_0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         add.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+
+    HPX_TEST_EQ(
+        42.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
 void test_add_operation_0d_lit()
@@ -52,9 +54,11 @@ void test_add_operation_0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         add.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+
+    HPX_TEST_EQ(
+        42.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
 void test_add_operation_1d()
@@ -77,12 +81,13 @@ void test_add_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         add.eval();
 
     Eigen::VectorXd expected = v1 + v2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_add_operation_1d_lit()
@@ -103,12 +108,13 @@ void test_add_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         add.eval();
 
     Eigen::VectorXd expected = v1 + v2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_add_operation_2d()
@@ -131,12 +137,13 @@ void test_add_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         add.eval();
 
     Eigen::MatrixXd expected = m1.array() + m2.array();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_add_operation_2d_lit()
@@ -157,12 +164,13 @@ void test_add_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         add.eval();
 
     Eigen::MatrixXd expected = m1.array() + m2.array();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/and_operation.cpp
+++ b/tests/unit/execution_tree/primitives/and_operation.cpp
@@ -17,7 +17,7 @@
 
 void test_and_operation_0d_false()
 {
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -25,13 +25,14 @@ void test_and_operation_0d_false()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
+
     HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_and_operation_0d_true()
 {
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -39,7 +40,8 @@ void test_and_operation_0d_true()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
+
     HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
@@ -51,7 +53,7 @@ void test_and_operation_0d_lit_false()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(1.0));
 
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -59,7 +61,8 @@ void test_and_operation_0d_lit_false()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
+
     HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
@@ -71,7 +74,7 @@ void test_and_operation_0d_lit_true()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(1.0));
 
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -79,7 +82,8 @@ void test_and_operation_0d_lit_true()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
+
     HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
@@ -96,7 +100,7 @@ void test_and_operation_1d()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(v2));
 
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -104,7 +108,7 @@ void test_and_operation_1d()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
 
     HPX_TEST_EQ(
         (v1.norm() != 0.0) && (v2.norm() != 0.0),
@@ -122,7 +126,7 @@ void test_and_operation_1d_lit()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(v2));
 
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -130,7 +134,7 @@ void test_and_operation_1d_lit()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
 
     HPX_TEST_EQ(
         (v1.norm() != 0.0) && (v2.norm() != 0.0),
@@ -150,7 +154,7 @@ void test_and_operation_2d()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(m2));
 
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -158,7 +162,7 @@ void test_and_operation_2d()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
 
     HPX_TEST_EQ(
         (m1.norm() != 0.0) && (m2.norm() != 0.0),
@@ -176,7 +180,7 @@ void test_and_operation_2d_lit()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(m2));
 
-    phylanx::execution_tree::primitive and =
+    phylanx::execution_tree::primitive and_ =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -184,7 +188,7 @@ void test_and_operation_2d_lit()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        and.eval();
+        and_.eval();
 
     HPX_TEST_EQ(
         (m1.norm() != 0.0) && (m2.norm() != 0.0),

--- a/tests/unit/execution_tree/primitives/and_operation.cpp
+++ b/tests/unit/execution_tree/primitives/and_operation.cpp
@@ -17,46 +17,30 @@
 
 void test_and_operation_0d_false()
 {
-    phylanx::execution_tree::primitive lhs =
-        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
-            hpx::find_here(), phylanx::ir::node_data<double>(0.0));
-
-    phylanx::execution_tree::primitive rhs =
-        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
-            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
-
     phylanx::execution_tree::primitive and =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                std::move(lhs), std::move(rhs)
+                true, false
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_and_operation_0d_true()
 {
-    phylanx::execution_tree::primitive lhs =
-        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
-            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
-
-    phylanx::execution_tree::primitive rhs =
-        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
-            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
-
     phylanx::execution_tree::primitive and =
         hpx::new_<phylanx::execution_tree::primitives::and_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                std::move(lhs), std::move(rhs)
+                true, true
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_and_operation_0d_lit_false()
@@ -74,9 +58,9 @@ void test_and_operation_0d_lit_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_and_operation_0d_lit_true()
@@ -94,9 +78,9 @@ void test_and_operation_0d_lit_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_and_operation_1d()
@@ -119,12 +103,12 @@ void test_and_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
 
-    Eigen::VectorXd expected = (v1.norm() != 0.0) && (v2.norm() != 0.0);
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (v1.norm() != 0.0) && (v2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_and_operation_1d_lit()
@@ -145,12 +129,12 @@ void test_and_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
 
-    Eigen::VectorXd expected = (v1.norm() != 0.0) && (v2.norm() != 0.0);
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (v1.norm() != 0.0) && (v2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_and_operation_2d()
@@ -173,12 +157,12 @@ void test_and_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
 
-    Eigen::MatrixXd expected = (m1.norm() != 0.0) && (m2.norm() != 0.0);
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (m1.norm() != 0.0) && (m2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_and_operation_2d_lit()
@@ -199,12 +183,12 @@ void test_and_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         and.eval();
 
-    Eigen::MatrixXd expected = (m1.norm() != 0.0) && (m2.norm() != 0.0);
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (m1.norm() != 0.0) && (m2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/and_operation.cpp
+++ b/tests/unit/execution_tree/primitives/and_operation.cpp
@@ -1,0 +1,226 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_and_operation_0d_false()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(0.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_and_operation_0d_true()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
+}
+
+void test_and_operation_0d_lit_false()
+{
+    phylanx::ir::node_data<double> lhs(0.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_and_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_and_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+
+    Eigen::VectorXd expected = (v1.norm() != 0.0) && (v2.norm() != 0.0);
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_and_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+
+    Eigen::VectorXd expected = (v1.norm() != 0.0) && (v2.norm() != 0.0);
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_and_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+
+    Eigen::MatrixXd expected = (m1.norm() != 0.0) && (m2.norm() != 0.0);
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_and_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive and =
+        hpx::new_<phylanx::execution_tree::primitives::and_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        and.eval();
+
+    Eigen::MatrixXd expected = (m1.norm() != 0.0) && (m2.norm() != 0.0);
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_and_operation_0d_false();
+    test_and_operation_0d_true();
+
+    test_and_operation_0d_lit_false();
+    test_and_operation_0d_lit_true();
+
+    test_and_operation_1d();
+    test_and_operation_1d_lit();
+
+    test_and_operation_2d();
+    test_and_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/div_operation.cpp
+++ b/tests/unit/execution_tree/primitives/div_operation.cpp
@@ -1,0 +1,357 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//   Copyright (c) 2017 Alireza Kheirkhahan
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_div_operation_0d()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(7.0));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+    HPX_TEST_EQ(
+        6.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+void test_div_operation_0d_lit()
+{
+    phylanx::ir::node_data<double> lhs(42.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(7.0));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+    HPX_TEST_EQ(
+        6.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+void test_div_operation_0d1d()
+{
+    Eigen::VectorXd v = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::VectorXd expected = 42.0 / v.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_0d1d_lit()
+{
+    Eigen::VectorXd v = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(42.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::VectorXd expected = 42.0 / v.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_0d2d()
+{
+    Eigen::MatrixXd m = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::MatrixXd expected = 6.0 / m.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_0d2d_lit()
+{
+    Eigen::MatrixXd m = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(6.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::MatrixXd expected = 6.0 / m.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_1d0d()
+{
+    Eigen::VectorXd v = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::VectorXd expected = v.array() / 6.0;
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_1d0d_lit()
+{
+    Eigen::VectorXd v = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::VectorXd expected = v.array() / 6.0;
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_2d0d()
+{
+    Eigen::MatrixXd m = Eigen::MatrixXd::Random(42, 42);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::MatrixXd expected = m.array() / 6.0;
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_2d0d_lit()
+{
+    Eigen::MatrixXd m = Eigen::MatrixXd::Random(42, 42);
+
+    phylanx::ir::node_data<double> lhs(m);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::MatrixXd expected = m.array() / 6.0;
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(42, 42);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(42, 42);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::MatrixXd expected = m1.array() / m2.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_div_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(42, 42);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(42, 42);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive div =
+        hpx::new_<phylanx::execution_tree::primitives::div_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        div.eval();
+
+    Eigen::MatrixXd expected = m1.array() / m2.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+int main(int argc, char* argv[])
+{
+    test_div_operation_0d();
+    test_div_operation_0d_lit();
+
+    test_div_operation_0d1d();
+    test_div_operation_0d1d_lit();
+
+    test_div_operation_0d2d();
+    test_div_operation_0d2d_lit();
+
+    test_div_operation_1d0d();
+    test_div_operation_1d0d_lit();
+
+    test_div_operation_2d0d();
+    test_div_operation_2d0d_lit();
+
+    test_div_operation_2d();
+    test_div_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/equal_operation.cpp
@@ -32,9 +32,9 @@ void test_equal_operation_0d_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_equal_operation_0d_true()
@@ -54,9 +54,9 @@ void test_equal_operation_0d_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_equal_operation_0d_lit_false()
@@ -74,9 +74,9 @@ void test_equal_operation_0d_lit_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_equal_operation_0d_lit_true()
@@ -94,9 +94,9 @@ void test_equal_operation_0d_lit_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_equal_operation_1d()
@@ -119,12 +119,13 @@ void test_equal_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
 
     Eigen::VectorXd expected = (v1.array() == v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_equal_operation_1d_lit()
@@ -145,12 +146,13 @@ void test_equal_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
 
     Eigen::VectorXd expected = (v1.array() == v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_equal_operation_2d()
@@ -173,12 +175,13 @@ void test_equal_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() == m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_equal_operation_2d_lit()
@@ -199,12 +202,13 @@ void test_equal_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() == m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/equal_operation.cpp
@@ -1,0 +1,225 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_equal_operation_0d_false()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_equal_operation_0d_true()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_equal_operation_0d_lit_false()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_equal_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(1.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_equal_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() == v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_equal_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() == v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_equal_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() == m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_equal_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive equal =
+        hpx::new_<phylanx::execution_tree::primitives::equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() == m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_equal_operation_0d_false();
+    test_equal_operation_0d_true();
+    test_equal_operation_0d_lit_false();
+    test_equal_operation_0d_lit_true();
+
+    test_equal_operation_1d();
+    test_equal_operation_1d_lit();
+
+    test_equal_operation_2d();
+    test_equal_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/file_primitives.cpp
+++ b/tests/unit/execution_tree/primitives/file_primitives.cpp
@@ -37,7 +37,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
     }
 
     // read back the file
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f;
+    hpx::future<phylanx::execution_tree::primitive_result_type> f;
     {
         phylanx::execution_tree::primitive infile =
             hpx::new_<phylanx::execution_tree::primitives::file_read>(
@@ -50,7 +50,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         f = infile.eval();
     }
 
-    HPX_TEST(in == f.get().value());
+    HPX_TEST(in == phylanx::execution_tree::extract_numeric_value(f.get()));
 
     std::remove(filename.c_str());
 }
@@ -73,7 +73,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
     }
 
     // read back the file
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f;
+    hpx::future<phylanx::execution_tree::primitive_result_type> f;
     {
         phylanx::execution_tree::primitive infile =
             hpx::new_<phylanx::execution_tree::primitives::file_read>(
@@ -86,7 +86,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         f = infile.eval();
     }
 
-    HPX_TEST(in == f.get().value());
+    HPX_TEST(in == phylanx::execution_tree::extract_numeric_value(f.get()));
 
     std::remove(filename.c_str());
 }

--- a/tests/unit/execution_tree/primitives/greater_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/greater_equal_operation.cpp
@@ -32,9 +32,9 @@ void test_greater_equal_operation_0d_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_equal_operation_0d_true()
@@ -54,9 +54,9 @@ void test_greater_equal_operation_0d_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_equal_operation_0d_lit_false()
@@ -74,9 +74,9 @@ void test_greater_equal_operation_0d_lit_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_equal_operation_0d_lit_true()
@@ -94,9 +94,9 @@ void test_greater_equal_operation_0d_lit_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_equal_operation_1d()
@@ -119,12 +119,13 @@ void test_greater_equal_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
 
     Eigen::VectorXd expected = (v1.array() >= v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_greater_equal_operation_1d_lit()
@@ -145,12 +146,13 @@ void test_greater_equal_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
 
     Eigen::VectorXd expected = (v1.array() >= v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_greater_equal_operation_2d()
@@ -173,12 +175,13 @@ void test_greater_equal_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() >= m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_greater_equal_operation_2d_lit()
@@ -199,12 +202,13 @@ void test_greater_equal_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater_equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() >= m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/greater_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/greater_equal_operation.cpp
@@ -1,0 +1,225 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_greater_equal_operation_0d_false()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_greater_equal_operation_0d_true()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_greater_equal_operation_0d_lit_false()
+{
+    phylanx::ir::node_data<double> lhs(1.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_greater_equal_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_greater_equal_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() >= v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_greater_equal_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() >= v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_greater_equal_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() >= m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_greater_equal_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive greater_equal =
+        hpx::new_<phylanx::execution_tree::primitives::greater_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater_equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() >= m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_greater_equal_operation_0d_false();
+    test_greater_equal_operation_0d_true();
+    test_greater_equal_operation_0d_lit_false();
+    test_greater_equal_operation_0d_lit_true();
+
+    test_greater_equal_operation_1d();
+    test_greater_equal_operation_1d_lit();
+
+    test_greater_equal_operation_2d();
+    test_greater_equal_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/greater_operation.cpp
+++ b/tests/unit/execution_tree/primitives/greater_operation.cpp
@@ -32,9 +32,9 @@ void test_greater_operation_0d_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_operation_0d_true()
@@ -54,9 +54,9 @@ void test_greater_operation_0d_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_operation_0d_lit_false()
@@ -74,9 +74,9 @@ void test_greater_operation_0d_lit_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_operation_0d_lit_true()
@@ -94,9 +94,9 @@ void test_greater_operation_0d_lit_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_greater_operation_1d()
@@ -119,12 +119,13 @@ void test_greater_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
 
     Eigen::VectorXd expected = (v1.array() > v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_greater_operation_1d_lit()
@@ -145,12 +146,13 @@ void test_greater_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
 
     Eigen::VectorXd expected = (v1.array() > v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_greater_operation_2d()
@@ -173,12 +175,13 @@ void test_greater_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
 
     Eigen::MatrixXd expected = (m1.array() > m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_greater_operation_2d_lit()
@@ -199,12 +202,13 @@ void test_greater_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         greater.eval();
 
     Eigen::MatrixXd expected = (m1.array() > m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/greater_operation.cpp
+++ b/tests/unit/execution_tree/primitives/greater_operation.cpp
@@ -1,0 +1,225 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_greater_operation_0d_false()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_greater_operation_0d_true()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_greater_operation_0d_lit_false()
+{
+    phylanx::ir::node_data<double> lhs(1.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_greater_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_greater_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+
+    Eigen::VectorXd expected = (v1.array() > v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_greater_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+
+    Eigen::VectorXd expected = (v1.array() > v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_greater_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+
+    Eigen::MatrixXd expected = (m1.array() > m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_greater_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive greater =
+        hpx::new_<phylanx::execution_tree::primitives::greater>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        greater.eval();
+
+    Eigen::MatrixXd expected = (m1.array() > m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_greater_operation_0d_false();
+    test_greater_operation_0d_true();
+    test_greater_operation_0d_lit_false();
+    test_greater_operation_0d_lit_true();
+
+    test_greater_operation_1d();
+    test_greater_operation_1d_lit();
+
+    test_greater_operation_2d();
+    test_greater_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/less_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/less_equal_operation.cpp
@@ -32,9 +32,9 @@ void test_less_equal_operation_0d_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_equal_operation_0d_true()
@@ -54,9 +54,9 @@ void test_less_equal_operation_0d_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_equal_operation_0d_lit_false()
@@ -74,9 +74,9 @@ void test_less_equal_operation_0d_lit_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_equal_operation_0d_lit_true()
@@ -94,9 +94,9 @@ void test_less_equal_operation_0d_lit_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_equal_operation_1d()
@@ -119,12 +119,13 @@ void test_less_equal_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
 
     Eigen::VectorXd expected = (v1.array() <= v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_less_equal_operation_1d_lit()
@@ -145,12 +146,13 @@ void test_less_equal_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
 
     Eigen::VectorXd expected = (v1.array() <= v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_less_equal_operation_2d()
@@ -173,12 +175,13 @@ void test_less_equal_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() <= m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_less_equal_operation_2d_lit()
@@ -199,12 +202,13 @@ void test_less_equal_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less_equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() <= m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/less_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/less_equal_operation.cpp
@@ -1,0 +1,225 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_less_equal_operation_0d_false()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_less_equal_operation_0d_true()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_less_equal_operation_0d_lit_false()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_less_equal_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(1.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_less_equal_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() <= v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_less_equal_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() <= v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_less_equal_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() <= m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_less_equal_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive less_equal =
+        hpx::new_<phylanx::execution_tree::primitives::less_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less_equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() <= m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_less_equal_operation_0d_false();
+    test_less_equal_operation_0d_true();
+    test_less_equal_operation_0d_lit_false();
+    test_less_equal_operation_0d_lit_true();
+
+    test_less_equal_operation_1d();
+    test_less_equal_operation_1d_lit();
+
+    test_less_equal_operation_2d();
+    test_less_equal_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/less_operation.cpp
+++ b/tests/unit/execution_tree/primitives/less_operation.cpp
@@ -1,0 +1,225 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_less_operation_0d_false()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_less_operation_0d_true()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_less_operation_0d_lit_false()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_less_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(1.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_less_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+
+    Eigen::VectorXd expected = (v1.array() < v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_less_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+
+    Eigen::VectorXd expected = (v1.array() < v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_less_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+
+    Eigen::MatrixXd expected = (m1.array() < m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_less_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive less =
+        hpx::new_<phylanx::execution_tree::primitives::less>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        less.eval();
+
+    Eigen::MatrixXd expected = (m1.array() < m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_less_operation_0d_false();
+    test_less_operation_0d_true();
+    test_less_operation_0d_lit_false();
+    test_less_operation_0d_lit_true();
+
+    test_less_operation_1d();
+    test_less_operation_1d_lit();
+
+    test_less_operation_2d();
+    test_less_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/less_operation.cpp
+++ b/tests/unit/execution_tree/primitives/less_operation.cpp
@@ -32,9 +32,9 @@ void test_less_operation_0d_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_operation_0d_true()
@@ -54,9 +54,9 @@ void test_less_operation_0d_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_operation_0d_lit_false()
@@ -74,9 +74,9 @@ void test_less_operation_0d_lit_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_operation_0d_lit_true()
@@ -94,9 +94,9 @@ void test_less_operation_0d_lit_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_less_operation_1d()
@@ -119,12 +119,13 @@ void test_less_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
 
     Eigen::VectorXd expected = (v1.array() < v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_less_operation_1d_lit()
@@ -145,12 +146,13 @@ void test_less_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
 
     Eigen::VectorXd expected = (v1.array() < v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_less_operation_2d()
@@ -173,12 +175,13 @@ void test_less_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
 
     Eigen::MatrixXd expected = (m1.array() < m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_less_operation_2d_lit()
@@ -199,12 +202,13 @@ void test_less_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         less.eval();
 
     Eigen::MatrixXd expected = (m1.array() < m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/literal_value.cpp
+++ b/tests/unit/execution_tree/primitives/literal_value.cpp
@@ -15,10 +15,11 @@ void test_literal_value()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(42.0));
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         val.eval();
 
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST_EQ(
+        42.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/mul_operation.cpp
+++ b/tests/unit/execution_tree/primitives/mul_operation.cpp
@@ -33,9 +33,10 @@ void test_mul_operation_0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST_EQ(
+        42.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
 void test_mul_operation_0d_lit()
@@ -53,9 +54,10 @@ void test_mul_operation_0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST_EQ(
+        42.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
 void test_mul_operation_0d1d()
@@ -77,12 +79,13 @@ void test_mul_operation_0d1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::VectorXd expected = 6.0 * v;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_0d1d_lit()
@@ -102,12 +105,13 @@ void test_mul_operation_0d1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::VectorXd expected = 6.0 * v;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_0d2d()
@@ -129,12 +133,13 @@ void test_mul_operation_0d2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::MatrixXd expected = 6.0 * m;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_0d2d_lit()
@@ -154,12 +159,13 @@ void test_mul_operation_0d2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::MatrixXd expected = 6.0 * m;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_1d0d()
@@ -181,12 +187,13 @@ void test_mul_operation_1d0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::VectorXd expected = v * 6.0;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_1d0d_lit()
@@ -206,12 +213,13 @@ void test_mul_operation_1d0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::VectorXd expected = v * 6.0;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_2d0d()
@@ -233,12 +241,13 @@ void test_mul_operation_2d0d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::MatrixXd expected = m * 6.0;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_2d0d_lit()
@@ -258,12 +267,13 @@ void test_mul_operation_2d0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::MatrixXd expected = m * 6.0;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_2d()
@@ -286,12 +296,13 @@ void test_mul_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::MatrixXd expected = m1 * m2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_mul_operation_2d_lit()
@@ -312,12 +323,13 @@ void test_mul_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         mul.eval();
 
     Eigen::MatrixXd expected = m1 * m2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/not_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/not_equal_operation.cpp
@@ -32,9 +32,9 @@ void test_not_equal_operation_0d_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_not_equal_operation_0d_true()
@@ -54,9 +54,9 @@ void test_not_equal_operation_0d_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_not_equal_operation_0d_lit_false()
@@ -74,9 +74,9 @@ void test_not_equal_operation_0d_lit_false()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
-    HPX_TEST_EQ(0.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_not_equal_operation_0d_lit_true()
@@ -94,9 +94,9 @@ void test_not_equal_operation_0d_lit_true()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
-    HPX_TEST_EQ(1.0, f.get().value()[0]);
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_not_equal_operation_1d()
@@ -119,12 +119,13 @@ void test_not_equal_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
 
     Eigen::VectorXd expected = (v1.array() != v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_not_equal_operation_1d_lit()
@@ -145,12 +146,13 @@ void test_not_equal_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
 
     Eigen::VectorXd expected = (v1.array() != v2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_not_equal_operation_2d()
@@ -173,12 +175,13 @@ void test_not_equal_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() != m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_not_equal_operation_2d_lit()
@@ -199,12 +202,13 @@ void test_not_equal_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         not_equal.eval();
 
     Eigen::MatrixXd expected = (m1.array() != m2.array()).cast<double>();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        expected.norm() != 0.0,
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/not_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/not_equal_operation.cpp
@@ -1,0 +1,225 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_not_equal_operation_0d_false()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_not_equal_operation_0d_true()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_not_equal_operation_0d_lit_false()
+{
+    phylanx::ir::node_data<double> lhs(1.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+    HPX_TEST_EQ(0.0, f.get().value()[0]);
+}
+
+void test_not_equal_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+    HPX_TEST_EQ(1.0, f.get().value()[0]);
+}
+
+void test_not_equal_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() != v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_not_equal_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+
+    Eigen::VectorXd expected = (v1.array() != v2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_not_equal_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() != m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_not_equal_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive not_equal =
+        hpx::new_<phylanx::execution_tree::primitives::not_equal>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        not_equal.eval();
+
+    Eigen::MatrixXd expected = (m1.array() != m2.array()).cast<double>();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_not_equal_operation_0d_false();
+    test_not_equal_operation_0d_true();
+    test_not_equal_operation_0d_lit_false();
+    test_not_equal_operation_0d_lit_true();
+
+    test_not_equal_operation_1d();
+    test_not_equal_operation_1d_lit();
+
+    test_not_equal_operation_2d();
+    test_not_equal_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/or_operation.cpp
+++ b/tests/unit/execution_tree/primitives/or_operation.cpp
@@ -17,7 +17,7 @@
 
 void test_or_operation_0d_false()
 {
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -25,13 +25,14 @@ void test_or_operation_0d_false()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
+
     HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_or_operation_0d_true()
 {
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -39,7 +40,8 @@ void test_or_operation_0d_true()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
+
     HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
@@ -51,7 +53,7 @@ void test_or_operation_0d_lit_false()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(1.0));
 
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -59,7 +61,8 @@ void test_or_operation_0d_lit_false()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
+
     HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
@@ -71,7 +74,7 @@ void test_or_operation_0d_lit_true()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(1.0));
 
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -79,7 +82,8 @@ void test_or_operation_0d_lit_true()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
+
     HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
@@ -96,7 +100,7 @@ void test_or_operation_1d()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(v2));
 
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -104,7 +108,7 @@ void test_or_operation_1d()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
 
     HPX_TEST_EQ(
         (v1.norm() != 0.0) || (v2.norm() != 0.0),
@@ -122,7 +126,7 @@ void test_or_operation_1d_lit()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(v2));
 
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -130,7 +134,7 @@ void test_or_operation_1d_lit()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
 
     HPX_TEST_EQ(
         (v1.norm() != 0.0) || (v2.norm() != 0.0),
@@ -150,7 +154,7 @@ void test_or_operation_2d()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(m2));
 
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -158,7 +162,7 @@ void test_or_operation_2d()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
 
     HPX_TEST_EQ(
         (m1.norm() != 0.0) || (m2.norm() != 0.0),
@@ -176,7 +180,7 @@ void test_or_operation_2d_lit()
         hpx::new_<phylanx::execution_tree::primitives::literal_value>(
             hpx::find_here(), phylanx::ir::node_data<double>(m2));
 
-    phylanx::execution_tree::primitive or =
+    phylanx::execution_tree::primitive or_ =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
@@ -184,7 +188,7 @@ void test_or_operation_2d_lit()
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-        or.eval();
+        or_.eval();
 
     HPX_TEST_EQ(
         (m1.norm() != 0.0) || (m2.norm() != 0.0),

--- a/tests/unit/execution_tree/primitives/or_operation.cpp
+++ b/tests/unit/execution_tree/primitives/or_operation.cpp
@@ -1,0 +1,181 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <Eigen/Dense>
+
+#include <iostream>
+#include <utility>
+#include <vector>
+
+void test_or_operation_0d()
+{
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        or.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
+}
+
+void test_or_operation_0d_lit()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        or.eval();
+    HPX_TEST_EQ(42.0, f.get().value()[0]);
+}
+
+void test_or_operation_1d()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        or.eval();
+
+    Eigen::VectorXd expected = v1 + v2;
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_or_operation_1d_lit()
+{
+    Eigen::VectorXd v1 = Eigen::VectorXd::Random(1007);
+    Eigen::VectorXd v2 = Eigen::VectorXd::Random(1007);
+
+    phylanx::ir::node_data<double> lhs(v1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v2));
+
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        or.eval();
+
+    Eigen::VectorXd expected = v1 + v2;
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_or_operation_2d()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::execution_tree::primitive lhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        or.eval();
+
+    Eigen::MatrixXd expected = m1.array() + m2.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+void test_or_operation_2d_lit()
+{
+    Eigen::MatrixXd m1 = Eigen::MatrixXd::Random(101, 101);
+    Eigen::MatrixXd m2 = Eigen::MatrixXd::Random(101, 101);
+
+    phylanx::ir::node_data<double> lhs(m1);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m2));
+
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+        or.eval();
+
+    Eigen::MatrixXd expected = m1.array() + m2.array();
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+}
+
+int main(int argc, char* argv[])
+{
+    test_or_operation_0d();
+    test_or_operation_0d_lit();
+
+    test_or_operation_1d();
+    test_or_operation_1d_lit();
+
+    test_or_operation_2d();
+    test_or_operation_2d_lit();
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/or_operation.cpp
+++ b/tests/unit/execution_tree/primitives/or_operation.cpp
@@ -15,29 +15,35 @@
 #include <utility>
 #include <vector>
 
-void test_or_operation_0d()
+void test_or_operation_0d_false()
 {
-    phylanx::execution_tree::primitive lhs =
-        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
-            hpx::find_here(), phylanx::ir::node_data<double>(41.0));
-
-    phylanx::execution_tree::primitive rhs =
-        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
-            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
-
     phylanx::execution_tree::primitive or =
         hpx::new_<phylanx::execution_tree::primitives::or_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                std::move(lhs), std::move(rhs)
+                false, false
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         or.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
-void test_or_operation_0d_lit()
+void test_or_operation_0d_true()
+{
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                false, true
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        or.eval();
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
+}
+
+void test_or_operation_0d_lit_false()
 {
     phylanx::ir::node_data<double> lhs(41.0);
 
@@ -52,9 +58,29 @@ void test_or_operation_0d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         or.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
+}
+
+void test_or_operation_0d_lit_true()
+{
+    phylanx::ir::node_data<double> lhs(41.0);
+
+    phylanx::execution_tree::primitive rhs =
+        hpx::new_<phylanx::execution_tree::primitives::literal_value>(
+            hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive or =
+        hpx::new_<phylanx::execution_tree::primitives::or_operation>(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs), std::move(rhs)
+            });
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+        or.eval();
+    HPX_TEST(phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
 void test_or_operation_1d()
@@ -77,12 +103,12 @@ void test_or_operation_1d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         or.eval();
 
-    Eigen::VectorXd expected = v1 + v2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (v1.norm() != 0.0) || (v2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_or_operation_1d_lit()
@@ -103,12 +129,12 @@ void test_or_operation_1d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         or.eval();
 
-    Eigen::VectorXd expected = v1 + v2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (v1.norm() != 0.0) || (v2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_or_operation_2d()
@@ -131,12 +157,12 @@ void test_or_operation_2d()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         or.eval();
 
-    Eigen::MatrixXd expected = m1.array() + m2.array();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (m1.norm() != 0.0) || (m2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 void test_or_operation_2d_lit()
@@ -157,18 +183,21 @@ void test_or_operation_2d_lit()
                 std::move(lhs), std::move(rhs)
             });
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         or.eval();
 
-    Eigen::MatrixXd expected = m1.array() + m2.array();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        (m1.norm() != 0.0) || (m2.norm() != 0.0),
+        phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
 int main(int argc, char* argv[])
 {
-    test_or_operation_0d();
-    test_or_operation_0d_lit();
+    test_or_operation_0d_false();
+    test_or_operation_0d_true();
+
+    test_or_operation_0d_lit_false();
+    test_or_operation_0d_lit_true();
 
     test_or_operation_1d();
     test_or_operation_1d_lit();

--- a/tests/unit/execution_tree/primitives/sub_operation.cpp
+++ b/tests/unit/execution_tree/primitives/sub_operation.cpp
@@ -31,9 +31,10 @@ void test_sub_operation_0d()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         sub.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST_EQ(
+        42.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
 void test_sub_operation_0d_lit()
@@ -50,9 +51,10 @@ void test_sub_operation_0d_lit()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         sub.eval();
-    HPX_TEST_EQ(42.0, f.get().value()[0]);
+    HPX_TEST_EQ(
+        42.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
 void test_sub_operation_1d()
@@ -74,12 +76,13 @@ void test_sub_operation_1d()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         sub.eval();
 
     Eigen::VectorXd expected = v1 - v2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_sub_operation_1d_lit()
@@ -99,12 +102,13 @@ void test_sub_operation_1d_lit()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         sub.eval();
 
     Eigen::VectorXd expected = v1 - v2;
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_sub_operation_2d()
@@ -126,12 +130,13 @@ void test_sub_operation_2d()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         sub.eval();
 
     Eigen::MatrixXd expected = m1.array() - m2.array();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_sub_operation_2d_lit()
@@ -151,12 +156,13 @@ void test_sub_operation_2d_lit()
             std::vector<phylanx::execution_tree::primitive_argument_type>{
                 std::move(lhs), std::move(rhs)});
 
-    hpx::future<phylanx::util::optional<phylanx::ir::node_data<double>>> f =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         sub.eval();
 
     Eigen::MatrixXd expected = m1.array() - m2.array();
     HPX_TEST_EQ(
-        phylanx::ir::node_data<double>(std::move(expected)), f.get().value());
+        phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 int main(int argc, char* argv[])

--- a/tools/VS/optional.natvis
+++ b/tools/VS/optional.natvis
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- Copyright (c) 2017 Hartmut Kaiser                                      -->
+
+<!-- Use, modification and distribution are subject to the Boost Software   -->
+<!-- License, Version 1.0. (See accompanying file LICENSE_1_0.txt           -->
+<!-- or copy at http://www.boost.org/LICENSE_1_0.txt)                       -->
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+    <Type Name="phylanx::util::optional&lt;*&gt;">
+        <DisplayString Condition="empty_ == true">empty</DisplayString>
+        <DisplayString Condition="empty_ == false">{*(($T1 *)(storage_._Pad))}</DisplayString>
+        <Expand>
+            <Item Condition="empty_ == false" Name="value">*(($T1 *)(storage_._Pad))</Item>
+        </Expand>
+    </Type>
+
+</AutoVisualizer>
+


### PR DESCRIPTION
This adds more primitives:

- conditionals: `==`, `!=`, `<`, `>`, `<=`, `>=`
- Boolean operators: `&&`, `||`
- while primitive
- element-wise division primitive

This also changes the return type for all primitives to be a variant holding either `nil` (empty), a literal value (`bool`, `int64_t`, `std::string`) or an instance of `node_data<double>`.
