### PR TITLE
Refactoring node_data for improved performance

### DIFF
--- a/cmake/Phylanx_SetupCompilerFlags.cmake
+++ b/cmake/Phylanx_SetupCompilerFlags.cmake
@@ -37,7 +37,7 @@ macro(phylanx_setup_compiler_flags)
 
       # Exceptions
       phylanx_add_target_compile_option(-EHsc)
-      if(MSVC14)
+      if(NOT (${MSVC_VERSION} LESS 1900))
         # assume conforming (throwing) operator new implementations
         phylanx_add_target_compile_option(/Zc:throwingNew)
 

--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -4,8 +4,10 @@
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
+
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/agas.hpp>
+#include <hpx/runtime_fwd.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -248,8 +250,6 @@ int hpx_main(boost::program_options::variables_map& vm)
     auto iterations = vm["num_iterations"].as<std::int64_t>();
     bool enable_output = vm.count("enable_output") != 0;
 
-    phylanx::ir::reset_node_statistics();
-
     // time execution
     hpx::util::high_resolution_timer t;
 
@@ -262,8 +262,6 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::cout << "Result: \n"
               << phylanx::execution_tree::extract_numeric_value(result) << "\n"
               << "Calculated in: " << elapsed << " seconds\n";
-
-    phylanx::ir::print_node_statistics();
 
     return hpx::finalize();
 }

--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -248,6 +248,8 @@ int hpx_main(boost::program_options::variables_map& vm)
     auto iterations = vm["num_iterations"].as<std::int64_t>();
     bool enable_output = vm.count("enable_output") != 0;
 
+    phylanx::ir::reset_node_statistics();
+
     // time execution
     hpx::util::high_resolution_timer t;
 
@@ -258,9 +260,10 @@ int hpx_main(boost::program_options::variables_map& vm)
     auto elapsed = t.elapsed();
 
     std::cout << "Result: \n"
-              << phylanx::execution_tree::extract_numeric_value(result)
-              << std::endl
-              << "Calculated in :" << elapsed << " seconds" << std::endl;
+              << phylanx::execution_tree::extract_numeric_value(result) << "\n"
+              << "Calculated in: " << elapsed << " seconds\n";
+
+    phylanx::ir::print_node_statistics();
 
     return hpx::finalize();
 }

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -76,7 +76,11 @@ namespace phylanx { namespace execution_tree { namespace compiler
         template <typename ... Ts>
         function operator()(Ts &&... ts) const
         {
-            std::list<function> elements = {std::forward<Ts>(ts)...};
+            std::list<function> elements;
+            int const sequencer_[] = {
+                0, (elements.emplace_back(std::forward<Ts>(ts)), 0)...
+            };
+            (void)sequencer_;
             return derived().compose(std::move(elements));
         }
 

--- a/phylanx/execution_tree/primitives/add_operation.hpp
+++ b/phylanx/execution_tree/primitives/add_operation.hpp
@@ -30,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         add_operation(std::vector<primitive_argument_type> && operands);
 
         hpx::future<primitive_result_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            std::vector<primitive_argument_type> const& args) const override;
     };
 }}}
 

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -62,8 +62,8 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type eval_direct(
             std::vector<primitive_argument_type> const& args) const;
 
-        hpx::future<void> store(primitive_argument_type const&);
-        void store(hpx::launch::sync_policy, primitive_argument_type const&);
+        hpx::future<void> store(primitive_argument_type);
+        void store(hpx::launch::sync_policy, primitive_argument_type);
 
         hpx::future<bool> bind(std::vector<primitive_argument_type> const&);
         bool bind(hpx::launch::sync_policy,
@@ -171,11 +171,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return eval(params).get();
         }
 
-        void store_nonvirtual(primitive_result_type const& data)
+        void store_nonvirtual(primitive_result_type data)
         {
-            store(data);
+            store(std::move(data));
         }
-        virtual void store(primitive_result_type const&)
+        virtual void store(primitive_result_type &&)
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "phylanx::execution_tree::primitives::base_primitive",

--- a/phylanx/execution_tree/primitives/define_variable.hpp
+++ b/phylanx/execution_tree/primitives/define_variable.hpp
@@ -39,7 +39,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // value as returned by evaluating the given body.
         primitive_result_type eval_direct(
             std::vector<primitive_argument_type> const& args) const override;
-        void store(primitive_result_type const& val) override;
+        void store(primitive_result_type && val) override;
 
     protected:
         std::string extract_function_name() const;

--- a/phylanx/execution_tree/primitives/variable.hpp
+++ b/phylanx/execution_tree/primitives/variable.hpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         primitive_result_type eval_direct(
             std::vector<primitive_argument_type> const& params) const override;
-        void store(primitive_result_type const& data) override;
+        void store(primitive_result_type && data) override;
         bool bind(std::vector<primitive_argument_type> const& params) override;
 
     private:

--- a/phylanx/util/serialization/blaze.hpp
+++ b/phylanx/util/serialization/blaze.hpp
@@ -122,6 +122,7 @@ namespace hpx { namespace serialization
         // Serialize vector
         std::size_t count = target.size();
         std::size_t spacing = target.spacing();
+        archive << count << spacing;
         archive << hpx::serialization::make_array(target.data(), spacing);
     }
 

--- a/phylanx/util/serialization/blaze.hpp
+++ b/phylanx/util/serialization/blaze.hpp
@@ -8,99 +8,98 @@
 
 #include <phylanx/config.hpp>
 #include <hpx/include/serialization.hpp>
+
 #include <blaze/Math.h>
 
 #include <cstddef>
 
 namespace hpx { namespace serialization
 {
+    ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    void load(input_archive& archive,
-        blaze::DynamicVector<T, blaze::columnVector>& target,
-        unsigned)
+    void load(input_archive& archive, blaze::DynamicVector<T>& target, unsigned)
     {
         // De-serialize Header
-        std::size_t count_ = 0UL;
-        archive >> count_;
-        target = blaze::DynamicVector<T, blaze::columnVector>(count_);
+        std::size_t count = 0UL;
+        archive >> count;
 
-        // DeserializeVector
-        T value{};
-        std::size_t j = 0UL;
-        // NOTE: I've assumed archive >> value always returns something
-        while (j != count_) {
-            archive >> value;
-            target[j] = value;
-            ++j;
-        }
+        target.resize(count, false);
+        archive >>
+            hpx::serialization::make_array(target.data(), target.spacing());
     }
 
     template <typename T>
-    void load(input_archive& archive,
-        blaze::DynamicMatrix<T>& target,
-        unsigned)
+    void load(input_archive& archive, blaze::DynamicMatrix<T>& target, unsigned)
     {
         // DeserializeHeader
-        std::size_t rows_ = 0UL;
-        std::size_t columns_ = 0UL;
+        std::size_t rows = 0UL;
+        std::size_t columns = 0UL;
+        archive >> rows >> columns;
 
-        archive >> rows_ >> columns_;
-        target = blaze::DynamicMatrix<T>(rows_, columns_);
-
-        // DeserializeMatrix
-        T value{};
-        for (std::size_t i = 0UL; i < rows_; ++i)
-        {
-            std::size_t j = 0UL;
-            // NOTE: I've assumed archive >> value always returns something
-            while (j != columns_) {
-                archive >> value;
-                target(i, j) = value;
-                ++j;
-            }
-        }
+        target.resize(rows, columns, false);
+        archive >> hpx::serialization::make_array(
+                       target.data(), target.spacing() * rows);
     }
 
+    template <typename T, bool AF, bool PF>
+    void load(input_archive& archive, blaze::CustomVector<T, AF, PF>& target,
+        unsigned)
+    {
+    }
+
+    template <typename T, bool AF, bool PF>
+    void load(input_archive& archive, blaze::CustomMatrix<T, AF, PF>& target,
+        unsigned)
+    {
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    void save(output_archive& archive,
-        blaze::DynamicVector<T, blaze::columnVector> const& target,
+    void save(output_archive& archive, blaze::DynamicVector<T> const& target,
         unsigned)
     {
         // SerializeVector
         archive << target.size();
-
-        // SerializeVector
-        for (std::size_t j = 0UL; j < target.size(); ++j)
-        {
-            archive << target[j];
-        }
+        archive << hpx::serialization::make_array(
+            target.data(), target.spacing());
     }
 
     template <typename T>
-    void save(output_archive& archive,
-        blaze::DynamicMatrix<T> const& target,
+    void save(output_archive& archive, blaze::DynamicMatrix<T> const& target,
         unsigned)
     {
         // Serialize header
         archive << target.rows() << target.columns();
-
-        // SerializeMatrix
-        for (std::size_t i = 0UL; i < target.rows(); ++i)
-        {
-            for (std::size_t j = 0UL; j < target.columns(); ++j)
-            {
-                archive << target(i, j);
-            }
-        }
+        archive << hpx::serialization::make_array(
+            target.data(), target.spacing() * target.rows());
     }
 
+    template <typename T, bool AF, bool PF>
+    void save(output_archive& archive,
+        blaze::CustomVector<T, AF, PF> const& target, unsigned)
+    {
+    }
+
+    template <typename T, bool AF, bool PF>
+    void save(output_archive& archive,
+        blaze::CustomMatrix<T, AF, PF> const& target, unsigned)
+    {
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
-        (template <typename T>),
-        (blaze::DynamicVector<T, blaze::columnVector>));
+        (template <typename T>), (blaze::DynamicVector<T>));
 
     HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
-        (template <typename T>),
-        (blaze::DynamicMatrix<T>));
+        (template <typename T>), (blaze::DynamicMatrix<T>));
+
+    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
+        (template <typename T, bool AF, bool PF>),
+        (blaze::CustomVector<T, AF, PF>));
+
+    HPX_SERIALIZATION_SPLIT_FREE_TEMPLATE(
+        (template <typename T, bool AF, bool PF>),
+        (blaze::CustomMatrix<T, AF, PF>));
 }}
 
 #endif

--- a/phylanx/util/serialization/blaze.hpp
+++ b/phylanx/util/serialization/blaze.hpp
@@ -44,7 +44,7 @@ namespace hpx { namespace serialization
 
         target.resize(rows, columns, false);
         archive >>
-            hpx::serialization::make_array(target.data(), rows * spacing);
+            hpx::serialization::make_array(target.data(), spacing * columns);
     }
 
     template <typename T>
@@ -59,7 +59,7 @@ namespace hpx { namespace serialization
 
         target.resize(rows, columns, false);
         archive >>
-            hpx::serialization::make_array(target.data(), spacing * columns);
+            hpx::serialization::make_array(target.data(), rows * spacing);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -98,7 +98,8 @@ namespace hpx { namespace serialization
         std::size_t columns = target.columns();
         std::size_t spacing = target.spacing();
         archive << rows << columns << spacing;
-        archive << hpx::serialization::make_array(target.data(), rows, spacing);
+        archive << hpx::serialization::make_array(
+            target.data(), spacing * columns);
     }
 
     template <typename T>
@@ -111,7 +112,7 @@ namespace hpx { namespace serialization
         std::size_t spacing = target.spacing();
         archive << rows << columns << spacing;
         archive << hpx::serialization::make_array(
-            target.data(), spacing * columns);
+            target.data(), rows * spacing);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -136,7 +137,7 @@ namespace hpx { namespace serialization
         std::size_t spacing = target.spacing();
         archive << rows << columns << spacing;
         archive << hpx::serialization::make_array(
-            target.data(), rows * spacing);
+            target.data(), spacing * columns);
     }
 
     template <typename T, bool AF, bool PF>
@@ -149,7 +150,7 @@ namespace hpx { namespace serialization
         std::size_t spacing = target.spacing();
         archive << rows << columns << spacing;
         archive << hpx::serialization::make_array(
-            target.data(), spacing * columns);
+            target.data(), rows * spacing);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,9 @@ add_phylanx_library_sources(phylanx
   GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/ir/*.cpp"
   APPEND)
 add_phylanx_library_sources(phylanx
+  GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/performance_counters/*.cpp"
+  APPEND)
+add_phylanx_library_sources(phylanx
   GLOB_RECURSE GLOBS "${PROJECT_SOURCE_DIR}/src/util/*.cpp"
   APPEND)
 

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "access_argument::eval_direct",
                 "argument count out of bounds: " + std::to_string(argnum_));
         }
-        return value_operand_sync(params[argnum_], params);
+        return value_operand_ref_sync(params[argnum_], params);
     }
 
     // Return whether this object could be evaluated using the given arguments

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -118,8 +118,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "to a vector only if there are exactly 2 operands");
                 }
 
-                args[1].vector(
-                    blaze::map(args[1].vector(), add_simd(args[0].scalar())));
+                args[1] =
+                    blaze::map(args[1].vector(), add_simd(args[0].scalar()));
 
                 return primitive_result_type(std::move(args[1]));
             }
@@ -134,8 +134,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "to a matrix only if there are exactly 2 operands");
                 }
 
-                args[1].matrix(
-                    blaze::map(args[1].matrix(), add_simd(args[0].scalar())));
+                args[1] =
+                    blaze::map(args[1].matrix(), add_simd(args[0].scalar()));
 
                 return primitive_result_type(std::move(args[1]));
             }
@@ -172,8 +172,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "to a vector only if there are exactly 2 operands");
                 }
 
-                args[0].vector(
-                    blaze::map(args[0].vector(), add_simd(args[1].scalar())));
+                args[0] =
+                    blaze::map(args[0].vector(), add_simd(args[1].scalar()));
 
                 return primitive_result_type(std::move(args[0]));
             }
@@ -195,7 +195,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 if (args.size() == 2)
                 {
-                    lhs.vector() += rhs.vector();
+                    lhs.custom_vector() += rhs.custom_vector();
                     return primitive_result_type(std::move(lhs));
                 }
 
@@ -204,7 +204,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     args.begin() + 1, args.end(), std::move(first_term),
                     [](arg_type& result, arg_type const& curr) -> arg_type
                     {
-                        result.vector() += curr.vector();
+                        result.custom_vector() += curr.custom_vector();
                         return std::move(result);
                     }));
             }
@@ -266,7 +266,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "to a matrix only if there are exactly 2 operands");
                 }
 
-                args[0].matrix() =
+                args[0] =
                     blaze::map(args[0].matrix(), add_simd(args[1].scalar()));
                 return primitive_result_type(std::move(args[0]));
             }
@@ -313,7 +313,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 if (args.size() == 2)
                 {
-                    lhs.matrix() += rhs.matrix();
+                    lhs.custom_matrix() += rhs.custom_matrix();
                     return primitive_result_type(std::move(lhs));
                 }
 
@@ -323,7 +323,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     [](arg_type& result, arg_type const& curr)
                     ->  arg_type
                     {
-                        result.matrix() += curr.matrix();
+                        result.custom_matrix() += curr.custom_matrix();
                         return std::move(result);
                     }));
             }

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -108,16 +108,17 @@ namespace phylanx { namespace execution_tree
         return eval_direct(params);
     }
 
-    hpx::future<void> primitive::store(primitive_argument_type const& data)
+    hpx::future<void> primitive::store(primitive_argument_type data)
     {
         using action_type = primitives::base_primitive::store_action;
-        return hpx::async(action_type(), this->base_type::get_id(), data);
+        return hpx::async(
+            action_type(), this->base_type::get_id(), std::move(data));
     }
 
     void primitive::store(hpx::launch::sync_policy,
-        primitive_argument_type const& data)
+        primitive_argument_type data)
     {
-        return store(data).get();
+        return store(std::move(data)).get();
     }
 
     hpx::future<bool> primitive::bind(

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -158,7 +158,73 @@ namespace phylanx { namespace execution_tree
             "primitive_argument_type does not hold a value type");
     }
 
-    primitive_argument_type && extract_value(primitive_argument_type&& val)
+    primitive_argument_type extract_copy_value(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+        case 1:     // bool
+        case 2:     // std::uint64_t
+        case 3:     // std::string
+        case 5:     // primitive
+        case 6:     // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return val;
+
+        case 4:     // phylanx::ir::node_data<double>
+            {
+                auto const& v = util::get<4>(val);
+                if (v.is_ref())
+                {
+                    return v.copy();
+                }
+                return v;
+            }
+            break;
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_copy_value",
+            "primitive_argument_type does not hold a value type");
+    }
+
+    primitive_argument_type extract_ref_value(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+        case 1:     // bool
+        case 2:     // std::uint64_t
+        case 3:     // std::string
+        case 5:     // primitive
+        case 6:     // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return val;
+
+        case 4:     // phylanx::ir::node_data<double>
+            {
+                auto const& v = util::get<4>(val);
+                if (v.is_ref())
+                {
+                    return v;
+                }
+                return v.ref();
+            }
+            break;
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_ref_value",
+            "primitive_argument_type does not hold a value type");
+    }
+
+    primitive_argument_type extract_value(primitive_argument_type&& val)
     {
         switch (val.index())
         {
@@ -171,6 +237,72 @@ namespace phylanx { namespace execution_tree
         case 6:     // std::vector<ast::expression>
         case 7:     // std::vector<primitive_argument_type>
             return std::move(val);
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_value",
+            "primitive_argument_type does not hold a value type");
+    }
+
+    primitive_argument_type extract_copy_value(primitive_argument_type&& val)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+        case 1:     // bool
+        case 2:     // std::uint64_t
+        case 3:     // std::string
+        case 5:     // primitive
+        case 6:     // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return std::move(val);
+
+        case 4:     // phylanx::ir::node_data<double>
+            {
+                auto && v = util::get<4>(std::move(val));
+                if (v.is_ref())
+                {
+                    return v.copy();
+                }
+                return std::move(v);
+            }
+            break;
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_value",
+            "primitive_argument_type does not hold a value type");
+    }
+
+    primitive_argument_type extract_ref_value(primitive_argument_type&& val)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+        case 1:     // bool
+        case 2:     // std::uint64_t
+        case 3:     // std::string
+        case 5:     // primitive
+        case 6:     // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return std::move(val);
+
+        case 4:     // phylanx::ir::node_data<double>
+            {
+                auto && v = util::get<4>(std::move(val));
+                if (v.is_ref())
+                {
+                    return std::move(v);
+                }
+                return v.ref();
+            }
+            break;
 
         default:
             break;
@@ -201,6 +333,38 @@ namespace phylanx { namespace execution_tree
 
         case 4:     // phylanx::ir::node_data<double>
             return util::get<4>(val);
+
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_literal_value",
+            "primitive_argument_type does not hold a literal value type");
+    }
+
+    primitive_argument_type extract_literal_ref_value(
+        primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+            return ast::nil{};
+
+        case 1:     // bool
+            return util::get<1>(val);
+
+        case 2:     // std::uint64_t
+            return util::get<2>(val);
+
+        case 3:     // std::string
+            return util::get<3>(val);
+
+        case 4:     // phylanx::ir::node_data<double>
+            return util::get<4>(val).ref();
 
         case 5: HPX_FALLTHROUGH;    // primitive
         case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
@@ -258,7 +422,7 @@ namespace phylanx { namespace execution_tree
             return ir::node_data<double>{double(util::get<2>(val))};
 
         case 4:     // phylanx::ir::node_data<double>
-            return util::get<4>(val);
+            return util::get<4>(val).ref();
 
         case 0: HPX_FALLTHROUGH;    // nil
         case 3: HPX_FALLTHROUGH;    // string
@@ -649,14 +813,14 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
         {
             return p->eval(args).then(
-                [&args](hpx::future<primitive_argument_type> && f)
+                [](hpx::future<primitive_argument_type> && f)
                 {
                     return extract_value(f.get());
                 });
         }
 
         HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(extract_value(val));
+        return hpx::make_ready_future(extract_ref_value(val));
     }
 
     primitive_argument_type value_operand_sync(
@@ -673,6 +837,20 @@ namespace phylanx { namespace execution_tree
         return extract_value(val);
     }
 
+    primitive_argument_type value_operand_ref_sync(
+        primitive_argument_type const& val,
+        std::vector<primitive_argument_type> const& args)
+    {
+        primitive const* p = util::get_if<primitive>(&val);
+        if (p != nullptr)
+        {
+            return extract_value(p->eval_direct(args));
+        }
+
+        HPX_ASSERT(valid(val));
+        return extract_ref_value(val);
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type const& val,
@@ -682,14 +860,14 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
         {
             return p->eval(args).then(
-                [&args](hpx::future<primitive_argument_type> && f)
+                [](hpx::future<primitive_argument_type> && f)
                 {
                     return extract_literal_value(f.get());
                 });
         }
 
         HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(extract_literal_value(val));
+        return hpx::make_ready_future(extract_literal_ref_value(val));
     }
 
     primitive_argument_type literal_operand_sync(
@@ -703,7 +881,7 @@ namespace phylanx { namespace execution_tree
         }
 
         HPX_ASSERT(valid(val));
-        return extract_literal_value(val);
+        return extract_literal_ref_value(val);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -104,19 +104,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 using storage1d_type = typename arg_type::storage1d_type;
 
+                auto arg0 = args[0].vector();
+
                 if (col_start < 0 && col_stop <= 0)    // slice from the end
                 {
-                    auto size = args[0].vector().size();
-
-                    auto sv = blaze::subvector(args[0].vector(),
-                        size + col_start, -col_start + col_stop);
+                    auto sv = blaze::subvector(
+                        arg0, arg0.size() + col_start, -col_start + col_stop);
 
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};
                 }
 
-                auto sv = blaze::subvector(
-                    args[0].vector(), col_start, col_stop - col_start);
+                auto sv =
+                    blaze::subvector(arg0, col_start, col_stop - col_start);
 
                 storage1d_type v{sv};
                 return ir::node_data<double>(std::move(v));
@@ -166,16 +166,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 using storage1d_type = typename arg_type::storage1d_type;
                 using storage2d_type = typename arg_type::storage2d_type;
 
+                auto arg0 = args[0].matrix();
+
                 if (col_start < 0 && col_stop <= 0)
                 {
-                    auto num_cols = args[0].matrix().columns();
+                    auto num_cols = arg0.columns();
 
                     // return a vector and not a matrix if the slice contains
                     // exactly one column
                     if (col_stop - col_start == 1)
                     {
                         auto sv = blaze::column(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 0, num_cols + col_start,
                                 num_matrix_rows, 1),
                             0);
@@ -184,7 +186,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         return ir::node_data<double>{std::move(v)};
                     }
 
-                    auto sm = blaze::submatrix(args[0].matrix(),
+                    auto sm = blaze::submatrix(arg0,
                         0, num_cols + col_start,
                         num_matrix_rows, -col_start + col_stop);
 
@@ -195,7 +197,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (col_stop - col_start == 1)
                 {
                     auto sv = blaze::column(
-                        blaze::submatrix(args[0].matrix(),
+                        blaze::submatrix(arg0,
                             0, col_start,
                             num_matrix_rows, 1),
                         0);
@@ -204,7 +206,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     return ir::node_data<double>{std::move(v)};
                 }
 
-                auto sm = blaze::submatrix(args[0].matrix(),
+                auto sm = blaze::submatrix(arg0,
                     0, col_start,
                     num_matrix_rows, col_stop - col_start);
 

--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Bibek Wagle
+//  Copyright (c) 2017 Bibek Wagle
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +7,6 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/column_slicing.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -57,12 +57,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             using arg_type = ir::node_data<double>;
             using args_type = std::vector<arg_type>;
 
-            using matrix_type = blaze::DynamicMatrix<double>;
-            using submatrix_type = blaze::Submatrix<matrix_type>;
-
-            using vector_type = blaze::DynamicVector<double>;
-            using subvector_type = blaze::Subvector<vector_type>;
-
             primitive_result_type column_slicing0d(args_type && args) const
             {
                 // return the input as it is if the input is of zero dimension or
@@ -108,20 +102,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "col_stop can not be negative if col_start is positive");
                 }
 
+                using storage1d_type = typename arg_type::storage1d_type;
+
                 if (col_start < 0 && col_stop <= 0)    // slice from the end
                 {
                     auto size = args[0].vector().size();
 
-                    subvector_type sv = blaze::subvector(args[0].vector(),
+                    auto sv = blaze::subvector(args[0].vector(),
                         size + col_start, -col_start + col_stop);
 
-                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                    storage1d_type v{sv};
+                    return ir::node_data<double>{std::move(v)};
                 }
 
-                subvector_type sv = blaze::subvector(
+                auto sv = blaze::subvector(
                     args[0].vector(), col_start, col_stop - col_start);
 
-                return ir::node_data<double>(vector_type(std::move(sv)));
+                storage1d_type v{sv};
+                return ir::node_data<double>(std::move(v));
             }
 
             primitive_result_type column_slicing2d(args_type && args) const
@@ -165,28 +163,53 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "negative");
                 }
 
+                using storage1d_type = typename arg_type::storage1d_type;
+                using storage2d_type = typename arg_type::storage2d_type;
+
                 if (col_start < 0 && col_stop <= 0)
                 {
                     auto num_cols = args[0].matrix().columns();
 
-                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
+                    // return a vector and not a matrix if the slice contains
+                    // exactly one column
+                    if (col_stop - col_start == 1)
+                    {
+                        auto sv = blaze::column(
+                            blaze::submatrix(args[0].matrix(),
+                                0, num_cols + col_start,
+                                num_matrix_rows, 1),
+                            0);
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
+                    }
+
+                    auto sm = blaze::submatrix(args[0].matrix(),
                         0, num_cols + col_start,
                         num_matrix_rows, -col_start + col_stop);
 
-                    if (col_stop - col_start == 1)
-                    {
-                        return ir::node_data<double>{column(sm, 0)};
-                    }
-
-                    return ir::node_data<double>{matrix_type{std::move(sm)}};
+                    storage2d_type m{sm};
+                    return ir::node_data<double>{std::move(m)};
                 }
 
-                submatrix_type sm =
-                    blaze::submatrix(args[0].matrix(),
-                        0, col_start,
-                        num_matrix_rows, col_stop - col_start);
+                if (col_stop - col_start == 1)
+                {
+                    auto sv = blaze::column(
+                        blaze::submatrix(args[0].matrix(),
+                            0, col_start,
+                            num_matrix_rows, 1),
+                        0);
 
-                return ir::node_data<double>(matrix_type(std::move(sm)));
+                    storage1d_type v{sv};
+                    return ir::node_data<double>{std::move(v)};
+                }
+
+                auto sm = blaze::submatrix(args[0].matrix(),
+                    0, col_start,
+                    num_matrix_rows, col_stop - col_start);
+
+                storage2d_type m{sm};
+                return ir::node_data<double>{std::move(m)};
             }
 
         public:

--- a/src/execution_tree/primitives/define_function.cpp
+++ b/src/execution_tree/primitives/define_function.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -70,7 +70,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 p->eval_direct(args);
             }
 
-            return target_;
+            return extract_ref_value(target_);
         }
 
         // just evaluate the expression bound to this name
@@ -79,7 +79,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             return extract_value(p->eval_direct(args));
         }
-        return extract_value(target_);
+        return extract_ref_value(target_);
     }
 
     void define_function::set_body(primitive_argument_type&& body)

--- a/src/execution_tree/primitives/define_variable.cpp
+++ b/src/execution_tree/primitives/define_variable.cpp
@@ -84,7 +84,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return extract_value(target_);
     }
 
-    void define_variable::store(primitive_result_type const& val)
+    void define_variable::store(primitive_result_type && val)
     {
         if (!valid(target_))
         {
@@ -102,6 +102,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "the variable associated with this define has not been "
                     "properly initialized");
         }
-        p->store(hpx::launch::sync, val);
+        p->store(hpx::launch::sync, std::move(val));
     }
 }}}

--- a/src/execution_tree/primitives/define_variable.cpp
+++ b/src/execution_tree/primitives/define_variable.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -72,7 +72,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 p->eval_direct(args);
             }
 
-            return target_;
+            return extract_ref_value(target_);
         }
 
         // just evaluate the expression bound to this name
@@ -81,7 +81,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             return extract_value(p->eval_direct(args));
         }
-        return extract_value(target_);
+
+        return extract_ref_value(target_);
     }
 
     void define_variable::store(primitive_result_type && val)

--- a/src/execution_tree/primitives/determinant.cpp
+++ b/src/execution_tree/primitives/determinant.cpp
@@ -7,7 +7,6 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/determinant.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>

--- a/src/execution_tree/primitives/dot_operation.cpp
+++ b/src/execution_tree/primitives/dot_operation.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //  Copyright (c) 2017 Parsa Amini
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,7 +7,6 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/dot_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -63,7 +62,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 ops[0].scalar() *= ops[1].scalar();
-                return std::move(ops[0]);
+                return ir::node_data<double>{std::move(ops[0])};
             }
 
             // lhs_num_dims == 1
@@ -103,9 +102,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 // lhs.dimension(0) == rhs.dimension(0)
-                lhs.scalar(blaze::dot(lhs.vector(), rhs.vector()));
-
-                return std::move(lhs);
+                lhs = double(blaze::dot(lhs.vector(), rhs.vector()));
+                return ir::node_data<double>{std::move(lhs)};
             }
 
             primitive_result_type dot1d2d(
@@ -118,9 +116,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "the operands have incompatible number of dimensions");
                 }
 
-                lhs.vector() =
-                    blaze::trans(blaze::trans(lhs.vector()) * rhs.matrix());
-                return std::move(lhs);
+                lhs = blaze::trans(blaze::trans(lhs.vector()) * rhs.matrix());
+                return ir::node_data<double>{std::move(lhs)};
             }
 
             // lhs_num_dims == 2
@@ -156,9 +153,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "the operands have incompatible number of dimensions");
                 }
 
-                rhs.vector(lhs.matrix() * rhs.vector());
-
-                return std::move(rhs);
+                rhs = lhs.matrix() * rhs.vector();
+                return ir::node_data<double>{std::move(rhs)};
             }
 
             primitive_result_type dot2d2d(
@@ -171,8 +167,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "the operands have incompatible number of dimensions");
                 }
 
-                lhs.matrix() *= rhs.matrix();
-                return std::move(lhs);
+                lhs = lhs.matrix() * rhs.matrix();
+                return ir::node_data<double>{std::move(lhs)};
             }
 
         public:

--- a/src/execution_tree/primitives/exponential_operation.cpp
+++ b/src/execution_tree/primitives/exponential_operation.cpp
@@ -1,7 +1,8 @@
-//   Copyright (c) 2017 Bibek Wagle
+//  Copyright (c) 2017 Bibek Wagle
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/exponential_operation.hpp>
@@ -56,7 +57,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         protected:
             ir::node_data<double> exponential0d(operands_type&& ops) const
             {
-                ops[0].scalar(std::exp(ops[0].scalar()));
+                ops[0] = double(std::exp(ops[0].scalar()));
                 return std::move(ops[0]);
             }
 

--- a/src/execution_tree/primitives/file_read_csv.cpp
+++ b/src/execution_tree/primitives/file_read_csv.cpp
@@ -136,8 +136,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
 
             // vector
-            blaze::DynamicVector<double> vector(
-                n_cols, matrix_array.data());
+            blaze::DynamicVector<double> vector(n_cols, matrix_array.data());
 
             return hpx::make_ready_future(primitive_result_type{
                 ir::node_data<double>{std::move(vector)}});

--- a/src/execution_tree/primitives/file_write_csv.cpp
+++ b/src/execution_tree/primitives/file_write_csv.cpp
@@ -76,7 +76,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 case 1:
                     {
-                        blaze::DynamicVector<double> const& v = val.vector();
+                        auto v = val.vector();
                         for (std::size_t i = 0UL; i != v.size(); ++i)
                         {
                             if (i != 0)
@@ -91,7 +91,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 case 2:
                     {
-                        blaze::DynamicMatrix<double> const& matrix = val.matrix();
+                        auto matrix = val.matrix();
                         for (std::size_t i = 0UL; i != matrix.rows(); ++i)
                         {
                             outfile << matrix(i, 0);

--- a/src/execution_tree/primitives/for_operation.cpp
+++ b/src/execution_tree/primitives/for_operation.cpp
@@ -61,8 +61,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "arguments");
                 }
 
-                if (!valid(operands_[0]) || !valid(operands_[1])
-                    || !valid(operands_[2]) || !valid(operands_[3]))
+                if (!valid(operands_[0]) || !valid(operands_[1]) ||
+                    !valid(operands_[2]) || !valid(operands_[3]))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "phylanx::execution_tree::primitives::for_operation::"
@@ -76,7 +76,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 auto this_ = this->shared_from_this();
                 return literal_operand(operands_[0], args_).then(
-                    [this_](auto val)
+                    [this_](hpx::future<primitive_result_type> && val)
                     {
                         val.get();
                         return this_->loop();

--- a/src/execution_tree/primitives/inverse_operation.cpp
+++ b/src/execution_tree/primitives/inverse_operation.cpp
@@ -1,4 +1,4 @@
-//   Copyright (c) 2017 Hartmut Kaiser
+//   Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,7 +7,6 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/inverse_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -114,9 +113,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "matrices to inverse have to be quadratic");
                 }
 
-                using matrix_type = blaze::DynamicMatrix<double>;
-
-                blaze::invert(ops[0].matrix());
+                if (ops[0].is_ref())
+                {
+                    ops[0] = blaze::inv(ops[0].matrix());
+                }
+                else
+                {
+                    blaze::invert(ops[0].matrix_non_ref());
+                }
                 return std::move(ops[0]);
             }
         };

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //  Copyright (c) 2017 Alireza Kheirkhahan
 //  Copyright (c) 2017 Parsa Amini
 //
@@ -116,7 +116,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& lhs = ops[0];
                 operand_type& rhs = ops[1];
 
-                rhs.custom_vector() *= lhs.scalar();
+                rhs = rhs.vector() * lhs.scalar();
                 return primitive_result_type{ std::move(rhs) };
             }
 
@@ -133,7 +133,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& lhs = ops[0];
                 operand_type& rhs = ops[1];
 
-                rhs.custom_matrix() *= lhs.scalar();
+                rhs = rhs.matrix() * lhs.scalar();
                 return primitive_result_type{ std::move(rhs) };
             }
 
@@ -170,7 +170,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& lhs = ops[0];
                 operand_type& rhs = ops[1];
 
-                lhs.custom_vector() *= rhs.scalar();
+                lhs = lhs.vector() * rhs.scalar();
                 return primitive_result_type{ std::move(lhs) };
             }
 
@@ -178,7 +178,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (ops.size() == 2)
                 {
-                    ops[0].custom_vector() *= ops[1].custom_vector();
+                    ops[0] = ops[0].vector() * ops[1].vector();
                     return primitive_result_type{ std::move(ops[0]) };
                 }
 
@@ -194,7 +194,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "mul_operation::mul1d1d",
                                     "all operands must be vectors");
                             }
-                            result.custom_vector() *= curr.custom_vector();
+                            result = result.vector() * curr.vector();
                             return std::move(result);
                         })
                     };
@@ -213,7 +213,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& rhs = ops[1];
 
                 rhs = blaze::trans(
-                    blaze::trans(lhs.custom_vector()) * rhs.custom_matrix());
+                    blaze::trans(lhs.vector()) * rhs.matrix());
                 return primitive_result_type{ std::move(rhs) };
             }
 
@@ -249,7 +249,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& lhs = ops[0];
                 operand_type& rhs = ops[1];
 
-                lhs.custom_matrix() *= rhs.scalar();
+                lhs = lhs.matrix() * rhs.scalar();
                 return primitive_result_type{ std::move(lhs) };
             }
 
@@ -265,7 +265,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& lhs = ops[0];
                 operand_type& rhs = ops[1];
 
-                rhs = lhs.custom_matrix() * rhs.custom_vector();
+                rhs = lhs.matrix() * rhs.vector();
                 return primitive_result_type{ std::move(rhs) };
             }
 
@@ -273,7 +273,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (ops.size() == 2)
                 {
-                    ops[0].custom_matrix() *= ops[1].custom_matrix();
+                    ops[0] = ops[0].matrix() * ops[1].matrix();
                     return primitive_result_type{ std::move(ops[0]) };
                 }
 
@@ -290,7 +290,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "all operands must be matrices");
                             }
 
-                            result.custom_matrix() *= curr.custom_matrix();
+                            result = result.matrix() * curr.matrix();
                             return std::move(result);
                         })
                     };

--- a/src/execution_tree/primitives/power_operation.cpp
+++ b/src/execution_tree/primitives/power_operation.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Parsa Amini
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +7,6 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/power_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -55,7 +55,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             primitive_result_type power0d(operands_type && ops) const
             {
-                ops[0].scalar(std::pow(ops[0].scalar(), ops[1][0]));
+                ops[0] = double(std::pow(ops[0].scalar(), ops[1][0]));
                 return std::move(ops[0]);
             }
 
@@ -64,7 +64,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& lhs = ops[0];
                 operand_type& rhs = ops[1];
 
-                lhs.vector(blaze::pow(lhs.vector(), rhs[0]));
+                lhs = blaze::pow(lhs.vector(), rhs[0]);
 
                 return std::move(lhs);
             }
@@ -74,7 +74,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 operand_type& lhs = ops[0];
                 operand_type& rhs = ops[1];
 
-                lhs.matrix(blaze::pow(lhs.matrix(), rhs[0]));
+                lhs = blaze::pow(lhs.matrix(), rhs[0]);
 
                 return std::move(lhs);
             }

--- a/src/execution_tree/primitives/random.cpp
+++ b/src/execution_tree/primitives/random.cpp
@@ -7,7 +7,6 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/random.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>

--- a/src/execution_tree/primitives/row_slicing.cpp
+++ b/src/execution_tree/primitives/row_slicing.cpp
@@ -115,16 +115,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 using storage1d_type = typename arg_type::storage1d_type;
                 using storage2d_type = typename arg_type::storage2d_type;
 
+                auto arg0 = args[0].matrix();
+
                 if (row_start < 0 && row_stop <= 0)
                 {
-                    auto num_rows = args[0].matrix().rows();
+                    auto num_rows = arg0.rows();
 
                     // return a vector and not a matrix if the slice contains
                     // exactly one row
                     if (row_stop - row_start == 1)
                     {
                         auto sv = blaze::trans(blaze::row(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 num_rows + row_start, 0,
                                 1, num_matrix_cols),
                             0));
@@ -133,7 +135,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         return ir::node_data<double>{std::move(v)};
                     }
 
-                    auto sm = blaze::submatrix(args[0].matrix(),
+                    auto sm = blaze::submatrix(arg0,
                         num_rows + row_start, 0,
                         -row_start + row_stop, num_matrix_cols);
 
@@ -146,7 +148,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (row_stop - row_start == 1)
                 {
                     auto sv = blaze::trans(blaze::row(
-                        blaze::submatrix(args[0].matrix(),
+                        blaze::submatrix(arg0,
                             row_start, 0,
                             1, num_matrix_cols),
                         0));
@@ -155,7 +157,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     return ir::node_data<double>{std::move(v)};
                 }
 
-                auto sm = blaze::submatrix(args[0].matrix(),
+                auto sm = blaze::submatrix(arg0,
                     row_start, 0,
                     row_stop - row_start, num_matrix_cols);
 

--- a/src/execution_tree/primitives/row_slicing.cpp
+++ b/src/execution_tree/primitives/row_slicing.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2017 Bibek Wagle
+//  Copyright (c) 2017 Bibek Wagle
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +7,6 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/row_slicing.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -55,9 +55,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         protected:
             using arg_type = ir::node_data<double>;
             using args_type = std::vector<arg_type>;
-
-            using matrix_type = blaze::DynamicMatrix<double>;
-            using submatrix_type = blaze::Submatrix<matrix_type>;
 
             primitive_result_type row_slicing0or1d(args_type && args) const
             {
@@ -115,30 +112,55 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "row_stop can not be negative if row_start is positive");
                 }
 
+                using storage1d_type = typename arg_type::storage1d_type;
+                using storage2d_type = typename arg_type::storage2d_type;
+
                 if (row_start < 0 && row_stop <= 0)
                 {
                     auto num_rows = args[0].matrix().rows();
 
-                    submatrix_type sm =
-                        blaze::submatrix(args[0].matrix(),
-                            num_rows + row_start, 0,
-                            -row_start + row_stop, num_matrix_cols);
-
+                    // return a vector and not a matrix if the slice contains
+                    // exactly one row
                     if (row_stop - row_start == 1)
                     {
-                        //return a vector in this case and not a matrix
-                        return ir::node_data<double>{blaze::trans(row(sm, 0))};
+                        auto sv = blaze::trans(blaze::row(
+                            blaze::submatrix(args[0].matrix(),
+                                num_rows + row_start, 0,
+                                1, num_matrix_cols),
+                            0));
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
                     }
 
-                    return ir::node_data<double>{matrix_type{std::move(sm)}};
+                    auto sm = blaze::submatrix(args[0].matrix(),
+                        num_rows + row_start, 0,
+                        -row_start + row_stop, num_matrix_cols);
+
+                    storage2d_type m{sm};
+                    return ir::node_data<double>{std::move(m)};
                 }
 
-                submatrix_type sm =
-                    blaze::submatrix(args[0].matrix(),
-                        row_start, 0,
-                        row_stop - row_start, num_matrix_cols);
+                // return a vector and not a matrix if the slice contains
+                // exactly one row
+                if (row_stop - row_start == 1)
+                {
+                    auto sv = blaze::trans(blaze::row(
+                        blaze::submatrix(args[0].matrix(),
+                            row_start, 0,
+                            1, num_matrix_cols),
+                        0));
 
-                return ir::node_data<double>{matrix_type{std::move(sm)}};
+                    storage1d_type v{sv};
+                    return ir::node_data<double>{std::move(v)};
+                }
+
+                auto sm = blaze::submatrix(args[0].matrix(),
+                    row_start, 0,
+                    row_stop - row_start, num_matrix_cols);
+
+                storage2d_type m{sm};
+                return ir::node_data<double>{std::move(m)};
             }
 
         public:

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -100,19 +100,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 using storage1d_type = typename arg_type::storage1d_type;
+
+                auto arg0 = args[0].vector();
+
                 if (col_start < 0 && col_stop <= 0)    // slice from the end
                 {
-                    auto size = args[0].vector().size();
-
-                    auto sv = blaze::subvector(args[0].vector(),
-                        size + col_start, -col_start + col_stop);
+                    auto sv = blaze::subvector(
+                        arg0, arg0.size() + col_start, -col_start + col_stop);
 
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};
                 }
 
-                auto sv = blaze::subvector(
-                    args[0].vector(), col_start, col_stop - col_start);
+                auto sv =
+                    blaze::subvector(arg0, col_start, col_stop - col_start);
 
                 storage1d_type v{sv};
                 return ir::node_data<double>{std::move(v)};
@@ -176,17 +177,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 using storage1d_type = typename arg_type::storage1d_type;
                 using storage2d_type = typename arg_type::storage2d_type;
 
+                auto arg0 = args[0].matrix();
+
                 if (col_start < 0 && col_stop <= 0 && row_start >= 0 &&
                     row_stop > 0)    //column slice from the end
                 {
-                    auto num_cols = args[0].matrix().columns();
+                    auto num_cols = arg0.columns();
 
                     // return a vector and not a matrix if the slice contains
                     // exactly one row/column
                     if (row_stop - row_start == 1)
                     {
                         auto sv = blaze::trans(blaze::row(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 row_start, num_cols + col_start,
                                 1, -col_start + col_stop),
                             0));
@@ -197,7 +200,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     if (col_stop - col_start == 1)
                     {
                         auto sv = blaze::column(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 row_start, num_cols + col_start,
                                 row_stop - row_start, 1),
                             0);
@@ -206,7 +209,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         return ir::node_data<double>{std::move(v)};
                     }
 
-                    auto sm = blaze::submatrix(args[0].matrix(),
+                    auto sm = blaze::submatrix(arg0,
                         row_start, num_cols + col_start,
                         row_stop - row_start, -col_start + col_stop);
 
@@ -217,14 +220,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (row_start < 0 && row_stop <= 0 && col_start >= 0 &&
                     col_stop > 0)    // row slice from the end
                 {
-                    auto num_rows = args[0].matrix().rows();
+                    auto num_rows = arg0.rows();
 
                     // return a vector and not a matrix if the slice contains
                     // exactly one row/column
                     if (row_stop - row_start == 1)
                     {
                         auto sv = blaze::trans(blaze::row(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 num_rows + row_start, col_start,
                                 1, col_stop - col_start),
                             0));
@@ -235,7 +238,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     if (col_stop - col_start == 1)
                     {
                         auto sv = blaze::column(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 num_rows + row_start, col_start,
                                 -row_start + row_stop, 1),
                             0);
@@ -244,7 +247,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         return ir::node_data<double>{std::move(v)};
                     }
 
-                    auto sm = blaze::submatrix(args[0].matrix(),
+                    auto sm = blaze::submatrix(arg0,
                         num_rows + row_start, col_start,
                         -row_start + row_stop, col_stop - col_start);
 
@@ -255,15 +258,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (row_start < 0 && row_stop <= 0 && col_start < 0 &&
                     col_stop <= 0)    // row and column , both, slice from end
                 {
-                    auto num_rows = args[0].matrix().rows();
-                    auto num_cols = args[0].matrix().columns();
+                    auto num_rows = arg0.rows();
+                    auto num_cols = arg0.columns();
 
                     // return a vector and not a matrix if the slice contains
                     // exactly one row/column
                     if (row_stop - row_start == 1)
                     {
                         auto sv = blaze::trans(blaze::row(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 num_rows + row_start, num_cols + col_start,
                                 1, -col_start + col_stop),
                             0));
@@ -274,7 +277,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     if (col_stop - col_start == 1)
                     {
                         auto sv = blaze::column(
-                            blaze::submatrix(args[0].matrix(),
+                            blaze::submatrix(arg0,
                                 num_rows + row_start, num_cols + col_start,
                                 -row_start + row_stop, 1),
                             0);
@@ -283,7 +286,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         return ir::node_data<double>{std::move(v)};
                     }
 
-                    auto sm = blaze::submatrix(args[0].matrix(),
+                    auto sm = blaze::submatrix(arg0,
                         num_rows + row_start, num_cols + col_start,
                         -row_start + row_stop, -col_start + col_stop);
 
@@ -296,7 +299,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (row_stop - row_start == 1)
                 {
                     auto sv = blaze::trans(blaze::row(
-                        blaze::submatrix(args[0].matrix(),
+                        blaze::submatrix(arg0,
                             row_start, col_start,
                             1, col_stop - col_start),
                         0));
@@ -307,7 +310,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (col_stop - col_start == 1)
                 {
                     auto sv = blaze::column(
-                        blaze::submatrix(args[0].matrix(),
+                        blaze::submatrix(arg0,
                             row_start, col_start,
                             row_stop - row_start, 1),
                         0);
@@ -316,7 +319,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     return ir::node_data<double>{std::move(v)};
                 }
 
-                auto sm = blaze::submatrix(args[0].matrix(),
+                auto sm = blaze::submatrix(arg0,
                     row_start, col_start,
                     row_stop - row_start, col_stop - col_start);
 

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Bibek Wagle
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +7,6 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/slicing_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -56,12 +56,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             using arg_type = ir::node_data<double>;
             using args_type = std::vector<arg_type>;
 
-            using matrix_type = blaze::DynamicMatrix<double>;
-            using submatrix_type = blaze::Submatrix<matrix_type>;
-
-            using vector_type = blaze::DynamicVector<double>;
-            using subvector_type = blaze::Subvector<vector_type>;
-
             primitive_result_type slicing0d(args_type && args) const
             {
                 // return the input as it is if the input is of zero dimensions
@@ -105,20 +99,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "negative");
                 }
 
+                using storage1d_type = typename arg_type::storage1d_type;
                 if (col_start < 0 && col_stop <= 0)    // slice from the end
                 {
                     auto size = args[0].vector().size();
 
-                    subvector_type sv = blaze::subvector(args[0].vector(),
-                        size + col_start, (-col_start) + col_stop);
+                    auto sv = blaze::subvector(args[0].vector(),
+                        size + col_start, -col_start + col_stop);
 
-                    return ir::node_data<double>{vector_type{std::move(sv)}};
+                    storage1d_type v{sv};
+                    return ir::node_data<double>{std::move(v)};
                 }
 
-                subvector_type sv = blaze::subvector(
-                    args[0].vector(), col_start, (col_stop - col_start));
+                auto sv = blaze::subvector(
+                    args[0].vector(), col_start, col_stop - col_start);
 
-                return ir::node_data<double>{vector_type{std::move(sv)}};
+                storage1d_type v{sv};
+                return ir::node_data<double>{std::move(v)};
             }
 
             primitive_result_type slicing2d(args_type&& args) const
@@ -176,26 +173,45 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "col_start/row_start is positive");
                 }
 
+                using storage1d_type = typename arg_type::storage1d_type;
+                using storage2d_type = typename arg_type::storage2d_type;
+
                 if (col_start < 0 && col_stop <= 0 && row_start >= 0 &&
                     row_stop > 0)    //column slice from the end
                 {
                     auto num_cols = args[0].matrix().columns();
 
-                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
-                        row_start, num_cols + col_start,
-                        row_stop - row_start, -col_start + col_stop);
-
+                    // return a vector and not a matrix if the slice contains
+                    // exactly one row/column
                     if (row_stop - row_start == 1)
                     {
-                        // return a vector in this case and not a matrix
-                        return ir::node_data<double>{blaze::trans(row(sm, 0))};
+                        auto sv = blaze::trans(blaze::row(
+                            blaze::submatrix(args[0].matrix(),
+                                row_start, num_cols + col_start,
+                                1, -col_start + col_stop),
+                            0));
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
                     }
                     if (col_stop - col_start == 1)
                     {
-                        return ir::node_data<double>{column(sm, 0)};
+                        auto sv = blaze::column(
+                            blaze::submatrix(args[0].matrix(),
+                                row_start, num_cols + col_start,
+                                row_stop - row_start, 1),
+                            0);
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
                     }
 
-                    return ir::node_data<double>{matrix_type{std::move(sm)}};
+                    auto sm = blaze::submatrix(args[0].matrix(),
+                        row_start, num_cols + col_start,
+                        row_stop - row_start, -col_start + col_stop);
+
+                    storage2d_type m{sm};
+                    return ir::node_data<double>{std::move(m)};
                 }
 
                 if (row_start < 0 && row_stop <= 0 && col_start >= 0 &&
@@ -203,21 +219,37 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     auto num_rows = args[0].matrix().rows();
 
-                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
-                        num_rows + row_start, col_start,
-                        -row_start + row_stop, (col_stop - col_start));
-
+                    // return a vector and not a matrix if the slice contains
+                    // exactly one row/column
                     if (row_stop - row_start == 1)
                     {
-                        // return a vector in this case and not a matrix
-                        return ir::node_data<double>{blaze::trans(row(sm, 0))};
+                        auto sv = blaze::trans(blaze::row(
+                            blaze::submatrix(args[0].matrix(),
+                                num_rows + row_start, col_start,
+                                1, col_stop - col_start),
+                            0));
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
                     }
-                    if ((col_stop - col_start) == 1)
+                    if (col_stop - col_start == 1)
                     {
-                        return ir::node_data<double>{column(sm, 0)};
+                        auto sv = blaze::column(
+                            blaze::submatrix(args[0].matrix(),
+                                num_rows + row_start, col_start,
+                                -row_start + row_stop, 1),
+                            0);
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
                     }
 
-                    return ir::node_data<double>{matrix_type{std::move(sm)}};
+                    auto sm = blaze::submatrix(args[0].matrix(),
+                        num_rows + row_start, col_start,
+                        -row_start + row_stop, col_stop - col_start);
+
+                    storage2d_type m{sm};
+                    return ir::node_data<double>{std::move(m)};
                 }
 
                 if (row_start < 0 && row_stop <= 0 && col_start < 0 &&
@@ -226,39 +258,70 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     auto num_rows = args[0].matrix().rows();
                     auto num_cols = args[0].matrix().columns();
 
-                    submatrix_type sm = blaze::submatrix(args[0].matrix(),
-                        num_rows + row_start, num_cols + col_start,
-                        -row_start + row_stop, -col_start + col_stop);
-
+                    // return a vector and not a matrix if the slice contains
+                    // exactly one row/column
                     if (row_stop - row_start == 1)
                     {
-                        // return a vector in this case and not a matrix
-                        return ir::node_data<double>{blaze::trans(row(sm, 0))};
+                        auto sv = blaze::trans(blaze::row(
+                            blaze::submatrix(args[0].matrix(),
+                                num_rows + row_start, num_cols + col_start,
+                                1, -col_start + col_stop),
+                            0));
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
                     }
                     if (col_stop - col_start == 1)
                     {
-                        return ir::node_data<double>{column(sm, 0)};
+                        auto sv = blaze::column(
+                            blaze::submatrix(args[0].matrix(),
+                                num_rows + row_start, num_cols + col_start,
+                                -row_start + row_stop, 1),
+                            0);
+
+                        storage1d_type v{sv};
+                        return ir::node_data<double>{std::move(v)};
                     }
 
-                    return ir::node_data<double>{matrix_type{std::move(sm)}};
+                    auto sm = blaze::submatrix(args[0].matrix(),
+                        num_rows + row_start, num_cols + col_start,
+                        -row_start + row_stop, -col_start + col_stop);
+
+                    storage2d_type m{sm};
+                    return ir::node_data<double>{std::move(m)};
                 }
 
-                submatrix_type sm =
-                    blaze::submatrix(args[0].matrix(),
-                        row_start, col_start,
-                        row_stop - row_start, col_stop - col_start);
-
-                if ((row_stop - row_start) == 1)
+                // return a vector and not a matrix if the slice contains
+                // exactly one row/column
+                if (row_stop - row_start == 1)
                 {
-                    // return a vector in this case and not a matrix
-                    return ir::node_data<double>{blaze::trans(row(sm, 0))};
+                    auto sv = blaze::trans(blaze::row(
+                        blaze::submatrix(args[0].matrix(),
+                            row_start, col_start,
+                            1, col_stop - col_start),
+                        0));
+
+                    storage1d_type v{sv};
+                    return ir::node_data<double>{std::move(v)};
                 }
-                if ((col_stop - col_start) == 1)
+                if (col_stop - col_start == 1)
                 {
-                    return ir::node_data<double>{column(sm, 0)};
+                    auto sv = blaze::column(
+                        blaze::submatrix(args[0].matrix(),
+                            row_start, col_start,
+                            row_stop - row_start, 1),
+                        0);
+
+                    storage1d_type v{sv};
+                    return ir::node_data<double>{std::move(v)};
                 }
 
-                return ir::node_data<double>{matrix_type{std::move(sm)}};
+                auto sm = blaze::submatrix(args[0].matrix(),
+                    row_start, col_start,
+                    row_stop - row_start, col_stop - col_start);
+
+                storage2d_type m{sm};
+                return ir::node_data<double>{std::move(m)};
             }
 
         public:

--- a/src/execution_tree/primitives/square_root_operation.cpp
+++ b/src/execution_tree/primitives/square_root_operation.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017 Parsa Amini
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -6,7 +7,6 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/square_root_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -55,20 +55,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             primitive_result_type square_root_0d(operands_type && ops) const
             {
-                ops[0].scalar(std::sqrt(ops[0].scalar()));
+                ops[0] = std::sqrt(ops[0].scalar());
                 return std::move(ops[0]);
             }
 
             primitive_result_type square_root_1d(operands_type && ops) const
             {
-                ops[0].vector(blaze::sqrt(ops[0].vector()));
+                ops[0] = blaze::sqrt(ops[0].vector());
 
                 return std::move(ops[0]);
             }
 
             primitive_result_type square_root_2d(operands_type && ops) const
             {
-                ops[0].matrix(blaze::sqrt(ops[0].matrix()));
+                ops[0] = blaze::sqrt(ops[0].matrix());
 
                 return std::move(ops[0]);
             }

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -84,12 +84,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 auto this_ = this->shared_from_this();
                 return literal_operand(operands_[1], args_)
                     .then(hpx::util::unwrapping(
-                        [this_](primitive_result_type&& val)
+                        [this_](primitive_result_type && val)
                         {
-                            primitive_operand(
-                                    this_->operands_[0]
-                                ).store(hpx::launch::sync, val);
-                            return std::move(val);
+                            primitive_operand(this_->operands_[0])
+                                .store(hpx::launch::sync, std::move(val));
+                            return primitive_result_type{};
                         }));
             }
 

--- a/src/execution_tree/primitives/transpose_operation.cpp
+++ b/src/execution_tree/primitives/transpose_operation.cpp
@@ -7,7 +7,6 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/transpose_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -106,7 +105,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             primitive_result_type transpose2d(operands_type && ops) const
             {
-                blaze::transpose(ops[0].matrix());
+                if (ops[0].is_ref())
+                {
+                    ops[0] = blaze::trans(ops[0].matrix());
+                }
+                else
+                {
+                    blaze::transpose(ops[0].matrix_non_ref());
+                }
                 return std::move(ops[0]);
             }
         };

--- a/src/execution_tree/primitives/unary_minus_operation.cpp
+++ b/src/execution_tree/primitives/unary_minus_operation.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,7 +7,6 @@
 #include <phylanx/ast/detail/is_literal_value.hpp>
 #include <phylanx/execution_tree/primitives/unary_minus_operation.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/blaze.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
@@ -64,13 +63,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             primitive_result_type neg1d(operands_type&& ops) const
             {
-                ops[0].vector(-ops[0].vector());
+                ops[0] = -ops[0].vector();
                 return primitive_result_type(std::move(ops[0]));
             }
 
             primitive_result_type neg2d(operands_type&& ops) const
             {
-                ops[0].matrix(-ops[0].matrix());
+                ops[0] = -ops[0].matrix();
                 return primitive_result_type(std::move(ops[0]));
             }
 

--- a/src/execution_tree/primitives/variable.cpp
+++ b/src/execution_tree/primitives/variable.cpp
@@ -87,9 +87,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return data_;
     }
 
-    void variable::store(primitive_result_type const& data)
+    void variable::store(primitive_result_type && data)
     {
-        data_ = data;
+        data_ = std::move(data);
     }
 
     bool variable::bind(std::vector<primitive_argument_type> const& params)

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //  Copyright (c) 2017 Parsa Amini
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,8 +6,11 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/serialization/blaze.hpp>
+#include <phylanx/util/serialization/variant.hpp>
 
 #include <hpx/exception.hpp>
+#include <hpx/include/serialization.hpp>
 
 #include <cstddef>
 #include <iosfwd>
@@ -15,6 +18,42 @@
 
 namespace phylanx { namespace ir
 {
+#if defined(PHYLANX_DEBUG)
+    ///////////////////////////////////////////////////////////////////////////
+    std::atomic<std::size_t> count_copy_constructions_;
+    std::atomic<std::size_t> count_move_constructions_;
+    std::atomic<std::size_t> count_copy_assignments_;
+    std::atomic<std::size_t> count_move_assignments_;
+
+    void reset_node_statistics()
+    {
+        count_copy_constructions_ = 0;
+        count_move_constructions_ = 0;
+        count_copy_assignments_ = 0;
+        count_move_assignments_ = 0;
+    }
+
+    void print_node_statistics()
+    {
+        std::cout << "count_copy_constructions: "
+                  << count_copy_constructions_ << "\n";
+        std::cout << "count_move_constructions: "
+                  << count_move_constructions_ << "\n";
+        std::cout << "count_copy_assignments:   "
+                  << count_copy_assignments_ << "\n";
+        std::cout << "count_move_assignments:   "
+                  << count_move_assignments_ << "\n";
+    }
+#else
+    void reset_node_statistics()
+    {
+    }
+
+    void print_node_statistics()
+    {
+    }
+#endif
+
     namespace detail
     {
         template <typename Range>
@@ -43,13 +82,15 @@ namespace phylanx { namespace ir
             out << std::to_string(nd[0]);
             break;
 
-        case 1:
-            detail::print_array(out, nd.custom_vector(), nd.size());
+        case 1: HPX_FALLTHROUGH;
+        case 3:
+            detail::print_array(out, nd.vector(), nd.size());
             break;
 
-        case 2:
+        case 2: HPX_FALLTHROUGH;
+        case 4:
             {
-                auto const& data = nd.custom_matrix();
+                auto data = nd.matrix();
                 for (std::size_t row = 0; row != data.rows(); ++row)
                 {
                     if (row != 0)
@@ -78,11 +119,13 @@ namespace phylanx { namespace ir
         case 0:
             return scalar() != 0;
 
-        case 1:
-            return custom_vector().nonZeros() > 0;
+        case 1: HPX_FALLTHROUGH;
+        case 3:
+            return vector().nonZeros() > 0;
 
-        case 2:
-            return custom_matrix().nonZeros() > 0;
+        case 2: HPX_FALLTHROUGH;
+        case 4:
+            return matrix().nonZeros() > 0;
 
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,
@@ -90,5 +133,84 @@ namespace phylanx { namespace ir
                 "invalid dimensionality: " + std::to_string(dims));
         }
         return false;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    void node_data<double>::serialize(hpx::serialization::output_archive& ar,
+        unsigned)
+    {
+        std::size_t index = data_.index();
+        ar << index;
+
+        switch (index)
+        {
+        case 0:
+            ar << util::get<0>(data_);
+            break;
+
+        case 1:
+            ar << util::get<1>(data_);
+            break;
+
+        case 2:
+            ar << util::get<2>(data_);
+            break;
+
+        case 3:
+            ar << util::get<3>(data_);
+            break;
+
+        case 4:
+            ar << util::get<4>(data_);
+            break;
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "node_data<double>::serialize",
+                "node_data object holds unsupported data type");
+        }
+    }
+
+    template <>
+    void node_data<double>::serialize(hpx::serialization::input_archive& ar,
+        unsigned)
+    {
+        std::size_t index = 0;
+        ar >> index;
+
+        switch (index)
+        {
+        case 0:
+            {
+                double val = 0;
+                ar >> val;
+                data_ = val;
+            }
+            break;
+
+        case 1: HPX_FALLTHROUGH;
+        case 3:     // deserialize CustomVector as DynamicVector
+            {
+                storage1d_type v;
+                ar >> v;
+                data_ = std::move(v);
+            }
+            break;
+
+        case 2: HPX_FALLTHROUGH;
+        case 4:     // deserialize CustomMatrix as DynamicMatrix
+            {
+                storage2d_type m;
+                ar >> m;
+                data_ = std::move(m);
+            }
+            break;
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "node_data<double>::serialize",
+                "node_data object holds unsupported data type");
+        }
     }
 }}

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -44,12 +44,12 @@ namespace phylanx { namespace ir
             break;
 
         case 1:
-            detail::print_array(out, nd.vector(), nd.size());
+            detail::print_array(out, nd.custom_vector(), nd.size());
             break;
 
         case 2:
             {
-                auto const& data = nd.matrix();
+                auto const& data = nd.custom_matrix();
                 for (std::size_t row = 0; row != data.rows(); ++row)
                 {
                     if (row != 0)
@@ -79,10 +79,10 @@ namespace phylanx { namespace ir
             return scalar() != 0;
 
         case 1:
-            return vector().nonZeros() > 0;
+            return custom_vector().nonZeros() > 0;
 
         case 2:
-            return matrix().nonZeros() > 0;
+            return custom_matrix().nonZeros() > 0;
 
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,

--- a/src/performance_counters/register_counters.cpp
+++ b/src/performance_counters/register_counters.cpp
@@ -1,0 +1,67 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/runtime/startup_function.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/include/performance_counters.hpp>
+
+#include <cstdint>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace performance_counters
+{
+    ///////////////////////////////////////////////////////////////////////////
+    // This function will be registered as a startup function for HPX below.
+    // That means it will be executed in an HPX-thread before hpx_main, but
+    // after the runtime has been initialized and started.
+    void startup()
+    {
+        // Install the counter types, de-installation of the types is handled
+        // automatically.
+        hpx::performance_counters::install_counter_type(
+            "/phylanx/count/node_data/copy_constructions",
+            &ir::node_data<double>::copy_construction_count,
+            "returns the current value of the copy-construction count of "
+                "any node_data<double>");
+
+        hpx::performance_counters::install_counter_type(
+            "/phylanx/count/node_data/move_constructions",
+            &ir::node_data<double>::move_construction_count,
+            "returns the current value of the move-construction count of "
+                "any node_data<double>");
+
+        hpx::performance_counters::install_counter_type(
+            "/phylanx/count/node_data/copy_assignments",
+            &ir::node_data<double>::copy_assignment_count,
+            "returns the current value of the copy-assignment count of "
+                "any node_data<double>");
+
+        hpx::performance_counters::install_counter_type(
+            "/phylanx/count/node_data/move_assignments",
+            &ir::node_data<double>::move_assignment_count,
+            "returns the current value of the move-assignment count of "
+                "any node_data<double>");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    bool get_startup(hpx::startup_function_type& startup_func,
+        bool& pre_startup)
+    {
+        // return our startup-function if performance counters are required
+        startup_func = startup;   // function to run during startup
+        pre_startup = true;       // run 'startup' as pre-startup function
+        return true;
+    }
+}}
+
+///////////////////////////////////////////////////////////////////////////////
+// Register a startup function that will be called as a HPX-thread during
+// runtime startup. We use this function to register our performance counter
+// type and performance counter instances.
+HPX_REGISTER_STARTUP_MODULE(phylanx::performance_counters::get_startup);
+

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -20,7 +20,7 @@ void test_serialization(Ast const& in)
     std::vector<char> buffer = phylanx::util::serialize(in);
     phylanx::util::detail::unserialize(buffer, out);
 
-    HPX_TEST(in == out);
+    HPX_TEST_EQ(in, out);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/execution_tree/generate_tree.cpp
+++ b/tests/unit/execution_tree/generate_tree.cpp
@@ -196,11 +196,11 @@ void test_store_primitive()
         define(D, 42.0)
     )";
 
-    test_generate_tree("store(C, A)", variables, 41.0);
-    test_generate_tree("store(C, A + B)", variables, 42.0);
+    test_generate_tree_nil("store(C, A)", variables);
+    test_generate_tree_nil("store(C, A + B)", variables);
 
     test_generate_tree("block(store(B, constant(0, A)), B)", variables, 0.0);
-    test_generate_tree("store(D, 0)", variables, 0.0);
+    test_generate_tree_nil("store(D, 0)", variables);
 }
 
 void test_complex_expression()

--- a/tests/unit/execution_tree/primitives/add_operation.cpp
+++ b/tests/unit/execution_tree/primitives/add_operation.cpp
@@ -1,4 +1,4 @@
-//   Copyright (c) 2017 Hartmut Kaiser
+//   Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -523,6 +523,8 @@ int main(int argc, char* argv[])
 
     test_add_operation_2d1d();
     test_add_operation_2d1d_lit();
+
+    phylanx::ir::print_node_statistics();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/add_operation.cpp
+++ b/tests/unit/execution_tree/primitives/add_operation.cpp
@@ -524,7 +524,5 @@ int main(int argc, char* argv[])
     test_add_operation_2d1d();
     test_add_operation_2d1d_lit();
 
-    phylanx::ir::print_node_statistics();
-
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/column_slicing.cpp
+++ b/tests/unit/execution_tree/primitives/column_slicing.cpp
@@ -155,74 +155,72 @@ void test_column_slicing_operation_2d()
 
 void test_column_slicing_operation_1d_negative_index()
 {
-
     blaze::Rand<blaze::DynamicVector<double>> gen{};
     blaze::DynamicVector<double> v1 = gen.generate(1007UL);
 
     phylanx::execution_tree::primitive input_vector =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(v1));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
 
     phylanx::execution_tree::primitive col_start =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
 
     phylanx::execution_tree::primitive col_stop =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
 
-    phylanx::execution_tree::primitive slice =
-            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
-                    hpx::find_here(),
-                    std::vector<phylanx::execution_tree::primitive_argument_type>{
-                            std::move(input_vector), std::move(col_start),
-                            std::move(col_stop)
-                    });
+    phylanx::execution_tree::primitive slice = hpx::new_<
+        phylanx::execution_tree::primitives::column_slicing_operation>(
+        hpx::find_here(),
+        std::vector<phylanx::execution_tree::primitive_argument_type>{
+            std::move(input_vector), std::move(col_start),
+            std::move(col_stop)
+        });
 
     auto sm = blaze::subvector(v1, 1002, 3);
     auto expected = sm;
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-            slice.eval();
+        slice.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-                phylanx::execution_tree::extract_numeric_value(f.get()));
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_column_slicing_operation_1d_single_slice_negative_index()
 {
-
     blaze::Rand<blaze::DynamicVector<double>> gen{};
     blaze::DynamicVector<double> v1 = gen.generate(1007UL);
 
     phylanx::execution_tree::primitive input_vector =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(v1));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
 
     phylanx::execution_tree::primitive col_start =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
 
     phylanx::execution_tree::primitive col_stop =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
 
-    phylanx::execution_tree::primitive slice =
-            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
-                    hpx::find_here(),
-                    std::vector<phylanx::execution_tree::primitive_argument_type>{
-                            std::move(input_vector), std::move(col_start),
-                            std::move(col_stop)
-                    });
+    phylanx::execution_tree::primitive slice = hpx::new_<
+        phylanx::execution_tree::primitives::column_slicing_operation>(
+        hpx::find_here(),
+        std::vector<phylanx::execution_tree::primitive_argument_type>{
+            std::move(input_vector), std::move(col_start),
+            std::move(col_stop)
+        });
 
     auto sm = blaze::subvector(v1, 1002, 1);
     auto expected = sm;
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-            slice.eval();
+        slice.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-                phylanx::execution_tree::extract_numeric_value(f.get()));
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_column_slicing_operation_2d_negative_index()
@@ -231,34 +229,33 @@ void test_column_slicing_operation_2d_negative_index()
     blaze::DynamicMatrix<double> m1 = gen.generate(90UL, 101UL);
 
     phylanx::execution_tree::primitive input_matrix =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
 
     phylanx::execution_tree::primitive col_start =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
 
     phylanx::execution_tree::primitive col_stop =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-2.0));
 
-    phylanx::execution_tree::primitive slice =
-            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
-                    hpx::find_here(),
-                    std::vector<phylanx::execution_tree::primitive_argument_type>{
-                            std::move(input_matrix), std::move(col_start),
-                            std::move(col_stop)
-                    });
-
+    phylanx::execution_tree::primitive slice = hpx::new_<
+        phylanx::execution_tree::primitives::column_slicing_operation>(
+        hpx::find_here(),
+        std::vector<phylanx::execution_tree::primitive_argument_type>{
+            std::move(input_matrix), std::move(col_start),
+            std::move(col_stop)
+        });
 
     auto sm = blaze::submatrix(m1, 0, 96, 90, 3);
     auto expected = sm;
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-            slice.eval();
+        slice.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-                phylanx::execution_tree::extract_numeric_value(f.get()));
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 void test_column_slicing_operation_2d_single_slice_negative_index()
@@ -267,36 +264,34 @@ void test_column_slicing_operation_2d_single_slice_negative_index()
     blaze::DynamicMatrix<double> m1 = gen.generate(90UL, 101UL);
 
     phylanx::execution_tree::primitive input_matrix =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
 
     phylanx::execution_tree::primitive col_start =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
 
     phylanx::execution_tree::primitive col_stop =
-            hpx::new_<phylanx::execution_tree::primitives::variable>(
-                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
 
-    phylanx::execution_tree::primitive slice =
-            hpx::new_<phylanx::execution_tree::primitives::column_slicing_operation>(
-                    hpx::find_here(),
-                    std::vector<phylanx::execution_tree::primitive_argument_type>{
-                            std::move(input_matrix), std::move(col_start),
-                            std::move(col_stop)
-                    });
-
+    phylanx::execution_tree::primitive slice = hpx::new_<
+        phylanx::execution_tree::primitives::column_slicing_operation>(
+        hpx::find_here(),
+        std::vector<phylanx::execution_tree::primitive_argument_type>{
+            std::move(input_matrix), std::move(col_start),
+            std::move(col_stop)
+        });
 
     auto sm = blaze::submatrix(m1, 0, 96, 90, 1);
     auto expected = blaze::column(sm, 0);
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
-            slice.eval();
+        slice.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-                phylanx::execution_tree::extract_numeric_value(f.get()));
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
-
 
 int main(int argc, char* argv[])
 {

--- a/tests/unit/execution_tree/primitives/for_operation.cpp
+++ b/tests/unit/execution_tree/primitives/for_operation.cpp
@@ -37,7 +37,8 @@ void test_for_operation_false()
         hpx::new_<phylanx::execution_tree::primitives::for_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                std::move(init), std::move(cond), std::move(reinit), std::move(body)
+                std::move(init), std::move(cond), std::move(reinit),
+                std::move(body)
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
@@ -73,7 +74,8 @@ void test_for_operation_true()
         hpx::new_<phylanx::execution_tree::primitives::for_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                std::move(init), std::move(cond), std::move(reinit), std::move(body)
+                std::move(init), std::move(cond), std::move(reinit),
+                std::move(body)
             });
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
@@ -82,16 +84,16 @@ void test_for_operation_true()
     HPX_TEST(!phylanx::execution_tree::extract_boolean_value(f.get()));
 }
 
-//init is stated at zero
-//for(init, init< 42,init=init+1; body)
-//body: track the value of init just so that we can verify
-//what its value was when the loop ended
-//body(
-//     set temp = init
-//    )
+// init is stated at zero
+// for(init, init< 42,init=init+1; body)
+// body: track the value of init just so that we can verify
+// what its value was when the loop ended
+// body(
+//      set temp = init
+//     )
 void test_for_operation_42()
 {
-    //initial condition init is set to 0.0
+    // initial condition init is set to 0.0
     phylanx::execution_tree::primitive init =
         hpx::new_<phylanx::execution_tree::primitives::variable>(
             hpx::find_here(), phylanx::ir::node_data<double>{0.0});
@@ -104,7 +106,7 @@ void test_for_operation_42()
         hpx::new_<phylanx::execution_tree::primitives::variable>(
             hpx::find_here(), phylanx::ir::node_data<double>{1.0});
 
-    //check if init is less than to 42 (this is true)
+    // check if init is less than to 42 (this is true)
     phylanx::execution_tree::primitive cond =
         hpx::new_<phylanx::execution_tree::primitives::less>(
             hpx::find_here(),
@@ -112,13 +114,13 @@ void test_for_operation_42()
                 init, forty_two
             });
 
-    //set temp=0.0 in the beginning
-     phylanx::execution_tree::primitive temp =
-      hpx::new_<phylanx::execution_tree::primitives::variable>(
-          hpx::find_here(), phylanx::ir::node_data<double>{0.0});
+    // set temp=0.0 in the beginning
+    phylanx::execution_tree::primitive temp =
+        hpx::new_<phylanx::execution_tree::primitives::variable>(
+            hpx::find_here(), phylanx::ir::node_data<double>{0.0});
 
-    //do something in the body
-    //here: set temp = init
+    // do something in the body
+    // here: set temp = init
     phylanx::execution_tree::primitive body =
       hpx::new_<phylanx::execution_tree::primitives::store_operation>(
           hpx::find_here(),
@@ -126,7 +128,7 @@ void test_for_operation_42()
               temp, init
           });
 
-    //in the reinit statement, add 1 to init
+    // in the reinit statement, add 1 to init
     phylanx::execution_tree::primitive reinit =
         hpx::new_<phylanx::execution_tree::primitives::store_operation>(
             hpx::find_here(),
@@ -138,12 +140,13 @@ void test_for_operation_42()
                 })
             });
 
-    //evaluate the for loop until condition is false
+    // evaluate the for loop until condition is false
     phylanx::execution_tree::primitive for_ =
         hpx::new_<phylanx::execution_tree::primitives::for_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                std::move(init), std::move(cond), std::move(reinit) , std::move(body)
+                std::move(init), std::move(cond), std::move(reinit) ,
+                std::move(body)
             });
 
     // when the loop ends the value obtained as the result
@@ -152,16 +155,17 @@ void test_for_operation_42()
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
         for_.eval();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_numeric_value(f.get())[0],41.0);
+    // store() returns nil
+    HPX_TEST(!phylanx::execution_tree::valid(f.get()));
+    HPX_TEST_EQ(41.0, phylanx::execution_tree::numeric_operand_sync(temp, {})[0]);
 }
 
-
-//for(init=3.0; init<42; init=init+5; body
-//body: track the value of init just so that we can verify
-//what its value was when the loop ended
-//body(
-//     set temp = init
-//    )
+// for(init=3.0; init<42; init=init+5; body
+// body: track the value of init just so that we can verify
+// what its value was when the loop ended
+// body(
+//      set temp = init
+//     )
 void test_for_operation_42_with_store()
 {
     //set init to zero
@@ -173,7 +177,7 @@ void test_for_operation_42_with_store()
         hpx::new_<phylanx::execution_tree::primitives::variable>(
             hpx::find_here(), phylanx::ir::node_data<double>(3.0));
 
-    //store 3 to init
+    // store 3 to init
     phylanx::execution_tree::primitive store =
         hpx::new_<phylanx::execution_tree::primitives::store_operation>(
             hpx::find_here(),
@@ -189,7 +193,7 @@ void test_for_operation_42_with_store()
         hpx::new_<phylanx::execution_tree::primitives::variable>(
             hpx::find_here(), phylanx::ir::node_data<double>{5.0});
 
-    //check if init is less than 42 (this is true)
+    // check if init is less than 42 (this is true)
     phylanx::execution_tree::primitive cond =
         hpx::new_<phylanx::execution_tree::primitives::less>(
             hpx::find_here(),
@@ -197,7 +201,7 @@ void test_for_operation_42_with_store()
                 init, forty_two
             });
 
-    //in the reinit statement add five to init
+    // in the reinit statement add five to init
     phylanx::execution_tree::primitive reinit =
       hpx::new_<phylanx::execution_tree::primitives::store_operation>(
           hpx::find_here(),
@@ -209,13 +213,13 @@ void test_for_operation_42_with_store()
                   })
           });
 
-    //set temp=0.0 in the beginning
+    // set temp=0.0 in the beginning
     phylanx::execution_tree::primitive temp =
       hpx::new_<phylanx::execution_tree::primitives::variable>(
           hpx::find_here(), phylanx::ir::node_data<double>{0.0});
 
-    //do something in the body
-    //here: set temp = init
+    // do something in the body
+    // here: set temp = init
     phylanx::execution_tree::primitive body =
       hpx::new_<phylanx::execution_tree::primitives::store_operation>(
           hpx::find_here(),
@@ -223,20 +227,23 @@ void test_for_operation_42_with_store()
               temp, init
           });
 
-    //evaluate the for loop
+    // evaluate the for loop
     phylanx::execution_tree::primitive for_ =
         hpx::new_<phylanx::execution_tree::primitives::for_operation>(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                std::move(store), std::move(cond), std::move(reinit), std::move(body)
+                std::move(store), std::move(cond), std::move(reinit),
+                std::move(body)
             });
 
-    //when the loop ends the value should be 38.0 as the condition will fail
-    //init is greater than 42.0
+    // when the loop ends the value should be 38.0 as the condition will fail
+    // init is greater than 42.0
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
         for_.eval();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_numeric_value(f.get())[0],38.0);
+    // store() returns nil
+    HPX_TEST(!phylanx::execution_tree::valid(f.get()));
+    HPX_TEST_EQ(38.0, phylanx::execution_tree::numeric_operand_sync(temp, {})[0]);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/primitives/store_operation.cpp
+++ b/tests/unit/execution_tree/primitives/store_operation.cpp
@@ -29,11 +29,11 @@ void test_store_operation()
 
     HPX_TEST_EQ(0.0, phylanx::execution_tree::numeric_operand_sync(lhs, {})[0]);
 
-    hpx::future<phylanx::execution_tree::primitive_result_type> result =
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
         store.eval();
 
-    HPX_TEST_EQ(
-        42.0, phylanx::execution_tree::extract_numeric_value(result.get())[0]);
+    HPX_TEST(!phylanx::execution_tree::valid(f.get()));
+    HPX_TEST_EQ(42.0, phylanx::execution_tree::numeric_operand_sync(lhs, {})[0]);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -18,7 +18,7 @@ void test_serialization(phylanx::ir::node_data<double> const& array_value1)
     std::vector<char> buffer = phylanx::util::serialize(array_value1);
     phylanx::util::detail::unserialize(buffer, array_value2);
 
-    HPX_TEST(array_value1 == array_value2);
+    HPX_TEST_EQ(array_value1, array_value2);
 }
 
 int main(int argc, char* argv[])

--- a/tools/VS/blaze.natvis
+++ b/tools/VS/blaze.natvis
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (c) 2017 Hartmut Kaiser                                      -->
+<!-- Copyright (c) 2017-2018 Hartmut Kaiser                                 -->
 <!-- Copyright (c) 2017 Parsa Amini                                         -->
 
 <!-- Use, modification and distribution are subject to the Boost Software   -->
@@ -37,6 +37,36 @@
         </Expand>
     </Type>
 
+    <Type Name="blaze::CustomMatrix&lt;*,*,*,0&gt;">
+        <DisplayString>{{rows={m_}, columns={n_}}}</DisplayString>
+        <Expand>
+            <Item Name="[rows]">m_</Item>
+            <Item Name="[columns]">n_</Item>
+            <Item Name="[padding]">nn_</Item>
+            <ArrayItems>
+                <Direction>Forward</Direction>
+                <Rank>2</Rank>
+                <Size>$i == 0 ? (int)n_ : (int)m_</Size>
+                <ValuePointer>($T1*)v_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="blaze::CustomMatrix&lt;*,*,*,1&gt;">
+        <DisplayString>{{rows={m_}, columns={n_}}}</DisplayString>
+        <Expand>
+            <Item Name="[rows]">m_</Item>
+            <Item Name="[columns]">n_</Item>
+            <Item Name="[padding]">nn_</Item>
+            <ArrayItems>
+                <Direction>Backward</Direction>
+                <Rank>2</Rank>
+                <Size>$i == 0 ? (int)m_ : (int)n_</Size>
+                <ValuePointer>($T1*)v_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
     <Type Name="blaze::DynamicVector&lt;*,0&gt;">
         <DisplayString>{{size={size_}}}</DisplayString>
         <Expand>
@@ -51,6 +81,32 @@
     </Type>
 
     <Type Name="blaze::DynamicVector&lt;*,1&gt;">
+        <DisplayString>{{size={size_}}}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size_</Item>
+            <ArrayItems>
+                <Direction>Backward</Direction>
+                <Rank>1</Rank>
+                <Size>size_</Size>
+                <ValuePointer>($T1*)v_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="blaze::CustomVector&lt;*,*,*,0&gt;">
+        <DisplayString>{{size={size_}}}</DisplayString>
+        <Expand>
+            <Item Name="[size]">size_</Item>
+            <ArrayItems>
+                <Direction>Forward</Direction>
+                <Rank>1</Rank>
+                <Size>size_</Size>
+                <ValuePointer>($T1*)v_</ValuePointer>
+            </ArrayItems>
+        </Expand>
+    </Type>
+
+    <Type Name="blaze::CustomVector&lt;*,*,*,1&gt;">
         <DisplayString>{{size={size_}}}</DisplayString>
         <Expand>
             <Item Name="[size]">size_</Item>


### PR DESCRIPTION
this fixes #129 

- also: add performance counter exposing copy/move construction/assignment counts for node_data<double>


This PR improves the performance of executing expression trees. @justwagle, please run your benchmarks and compare those to the baseline results collected a while back.