### PR TITLE
Reverted isZero calls to nonZeros

### DIFF
--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -79,10 +79,10 @@ namespace phylanx { namespace ir
             return scalar() != 0;
 
         case 1:
-            return !blaze::isZero(vector());
+            return vector().nonZeros() > 0;
 
         case 2:
-            return !blaze::isZero(matrix());
+            return matrix().nonZeros() > 0;
 
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,

--- a/tests/unit/execution_tree/primitives/and_operation.cpp
+++ b/tests/unit/execution_tree/primitives/and_operation.cpp
@@ -110,7 +110,7 @@ void test_and_operation_1d()
         and_.eval();
 
     HPX_TEST_EQ(
-        (!blaze::isZero(v1)) && (!blaze::isZero(v2)),
+        (v1.nonZeros() > 0) && (v2.nonZeros() > 0),
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
@@ -137,7 +137,7 @@ void test_and_operation_1d_lit()
         and_.eval();
 
     HPX_TEST_EQ(
-        (!blaze::isZero(v1)) && (!blaze::isZero(v2)),
+        (v1.nonZeros() > 0) && (v2.nonZeros() > 0),
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
@@ -166,7 +166,7 @@ void test_and_operation_2d()
         and_.eval();
 
     HPX_TEST_EQ(
-        (!blaze::isZero(m1)) && (!blaze::isZero(m2)),
+        (m1.nonZeros() > 0) && (m2.nonZeros() > 0),
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
@@ -193,7 +193,7 @@ void test_and_operation_2d_lit()
         and_.eval();
 
     HPX_TEST_EQ(
-        (!blaze::isZero(m1)) && (!blaze::isZero(m2)),
+        (m1.nonZeros() > 0) && (m2.nonZeros() > 0),
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 

--- a/tests/unit/execution_tree/primitives/or_operation.cpp
+++ b/tests/unit/execution_tree/primitives/or_operation.cpp
@@ -138,7 +138,7 @@ void test_or_operation_1d_lit()
         or_.eval();
 
     HPX_TEST_EQ(
-        (!blaze::isZero(v1) || !blaze::isZero(v2)),
+        (v1.nonZeros() > 0) && (v2.nonZeros() > 0),
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
@@ -167,7 +167,7 @@ void test_or_operation_2d()
         or_.eval();
 
     HPX_TEST_EQ(
-        (!blaze::isZero(m1) || !blaze::isZero(m2)),
+        (m1.nonZeros() > 0) && (m2.nonZeros() > 0),
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 
@@ -194,7 +194,7 @@ void test_or_operation_2d_lit()
         or_.eval();
 
     HPX_TEST_EQ(
-        (!blaze::isZero(m1) || !blaze::isZero(m2)),
+        (m1.nonZeros() > 0) && (m2.nonZeros() > 0),
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 

--- a/tests/unit/execution_tree/primitives/unary_not_operation.cpp
+++ b/tests/unit/execution_tree/primitives/unary_not_operation.cpp
@@ -68,7 +68,7 @@ void test_unary_not_operation_2d()
         unary_not.eval();
 
     HPX_TEST_EQ(
-        blaze::isZero(m),
+        m.nonZeros() == 0,
         phylanx::execution_tree::extract_boolean_value(f.get()) != 0);
 }
 


### PR DESCRIPTION
`blaze::isZero` is designed to operate on scalar type and will always return `false` for a non-scalar type (e.g. `DynamicMatrix<T>`). This PR reverts all such uses of `isZero(obj)` to use previously used `nonZeros()`.

> Note: This bug did not become visible in form of unit test failures because current test cases only produce and check correct answers.