### PR TITLE
Add missing tests for slicing operations

### DIFF
--- a/tests/unit/execution_tree/primitives/column_slicing.cpp
+++ b/tests/unit/execution_tree/primitives/column_slicing.cpp
@@ -189,6 +189,42 @@ void test_column_slicing_operation_1d_negative_index()
                 phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_column_slicing_operation_1d_single_slice_negative_index()
+{
+
+    blaze::Rand<blaze::DynamicVector<double>> gen{};
+    blaze::DynamicVector<double> v1 = gen.generate(1007UL);
+
+    phylanx::execution_tree::primitive input_vector =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_vector), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+    auto sm = blaze::subvector(v1, 1002, 1);
+    auto expected = sm;
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
 void test_column_slicing_operation_2d_negative_index()
 {
     blaze::Rand<blaze::DynamicMatrix<double>> gen{};
@@ -225,6 +261,42 @@ void test_column_slicing_operation_2d_negative_index()
                 phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_column_slicing_operation_2d_single_slice_negative_index()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(90UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 0, 96, 90, 1);
+    auto expected = blaze::column(sm, 0);
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
 
 int main(int argc, char* argv[])
 {
@@ -234,6 +306,10 @@ int main(int argc, char* argv[])
 
   test_column_slicing_operation_1d_negative_index();
   test_column_slicing_operation_2d_negative_index();
+
+  test_column_slicing_operation_1d_single_slice_negative_index();
+  test_column_slicing_operation_2d_single_slice_negative_index();
+
 
   return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/row_slicing.cpp
+++ b/tests/unit/execution_tree/primitives/row_slicing.cpp
@@ -167,6 +167,42 @@ void test_row_slicing_operation_2d_negative_index()
                 phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_row_slicing_operation_2d_single_slice_negative_index()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(90UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::row_slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 85, 0, 1, 101);
+    auto expected = blaze::trans(blaze::row(sm, 0));
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
 
 int main(int argc, char* argv[])
 {
@@ -175,6 +211,7 @@ int main(int argc, char* argv[])
   test_row_slicing_operation_2d();
 
   test_row_slicing_operation_2d_negative_index();
+  test_row_slicing_operation_2d_single_slice_negative_index();
 
   return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/slicing_operation.cpp
+++ b/tests/unit/execution_tree/primitives/slicing_operation.cpp
@@ -560,6 +560,100 @@ void test_row_and_column_slicing_from_end_negative_start_stop()
                 phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+
+void test_col_slicing_operation_from_end_single_column()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(0.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(47.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 0, 96, 47, 1);
+    auto expected = blaze::column(sm,0);
+
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_row_slicing_operation_from_end_single_row()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(16.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 96, 6, 1, 10);
+    auto expected = blaze::trans(blaze::row(sm,0));
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+
 int main(int argc, char* argv[])
 {
     test_slicing_operation_0d();
@@ -576,6 +670,9 @@ int main(int argc, char* argv[])
     test_row_slicing_operation_from_end_negative_start_stop();
 
     test_row_and_column_slicing_from_end_negative_start_stop();
+
+    test_col_slicing_operation_from_end_single_column();
+    test_row_slicing_operation_from_end_single_row();
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
This pull request adds the missing test cases in the negative index slicing operations.