### PR TITLE
Extending `slice()` primitives to support negative indicies

### DIFF
--- a/examples/algorithms/lra_csv.cpp
+++ b/examples/algorithms/lra_csv.cpp
@@ -28,8 +28,8 @@ char const* const read_x_code = R"(block(
     //
     // Read X-data from given CSV file
     //
-    define(read_x, filepath,
-        slice(file_read_csv(filepath), 0, 569, 0, 30)
+    define(read_x, filepath, row_start, row_stop, col_start, col_stop,
+        slice(file_read_csv(filepath), row_start, row_stop, col_start, col_stop)
     ),
     read_x
 ))";
@@ -38,8 +38,8 @@ char const* const read_y_code = R"(block(
     //
     // Read Y-data from given CSV file
     //
-    define(read_y, filepath,
-        slice(file_read_csv(filepath), 0, 569, 30, 31)
+    define(read_y, filepath, row_start, row_stop,
+        slice(file_read_csv(filepath), row_start, row_stop, -1, 0)
     ),
     read_y
 ))";
@@ -87,26 +87,33 @@ int hpx_main(boost::program_options::variables_map& vm)
         return hpx::finalize();
     }
 
-    // Add high resolution timer
-    hpx::util::high_resolution_timer t;
-
     // compile the given code
     phylanx::execution_tree::compiler::function_list snippets;
     auto read_x = phylanx::execution_tree::compile(read_x_code, snippets);
     auto read_y = phylanx::execution_tree::compile(read_y_code, snippets);
 
+    auto row_start = vm["row_start"].as<std::int64_t>();
+    auto col_start = vm["col_start"].as<std::int64_t>();
+    auto row_stop = vm["row_stop"].as<std::int64_t>();
+    auto col_stop = vm["col_stop"].as<std::int64_t>();
+
     // read the data from the files
-    auto x = read_x(vm["data_csv"].as<std::string>());
-    auto y = read_y(vm["data_csv"].as<std::string>());
+    auto x = read_x(vm["data_csv"].as<std::string>(), row_start, row_stop, col_start, col_stop);
+
+    //col_start and col_stop omitted in this case as we know the last column in our csv file
+    //has the y values.
+    auto y = read_y(vm["data_csv"].as<std::string>(), row_start, row_stop);
 
     auto alpha = vm["alpha"].as<double>();
 
     auto iterations = vm["num_iterations"].as<std::int64_t>();
     bool enable_output = vm.count("enable_output") != 0;
 
+    // Add high resolution timer
+    hpx::util::high_resolution_timer t;
+
     // evaluate LRA using the read data
     // time the execution
-    t.restart();
 
     auto lra = phylanx::execution_tree::compile(lra_code, snippets);
     auto result =
@@ -138,6 +145,18 @@ int main(int argc, char* argv[])
         ("data_csv",
             boost::program_options::value<std::string>(),
             "file name for reading data")
+        ("row_start",
+            boost::program_options::value<std::int64_t>()->default_value(0),
+            "row_start (default: 0)")
+        ("col_start",
+            boost::program_options::value<std::int64_t>()->default_value(0),
+            "col_start (default: 0)")
+        ("row_stop",
+            boost::program_options::value<std::int64_t>()->default_value(569),
+            "row_stop (default: 569)")
+        ("col_stop",
+            boost::program_options::value<std::int64_t>()->default_value(30),
+            "col_stop (default: 10000)")
         ;
 
     return hpx::init(desc, argc, argv);

--- a/examples/algorithms/lra_csv.cpp
+++ b/examples/algorithms/lra_csv.cpp
@@ -156,7 +156,7 @@ int main(int argc, char* argv[])
             "row_stop (default: 569)")
         ("col_stop",
             boost::program_options::value<std::int64_t>()->default_value(30),
-            "col_stop (default: 10000)")
+            "col_stop (default: 30)")
         ;
 
     return hpx::init(desc, argc, argv);

--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -93,6 +93,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // column = col_start
                 // n = (col_stop - col_start)
 
+                if (col_start < 0 && col_stop >= 0)    //slice from the end
+                {
+                    auto size = args[0].vector().size();
+
+                    subvector_type sv = blaze::subvector(
+                            args[0].vector(), size + col_start, (-col_start));
+
+                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                }
+
+                if (col_start < 0 && col_stop < 0)    //slice from the end
+                {
+                    auto size = args[0].vector().size();
+
+                    subvector_type sv = blaze::subvector(args[0].vector(),
+                                                         size + col_start, (-col_start) + col_stop);
+
+                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                }
+
                 subvector_type sv =
                     blaze::subvector(args[0].vector(),
                         col_start, (col_stop - col_start));
@@ -131,6 +151,43 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // column = col_start
                 // m = number of rows in the input matrix
                 // n = (col_stop - col_start)
+
+                if (col_start < 0 && col_stop >= 0 )    //column slice from the end
+                {
+                    auto num_cols = args[0].matrix().columns();
+
+                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                                                         0, num_cols + col_start, num_matrix_rows,
+                                                         -(col_start));
+
+                    if (col_start == -1)
+                    {
+                        return ir::node_data<double>{std::move(column(sm, 0))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                                matrix_type{std::move(sm)}};
+                    }
+                }
+                else if (col_start < 0 && col_stop < 0 )
+                {
+                    auto num_cols = args[0].matrix().columns();
+
+                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                                                         0, num_cols + col_start, num_matrix_rows,
+                                                         -(col_start) + col_stop);
+
+                    if (col_stop - col_start == -1)
+                    {
+                        return ir::node_data<double>{std::move(column(sm, 0))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                                matrix_type{std::move(sm)}};
+                    }
+                }
 
                 submatrix_type sm =
                     blaze::submatrix(args[0].matrix(),

--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -101,7 +101,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                         "col_stop can not be positive if col_start is negative");
                 }
 
-                if (col_start < 0 && col_stop < 0)    //slice from the end
+                if (col_start < 0 && col_stop <= 0)    //slice from the end
                 {
                     auto size = args[0].vector().size();
 

--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -93,14 +93,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // column = col_start
                 // n = (col_stop - col_start)
 
-                if (col_start < 0 && col_stop >= 0)    //slice from the end
+                if (col_start < 0 && col_stop > 0)    //slice from the end
                 {
-                    auto size = args[0].vector().size();
-
-                    subvector_type sv = blaze::subvector(
-                            args[0].vector(), size + col_start, (-col_start));
-
-                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                        "phylanx::execution_tree::primitives::"
+                                                "column_slicing_operation::column_slicing_operation",
+                                        "col_stop can not be positive if col_start is negative");
                 }
 
                 if (col_start < 0 && col_stop < 0)    //slice from the end
@@ -152,25 +150,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // m = number of rows in the input matrix
                 // n = (col_stop - col_start)
 
-                if (col_start < 0 && col_stop >= 0 )    //column slice from the end
+                if (col_start < 0 && col_stop > 0 )    //column slice from the end
                 {
-                    auto num_cols = args[0].matrix().columns();
-
-                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
-                                                         0, num_cols + col_start, num_matrix_rows,
-                                                         -(col_start));
-
-                    if (col_start == -1)
-                    {
-                        return ir::node_data<double>{std::move(column(sm, 0))};
-                    }
-                    else
-                    {
-                        return ir::node_data<double>{
-                                matrix_type{std::move(sm)}};
-                    }
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                        "phylanx::execution_tree::primitives::"
+                                                "column_slicing_operation::column_slicing_operation",
+                                        "col_stop can not be positive if col_start is negative");
                 }
-                else if (col_start < 0 && col_stop < 0 )
+                else if (col_start < 0 && col_stop <= 0 )
                 {
                     auto num_cols = args[0].matrix().columns();
 

--- a/src/execution_tree/primitives/row_slicing.cpp
+++ b/src/execution_tree/primitives/row_slicing.cpp
@@ -100,27 +100,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // m = (row_stop - row_start)
                 // n = number of columns in the input matrix
 
-                if (row_start < 0 && row_stop >= 0 )    //row slice from the end
+                if (row_start < 0 && row_stop > 0 )    //row slice from the end
                 {
-                    auto num_rows = args[0].matrix().rows();
-
-                    submatrix_type sm =
-                            blaze::submatrix(args[0].matrix(), num_rows + row_start,
-                                             0, -(row_start), num_matrix_cols);
-
-                    if (row_start == -1)
-                    {
-                        //return a vector in this case and not a matrix
-                        return ir::node_data<double>{
-                                std::move(blaze::trans(row(sm, 0)))};
-                    }
-                    else
-                    {
-                        return ir::node_data<double>{
-                                matrix_type{std::move(sm)}};
-                    }
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                        "phylanx::execution_tree::primitives::"
+                                                "row_slicing_operation::row_slicing_operation",
+                                        "row_stop can not be positive if row_start is negative");
                 }
-                else if (row_start < 0 && row_stop < 0 )
+                else if (row_start < 0 && row_stop <= 0 )
                 {
                     auto num_rows = args[0].matrix().rows();
 

--- a/src/execution_tree/primitives/row_slicing.cpp
+++ b/src/execution_tree/primitives/row_slicing.cpp
@@ -100,6 +100,47 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // m = (row_stop - row_start)
                 // n = number of columns in the input matrix
 
+                if (row_start < 0 && row_stop >= 0 )    //row slice from the end
+                {
+                    auto num_rows = args[0].matrix().rows();
+
+                    submatrix_type sm =
+                            blaze::submatrix(args[0].matrix(), num_rows + row_start,
+                                             0, -(row_start), num_matrix_cols);
+
+                    if (row_start == -1)
+                    {
+                        //return a vector in this case and not a matrix
+                        return ir::node_data<double>{
+                                std::move(blaze::trans(row(sm, 0)))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                                matrix_type{std::move(sm)}};
+                    }
+                }
+                else if (row_start < 0 && row_stop < 0 )
+                {
+                    auto num_rows = args[0].matrix().rows();
+
+                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                                                         num_rows + row_start, 0,
+                                                         -(row_start) + row_stop, num_matrix_cols);
+
+                    if (row_stop - row_start == -1)
+                    {
+                        //return a vector in this case and not a matrix
+                        return ir::node_data<double>{
+                                std::move(blaze::trans(row(sm, 0)))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                                matrix_type{std::move(sm)}};
+                    }
+                }
+
                 submatrix_type sm =
                     blaze::submatrix(args[0].matrix(),
                         row_start, 0,

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -96,6 +96,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // column = col_start
                 // n = (col_stop - col_start)
 
+                if (col_start < 0) //slice from the end
+                {
+                    auto size = args[0].vector().size();
+
+                    subvector_type sv = blaze::subvector(
+                        args[0].vector(), size + col_start, (-col_start));
+
+                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                }
+
                 subvector_type sv =
                     blaze::subvector(args[0].vector(),
                         col_start, (col_stop - col_start));
@@ -137,6 +147,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // column = col_start
                 // m = (row_stop - row_start)
                 // n = (col_stop - col_start)
+
+                if (col_start < 0) //slice from the end
+                {
+                    auto num_cols = args[0].matrix().columns();
+
+                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                        row_start, num_cols + col_start, (row_stop - row_start),
+                        -(col_start));
+
+                    if ((row_stop - row_start) == 1)
+                    {
+                        //return a vector in this case and not a matrix
+                        return ir::node_data<double>{
+                            std::move(blaze::trans(row(sm, 0)))};
+                    }
+                    else if (col_start == -1)
+                    {
+                        return ir::node_data<double>{std::move(column(sm, 0))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                            matrix_type{std::move(sm)}};
+                    }
+                }
 
                 submatrix_type sm =
                     blaze::submatrix(args[0].matrix(), row_start, col_start,

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -96,17 +96,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // column = col_start
                 // n = (col_stop - col_start)
 
-                if (col_start < 0 && col_stop >= 0)    //slice from the end
+                if (col_start < 0 && col_stop > 0)    //slice from the end
                 {
-                    auto size = args[0].vector().size();
-
-                    subvector_type sv = blaze::subvector(
-                        args[0].vector(), size + col_start, (-col_start));
-
-                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                        "phylanx::execution_tree::primitives::"
+                                                "slicing_operation::slicing_operation",
+                                        "col_stop can not be positive if col_start is negative");
                 }
 
-                if (col_start < 0 && col_stop < 0)    //slice from the end
+                if (col_start < 0 && col_stop <= 0)    //slice from the end
                 {
                     auto size = args[0].vector().size();
 
@@ -157,33 +155,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // m = (row_stop - row_start)
                 // n = (col_stop - col_start)
 
-                if (col_start < 0 && col_stop >= 0 && row_start >= 0 &&
-                    row_stop > 0)    //column slice from the end
+                if ((col_start < 0 && col_stop > 0) ||
+                    (row_start < 0 && row_stop > 0))
                 {
-                    auto num_cols = args[0].matrix().columns();
-
-                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
-                        row_start, num_cols + col_start, (row_stop - row_start),
-                        -(col_start));
-
-                    if ((row_stop - row_start) == 1)
-                    {
-                        //return a vector in this case and not a matrix
-                        return ir::node_data<double>{
-                            std::move(blaze::trans(row(sm, 0)))};
-                    }
-                    else if (col_start == -1)
-                    {
-                        return ir::node_data<double>{std::move(column(sm, 0))};
-                    }
-                    else
-                    {
-                        return ir::node_data<double>{
-                            matrix_type{std::move(sm)}};
-                    }
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "phylanx::execution_tree::primitives::"
+                        "slicing_operation::slicing_operation",
+                        "col_stop/row_stop can not be positive if "
+                        "col_start/row_start is negative");
                 }
-                else if (col_start < 0 && col_stop < 0 && row_start >= 0 &&
-                    row_stop > 0)
+
+                if (col_start < 0 && col_stop <= 0 && row_start >= 0 &&
+                    row_stop > 0)    //column slice from the end
                 {
                     auto num_cols = args[0].matrix().columns();
 
@@ -208,32 +191,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     }
                 }
 
-                if (row_start < 0 && row_stop >= 0 && col_start >= 0 &&
-                    col_stop > 0)    //row slice from the end
-                {
-                    auto num_rows = args[0].matrix().rows();
-
-                    submatrix_type sm =
-                        blaze::submatrix(args[0].matrix(), num_rows + row_start,
-                            col_start, -(row_start), (col_stop - col_start));
-
-                    if (row_start == -1)
-                    {
-                        //return a vector in this case and not a matrix
-                        return ir::node_data<double>{
-                            std::move(blaze::trans(row(sm, 0)))};
-                    }
-                    else if ((col_stop - col_start) == 1)
-                    {
-                        return ir::node_data<double>{std::move(column(sm, 0))};
-                    }
-                    else
-                    {
-                        return ir::node_data<double>{
-                            matrix_type{std::move(sm)}};
-                    }
-                }
-                else if (row_start < 0 && row_stop < 0 && col_start >= 0 &&
+                if (row_start < 0 && row_stop <= 0 && col_start >= 0 &&
                     col_stop > 0)    //row slice from the end
                 {
                     auto num_rows = args[0].matrix().rows();
@@ -259,8 +217,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     }
                 }
 
-                if (row_start < 0 && row_stop < 0 && col_start < 0 &&
-                    col_stop < 0)
+                if (row_start < 0 && row_stop <= 0 && col_start < 0 &&
+                    col_stop <= 0)    //row and column , both, slice from end
                 {
                     auto num_rows = args[0].matrix().rows();
                     auto num_cols = args[0].matrix().columns();

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -71,7 +71,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 return primitive_result_type(std::move(args[0]));
             }
 
-            primitive_result_type slicing1d(args_type && args) const
+            primitive_result_type slicing1d(args_type&& args) const
             {
                 // return elements starting from col_start to col_stop(exclusive)
                 // the values passed to row_stat and row_stop does not have an
@@ -96,7 +96,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // column = col_start
                 // n = (col_stop - col_start)
 
-                if (col_start < 0) //slice from the end
+                if (col_start < 0 && col_stop >= 0)    //slice from the end
                 {
                     auto size = args[0].vector().size();
 
@@ -106,14 +106,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     return ir::node_data<double>{vector_type{std::move(sv)}};
                 }
 
-                subvector_type sv =
-                    blaze::subvector(args[0].vector(),
-                        col_start, (col_stop - col_start));
+                if (col_start < 0 && col_stop < 0)    //slice from the end
+                {
+                    auto size = args[0].vector().size();
+
+                    subvector_type sv = blaze::subvector(args[0].vector(),
+                        size + col_start, (-col_start) + col_stop);
+
+                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                }
+
+                subvector_type sv = blaze::subvector(
+                    args[0].vector(), col_start, (col_stop - col_start));
 
                 return ir::node_data<double>{vector_type{std::move(sv)}};
             }
 
-            primitive_result_type slicing2d(args_type && args) const
+            primitive_result_type slicing2d(args_type&& args) const
             {
                 // returns the sliced matrix, depending upon the values
                 // provided in row_start, row_stop(exclusive), col_start, col_stop(exclusive)
@@ -148,7 +157,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // m = (row_stop - row_start)
                 // n = (col_stop - col_start)
 
-                if (col_start < 0) //column slice from the end
+                if (col_start < 0 && col_stop >= 0 && row_start >= 0 &&
+                    row_stop > 0)    //column slice from the end
                 {
                     auto num_cols = args[0].matrix().columns();
 
@@ -172,8 +182,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             matrix_type{std::move(sm)}};
                     }
                 }
+                else if (col_start < 0 && col_stop < 0 && row_start >= 0 &&
+                    row_stop > 0)
+                {
+                    auto num_cols = args[0].matrix().columns();
 
-                if(row_start < 0) //row slice from the end
+                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                        row_start, num_cols + col_start, (row_stop - row_start),
+                        -(col_start) + col_stop);
+
+                    if ((row_stop - row_start) == 1)
+                    {
+                        //return a vector in this case and not a matrix
+                        return ir::node_data<double>{
+                            std::move(blaze::trans(row(sm, 0)))};
+                    }
+                    else if (col_stop - col_start == -1)
+                    {
+                        return ir::node_data<double>{std::move(column(sm, 0))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                            matrix_type{std::move(sm)}};
+                    }
+                }
+
+                if (row_start < 0 && row_stop >= 0 && col_start >= 0 &&
+                    col_stop > 0)    //row slice from the end
                 {
                     auto num_rows = args[0].matrix().rows();
 
@@ -188,6 +224,58 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             std::move(blaze::trans(row(sm, 0)))};
                     }
                     else if ((col_stop - col_start) == 1)
+                    {
+                        return ir::node_data<double>{std::move(column(sm, 0))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                            matrix_type{std::move(sm)}};
+                    }
+                }
+                else if (row_start < 0 && row_stop < 0 && col_start >= 0 &&
+                    col_stop > 0)    //row slice from the end
+                {
+                    auto num_rows = args[0].matrix().rows();
+
+                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                        num_rows + row_start, col_start,
+                        -(row_start) + row_stop, (col_stop - col_start));
+
+                    if (row_stop - row_start == -1)
+                    {
+                        //return a vector in this case and not a matrix
+                        return ir::node_data<double>{
+                            std::move(blaze::trans(row(sm, 0)))};
+                    }
+                    else if ((col_stop - col_start) == 1)
+                    {
+                        return ir::node_data<double>{std::move(column(sm, 0))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                            matrix_type{std::move(sm)}};
+                    }
+                }
+
+                if (row_start < 0 && row_stop < 0 && col_start < 0 &&
+                    col_stop < 0)
+                {
+                    auto num_rows = args[0].matrix().rows();
+                    auto num_cols = args[0].matrix().columns();
+
+                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                        num_rows + row_start, num_cols + col_start,
+                        -(row_start) + row_stop, -(col_start) + col_stop);
+
+                    if (row_stop - row_start == -1)
+                    {
+                        //return a vector in this case and not a matrix
+                        return ir::node_data<double>{
+                            std::move(blaze::trans(row(sm, 0)))};
+                    }
+                    else if (col_stop - col_start == -1)
                     {
                         return ir::node_data<double>{std::move(column(sm, 0))};
                     }

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -148,7 +148,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // m = (row_stop - row_start)
                 // n = (col_stop - col_start)
 
-                if (col_start < 0) //slice from the end
+                if (col_start < 0) //column slice from the end
                 {
                     auto num_cols = args[0].matrix().columns();
 
@@ -163,6 +163,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             std::move(blaze::trans(row(sm, 0)))};
                     }
                     else if (col_start == -1)
+                    {
+                        return ir::node_data<double>{std::move(column(sm, 0))};
+                    }
+                    else
+                    {
+                        return ir::node_data<double>{
+                            matrix_type{std::move(sm)}};
+                    }
+                }
+
+                if(row_start < 0) //row slice from the end
+                {
+                    auto num_rows = args[0].matrix().rows();
+
+                    submatrix_type sm =
+                        blaze::submatrix(args[0].matrix(), num_rows + row_start,
+                            col_start, -(row_start), (col_stop - col_start));
+
+                    if (row_start == -1)
+                    {
+                        //return a vector in this case and not a matrix
+                        return ir::node_data<double>{
+                            std::move(blaze::trans(row(sm, 0)))};
+                    }
+                    else if ((col_stop - col_start) == 1)
                     {
                         return ir::node_data<double>{std::move(column(sm, 0))};
                     }

--- a/tests/unit/execution_tree/primitives/column_slicing.cpp
+++ b/tests/unit/execution_tree/primitives/column_slicing.cpp
@@ -153,11 +153,87 @@ void test_column_slicing_operation_2d()
               phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_column_slicing_operation_1d_negative_index()
+{
+
+    blaze::Rand<blaze::DynamicVector<double>> gen{};
+    blaze::DynamicVector<double> v1 = gen.generate(1007UL);
+
+    phylanx::execution_tree::primitive input_vector =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_vector), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+    auto sm = blaze::subvector(v1, 1002, 3);
+    auto expected = sm;
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_column_slicing_operation_2d_negative_index()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(90UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 0, 96, 90, 3);
+    auto expected = sm;
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+
 int main(int argc, char* argv[])
 {
   test_column_slicing_operation_0d();
   test_column_slicing_operation_1d();
   test_column_slicing_operation_2d();
+
+  test_column_slicing_operation_1d_negative_index();
+  test_column_slicing_operation_2d_negative_index();
 
   return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/row_slicing.cpp
+++ b/tests/unit/execution_tree/primitives/row_slicing.cpp
@@ -131,11 +131,50 @@ void test_row_slicing_operation_2d()
               phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_row_slicing_operation_2d_negative_index()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(90UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::row_slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 85, 0, 3, 101);
+    auto expected = sm;
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+
 int main(int argc, char* argv[])
 {
   test_row_slicing_operation_0d();
   test_row_slicing_operation_1d();
   test_row_slicing_operation_2d();
+
+  test_row_slicing_operation_2d_negative_index();
 
   return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/slicing_operation.cpp
+++ b/tests/unit/execution_tree/primitives/slicing_operation.cpp
@@ -328,6 +328,103 @@ void test_slicing_operation_2d_zero_start()
         phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_col_slicing_operation_from_end()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(0.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(47.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+
+    //col_stop has has no effect as the total number of columns in the matrix
+    //is calculated internally in the slicing primitive
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(0.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 0, 99, 47, 2);
+    auto expected = sm;
+
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_row_slicing_operation_from_end()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    //row_stop has has no effect as the total number of rows in the matrix
+    //is calculated internally in the slicing primitive
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(0.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(16.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 96, 6, 5, 10);
+    auto expected = sm;
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+
 int main(int argc, char* argv[])
 {
     test_slicing_operation_0d();
@@ -336,6 +433,9 @@ int main(int argc, char* argv[])
 
     test_slicing_operation_1d_zero_start();
     test_slicing_operation_2d_zero_start();
+
+    test_col_slicing_operation_from_end();
+    test_row_slicing_operation_from_end();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/slicing_operation.cpp
+++ b/tests/unit/execution_tree/primitives/slicing_operation.cpp
@@ -425,6 +425,143 @@ void test_row_slicing_operation_from_end()
 }
 
 
+void test_col_slicing_operation_from_end_negative_start_stop()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(0.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(47.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 0, 96, 47, 3);
+    auto expected = sm;
+
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_row_slicing_operation_from_end_negative_start_stop()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(16.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 96, 6, 3, 10);
+    auto expected = sm;
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_row_and_column_slicing_from_end_negative_start_stop()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-3.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 96, 96, 3, 2);
+    auto expected = sm;
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
 int main(int argc, char* argv[])
 {
     test_slicing_operation_0d();
@@ -436,6 +573,11 @@ int main(int argc, char* argv[])
 
     test_col_slicing_operation_from_end();
     test_row_slicing_operation_from_end();
+
+    test_col_slicing_operation_from_end_negative_start_stop();
+    test_row_slicing_operation_from_end_negative_start_stop();
+
+    test_row_and_column_slicing_from_end_negative_start_stop();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/slicing_operation.cpp
+++ b/tests/unit/execution_tree/primitives/slicing_operation.cpp
@@ -349,8 +349,7 @@ void test_col_slicing_operation_from_end()
             hpx::new_<phylanx::execution_tree::primitives::variable>(
                     hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
 
-    //col_stop has has no effect as the total number of columns in the matrix
-    //is calculated internally in the slicing primitive
+
     phylanx::execution_tree::primitive col_stop =
             hpx::new_<phylanx::execution_tree::primitives::variable>(
                     hpx::find_here(), phylanx::ir::node_data<double>(0.0));
@@ -390,8 +389,7 @@ void test_row_slicing_operation_from_end()
             hpx::new_<phylanx::execution_tree::primitives::variable>(
                     hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
 
-    //row_stop has has no effect as the total number of rows in the matrix
-    //is calculated internally in the slicing primitive
+
     phylanx::execution_tree::primitive row_stop =
             hpx::new_<phylanx::execution_tree::primitives::variable>(
                     hpx::find_here(), phylanx::ir::node_data<double>(0.0));


### PR DESCRIPTION
This pull request tries to address #128 by adding support for negative indices in the slice primitive. 

***slice ( matrix, row_start , row_stop, col_start , col_stop)*** now allows ***row_start*** to have negative values which effectively slices the matrix ***row_start*** rows from the end. 
similarly, negative ***col_start*** effectively slices the matrix ***col_start*** columns from the end. 
The parameters ***row_stop / col_stop*** does not have any effect when using negative indices to slice from the end. Any values passed to these parameters are simply ignored. 

This pull request also modifies the lra_csv example to remove hard coded values. 