### PR TITLE
Adding buildbot scripts as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "tools/buildbot"]
+	path = tools/buildbot
+	url = https://github.com/khuck/phylanx-buildbot-scripts.git
+	branch = master


### PR DESCRIPTION
I added the buildbot script repository as a submodule.  Is this acceptable?