### PR TITLE
Adding sequence numbers to the names generated for the primitives.

### DIFF
--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <functional>
 #include <list>
+#include <map>
 #include <utility>
 #include <vector>
 
@@ -151,6 +152,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
 
         std::size_t compile_id_;
         std::list<function> defines_;
+        std::map<std::string, std::size_t> sequence_numbers_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -197,14 +197,18 @@ namespace phylanx { namespace execution_tree { namespace compiler
     // compose an argument selector
     struct argument
     {
-        argument(hpx::id_type const& locality = hpx::find_here())
-          : locality_(locality)
+        argument(std::size_t sequence_number,
+                hpx::id_type const& locality = hpx::find_here())
+          : sequence_number_(sequence_number),
+            locality_(locality)
         {
         }
 
         function operator()(std::size_t n, std::string const& name) const
         {
-            std::string full_name = "argument:" + name;
+            std::string full_name =
+                "argument:" + std::to_string(sequence_number_) + ":" + name;
+
             return function{
                     primitive(
                         hpx::new_<primitives::access_argument>(locality_, n),
@@ -213,6 +217,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 };
         }
 
+        std::size_t sequence_number_;
         hpx::id_type locality_;
     };
 


### PR DESCRIPTION
This will enable identifying every primitive instance in an unique way (needed for performance counters).
The full name of every component is patterned after

     /phylanx/<primitive>:<sequence-nr>[:<instance>]/<compile_id>#<tag>

where:
```
     <primitive>:   the name of primitive type representing the given
                    node in the expression tree
     <sequence-nr>: the sequence number of the corresponding instance
                    of type <primitive>
     <instance>:    (optional), some primitives have additional instance
                    names, for instance references to function arguments
                    have the name of the argument as their <instance>
     <compile_id>:  the sequence number of the invocation of the
                    function phylanx::execution_tree::compile
     <tag>:         the index into the vector of iterators, where the
                    iterator refers to the point of usage of the
                    primitive in the compiled source code
```