### PR TITLE
Fixing pybind architecture for ppc64le

### DIFF
--- a/cmake/Phylanx_GetPythonExtensionLocation.cmake
+++ b/cmake/Phylanx_GetPythonExtensionLocation.cmake
@@ -21,12 +21,14 @@ macro(phylanx_get_python_extension_location suffix result)
 	      _result ${suffix})
 
 	else()
+        # Pybind gets the architecture wrong for POWER8.
+        string(REPLACE "powerpc64le" "ppc64le" _suffix ${suffix})
 		# suffix will be something like '.cpython-35m-x86_64-linux-gnu.so'
 		# result should be something like 'lib.linux-x86_64-3.5'
 		string(REGEX REPLACE
 			"\\..*([0-9])([0-9]).*-(.*)-(.*)-.*"
 			"lib.\\4-\\3-\\1.\\2"
-		_result ${suffix})
+		_result ${_suffix})
 	endif()
 
 	# compose full path


### PR DESCRIPTION
The pybind library decides that POWER8 architecture is a non-standard "powerpc64le", instead of the standard "ppc64le".  This causes the tests to set the wrong PYTHONPATH directory (because phylanx uses ppc64le) and the tests fail. After this fix, the Clang 5.0 build on POWER8 should be working.