### PR TITLE
Adding missing overload for is_literal_value(unary_expr)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ phylanx_option(
 phylanx_option(
   PHYLANX_WITH_TESTS_REGRESSIONS BOOL
   "Enable or disable the compilation of regression tests"
-  OFF ADVANCED CATEGORY "Build")
+  ON ADVANCED CATEGORY "Build")
 
 phylanx_option(
   PHYLANX_WITH_TESTS_UNIT BOOL

--- a/phylanx/ast/detail/is_literal_value.hpp
+++ b/phylanx/ast/detail/is_literal_value.hpp
@@ -36,6 +36,9 @@ namespace phylanx { namespace ast { namespace detail
     PHYLANX_EXPORT bool is_literal_value(operand const& op);
     PHYLANX_EXPORT literal_value_type literal_value(operand const& op);
 
+    inline bool is_literal_value(unary_expr const& ue);
+    inline literal_value_type literal_value(unary_expr const& ue);
+
     inline bool is_literal_value(operation const& op);
     inline literal_value_type literal_value(operation const& op);
 
@@ -52,6 +55,15 @@ namespace phylanx { namespace ast { namespace detail
     literal_value_type literal_value(util::recursive_wrapper<Ast> const& ast)
     {
         return literal_value(ast.get());
+    }
+
+    inline bool is_literal_value(unary_expr const& ue)
+    {
+        return is_literal_value(ue.operand_);
+    }
+    inline literal_value_type literal_value(unary_expr const& ue)
+    {
+        return is_literal_value(ue.operand_);
     }
 
     inline bool is_literal_value(operation const& op)

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -41,7 +41,7 @@ namespace phylanx { namespace ast { namespace parser
         qi::alpha_type alpha;
         qi::alnum_type alnum;
         qi::bool_type bool_;
-        qi::uint_parser<std::uint64_t> ulong_long;
+        qi::int_parser<std::int64_t> long_long;
 
         using qi::on_error;
         using qi::on_success;
@@ -99,7 +99,7 @@ namespace phylanx { namespace ast { namespace parser
             |   list
             |   as<ast::identifier>()[identifier]
             |   bool_
-            |   ulong_long
+            |   long_long
             |   string
             |   '(' > expr > ')'
             ;

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) 2017 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(subdirs
+    execution_tree
+   )
+
+foreach(subdir ${subdirs})
+  add_phylanx_pseudo_target(tests.regressions.${subdir}_)
+  add_subdirectory(${subdir})
+  add_phylanx_pseudo_dependencies(tests.regressions tests.regressions.${subdir}_)
+endforeach()
+

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2017 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    negative_integral_value_131
+   )
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add executable
+  add_phylanx_executable(${test}_test
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Regression/ExecutionTree/")
+
+  add_phylanx_regression_test("execution_tree" ${test} ${${test}_PARAMETERS})
+
+  add_phylanx_pseudo_target(tests.regressions.execution_tree_.${test})
+  add_phylanx_pseudo_dependencies(tests.regressions.execution_tree_
+    tests.regressions.execution_tree_.${test})
+  add_phylanx_pseudo_dependencies(tests.regressions.execution_tree_.${test} 
+    ${test}_test_exe)
+
+endforeach()
+
+

--- a/tests/regressions/execution_tree/negative_integral_value_131.cpp
+++ b/tests/regressions/execution_tree/negative_integral_value_131.cpp
@@ -1,0 +1,35 @@
+//   Copyright (c) 2017 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Fixing #131: Pattern matching is not working for negative values
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+
+std::string const code = R"(block(
+    define(x, y,
+        slice(y, 0, 569, -1, 0)
+    ),
+    x
+))";
+
+int main(int argc, char* argv[])
+{
+    try
+    {
+        phylanx::execution_tree::compiler::function_list snippets;
+        phylanx::execution_tree::compile(code, snippets);
+    }
+    catch(...)
+    {
+        HPX_TEST(false);        // shouldn't throw any exceptions
+    }
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/execution_tree/instrumentation.cpp
+++ b/tests/unit/execution_tree/instrumentation.cpp
@@ -1,0 +1,36 @@
+//  Copyright (c) 2017 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <vector>
+
+void test_unary_expr()
+{
+    std::string code =
+        R"(block(
+            define(func, A, B, C, store(A, A - B))
+        ))";
+
+    std::vector<std::string::const_iterator> iterators;
+    phylanx::execution_tree::compiler::function_list snippets;
+
+    auto f = phylanx::execution_tree::compile(
+        phylanx::ast::generate_ast(code, iterators), snippets);
+
+    auto entries = hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*");
+
+}
+
+int main(int argc, char* argv[])
+{
+    test_unary_expr();
+
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
- flyby: make parser recognize negative integral values as primary_expr's
- flyby: add regression testing infrastructure

This fixes #131