### PR TITLE
Fixing LRA so that the output matches naive python version

### DIFF
--- a/examples/algorithms/lra.cpp
+++ b/examples/algorithms/lra.cpp
@@ -19,16 +19,19 @@ char const* const lra_code = R"(block(
     //   y: [30]
     define(lra, x, y, alpha, iterations,
         block(
-            define(weights, constant(0, shape(x, 1))),                  // weights: [2]
+            define(weights, constant(0.0, shape(x, 1))),                // weights: [2]
             define(transx, transpose(x)),                               // transx:  [2, 30]
+            define(pred, constant(0.0,shape(x,0))),
+            define(error, constant(0.0,shape(x,0))),
+            define(gradient, constant(0.0, shape(x, 1))),
             define(step, 0),
             while(
                 step < iterations,
                 block(
                     cout("step: ", step, ", ", weights),
-                    define(pred, 1.0 / (1.0 + exp(-dot(x, weights)))),  // exp(-dot(x, weights)): [30], pred: [30]
-                    define(error, pred - y),                            // error: [30]
-                    define(gradient, dot(transx, error)),               // gradient: [2]
+                    store(pred, 1.0 / (1.0 + exp(-dot(x, weights)))),  // exp(-dot(x, weights)): [30], pred: [30]
+                    store(error, pred - y),                            // error: [30]
+                    store(gradient, dot(transx, error)),               // gradient: [2]
                     parallel_block(
                         store(weights, weights - (alpha * gradient)),
                         store(step, step + 1)


### PR DESCRIPTION
Defines needed to be moved out of the loop body else it would not be executed more than once and subsequent iterations used old values. 