### PR TITLE
Minor fixes to PhyLisp.

### DIFF
--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -68,6 +68,7 @@ namespace phylanx { namespace ast { namespace parser
             ("-", ast::optoken::op_minus)
             ("*", ast::optoken::op_times)
             ("/", ast::optoken::op_divide)
+            ("%", ast::optoken::op_mod)
             ;
 
         unary_op.add
@@ -123,7 +124,7 @@ namespace phylanx { namespace ast { namespace parser
             >>  raw[lexeme[(alpha | '_') >> *(alnum | '_')]]
             ;
 
-        string = '"' > raw[lexeme[+(char_ - '"')]] > '"'
+        string = lexeme['"' > raw[*(char_ - '"')] > '"']
             ;
 
         ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Currently, it is impossible to parse blank strings in the lisp intermediate language, i.e. " " or "". This fix makes that possible. Also, add the modulus token.