### PR TITLE
Adding support for defining first order functions

### DIFF
--- a/phylanx/execution_tree/generate_tree.hpp
+++ b/phylanx/execution_tree/generate_tree.hpp
@@ -10,16 +10,36 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 
-#include <map>
+#include <hpx/util/tuple.hpp>
+
 #include <string>
+#include <vector>
 
 namespace phylanx { namespace execution_tree
 {
-    using variables = std::map<std::string, primitive_argument_type>;
-
+    ///////////////////////////////////////////////////////////////////////////
     /// Retrieve the full list of known patterns to be used with any of the
     /// \a generate_tree functions below.
     PHYLANX_EXPORT pattern_list const& get_all_known_patterns();
+
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        using expression_pattern =
+            hpx::util::tuple<
+                std::string, std::string, ast::expression, factory_function_type
+            >;
+        using expression_pattern_list = std::vector<expression_pattern>;
+
+        PHYLANX_EXPORT expression_pattern_list generate_patterns(
+            pattern_list const& patterns_list);
+
+        PHYLANX_EXPORT primitive_argument_type generate_tree(
+            ast::expression const& expr,
+            expression_pattern_list const& patterns,
+            phylanx::execution_tree::variables& variables,
+            phylanx::execution_tree::functions& functions);
+    }
 
     /// Generate an expression tree corresponding to the given textual
     /// expression. All variables used by the expression will be implicitly
@@ -31,8 +51,7 @@ namespace phylanx { namespace execution_tree
     /// expression. The given symbol-table is used to populate variables used
     /// in the expression. Unknown variables will be implicitly created.
     PHYLANX_EXPORT primitive_argument_type generate_tree(
-        std::string const& exprstr,
-        variables const& variables);
+        std::string const& exprstr, variables const& variables);
 
     PHYLANX_EXPORT primitive_argument_type generate_tree(
         std::string const& exprstr, pattern_list const& patterns,
@@ -41,6 +60,23 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT primitive_argument_type generate_tree(
         ast::expression const& expr, pattern_list const& patterns,
         variables const& variables);
+
+    /// Generate an expression tree corresponding to the given textual
+    /// expression. The given symbol-table is used to populate variables used
+    /// in the expression. Unknown variables will be implicitly created.
+    /// The given function table is used to expand invocations of unknown
+    /// functions.
+    PHYLANX_EXPORT primitive_argument_type generate_tree(
+        std::string const& exprstr, variables const& variables,
+        functions const& funcs);
+
+    PHYLANX_EXPORT primitive_argument_type generate_tree(
+        std::string const& exprstr, pattern_list const& patterns,
+        variables const& variables, functions const& funcs);
+
+    PHYLANX_EXPORT primitive_argument_type generate_tree(
+        ast::expression const& expr, pattern_list const& patterns,
+        variables const& variables, functions const& funcs);
 }}
 
 #endif

--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -10,6 +10,7 @@
 #include <phylanx/execution_tree/primitives/and_operation.hpp>
 #include <phylanx/execution_tree/primitives/block_operation.hpp>
 #include <phylanx/execution_tree/primitives/constant.hpp>
+#include <phylanx/execution_tree/primitives/define.hpp>
 #include <phylanx/execution_tree/primitives/determinant.hpp>
 #include <phylanx/execution_tree/primitives/div_operation.hpp>
 #include <phylanx/execution_tree/primitives/dot_operation.hpp>

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -15,6 +15,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/util.hpp>
 
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -173,21 +174,35 @@ namespace phylanx { namespace execution_tree
         boolean_operand(primitive_argument_type const& val);
 
     ///////////////////////////////////////////////////////////////////////////
+    // Symbol table
+    using variables = std::map<std::string, primitive_argument_type>;
+
+    // Function definition table
+    using functions = std::map<
+            std::string,
+            std::pair<std::vector<ast::expression>, ast::expression>
+        >;
+
+    ///////////////////////////////////////////////////////////////////////////
     // Factory functions
     using factory_function_type =
         hpx::util::function_nonser<
-            primitive(hpx::id_type, std::vector<primitive_argument_type>&&)
+            primitive(hpx::id_type, std::vector<primitive_argument_type>&&,
+                variables const&, functions const&)
         >;
 
+    // Generic creation helper for creating an instance of the given primitive.
     template <typename Primitive>
     primitive create(hpx::id_type locality,
-        std::vector<primitive_argument_type>&& operands)
+        std::vector<primitive_argument_type>&& operands, variables const&,
+        functions const&)
     {
         return primitive(hpx::new_<Primitive>(locality, std::move(operands)));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    using match_pattern_type = std::pair<std::string, factory_function_type>;
+    using match_pattern_type =
+        hpx::util::tuple<std::string, std::string, factory_function_type>;
     using pattern_list = std::vector<std::vector<match_pattern_type>>;
 }}
 

--- a/phylanx/execution_tree/primitives/define.hpp
+++ b/phylanx/execution_tree/primitives/define.hpp
@@ -1,0 +1,31 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_DEF_OPERATION_OCT_13_2017_1120AM)
+#define PHYLANX_PRIMITIVES_DEF_OPERATION_OCT_13_2017_1120AM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/node.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/util/optional.hpp>
+#include <phylanx/util/serialization/optional.hpp>
+
+#include <hpx/include/components.hpp>
+
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    struct define_
+    {
+        static std::vector<match_pattern_type> const match_data;
+        static std::vector<match_pattern_type> const invocation_match_data;
+    };
+}}}
+
+#endif
+
+

--- a/src/execution_tree/generate_tree.cpp
+++ b/src/execution_tree/generate_tree.cpp
@@ -17,6 +17,8 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/tuple.hpp>
 
+#include <algorithm>
+#include <cstddef>
 #include <map>
 #include <string>
 #include <utility>
@@ -27,11 +29,6 @@ namespace phylanx { namespace execution_tree
     namespace detail
     {
         ///////////////////////////////////////////////////////////////////////
-        using expression_pattern_list =
-            std::vector<
-                hpx::util::tuple<std::string, ast::expression, factory_function_type
-            >>;
-
         expression_pattern_list generate_patterns(
             pattern_list const& patterns_list)
         {
@@ -42,8 +39,12 @@ namespace phylanx { namespace execution_tree
             {
                 for (auto const& pattern : patterns)
                 {
-                    result.push_back(hpx::util::make_tuple(pattern.first,
-                        ast::generate_ast(pattern.first), pattern.second));
+                    result.push_back(
+                        hpx::util::make_tuple(
+                            hpx::util::get<0>(pattern),
+                            hpx::util::get<1>(pattern),
+                            ast::generate_ast(hpx::util::get<1>(pattern)),
+                            hpx::util::get<2>(pattern)));
                 }
             }
 
@@ -96,84 +97,268 @@ namespace phylanx { namespace execution_tree
             }
         };
 
+        ///////////////////////////////////////////////////////////////////////
+        primitive_argument_type handle_placeholders(
+            std::multimap<std::string, ast::expression>& placeholders,
+            phylanx::execution_tree::variables& variables,
+            phylanx::execution_tree::functions& functions,
+            expression_pattern_list const& patterns,
+            expression_pattern const& pattern)
+        {
+            std::vector<primitive_argument_type> arguments;
+            arguments.reserve(placeholders.size());
+
+            for (auto const& placeholder : placeholders)
+            {
+                if (ast::detail::is_literal_value(placeholder.second))
+                {
+                    arguments.push_back(to_primitive_value_type(
+                        ast::detail::literal_value(placeholder.second)));
+                }
+                else
+                {
+                    arguments.push_back(generate_tree(
+                        placeholder.second, patterns, variables, functions));
+                }
+            }
+
+            // create primitive with given arguments
+            return hpx::util::get<3>(pattern)(
+                hpx::find_here(), std::move(arguments), variables, functions);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        primitive_argument_type handle_variable(ast::expression const& expr,
+            phylanx::execution_tree::variables& variables,
+            phylanx::execution_tree::functions& functions)
+        {
+            std::string name = ast::detail::identifier_name(expr);
+            auto it = variables.find(name);
+            if (it != variables.end())
+            {
+                if (!is_primitive_operand(it->second))
+                {
+                    // create a new variable from the given value, replace
+                    // entry in symbol table
+                    it->second =
+                        hpx::new_<primitives::variable>(hpx::find_here(),
+                            std::move(it->second), std::move(name));
+                }
+                return it->second;
+            }
+            else if (functions.find(name) != functions.end())
+            {
+                return primitive_argument_type{std::move(name)};
+            }
+            else
+            {
+                // create an empty variable
+                primitive p =
+                    hpx::new_<primitives::variable>(hpx::find_here(), name);
+
+                // attempt to insert the new variable into the symbol table
+                auto r = variables.insert(
+                    execution_tree::variables::value_type(std::move(name), p));
+                if (!r.second)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "phylanx::execution_tree::extract_arguments",
+                        "couldn't insert variable into symbol table: " + name);
+                }
+                return p;
+            }
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Iterator>
+        ast::expression extract_name(std::pair<Iterator, Iterator> const& p)
+        {
+            if (std::distance(p.first, p.second) < 2)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::detail::extract_name",
+                    "the define() operation requires at least 2 arguments");
+            }
+
+            if (!ast::detail::is_identifier(p.first->second))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::detail::extract_name",
+                    "the define() operation requires that the name of the "
+                        "function to define is represented as a variable name "
+                        "(not an expression)");
+            }
+
+            return p.first->second;
+        }
+
+        template <typename Iterator>
+        std::vector<ast::expression> extract_arguments(
+            std::pair<Iterator, Iterator> const& p)
+        {
+            std::ptrdiff_t size = std::distance(p.first, p.second);
+            if (size < 2)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::detail::extract_arguments",
+                    "the define() operation requires at least 2 arguments");
+            }
+
+            std::vector<ast::expression> args;
+            args.reserve(size - 2);
+
+            auto first = p.first; ++first;
+            auto last = p.second; --last;
+            for (auto it = first; it != last; ++it)
+            {
+                if (!ast::detail::is_identifier(it->second))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "phylanx::execution_tree::detail::extract_arguments",
+                        "the define() operation requires that all arguments "
+                            "are represented as variable names (not "
+                            "expressions)");
+                }
+                args.push_back(it->second);
+            }
+
+            return args;
+        }
+
+        template <typename Iterator>
+        ast::expression extract_body(std::pair<Iterator, Iterator> const& p)
+        {
+            if (std::distance(p.first, p.second) < 2)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::detail::extract_body",
+                    "the define() operation requires at least 2 arguments");
+            }
+
+            auto last = p.second; --last;
+            return last->second;
+        }
+
+        primitive_argument_type handle_define_variable(
+            ast::expression && nameexpr, ast::expression && bodyexpr,
+            phylanx::execution_tree::variables& variables,
+            phylanx::execution_tree::functions& functions,
+            expression_pattern_list const& patterns)
+        {
+            std::string name = ast::detail::identifier_name(nameexpr);
+            auto it = variables.find(name);
+
+            if (it != variables.end())
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::detail::handle_define_variable",
+                    "the define() operation attempts to redefine a "
+                        "variable: " + name);
+            }
+
+            // create a new variable from the given expression (body)
+            primitive_argument_type p =
+                generate_tree(bodyexpr, patterns, variables, functions);
+
+            if (!is_primitive_operand(p))
+            {
+                HPX_THROW_EXCEPTION(hpx::invalid_status,
+                    "phylanx::execution_tree::handle_define_variable",
+                    "couldn't create variable: " + name);
+            }
+
+            // attempt to insert the new variable into the symbol table
+            auto r = variables.insert(execution_tree::variables::value_type(
+                std::move(name), primitive_operand(p)));
+            if (!r.second)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::handle_define_variable",
+                    "couldn't insert variable into symbol table: " + name);
+            }
+            return p;
+        }
+
+        primitive_argument_type handle_define(
+            std::multimap<std::string, ast::expression>& placeholders,
+            phylanx::execution_tree::variables& variables,
+            phylanx::execution_tree::functions& functions,
+            expression_pattern_list const& patterns,
+            expression_pattern const& pattern)
+        {
+            // we know that 'define()' uses '__1' to match arguments
+            using iterator =
+                typename std::multimap<std::string, ast::expression>::iterator;
+            std::pair<iterator, iterator> p = placeholders.equal_range("__1");
+
+            // extract expressions representing the newly defined function
+            ast::expression name = extract_name(p);
+            std::vector<ast::expression> args = extract_arguments(p);
+            ast::expression body = extract_body(p);
+
+            // a define() without arguments defines a variable
+            if (args.empty())
+            {
+                return handle_define_variable(std::move(name), std::move(body),
+                    variables, functions, patterns);
+            }
+
+            // store new function description for later use
+            using value_type =
+                typename phylanx::execution_tree::functions::value_type;
+            auto result = functions.insert(value_type(
+                    ast::detail::identifier_name(name),
+                    std::make_pair(std::move(args), std::move(body))
+                ));
+            if (!result.second)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::detail::extract_name",
+                    "the define() operation attempted to redefine the "
+                        "function: " + ast::detail::identifier_name(name));
+            }
+
+            return primitive_argument_type{};
+        }
+
         primitive_argument_type generate_tree(
             ast::expression const& expr,
             expression_pattern_list const& patterns,
-            phylanx::execution_tree::variables& variables)
+            phylanx::execution_tree::variables& variables,
+            phylanx::execution_tree::functions& functions)
         {
             primitive_argument_type result;
             for (auto const& pattern : patterns)
             {
                 std::multimap<std::string, ast::expression> placeholders;
-                if (!ast::match_ast(expr, hpx::util::get<1>(pattern),
+                if (!ast::match_ast(expr, hpx::util::get<2>(pattern),
                         on_placeholder_match{placeholders}))
                 {
-                    continue;
+                    continue;   // no match found for the current pattern
                 }
 
-                std::vector<primitive_argument_type> arguments;
-                arguments.reserve(placeholders.size());
-
-                for (auto const& placeholder : placeholders)
+                // Handle define(__1)
+                if (hpx::util::get<0>(pattern) == "define")
                 {
-                    if (ast::detail::is_literal_value(placeholder.second))
-                    {
-                        arguments.push_back(
-                            to_primitive_value_type(
-                                ast::detail::literal_value(placeholder.second)
-                            ));
-                    }
-                    else
-                    {
-                        arguments.push_back(generate_tree(
-                            placeholder.second, patterns, variables));
-                    }
+                    return handle_define(
+                        placeholders, variables, functions, patterns, pattern);
                 }
 
-                // create primitive with given arguments
-                result = hpx::util::get<2>(pattern)(
-                    hpx::find_here(), std::move(arguments));
-
-                return result;
+                return handle_placeholders(
+                    placeholders, variables, functions, patterns, pattern);
             }
 
             // remaining expression could refer to a variable
             if (ast::detail::is_identifier(expr))
             {
-                std::string name = ast::detail::identifier_name(expr);
-                auto it = variables.find(name);
-                if (it != variables.end())
-                {
-                    if (!is_primitive_operand(it->second))
-                    {
-                        // create a new variable from the given value, replace
-                        // entry in symbol table
-                        it->second =
-                            hpx::new_<primitives::variable>(hpx::find_here(),
-                                std::move(it->second), std::move(name));
-                    }
-                    return it->second;
-                }
-                else
-                {
-                    // create an empty variable
-                    primitive p = hpx::new_<primitives::variable>(
-                        hpx::find_here(), name);
+                return handle_variable(expr, variables, functions);
+            }
 
-                    // attempt to insert the new variable into the symbol
-                    // table
-                    auto r = variables.insert(
-                        execution_tree::variables::value_type(
-                            std::move(name), p));
-                    if (!r.second)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::generate_tree",
-                            "couldn't insert variable into symbol "
-                                "table: " + name);
-                    }
-                    return p;
-                }
+            // alternatively it could refer to a literal value
+            if (ast::detail::is_literal_value(expr))
+            {
+                return hpx::new_<primitives::variable>(hpx::find_here(),
+                    to_primitive_value_type(ast::detail::literal_value(expr)));
             }
 
             // otherwise the match was not complete, bail out
@@ -191,6 +376,7 @@ namespace phylanx { namespace execution_tree
             // variadic functions
             primitives::block_operation::match_data,
             primitives::parallel_block_operation::match_data,
+            primitives::define_::match_data,
             // binary functions
             primitives::dot_operation::match_data,
             primitives::file_read::match_data,
@@ -220,7 +406,10 @@ namespace phylanx { namespace execution_tree
             primitives::store_operation::match_data,
             // unary operations
             primitives::unary_minus_operation::match_data,
-            primitives::unary_not_operation::match_data
+            primitives::unary_not_operation::match_data,
+            // must be last, otherwise it might intercept some predefined
+            // function
+            primitives::define_::invocation_match_data
         };
 
         return patterns;
@@ -230,16 +419,19 @@ namespace phylanx { namespace execution_tree
     primitive_argument_type generate_tree(std::string const& exprstr)
     {
         phylanx::execution_tree::variables vars;
+        phylanx::execution_tree::functions funcs;
         return detail::generate_tree(ast::generate_ast(exprstr),
-            detail::generate_patterns(get_all_known_patterns()), vars);
+            detail::generate_patterns(get_all_known_patterns()), vars, funcs);
     }
 
+    ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type generate_tree(std::string const& exprstr,
         phylanx::execution_tree::variables const& variables)
     {
         phylanx::execution_tree::variables vars(variables);
+        phylanx::execution_tree::functions funcs;
         return detail::generate_tree(ast::generate_ast(exprstr),
-            detail::generate_patterns(get_all_known_patterns()), vars);
+            detail::generate_patterns(get_all_known_patterns()), vars, funcs);
     }
 
     primitive_argument_type generate_tree(ast::expression const& expr,
@@ -247,8 +439,9 @@ namespace phylanx { namespace execution_tree
         phylanx::execution_tree::variables const& variables)
     {
         phylanx::execution_tree::variables vars(variables);
+        phylanx::execution_tree::functions funcs;
         return detail::generate_tree(
-            expr, detail::generate_patterns(patterns), vars);
+            expr, detail::generate_patterns(patterns), vars, funcs);
     }
 
     primitive_argument_type generate_tree(std::string const& exprstr,
@@ -256,8 +449,42 @@ namespace phylanx { namespace execution_tree
         phylanx::execution_tree::variables const& variables)
     {
         phylanx::execution_tree::variables vars(variables);
+        phylanx::execution_tree::functions funcs;
         return detail::generate_tree(ast::generate_ast(exprstr),
-            detail::generate_patterns(patterns), vars);
+            detail::generate_patterns(patterns), vars, funcs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type generate_tree(std::string const& exprstr,
+        phylanx::execution_tree::variables const& variables,
+        phylanx::execution_tree::functions const& functions)
+    {
+        phylanx::execution_tree::variables vars(variables);
+        phylanx::execution_tree::functions funcs(functions);
+        return detail::generate_tree(ast::generate_ast(exprstr),
+            detail::generate_patterns(get_all_known_patterns()), vars, funcs);
+    }
+
+    primitive_argument_type generate_tree(ast::expression const& expr,
+        pattern_list const& patterns,
+        phylanx::execution_tree::variables const& variables,
+        phylanx::execution_tree::functions const& functions)
+    {
+        phylanx::execution_tree::variables vars(variables);
+        phylanx::execution_tree::functions funcs(functions);
+        return detail::generate_tree(
+            expr, detail::generate_patterns(patterns), vars, funcs);
+    }
+
+    primitive_argument_type generate_tree(std::string const& exprstr,
+        pattern_list const& patterns,
+        phylanx::execution_tree::variables const& variables,
+        phylanx::execution_tree::functions const& functions)
+    {
+        phylanx::execution_tree::variables vars(variables);
+        phylanx::execution_tree::functions funcs(functions);
+        return detail::generate_tree(ast::generate_ast(exprstr),
+            detail::generate_patterns(patterns), vars, funcs);
     }
 }}
 

--- a/src/execution_tree/generate_tree.cpp
+++ b/src/execution_tree/generate_tree.cpp
@@ -133,20 +133,20 @@ namespace phylanx { namespace execution_tree
             phylanx::execution_tree::functions& functions)
         {
             std::string name = ast::detail::identifier_name(expr);
-            auto it = variables.find(name);
-            if (it != variables.end())
+            auto p = variables.find(name);
+            if (is_empty_range(p))
             {
-                if (!is_primitive_operand(it->second))
+                if (!is_primitive_operand(p.first->second))
                 {
                     // create a new variable from the given value, replace
                     // entry in symbol table
-                    it->second =
+                    p.first->second =
                         hpx::new_<primitives::variable>(hpx::find_here(),
-                            std::move(it->second), std::move(name));
+                            std::move(p.first->second), std::move(name));
                 }
-                return it->second;
+                return p.first->second;
             }
-            else if (functions.find(name) != functions.end())
+            else if (is_empty_range(functions.find(name)))
             {
                 return primitive_argument_type{std::move(name)};
             }
@@ -246,9 +246,8 @@ namespace phylanx { namespace execution_tree
             expression_pattern_list const& patterns)
         {
             std::string name = ast::detail::identifier_name(nameexpr);
-            auto it = variables.find(name);
-
-            if (it != variables.end())
+            auto pv = variables.find(name);
+            if (!is_empty_range(pv))
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::detail::handle_define_variable",

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const add_operation::match_data =
     {
-        {"_1 + __2", &create<add_operation>}
+        hpx::util::make_tuple("add", "_1 + __2", &create<add_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/and_operation.cpp
+++ b/src/execution_tree/primitives/and_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const and_operation::match_data =
     {
-        {"_1 && __2", &create<and_operation>}
+        hpx::util::make_tuple("and", "_1 && __2", &create<and_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/block_operation.cpp
+++ b/src/execution_tree/primitives/block_operation.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const block_operation::match_data =
     {
-        {"block(__1)", &create<block_operation>}
+        hpx::util::make_tuple("block", "block(__1)", &create<block_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -48,24 +48,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "block_operation",
                 "the block_operation primitive requires at least one argument");
         }
-
-        bool arguments_valid = true;
-        for (std::size_t i = 0; i != operands_.size(); ++i)
-        {
-            if (!valid(operands_[i]))
-            {
-                arguments_valid = false;
-            }
-        }
-
-        if (!arguments_valid)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "phylanx::execution_tree::primitives::block_operation::"
-                    "block_operation",
-                "the block_operation primitive requires that the arguments "
-                    "given by the operands array are valid");
-        }
     }
 
     namespace detail
@@ -78,6 +60,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             void next(std::size_t i)
             {
+                // skip statements that don't return anything
+                while (i != operands_.size() && !valid(operands_[i]))
+                    ++i;
+
                 if (i == operands_.size())
                     return;
 

--- a/src/execution_tree/primitives/constant.cpp
+++ b/src/execution_tree/primitives/constant.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const constant::match_data =
     {
-        {"constant(_1, _2)", &create<constant>}
+        hpx::util::make_tuple("constant", "constant(_1, _2)", &create<constant>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/define.cpp
+++ b/src/execution_tree/primitives/define.cpp
@@ -1,0 +1,94 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ast/detail/is_identifier.hpp>
+#include <phylanx/execution_tree/generate_tree.hpp>
+#include <phylanx/execution_tree/primitives/define.hpp>
+
+#include <hpx/include/util.hpp>
+
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    std::vector<match_pattern_type> const define_::match_data =
+    {
+        // We don't need a creation function as 'define()' is explicitly
+        // handled by generate_tree.
+        hpx::util::make_tuple("define", "define(__1)", nullptr)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_function_invocation(hpx::id_type where,
+        std::vector<primitive_argument_type>&& args, variables const& vars,
+        functions const& funcs)
+    {
+        // args[0] represents the function name the remaining elements in args
+        // refer to the parameters (variables) or literal values to use while
+        // instantiating the function.
+
+        std::string* name = util::get_if<std::string>(&args[0]);
+        if (name == nullptr)
+        {
+            // function name is invalid
+        }
+
+        auto it = funcs.find(*name);
+        if (it != funcs.end())
+        {
+            // function was not defined
+        }
+
+        if (it->second.first.size() != args.size() - 1)
+        {
+            // argument number mismatch
+        }
+
+        // create a copy of the symbol and function tables
+        phylanx::execution_tree::variables variables(vars);
+        phylanx::execution_tree::functions functions(funcs);
+
+        // replace formal arguments
+        for (std::size_t i = 0; i != args.size() - 1 ; ++i)
+        {
+            using value_type =
+                typename phylanx::execution_tree::variables::value_type;
+
+            if (!ast::detail::is_identifier(it->second.first[i]))
+            {
+            }
+
+            std::string argname =
+                ast::detail::identifier_name(it->second.first[i]);
+
+            auto varit = variables.find(argname);
+            if (varit == variables.end())
+            {
+                variables.insert(
+                    value_type(std::move(argname), std::move(args[i + 1])));
+            }
+            else
+            {
+                varit->second = std::move(args[i + 1]);
+            }
+        }
+
+        // instantiate the new function
+        auto result = execution_tree::detail::generate_tree(it->second.second,
+            execution_tree::detail::generate_patterns(get_all_known_patterns()),
+            variables, functions);
+
+        return primitive_operand(result);
+    }
+
+    std::vector<match_pattern_type> const define_::invocation_match_data =
+    {
+        hpx::util::make_tuple(
+            "any_function", "_1(__2)", &create_function_invocation)
+    };
+}}}

--- a/src/execution_tree/primitives/define.cpp
+++ b/src/execution_tree/primitives/define.cpp
@@ -35,18 +35,35 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::string* name = util::get_if<std::string>(&args[0]);
         if (name == nullptr)
         {
-            // function name is invalid
+            if (args.size() != 1 || !is_primitive_operand(args[0]))
+            {
+                // function name is invalid
+                HPX_THROW_EXCEPTION(hpx::invalid_status,
+                    "phylanx::execution_tree::primitives::"
+                        "create_function_invocation",
+                    "the given function name is invalid");
+            }
+            return primitive_operand(args[0]);
         }
 
         auto it = funcs.find(*name);
-        if (it != funcs.end())
+        if (it == funcs.end())
         {
             // function was not defined
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::execution_tree::primitives::"
+                    "create_function_invocation",
+                "the function to invoke was not defined: " + *name);
         }
 
         if (it->second.first.size() != args.size() - 1)
         {
             // argument number mismatch
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "create_function_invocation",
+                "the number of given arguments does not match the expected "
+                    "number of formal parameters for function: " + *name);
         }
 
         // create a copy of the symbol and function tables
@@ -61,6 +78,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             if (!ast::detail::is_identifier(it->second.first[i]))
             {
+                HPX_THROW_EXCEPTION(hpx::invalid_status,
+                    "phylanx::execution_tree::primitives::"
+                        "create_function_invocation",
+                    "the formal parameter does not represent a valid variable "
+                        "name");
             }
 
             std::string argname =

--- a/src/execution_tree/primitives/determinant.cpp
+++ b/src/execution_tree/primitives/determinant.cpp
@@ -36,7 +36,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const determinant::match_data =
     {
-        {"determinant(_1)", &create<determinant>}
+        hpx::util::make_tuple(
+            "determinant", "determinant(_1)", &create<determinant>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/div_operation.cpp
+++ b/src/execution_tree/primitives/div_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const div_operation::match_data =
     {
-        {"_1 / __2", &create<div_operation>}
+        hpx::util::make_tuple("div", "_1 / __2", &create<div_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/dot_operation.cpp
+++ b/src/execution_tree/primitives/dot_operation.cpp
@@ -34,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const dot_operation::match_data =
     {
-        {"dot(_1, _2)", &create<dot_operation>}
+        hpx::util::make_tuple("dot", "dot(_1, _2)", &create<dot_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const equal::match_data =
     {
-        {"_1 == _2", &create<equal>}
+        hpx::util::make_tuple("equal", "_1 == _2", &create<equal>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/exponential_operation.cpp
+++ b/src/execution_tree/primitives/exponential_operation.cpp
@@ -34,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const exponential_operation::match_data =
     {
-        {"exp(_1)", &create<exponential_operation>}
+        hpx::util::make_tuple("exp", "exp(_1)", &create<exponential_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/file_read.cpp
+++ b/src/execution_tree/primitives/file_read.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const file_read::match_data =
     {
-        {"file_read(_1)", &create<file_read>}
+        hpx::util::make_tuple("file_read", "file_read(_1)", &create<file_read>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -35,7 +35,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const file_write::match_data =
     {
-        {"file_write(_1, _2)", &create<file_write>}
+        hpx::util::make_tuple(
+            "file_write", "file_write(_1, _2)", &create<file_write>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const greater::match_data =
     {
-        {"_1 > _2", &create<greater>}
+        hpx::util::make_tuple("greater", "_1 > _2", &create<greater>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -32,7 +32,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const greater_equal::match_data =
     {
-        {"_1 >= _2", &create<greater_equal>}
+        hpx::util::make_tuple(
+            "greater_equal", "_1 >= _2", &create<greater_equal>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/inverse_operation.cpp
+++ b/src/execution_tree/primitives/inverse_operation.cpp
@@ -34,7 +34,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const inverse_operation::match_data =
     {
-        {"inverse(_1)", &create<inverse_operation>}
+        hpx::util::make_tuple(
+            "inverse", "inverse(_1)", &create<inverse_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const less::match_data =
     {
-        {"_1 < _2", &create<less>}
+        hpx::util::make_tuple("less", "_1 < _2", &create<less>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const less_equal::match_data =
     {
-        {"_1 <= _2", &create<less_equal>}
+        hpx::util::make_tuple("less_equal", "_1 <= _2", &create<less_equal>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const mul_operation::match_data =
     {
-        {"_1 * __2", &create<mul_operation>}
+        hpx::util::make_tuple("mul", "_1 * __2", &create<mul_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const not_equal::match_data =
     {
-        {"_1 != _2", &create<not_equal>}
+        hpx::util::make_tuple("not_equal", "_1 != _2", &create<not_equal>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/or_operation.cpp
+++ b/src/execution_tree/primitives/or_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const or_operation::match_data =
     {
-        {"_1 || __2", &create<or_operation>}
+        hpx::util::make_tuple("or", "_1 || __2", &create<or_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/parallel_block_operation.cpp
+++ b/src/execution_tree/primitives/parallel_block_operation.cpp
@@ -34,7 +34,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const parallel_block_operation::match_data =
     {
-        {"parallel_block(__1)", &create<parallel_block_operation>}
+        hpx::util::make_tuple("parallel_block", "parallel_block(__1)",
+            &create<parallel_block_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -49,24 +50,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "parallel_block_operation::parallel_block_operation",
                 "the parallel_block_operation primitive requires at least one "
                     "argument");
-        }
-
-        bool arguments_valid = true;
-        for (std::size_t i = 0; i != operands_.size(); ++i)
-        {
-            if (!valid(operands_[i]))
-            {
-                arguments_valid = false;
-            }
-        }
-
-        if (!arguments_valid)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "phylanx::execution_tree::primitives::"
-                    "parallel_block_operation::parallel_block_operation",
-                "the parallel_block_operation primitive requires that the "
-                    "arguments given by the operands array are valid");
         }
     }
 

--- a/src/execution_tree/primitives/random.cpp
+++ b/src/execution_tree/primitives/random.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const random::match_data =
     {
-        {"random(_1)", &create<random>}
+        hpx::util::make_tuple("random", "random(_1)", &create<random>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -35,7 +35,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const store_operation::match_data =
     {
-        {"store(_1, _2)", &create<store_operation>}
+        hpx::util::make_tuple(
+            "store", "store(_1, _2)", &create<store_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/sub_operation.cpp
+++ b/src/execution_tree/primitives/sub_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const sub_operation::match_data =
     {
-        {"_1 - __2", &create<sub_operation>}
+        hpx::util::make_tuple("sub", "_1 - __2", &create<sub_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/transpose_operation.cpp
+++ b/src/execution_tree/primitives/transpose_operation.cpp
@@ -36,7 +36,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const transpose_operation::match_data =
     {
-        {"transpose(_1)", &create<transpose_operation>}
+        hpx::util::make_tuple(
+            "transpose", "transpose(_1)", &create<transpose_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/unary_minus_operation.cpp
+++ b/src/execution_tree/primitives/unary_minus_operation.cpp
@@ -36,7 +36,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const unary_minus_operation::match_data =
     {
-        {"-_1", &create<unary_minus_operation>}
+        hpx::util::make_tuple(
+            "unary_minus", "-_1", &create<unary_minus_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/unary_not_operation.cpp
+++ b/src/execution_tree/primitives/unary_not_operation.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const unary_not_operation::match_data =
     {
-        {"!_1", &create<unary_not_operation>}
+        hpx::util::make_tuple("unary_not", "!_1", &create<unary_not_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/while_operation.cpp
+++ b/src/execution_tree/primitives/while_operation.cpp
@@ -33,7 +33,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const while_operation::match_data =
     {
-        {"while(_1, _2)", &create<while_operation>}
+        hpx::util::make_tuple(
+            "while", "while(_1, _2)", &create<while_operation>)
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/tests/unit/execution_tree/generate_tree.cpp
+++ b/tests/unit/execution_tree/generate_tree.cpp
@@ -252,10 +252,10 @@ void test_multi_patterns()
 
     phylanx::execution_tree::pattern_list patterns = {
         std::vector<phylanx::execution_tree::match_pattern_type>{
-            {"block(_1, _2, __3)",
-                &create<phylanx::execution_tree::primitives::block_operation>},
-            {"block(__1)",
-                &create<phylanx::execution_tree::primitives::block_operation>},
+            hpx::util::make_tuple("block1", "block(_1, _2, __3)",
+                &create<phylanx::execution_tree::primitives::block_operation>),
+            hpx::util::make_tuple("block2", "block(__1)",
+                &create<phylanx::execution_tree::primitives::block_operation>)
         }
     };
 

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
     add_operation
     and_operation
     block_operation
+    define_operation
     determinant
     div_operation
     equal_operation
@@ -15,6 +16,7 @@ set(tests
     greater_operation
     greater_equal_operation
     inverse_operation
+    invoke_operation
     less_operation
     less_equal_operation
     literal_value

--- a/tests/unit/execution_tree/primitives/define_operation.cpp
+++ b/tests/unit/execution_tree/primitives/define_operation.cpp
@@ -1,0 +1,53 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+void test_define_operation(char const* expr, char const* name,
+    std::vector<char const*> const& args, char const* body)
+{
+    phylanx::execution_tree::variables variables;
+    phylanx::execution_tree::functions functions;
+
+    auto result = phylanx::execution_tree::detail::generate_tree(
+        phylanx::ast::generate_ast(expr),
+        phylanx::execution_tree::detail::generate_patterns(
+            phylanx::execution_tree::get_all_known_patterns()),
+        variables, functions);
+
+    HPX_TEST_EQ(variables.size(), std::size_t(0));
+    HPX_TEST_EQ(functions.size(), std::size_t(1));
+
+    // verify function name
+    auto it = functions.find(name);
+    HPX_TEST(it != functions.end());
+
+    // verify arguments
+    std::vector<phylanx::ast::expression> argexprs;
+    argexprs.reserve(args.size());
+    for (auto const& s : args)
+    {
+        argexprs.push_back(phylanx::ast::generate_ast(s));
+    }
+
+    HPX_TEST(it->second.first == argexprs);
+
+    // verify body
+    phylanx::ast::expression bodyexpr = phylanx::ast::generate_ast(body);
+    HPX_TEST(it->second.second == bodyexpr);
+}
+
+int main(int argc, char* argv[])
+{
+    test_define_operation("define(x, 3.14)", "x", {}, "3.14");
+    test_define_operation("define(y, x, x + 1)", "y", {"x"}, "x + 1");
+    test_define_operation("define(add, x, y, x + y)", "add", {"x", "y"}, "x + y");
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/define_operation.cpp
+++ b/tests/unit/execution_tree/primitives/define_operation.cpp
@@ -24,8 +24,8 @@ void test_define_operation(char const* expr, char const* name,
     HPX_TEST_EQ(functions.size(), std::size_t(1));
 
     // verify function name
-    auto it = functions.find(name);
-    HPX_TEST(it != functions.end());
+    auto p = functions.find(name);
+    HPX_TEST(p.first != p.second);
 
     // verify arguments
     std::vector<phylanx::ast::expression> argexprs;
@@ -35,11 +35,11 @@ void test_define_operation(char const* expr, char const* name,
         argexprs.push_back(phylanx::ast::generate_ast(s));
     }
 
-    HPX_TEST(it->second.first == argexprs);
+    HPX_TEST(p.first->second.first == argexprs);
 
     // verify body
     phylanx::ast::expression bodyexpr = phylanx::ast::generate_ast(body);
-    HPX_TEST(it->second.second == bodyexpr);
+    HPX_TEST(p.first->second.second == bodyexpr);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/define_operation.cpp
+++ b/tests/unit/execution_tree/primitives/define_operation.cpp
@@ -8,6 +8,26 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+void test_define_operation_var(char const* expr, char const* name,
+    std::vector<char const*> const& args, char const* body)
+{
+    phylanx::execution_tree::variables variables;
+    phylanx::execution_tree::functions functions;
+
+    auto result = phylanx::execution_tree::detail::generate_tree(
+        phylanx::ast::generate_ast(expr),
+        phylanx::execution_tree::detail::generate_patterns(
+            phylanx::execution_tree::get_all_known_patterns()),
+        variables, functions);
+
+    HPX_TEST_EQ(variables.size(), std::size_t(1));
+    HPX_TEST_EQ(functions.size(), std::size_t(0));
+
+    // verify function name
+    auto p = functions.find(name);
+    HPX_TEST(p.first == p.second);
+}
+
 void test_define_operation(char const* expr, char const* name,
     std::vector<char const*> const& args, char const* body)
 {
@@ -44,7 +64,7 @@ void test_define_operation(char const* expr, char const* name,
 
 int main(int argc, char* argv[])
 {
-    test_define_operation("define(x, 3.14)", "x", {}, "3.14");
+    test_define_operation_var("define(x, 3.14)", "x", {}, "3.14");
     test_define_operation("define(y, x, x + 1)", "y", {"x"}, "x + 1");
     test_define_operation("define(add, x, y, x + y)", "add", {"x", "y"}, "x + y");
 

--- a/tests/unit/execution_tree/primitives/invoke_operation.cpp
+++ b/tests/unit/execution_tree/primitives/invoke_operation.cpp
@@ -1,0 +1,52 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+void test_invoke_operation(char const* expr, double expected)
+{
+    auto p = phylanx::execution_tree::generate_tree(expr);
+
+    HPX_TEST_EQ(expected, phylanx::execution_tree::numeric_operand(p).get()[0]);
+}
+
+int main(int argc, char* argv[])
+{
+    test_invoke_operation(R"(
+        block(
+            define(x, 3.14),
+            x
+        )
+    )", 3.14);
+
+    test_invoke_operation(R"(
+        block(
+            define(y, x, x + 1),
+            y(3.0)
+        )
+    )", 4.0);
+
+    test_invoke_operation(R"(
+        block(
+            define(add, x, y, x + y),
+            add(41.0, 1.0)
+        )
+    )", 42.0);
+
+    test_invoke_operation(R"(
+        block(
+            define(add, x, y, x + y),
+            define(x1, 41.0),
+            define(x2, 1.0),
+            add(x1, x2)
+        )
+    )", 42.0);
+
+    return hpx::util::report_errors();
+}
+

--- a/tests/unit/execution_tree/primitives/invoke_operation.cpp
+++ b/tests/unit/execution_tree/primitives/invoke_operation.cpp
@@ -24,6 +24,14 @@ int main(int argc, char* argv[])
         )
     )", 3.14);
 
+    // variables can be invoked as nullary functions
+    test_invoke_operation(R"(
+        block(
+            define(x, 3.14),
+            x()
+        )
+    )", 3.14);
+
     test_invoke_operation(R"(
         block(
             define(y, x, x + 1),


### PR DESCRIPTION
    block(
        define(newfunc, arg1, arg2, arg1 + arg2),
        newfunc(41.0, 1.0)
    )

will evaluate to 42 ;)

A `define(x 42)` is equivalent to a variable definition. We might want to remove creating variables implicitly now (on first access).