### PR TITLE
Making sure primitives don't trigger any unneeded allocations and/or argument copy operations

### DIFF
--- a/phylanx/execution_tree/primitives/add_operation.hpp
+++ b/phylanx/execution_tree/primitives/add_operation.hpp
@@ -38,18 +38,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> add0d(operands_type const& ops) const;
-        ir::node_data<double> add0d0d(operands_type const& ops) const;
-        ir::node_data<double> add0d1d(operands_type const& ops) const;
-        ir::node_data<double> add0d2d(operands_type const& ops) const;
+        ir::node_data<double> add0d(operands_type && ops) const;
+        ir::node_data<double> add0d0d(operands_type && ops) const;
+        ir::node_data<double> add0d1d(operands_type && ops) const;
+        ir::node_data<double> add0d2d(operands_type && ops) const;
 
-        ir::node_data<double> add1d(operands_type const& ops) const;
-        ir::node_data<double> add1d0d(operands_type const& ops) const;
-        ir::node_data<double> add1d1d(operands_type const& ops) const;
+        ir::node_data<double> add1d(operands_type && ops) const;
+        ir::node_data<double> add1d0d(operands_type && ops) const;
+        ir::node_data<double> add1d1d(operands_type && ops) const;
 
-        ir::node_data<double> add2d(operands_type const& ops) const;
-        ir::node_data<double> add2d0d(operands_type const& ops) const;
-        ir::node_data<double> add2d2d(operands_type const& ops) const;
+        ir::node_data<double> add2d(operands_type && ops) const;
+        ir::node_data<double> add2d0d(operands_type && ops) const;
+        ir::node_data<double> add2d2d(operands_type && ops) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/div_operation.hpp
+++ b/phylanx/execution_tree/primitives/div_operation.hpp
@@ -38,18 +38,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> div0d(operands_type const& ops) const;
-        ir::node_data<double> div0d0d(operands_type const& ops) const;
-        ir::node_data<double> div0d1d(operands_type const& ops) const;
-        ir::node_data<double> div0d2d(operands_type const& ops) const;
+        ir::node_data<double> div0d(operands_type && ops) const;
+        ir::node_data<double> div0d0d(operands_type && ops) const;
+        ir::node_data<double> div0d1d(operands_type && ops) const;
+        ir::node_data<double> div0d2d(operands_type && ops) const;
 
-        ir::node_data<double> div1d(operands_type const& ops) const;
-        ir::node_data<double> div1d0d(operands_type const& ops) const;
-        ir::node_data<double> div1d1d(operands_type const& ops) const;
+        ir::node_data<double> div1d(operands_type && ops) const;
+        ir::node_data<double> div1d0d(operands_type && ops) const;
+        ir::node_data<double> div1d1d(operands_type && ops) const;
 
-        ir::node_data<double> div2d(operands_type const& ops) const;
-        ir::node_data<double> div2d0d(operands_type const& ops) const;
-        ir::node_data<double> div2d2d(operands_type const& ops) const;
+        ir::node_data<double> div2d(operands_type && ops) const;
+        ir::node_data<double> div2d0d(operands_type && ops) const;
+        ir::node_data<double> div2d2d(operands_type && ops) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/equal.hpp
+++ b/phylanx/execution_tree/primitives/equal.hpp
@@ -23,6 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<equal>
     {
     private:
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<primitive_result_type>;
 
     public:
@@ -35,21 +36,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        bool equal0d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool equal1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool equal2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool equal0d(operand_type&& lhs, operand_type&& rhs) const;
+        bool equal1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool equal2d(operand_type&& lhs, operand_type&& rhs) const;
 
-        bool equal1d1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool equal2d2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool equal1d1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool equal2d2d(operand_type&& lhs, operand_type&& rhs) const;
 
     public:
-        bool equal_all(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool equal_all(operand_type&& lhs, operand_type&& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/exponential_operation.hpp
+++ b/phylanx/execution_tree/primitives/exponential_operation.hpp
@@ -38,9 +38,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> exponential0d(operands_type const& ops) const;
-        ir::node_data<double> exponential1d(operands_type const& ops) const;
-        ir::node_data<double> exponentialxd(operands_type const& ops) const;
+        ir::node_data<double> exponential0d(operands_type && ops) const;
+        ir::node_data<double> exponential1d(operands_type && ops) const;
+        ir::node_data<double> exponentialxd(operands_type && ops) const;
     };
 }}}
 

--- a/phylanx/execution_tree/primitives/greater.hpp
+++ b/phylanx/execution_tree/primitives/greater.hpp
@@ -23,6 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<greater>
     {
     private:
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<primitive_result_type>;
 
     public:
@@ -35,21 +36,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        bool greater0d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool greater1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool greater2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool greater0d(operand_type&& lhs, operand_type&& rhs) const;
+        bool greater1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool greater2d(operand_type&& lhs, operand_type&& rhs) const;
 
-        bool greater1d1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool greater2d2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool greater1d1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool greater2d2d(operand_type&& lhs, operand_type&& rhs) const;
 
     public:
-        bool greater_all(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool greater_all(operand_type&& lhs, operand_type&& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/greater_equal.hpp
+++ b/phylanx/execution_tree/primitives/greater_equal.hpp
@@ -23,6 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<greater_equal>
     {
     private:
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<primitive_result_type>;
 
     public:
@@ -35,21 +36,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        bool greater_equal0d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool greater_equal1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool greater_equal2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool greater_equal0d(operand_type&& lhs, operand_type&& rhs) const;
+        bool greater_equal1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool greater_equal2d(operand_type&& lhs, operand_type&& rhs) const;
 
-        bool greater_equal1d1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool greater_equal2d2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool greater_equal1d1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool greater_equal2d2d(operand_type&& lhs, operand_type&& rhs) const;
 
     public:
-        bool greater_equal_all(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool greater_equal_all(operand_type&& lhs, operand_type&& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/less.hpp
+++ b/phylanx/execution_tree/primitives/less.hpp
@@ -23,6 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<less>
     {
     private:
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<primitive_result_type>;
 
     public:
@@ -35,21 +36,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        bool less0d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool less1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool less2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool less0d(operand_type&& lhs, operand_type&& rhs) const;
+        bool less1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool less2d(operand_type&& lhs, operand_type&& rhs) const;
 
-        bool less1d1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool less2d2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool less1d1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool less2d2d(operand_type&& lhs, operand_type&& rhs) const;
 
     public:
-        bool less_all(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool less_all(operand_type&& lhs, operand_type&& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/less_equal.hpp
+++ b/phylanx/execution_tree/primitives/less_equal.hpp
@@ -23,6 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<less_equal>
     {
     private:
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<primitive_result_type>;
 
     public:
@@ -35,21 +36,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        bool less_equal0d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool less_equal1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool less_equal2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool less_equal0d(operand_type&& lhs, operand_type&& rhs) const;
+        bool less_equal1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool less_equal2d(operand_type&& lhs, operand_type&& rhs) const;
 
-        bool less_equal1d1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool less_equal2d2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool less_equal1d1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool less_equal2d2d(operand_type&& lhs, operand_type&& rhs) const;
 
     public:
-        bool less_equal_all(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool less_equal_all(operand_type&& lhs, operand_type&& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/mul_operation.hpp
+++ b/phylanx/execution_tree/primitives/mul_operation.hpp
@@ -39,8 +39,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> mul0d(operands_type const& ops) const;
-        ir::node_data<double> mulxd(operands_type const& ops) const;
+        ir::node_data<double> mul0d(operands_type && ops) const;
+        ir::node_data<double> mulxd(operands_type && ops) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/not_equal.hpp
+++ b/phylanx/execution_tree/primitives/not_equal.hpp
@@ -23,6 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public hpx::components::component_base<not_equal>
     {
     private:
+        using operand_type = ir::node_data<double>;
         using operands_type = std::vector<primitive_result_type>;
 
     public:
@@ -34,22 +35,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_result_type> eval() const override;
 
-    protected:
-        bool not_equal0d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool not_equal1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool not_equal2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool not_equal0d(operand_type&& lhs, operand_type&& rhs) const;
+        bool not_equal1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool not_equal2d(operand_type&& lhs, operand_type&& rhs) const;
 
-        bool not_equal1d1d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
-        bool not_equal2d2d(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool not_equal1d1d(operand_type&& lhs, operand_type&& rhs) const;
+        bool not_equal2d2d(operand_type&& lhs, operand_type&& rhs) const;
 
     public:
-        bool not_equal_all(ir::node_data<double> const& lhs,
-            ir::node_data<double> const& rhs) const;
+        bool not_equal_all(operand_type&& lhs, operand_type&& rhs) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/execution_tree/primitives/sub_operation.hpp
+++ b/phylanx/execution_tree/primitives/sub_operation.hpp
@@ -38,18 +38,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_result_type> eval() const override;
 
     protected:
-        ir::node_data<double> sub0d(operands_type const& ops) const;
-        ir::node_data<double> sub0d0d(operands_type const& ops) const;
-        ir::node_data<double> sub0d1d(operands_type const& ops) const;
-        ir::node_data<double> sub0d2d(operands_type const& ops) const;
+        ir::node_data<double> sub0d(operands_type && ops) const;
+        ir::node_data<double> sub0d0d(operands_type && ops) const;
+        ir::node_data<double> sub0d1d(operands_type && ops) const;
+        ir::node_data<double> sub0d2d(operands_type && ops) const;
 
-        ir::node_data<double> sub1d(operands_type const& ops) const;
-        ir::node_data<double> sub1d0d(operands_type const& ops) const;
-        ir::node_data<double> sub1d1d(operands_type const& ops) const;
+        ir::node_data<double> sub1d(operands_type && ops) const;
+        ir::node_data<double> sub1d0d(operands_type && ops) const;
+        ir::node_data<double> sub1d1d(operands_type && ops) const;
 
-        ir::node_data<double> sub2d(operands_type const& ops) const;
-        ir::node_data<double> sub2d0d(operands_type const& ops) const;
-        ir::node_data<double> sub2d2d(operands_type const& ops) const;
+        ir::node_data<double> sub2d(operands_type && ops) const;
+        ir::node_data<double> sub2d0d(operands_type && ops) const;
+        ir::node_data<double> sub2d2d(operands_type && ops) const;
 
     private:
         std::vector<primitive_argument_type> operands_;

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -177,7 +177,43 @@ namespace phylanx { namespace ir
         {
         }
 
+        node_data(node_data const& d)
+          : data_(d.data_)
+        {
+        }
+        node_data(node_data && d)
+          : data_(std::move(d.data_))
+        {
+        }
+
+        node_data& operator=(node_data const& d)
+        {
+            if (this != &d)
+            {
+                data_ = d.data_;
+            }
+            return *this;
+        }
+        node_data& operator=(node_data && d)
+        {
+            if (this != &d)
+            {
+                data_ = std::move(d.data_);
+            }
+            return *this;
+        }
+
+
         /// Access a specific element of the underlying N-dimensional array
+        T& operator[](std::ptrdiff_t index)
+        {
+            return data_.data()[index];
+        }
+        T& operator[](dimensions_type const& indicies)
+        {
+            return data_(indicies[0], indicies[1]);
+        }
+
         T const& operator[](std::ptrdiff_t index) const
         {
             return data_.data()[index];
@@ -220,6 +256,10 @@ namespace phylanx { namespace ir
             return data_.size();
         }
 
+        storage_type& matrix()
+        {
+            return data_;
+        }
         storage_type const& matrix() const
         {
             return data_;

--- a/src/execution_tree/primitives/and_operation.cpp
+++ b/src/execution_tree/primitives/and_operation.cpp
@@ -76,12 +76,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (ops.size() == 2)
                 {
-                    return primitive_result_type(ops[0] && ops[1]);
+                    return primitive_result_type(ops[0] != 0 && ops[1] != 0);
                 }
 
                 return primitive_result_type(
-                    std::all_of(ops.begin(), ops.end(),
-                        [](std::uint8_t curr) { return curr; }));
+                    std::all_of(
+                        ops.begin(), ops.end(),
+                        [](std::uint8_t curr)
+                        {
+                            return curr != 0;
+                        }));
             }),
             detail::map_operands(operands_, boolean_operand)
         );

--- a/src/execution_tree/primitives/div_operation.cpp
+++ b/src/execution_tree/primitives/div_operation.cpp
@@ -68,77 +68,27 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> div_operation::div0d0d(operands_type const& ops) const
+    ir::node_data<double> div_operation::div0d0d(operands_type && ops) const
     {
-        auto const& lhs = ops[0];
-        auto const& rhs = ops[1];
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
 
         if (ops.size() == 2)
         {
-            return lhs[0] / rhs[0];
+            lhs[0] /= rhs[0];
+            return std::move(lhs);
         }
 
-        return ir::node_data<double>(
-            std::accumulate(ops.begin() + 1, ops.end(), lhs[0],
-                [](double result, operand_type const& curr)
-                {
-                    return result / curr[0];
-                }));
+        return std::accumulate(
+            ops.begin() + 1, ops.end(), std::move(lhs),
+            [](operand_type& result, operand_type const& curr) -> operand_type
+            {
+                result[0] /= curr[0];
+                return std::move(result);
+            });
     }
 
-    ir::node_data<double> div_operation::div0d1d(operands_type const& ops) const
-    {
-        if (ops.size() != 2)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "div_operation::div0d1d",
-                "the div_operation primitive can div a single value to a "
-                    "vector only if there are exectly 2 operands");
-        }
-
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-        matrix_type result = ops[0][0] / ops[1].matrix().array();
-        return ir::node_data<double>(std::move(result));
-    }
-
-    ir::node_data<double> div_operation::div0d2d(operands_type const& ops) const
-    {
-        if (ops.size() != 2)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "div_operation::div0d2d",
-                "the div_operation primitive can div a single value to a "
-                    "matrix only if there are exectly 2 operands");
-        }
-
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-        matrix_type result = ops[0][0] / ops[1].matrix().array();
-        return ir::node_data<double>(std::move(result));
-    }
-
-    ir::node_data<double> div_operation::div0d(operands_type const& ops) const
-    {
-        std::size_t rhs_dims = ops[1].num_dimensions();
-        switch(rhs_dims)
-        {
-        case 0:
-            return div0d0d(ops);
-
-        case 1:
-            return div0d1d(ops);
-
-        case 2:
-            return div0d2d(ops);
-
-        default:
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "div_operation::div0d",
-                "the operands have incompatible number of dimensions");
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> div_operation::div1d0d(operands_type const& ops) const
+    ir::node_data<double> div_operation::div0d1d(operands_type && ops) const
     {
         if (ops.size() != 2)
         {
@@ -148,15 +98,64 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "vector only if there are exactly 2 operands");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-        matrix_type result = ops[0].matrix().array() / ops[1][0];
-        return ir::node_data<double>(std::move(result));
+        ops[1].matrix().array() = ops[0][0] / ops[1].matrix().array();
+        return std::move(ops[1]);
     }
 
-    ir::node_data<double> div_operation::div1d1d(operands_type const& ops) const
+    ir::node_data<double> div_operation::div0d2d(operands_type && ops) const
     {
-        auto const& lhs = ops[0];
-        auto const& rhs = ops[1];
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "div_operation::div0d2d",
+                "the div_operation primitive can div a single value to a "
+                    "matrix only if there are exactly 2 operands");
+        }
+
+        ops[1].matrix().array() = ops[0][0] / ops[1].matrix().array();
+        return std::move(ops[1]);
+    }
+
+    ir::node_data<double> div_operation::div0d(operands_type && ops) const
+    {
+        std::size_t rhs_dims = ops[1].num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return div0d0d(std::move(ops));
+
+        case 1:
+            return div0d1d(std::move(ops));
+
+        case 2:
+            return div0d2d(std::move(ops));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "div_operation::div0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> div_operation::div1d0d(operands_type && ops) const
+    {
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "div_operation::div0d1d",
+                "the div_operation primitive can div a single value to a "
+                    "vector only if there are exactly 2 operands");
+        }
+
+        ops[0].matrix().array() /= ops[1][0];
+        return std::move(ops[0]);
+    }
+
+    ir::node_data<double> div_operation::div1d1d(operands_type && ops) const
+    {
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
 
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -168,39 +167,33 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using array_type = Eigen::Array<double, Eigen::Dynamic, 1>;
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-
         if (ops.size() == 2)
         {
-            matrix_type result = lhs.matrix().array() / rhs.matrix().array();
-            return ir::node_data<double>(std::move(result));
+            lhs.matrix().array() /= rhs.matrix().array();
+            return std::move(lhs);
         }
 
-        array_type first_term = ops.begin()->matrix().array();
-        matrix_type result =
-            std::accumulate(
-                ops.begin() + 1, ops.end(), std::move(first_term),
-                [](array_type& result, operand_type const& curr)
-                ->  array_type
-                {
-                    return result /= curr.matrix().array();
-                });
-
-        return ir::node_data<double>(std::move(result));
+        operand_type& first_term = *ops.begin();
+        return std::accumulate(
+            ops.begin() + 1, ops.end(), std::move(first_term),
+            [](operand_type& result, operand_type const& curr) -> operand_type
+            {
+                result.matrix().array() /= curr.matrix().array();
+                return std::move(result);
+            });
     }
 
-    ir::node_data<double> div_operation::div1d(operands_type const& ops) const
+    ir::node_data<double> div_operation::div1d(operands_type && ops) const
     {
         std::size_t rhs_dims = ops[1].num_dimensions();
 
         switch(rhs_dims)
         {
         case 0:
-            return div1d0d(ops);
+            return div1d0d(std::move(ops));
 
         case 1:
-            return div1d1d(ops);
+            return div1d1d(std::move(ops));
 
         case 2: HPX_FALLTHROUGH;
         default:
@@ -211,7 +204,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> div_operation::div2d0d(operands_type const& ops) const
+    ir::node_data<double> div_operation::div2d0d(operands_type && ops) const
     {
         if (ops.size() != 2)
         {
@@ -221,15 +214,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "matrix only if there are exactly 2 operands");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-        matrix_type result = ops[0].matrix().array() / ops[1][0];
-        return ir::node_data<double>(std::move(result));
+        ops[0].matrix().array() /= ops[1][0];
+        return std::move(ops[0]);
     }
 
-    ir::node_data<double> div_operation::div2d2d(operands_type const& ops) const
+    ir::node_data<double> div_operation::div2d2d(operands_type && ops) const
     {
-        auto const& lhs = ops[0];
-        auto const& rhs = ops[1];
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
 
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -241,38 +233,32 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using array_type = Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>;
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-
         if (ops.size() == 2)
         {
-            matrix_type result = lhs.matrix().array() / rhs.matrix().array();
-            return ir::node_data<double>(std::move(result));
+            lhs.matrix().array() /= rhs.matrix().array();
+            return std::move(lhs);
         }
 
-        array_type first_term = ops.begin()->matrix().array();
-        matrix_type result =
-            std::accumulate(
-                ops.begin() + 1, ops.end(), std::move(first_term),
-                [](array_type& result, operand_type const& curr)
-                ->  array_type
-                {
-                    return result /= curr.matrix().array();
-                });
-
-        return ir::node_data<double>(std::move(result));
+        operand_type& first_term = *ops.begin();
+        return std::accumulate(
+            ops.begin() + 1, ops.end(), std::move(first_term),
+            [](operand_type& result, operand_type const& curr) -> operand_type
+            {
+                result.matrix().array() /= curr.matrix().array();
+                return std::move(result);
+            });
     }
 
-    ir::node_data<double> div_operation::div2d(operands_type const& ops) const
+    ir::node_data<double> div_operation::div2d(operands_type && ops) const
     {
         std::size_t rhs_dims = ops[1].num_dimensions();
         switch(rhs_dims)
         {
         case 0:
-            return div2d0d(ops);
+            return div2d0d(std::move(ops));
 
         case 2:
-            return div2d2d(ops);
+            return div2d2d(std::move(ops));
 
         case 1: HPX_FALLTHROUGH;
         default:
@@ -292,13 +278,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 switch (lhs_dims)
                 {
                 case 0:
-                    return primitive_result_type(div0d(ops));
+                    return primitive_result_type(div0d(std::move(ops)));
 
                 case 1:
-                    return primitive_result_type(div1d(ops));
+                    return primitive_result_type(div1d(std::move(ops)));
 
                 case 2:
-                    return primitive_result_type(div2d(ops));
+                    return primitive_result_type(div2d(std::move(ops)));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -56,8 +56,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool equal::equal0d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool equal::equal0d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -75,33 +74,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool equal::equal1d1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool equal::equal1d1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
-        if (lhs_size  != rhs_size)
+        if (lhs_size != rhs_size)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "equal::equal1d1d",
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() == rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool equal::equal1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool equal::equal1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return equal1d1d(lhs, rhs);
+            return equal1d1d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -113,8 +110,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool equal::equal2d2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool equal::equal2d2d(operand_type&& lhs, operand_type&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -126,20 +122,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() == rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool equal::equal2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool equal::equal2d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return equal2d2d(lhs, rhs);
+            return equal2d2d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -150,20 +145,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    bool equal::equal_all(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool equal::equal_all(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
         {
         case 0:
-            return equal0d(lhs, rhs);
+            return equal0d(std::move(lhs), std::move(rhs));
 
         case 1:
-            return equal1d(lhs, rhs);
+            return equal1d(std::move(lhs), std::move(rhs));
 
         case 2:
-            return equal2d(lhs, rhs);
+            return equal2d(std::move(lhs), std::move(rhs));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -177,6 +171,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         struct visit_equal
         {
+            using operand_type = ir::node_data<double>;
+
             visit_equal(equal const& this_)
               : equal_(this_)
             {}
@@ -191,15 +187,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
 
             template <typename T>
-            bool operator()(T const& lhs, T const& rhs) const
+            bool operator()(T && lhs, T && rhs) const
             {
                 return lhs == rhs;
             }
 
-            bool operator()(ir::node_data<double> const& lhs,
-                ir::node_data<double> const& rhs) const
+            bool operator()(operand_type&& lhs, operand_type&& rhs) const
             {
-                return equal_.equal_all(lhs, rhs);
+                return equal_.equal_all(std::move(lhs), std::move(rhs));
             }
 
             equal const& equal_;
@@ -213,7 +208,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [this](operands_type && ops)
             {
                 return primitive_result_type(
-                    util::visit(detail::visit_equal(*this), ops[0], ops[1]));
+                    util::visit(detail::visit_equal(*this),
+                        std::move(ops[0]), std::move(ops[1])));
             }),
             detail::map_operands(operands_, literal_operand)
         );

--- a/src/execution_tree/primitives/exponential_operation.cpp
+++ b/src/execution_tree/primitives/exponential_operation.cpp
@@ -63,16 +63,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> exponential_operation::exponential0d(
-        operands_type const& ops) const
+        operands_type && ops) const
     {
-        return std::exp(ops[0][0]);
+        return operand_type(std::exp(ops[0][0]));
     }
 
     ir::node_data<double> exponential_operation::exponential1d(
-        operands_type const& ops) const
+        operands_type && ops) const
     {
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-
         auto const& val = ops[0].matrix();
         if (val.rows() != val.cols())
         {
@@ -81,13 +79,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "matrix exponentiation requires quadratic matrices");
         }
 
+        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+
         matrix_type result = ops[0].matrix().exp();
         return ir::node_data<double>(std::move(result));
     }
 
     ir::node_data<double> exponential_operation::exponentialxd(
-        operands_type const& ops) const
+        operands_type && ops) const
     {
+        auto const& val = ops[0].matrix();
+        if (val.rows() != val.cols())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "exponential_operation::exponential1d",
+                "matrix exponentiation requires quadratic matrices");
+        }
+
         using matrix_type =
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
 
@@ -104,13 +112,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 switch (dims)
                 {
                 case 0:
-                    return primitive_result_type(exponential0d(ops));
+                    return primitive_result_type(exponential0d(std::move(ops)));
 
                 case 1:
-                    return primitive_result_type(exponential1d(ops));
+                    return primitive_result_type(exponential1d(std::move(ops)));
 
                 case 2:
-                    return primitive_result_type(exponentialxd(ops));
+                    return primitive_result_type(exponentialxd(std::move(ops)));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -56,8 +56,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool greater::greater0d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater::greater0d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -75,33 +74,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool greater::greater1d1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater::greater1d1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
-        if (lhs_size  != rhs_size)
+        if (lhs_size != rhs_size)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "greater::greater1d1d",
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() > rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool greater::greater1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater::greater1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return greater1d1d(lhs, rhs);
+            return greater1d1d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -113,8 +110,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool greater::greater2d2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater::greater2d2d(operand_type&& lhs, operand_type&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -126,20 +122,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() > rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool greater::greater2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater::greater2d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return greater2d2d(lhs, rhs);
+            return greater2d2d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -150,20 +145,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    bool greater::greater_all(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater::greater_all(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
         {
         case 0:
-            return greater0d(lhs, rhs);
+            return greater0d(std::move(lhs), std::move(rhs));
 
         case 1:
-            return greater1d(lhs, rhs);
+            return greater1d(std::move(lhs), std::move(rhs));
 
         case 2:
-            return greater2d(lhs, rhs);
+            return greater2d(std::move(lhs), std::move(rhs));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -177,6 +171,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         struct visit_greater
         {
+            using operand_type = ir::node_data<double>;
+
             visit_greater(greater const& this_)
               : greater_(this_)
             {}
@@ -191,15 +187,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
 
             template <typename T>
-            bool operator()(T const& lhs, T const& rhs) const
+            bool operator()(T && lhs, T && rhs) const
             {
                 return lhs > rhs;
             }
 
-            bool operator()(ir::node_data<double> const& lhs,
-                ir::node_data<double> const& rhs) const
+            bool operator()(operand_type&& lhs, operand_type&& rhs) const
             {
-                return greater_.greater_all(lhs, rhs);
+                return greater_.greater_all(std::move(lhs), std::move(rhs));
             }
 
             greater const& greater_;
@@ -213,7 +208,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [this](operands_type && ops)
             {
                 return primitive_result_type(
-                    util::visit(detail::visit_greater(*this), ops[0], ops[1]));
+                    util::visit(detail::visit_greater(*this),
+                        std::move(ops[0]), std::move(ops[1])));
             }),
             detail::map_operands(operands_, literal_operand)
         );

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -56,8 +56,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool greater_equal::greater_equal0d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater_equal::greater_equal0d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -75,33 +74,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool greater_equal::greater_equal1d1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater_equal::greater_equal1d1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
-        if (lhs_size  != rhs_size)
+        if (lhs_size != rhs_size)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "greater_equal::greater_equal1d1d",
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() >= rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool greater_equal::greater_equal1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater_equal::greater_equal1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return greater_equal1d1d(lhs, rhs);
+            return greater_equal1d1d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -113,8 +110,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool greater_equal::greater_equal2d2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater_equal::greater_equal2d2d(operand_type&& lhs, operand_type&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -126,20 +122,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() >= rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool greater_equal::greater_equal2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater_equal::greater_equal2d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return greater_equal2d2d(lhs, rhs);
+            return greater_equal2d2d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -150,20 +145,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    bool greater_equal::greater_equal_all(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool greater_equal::greater_equal_all(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
         {
         case 0:
-            return greater_equal0d(lhs, rhs);
+            return greater_equal0d(std::move(lhs), std::move(rhs));
 
         case 1:
-            return greater_equal1d(lhs, rhs);
+            return greater_equal1d(std::move(lhs), std::move(rhs));
 
         case 2:
-            return greater_equal2d(lhs, rhs);
+            return greater_equal2d(std::move(lhs), std::move(rhs));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -177,6 +171,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         struct visit_greater_equal
         {
+            using operand_type = ir::node_data<double>;
+
             visit_greater_equal(greater_equal const& this_)
               : greater_equal_(this_)
             {}
@@ -191,15 +187,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
 
             template <typename T>
-            bool operator()(T const& lhs, T const& rhs) const
+            bool operator()(T && lhs, T && rhs) const
             {
                 return lhs >= rhs;
             }
 
-            bool operator()(ir::node_data<double> const& lhs,
-                ir::node_data<double> const& rhs) const
+            bool operator()(operand_type&& lhs, operand_type&& rhs) const
             {
-                return greater_equal_.greater_equal_all(lhs, rhs);
+                return greater_equal_.greater_equal_all(
+                    std::move(lhs), std::move(rhs));
             }
 
             greater_equal const& greater_equal_;
@@ -213,7 +209,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [this](operands_type && ops)
             {
                 return primitive_result_type(
-                    util::visit(detail::visit_greater_equal(*this), ops[0], ops[1]));
+                    util::visit(detail::visit_greater_equal(*this),
+                        std::move(ops[0]), std::move(ops[1])));
             }),
             detail::map_operands(operands_, literal_operand)
         );

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -56,8 +56,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool less::less0d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less::less0d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -75,33 +74,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool less::less1d1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less::less1d1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
-        if (lhs_size  != rhs_size)
+        if (lhs_size != rhs_size)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "less::less1d1d",
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool less::less1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less::less1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return less1d1d(lhs, rhs);
+            return less1d1d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -113,8 +110,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool less::less2d2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less::less2d2d(operand_type&& lhs, operand_type&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -126,20 +122,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() < rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool less::less2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less::less2d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return less2d2d(lhs, rhs);
+            return less2d2d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -150,20 +145,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    bool less::less_all(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less::less_all(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
         {
         case 0:
-            return less0d(lhs, rhs);
+            return less0d(std::move(lhs), std::move(rhs));
 
         case 1:
-            return less1d(lhs, rhs);
+            return less1d(std::move(lhs), std::move(rhs));
 
         case 2:
-            return less2d(lhs, rhs);
+            return less2d(std::move(lhs), std::move(rhs));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -177,6 +171,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         struct visit_less
         {
+            using operand_type = ir::node_data<double>;
+
             visit_less(less const& this_)
               : less_(this_)
             {}
@@ -191,15 +187,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
 
             template <typename T>
-            bool operator()(T const& lhs, T const& rhs) const
+            bool operator()(T && lhs, T && rhs) const
             {
                 return lhs < rhs;
             }
 
-            bool operator()(ir::node_data<double> const& lhs,
-                ir::node_data<double> const& rhs) const
+            bool operator()(operand_type&& lhs, operand_type&& rhs) const
             {
-                return less_.less_all(lhs, rhs);
+                return less_.less_all(std::move(lhs), std::move(rhs));
             }
 
             less const& less_;
@@ -213,7 +208,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [this](operands_type && ops)
             {
                 return primitive_result_type(
-                    util::visit(detail::visit_less(*this), ops[0], ops[1]));
+                    util::visit(detail::visit_less(*this),
+                        std::move(ops[0]), std::move(ops[1])));
             }),
             detail::map_operands(operands_, literal_operand)
         );

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -56,8 +56,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool less_equal::less_equal0d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less_equal::less_equal0d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -75,33 +74,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool less_equal::less_equal1d1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less_equal::less_equal1d1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
 
-        if (lhs_size  != rhs_size)
+        if (lhs_size != rhs_size)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "less_equal::less_equal1d1d",
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, 1> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() <= rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool less_equal::less_equal1d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less_equal::less_equal1d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 1:
-            return less_equal1d1d(lhs, rhs);
+            return less_equal1d1d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 2: HPX_FALLTHROUGH;
@@ -113,8 +110,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool less_equal::less_equal2d2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less_equal::less_equal2d2d(operand_type&& lhs, operand_type&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -126,20 +122,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> result =
+        lhs.matrix().array() =
             (lhs.matrix().array() <= rhs.matrix().array()).cast<double>();
 
-        return result.norm() != 0.0;
+        return lhs.matrix().norm() != 0.0;
     }
 
-    bool less_equal::less_equal2d(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less_equal::less_equal2d(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 2:
-            return less_equal2d2d(lhs, rhs);
+            return less_equal2d2d(std::move(lhs), std::move(rhs));
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -150,20 +145,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    bool less_equal::less_equal_all(ir::node_data<double> const& lhs,
-        ir::node_data<double> const& rhs) const
+    bool less_equal::less_equal_all(operand_type&& lhs, operand_type&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
         {
         case 0:
-            return less_equal0d(lhs, rhs);
+            return less_equal0d(std::move(lhs), std::move(rhs));
 
         case 1:
-            return less_equal1d(lhs, rhs);
+            return less_equal1d(std::move(lhs), std::move(rhs));
 
         case 2:
-            return less_equal2d(lhs, rhs);
+            return less_equal2d(std::move(lhs), std::move(rhs));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -177,6 +171,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         struct visit_less_equal
         {
+            using operand_type = ir::node_data<double>;
+
             visit_less_equal(less_equal const& this_)
               : less_equal_(this_)
             {}
@@ -191,15 +187,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
 
             template <typename T>
-            bool operator()(T const& lhs, T const& rhs) const
+            bool operator()(T && lhs, T && rhs) const
             {
                 return lhs <= rhs;
             }
 
-            bool operator()(ir::node_data<double> const& lhs,
-                ir::node_data<double> const& rhs) const
+            bool operator()(operand_type&& lhs, operand_type&& rhs) const
             {
-                return less_equal_.less_equal_all(lhs, rhs);
+                return less_equal_.less_equal_all(
+                    std::move(lhs), std::move(rhs));
             }
 
             less_equal const& less_equal_;
@@ -213,7 +209,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [this](operands_type && ops)
             {
                 return primitive_result_type(
-                    util::visit(detail::visit_less_equal(*this), ops[0], ops[1]));
+                    util::visit(detail::visit_less_equal(*this),
+                        std::move(ops[0]), std::move(ops[1])));
             }),
             detail::map_operands(operands_, literal_operand)
         );

--- a/src/execution_tree/primitives/or_operation.cpp
+++ b/src/execution_tree/primitives/or_operation.cpp
@@ -76,12 +76,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (ops.size() == 2)
                 {
-                    return primitive_result_type(ops[0] || ops[1]);
+                    return primitive_result_type(ops[0] != 0 || ops[1] != 0);
                 }
 
                 return primitive_result_type(
-                    std::any_of(ops.begin(), ops.end(),
-                        [](std::uint8_t curr) { return curr; }));
+                    std::any_of(
+                        ops.begin(), ops.end(),
+                        [](std::uint8_t curr)
+                        {
+                            return curr != 0;
+                        }));
             }),
             detail::map_operands(operands_, boolean_operand)
         );

--- a/src/execution_tree/primitives/sub_operation.cpp
+++ b/src/execution_tree/primitives/sub_operation.cpp
@@ -69,77 +69,27 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> sub_operation::sub0d0d(operands_type const& ops) const
+    ir::node_data<double> sub_operation::sub0d0d(operands_type && ops) const
     {
-        auto const& lhs = ops[0];
-        auto const& rhs = ops[1];
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
 
         if (ops.size() == 2)
         {
-            return lhs[0] - rhs[0];
+            lhs[0] -= rhs[0];
+            return std::move(lhs);
         }
 
-        return ir::node_data<double>(
-            std::accumulate(ops.begin() + 1, ops.end(), lhs[0],
-                [](double result, operand_type const& curr)
-                {
-                    return result - curr[0];
-                }));
+        return std::accumulate(
+            ops.begin() + 1, ops.end(), std::move(lhs),
+            [](operand_type& result, operand_type const& curr) -> operand_type
+            {
+                result[0] -= curr[0];
+                return std::move(result);
+            });
     }
 
-    ir::node_data<double> sub_operation::sub0d1d(operands_type const& ops) const
-    {
-        if (ops.size() != 2)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "sub_operation::sub0d1d",
-                "the sub_operation primitive can sub a single value to a "
-                    "vector only if there are exectly 2 operands");
-        }
-
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-        matrix_type result = ops[0][0] - ops[1].matrix().array();
-        return ir::node_data<double>(std::move(result));
-    }
-
-    ir::node_data<double> sub_operation::sub0d2d(operands_type const& ops) const
-    {
-        if (ops.size() != 2)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "sub_operation::sub0d2d",
-                "the sub_operation primitive can sub a single value to a "
-                    "matrix only if there are exectly 2 operands");
-        }
-
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-        matrix_type result = ops[0][0] - ops[1].matrix().array();
-        return ir::node_data<double>(std::move(result));
-    }
-
-    ir::node_data<double> sub_operation::sub0d(operands_type const& ops) const
-    {
-        std::size_t rhs_dims = ops[1].num_dimensions();
-        switch (rhs_dims)
-        {
-        case 0:
-            return sub0d0d(ops);
-
-        case 1:
-            return sub0d1d(ops);
-
-        case 2:
-            return sub0d2d(ops);
-
-        default:
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "sub_operation::sub0d",
-                "the operands have incompatible number of dimensions");
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> sub_operation::sub1d0d(operands_type const& ops) const
+    ir::node_data<double> sub_operation::sub0d1d(operands_type && ops) const
     {
         if (ops.size() != 2)
         {
@@ -149,15 +99,64 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "vector only if there are exactly 2 operands");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-        matrix_type result = ops[0].matrix().array() - ops[1][0];
-        return ir::node_data<double>(std::move(result));
+        ops[1].matrix().array() = ops[0][0] - ops[1].matrix().array();
+        return std::move(ops[1]);
     }
 
-    ir::node_data<double> sub_operation::sub1d1d(operands_type const& ops) const
+    ir::node_data<double> sub_operation::sub0d2d(operands_type && ops) const
     {
-        auto const& lhs = ops[0];
-        auto const& rhs = ops[1];
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "sub_operation::sub0d2d",
+                "the sub_operation primitive can sub a single value to a "
+                    "matrix only if there are exactly 2 operands");
+        }
+
+        ops[1].matrix().array() = ops[0][0] - ops[1].matrix().array();
+        return std::move(ops[1]);
+    }
+
+    ir::node_data<double> sub_operation::sub0d(operands_type && ops) const
+    {
+        std::size_t rhs_dims = ops[1].num_dimensions();
+        switch (rhs_dims)
+        {
+        case 0:
+            return sub0d0d(std::move(ops));
+
+        case 1:
+            return sub0d1d(std::move(ops));
+
+        case 2:
+            return sub0d2d(std::move(ops));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "sub_operation::sub0d",
+                "the operands have incompatible number of dimensions");
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ir::node_data<double> sub_operation::sub1d0d(operands_type && ops) const
+    {
+        if (ops.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "sub_operation::sub0d1d",
+                "the sub_operation primitive can sub a single value to a "
+                    "vector only if there are exactly 2 operands");
+        }
+
+        ops[0].matrix().array() -= ops[1][0];
+        return std::move(ops[0]);
+    }
+
+    ir::node_data<double> sub_operation::sub1d1d(operands_type && ops) const
+    {
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
 
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -169,37 +168,32 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using array_type = Eigen::Array<double, Eigen::Dynamic, 1>;
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, 1>;
-
         if (ops.size() == 2)
         {
-            matrix_type result = lhs.matrix().array() - rhs.matrix().array();
-            return ir::node_data<double>(std::move(result));
+            lhs.matrix().array() -= rhs.matrix().array();
+            return std::move(lhs);
         }
 
-        array_type first_term = ops.begin()->matrix().array();
-        matrix_type result =
-            std::accumulate(ops.begin() + 1, ops.end(), std::move(first_term),
-                [](array_type& result, operand_type const& curr)
-                ->  array_type
-                {
-                    return result -= curr.matrix().array();
-                });
-
-        return ir::node_data<double>(std::move(result));
+        operand_type& first_term = *ops.begin();
+        return std::accumulate(
+            ops.begin() + 1, ops.end(), std::move(first_term),
+            [](operand_type& result, operand_type const& curr) -> operand_type
+            {
+                result.matrix().array() -= curr.matrix().array();
+                return std::move(result);
+            });
     }
 
-    ir::node_data<double> sub_operation::sub1d(operands_type const& ops) const
+    ir::node_data<double> sub_operation::sub1d(operands_type && ops) const
     {
         std::size_t rhs_dims = ops[1].num_dimensions();
         switch (rhs_dims)
         {
         case 0:
-            return sub1d0d(ops);
+            return sub1d0d(std::move(ops));
 
         case 1:
-            return sub1d1d(ops);
+            return sub1d1d(std::move(ops));
 
         case 2: HPX_FALLTHROUGH;
         default:
@@ -210,7 +204,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<double> sub_operation::sub2d0d(operands_type const& ops) const
+    ir::node_data<double> sub_operation::sub2d0d(operands_type && ops) const
     {
         if (ops.size() != 2)
         {
@@ -220,15 +214,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "matrix only if there are exactly 2 operands");
         }
 
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-        matrix_type result = ops[0].matrix().array() + ops[1][0];
-        return ir::node_data<double>(std::move(result));
+        ops[0].matrix().array() -= ops[1][0];
+        return std::move(ops[0]);
     }
 
-    ir::node_data<double> sub_operation::sub2d2d(operands_type const& ops) const
+    ir::node_data<double> sub_operation::sub2d2d(operands_type && ops) const
     {
-        auto const& lhs = ops[0];
-        auto const& rhs = ops[1];
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
 
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -240,38 +233,33 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the dimensions of the operands do not match");
         }
 
-        using array_type = Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic>;
-        using matrix_type = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>;
-
         if (ops.size() == 2)
         {
-            matrix_type result = lhs.matrix().array() - rhs.matrix().array();
-            return ir::node_data<double>(std::move(result));
+            lhs.matrix().array() -= rhs.matrix().array();
+            return std::move(lhs);
         }
 
-        array_type first_term = ops.begin()->matrix().array();
-        matrix_type result =
-            std::accumulate(ops.begin() + 1, ops.end(), std::move(first_term),
-                [](array_type& result, operand_type const& curr)
-                ->  array_type
-                {
-                    return result -= curr.matrix().array();
-                });
-
-        return ir::node_data<double>(std::move(result));
+        operand_type& first_term = *ops.begin();
+        return std::accumulate(
+            ops.begin() + 1, ops.end(), std::move(first_term),
+            [](operand_type& result, operand_type const& curr) -> operand_type
+            {
+                result.matrix().array() -= curr.matrix().array();
+                return std::move(result);
+            });
     }
 
     ir::node_data<double> sub_operation::sub2d(
-        operands_type const& ops) const
+        operands_type && ops) const
     {
         std::size_t rhs_dims = ops[1].num_dimensions();
         switch (rhs_dims)
         {
         case 0:
-            return sub2d0d(ops);
+            return sub2d0d(std::move(ops));
 
         case 2:
-            return sub2d2d(ops);
+            return sub2d2d(std::move(ops));
 
         case 1: HPX_FALLTHROUGH;
         default:
@@ -291,13 +279,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 switch (lhs_dims)
                 {
                 case 0:
-                    return primitive_result_type(sub0d(ops));
+                    return primitive_result_type(sub0d(std::move(ops)));
 
                 case 1:
-                    return primitive_result_type(sub1d(ops));
+                    return primitive_result_type(sub1d(std::move(ops)));
 
                 case 2:
-                    return primitive_result_type(sub2d(ops));
+                    return primitive_result_type(sub2d(std::move(ops)));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,


### PR DESCRIPTION
This PR changes all primitives to avoid allocations and copy operations as much as possible