### PR TITLE
Generate newick tree

### DIFF
--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -1,4 +1,4 @@
-//   Copyright (c) 2017 Hartmut Kaiser
+//   Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -164,8 +164,9 @@ std::pair<std::size_t, std::int64_t> extract_tags(std::string const& name)
 //                    iterator refers to the point of usage of the
 //                    primitive in the compiled source code
 //
-void print_instrumentation(char const* const name, int compile_id,
-    std::string const& code,
+void print_instrumentation(
+    char const* const name, int compile_id, std::string const& code,
+    phylanx::execution_tree::compiler::function const& func,
     std::vector<std::string::const_iterator> const& iterators,
     std::map<std::string, hpx::id_type> const& entries)
 {
@@ -202,6 +203,9 @@ void print_instrumentation(char const* const name, int compile_id,
     }
 
     std::cout << "\n";
+
+    std::cout << "Tree information for function: " << name << "\n";
+    std::cout << func.get_newick_tree() << "\n\n";
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -230,9 +234,9 @@ int hpx_main(boost::program_options::variables_map& vm)
         auto entries =
             hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*");
 
-        print_instrumentation("read_x", 0, read_x_code, iterators, entries);
-        print_instrumentation("read_y", 1, read_y_code, iterators, entries);
-        print_instrumentation("lra", 2, lra_code, iterators, entries);
+        print_instrumentation("read_x", 0, read_x_code, read_x, iterators, entries);
+        print_instrumentation("read_y", 1, read_y_code, read_y, iterators, entries);
+        print_instrumentation("lra", 2, lra_code, lra, iterators, entries);
     }
 
     auto row_start = vm["row_start"].as<std::int64_t>();

--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -195,7 +195,9 @@ void print_instrumentation(
     std::cout << "\n";
 
     std::cout << "Tree information for function: " << name << "\n";
-    std::cout << func.get_newick_tree() << "\n\n";
+    std::cout << phylanx::execution_tree::newick_tree(
+                     func.get_expression_topology())
+              << "\n\n";
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -131,38 +131,28 @@ std::pair<std::size_t, std::size_t> get_pos(std::string const& code,
 //
 std::pair<std::size_t, std::int64_t> extract_tags(std::string const& name)
 {
-    std::size_t compile_id = 0;
-    std::int64_t tag = 0;
-
-    auto p = name.find_last_of("#");
-    if (p != std::string::npos)
-    {
-        char* end = nullptr;
-        tag = std::strtoll(name.c_str() + p + 1, &end, 10);
-
-        p = name.find_last_of("/", p);
-        if (p != std::string::npos)
-        {
-            compile_id = std::strtoll(name.c_str() + p + 1, &end, 10);
-        }
-    }
-
-    return std::make_pair(compile_id, tag);
+    auto data = phylanx::execution_tree::compiler::parse_primitive_name(name);
+    return std::make_pair(data.compile_id, data.tag);
 }
 
 // The symbolic names registered in AGAS that identify the created
 // primitive instances have the following structure:
 //
-//      /phylanx/<primitive>/<compile_id>#<tag>
+//      /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag>
 //
-// where:
-//      <primitive>:  the name of primitive type representing the given
-//                    node in the expression tree
-//      <compile_id>: the sequence number of the invocation of the
-//                    function phylanx::execution_tree::compile
-//      <tag>:        the index into the vector of iterators, where the
-//                    iterator refers to the point of usage of the
-//                    primitive in the compiled source code
+//  where:
+//      <primitive>:   the name of primitive type representing the given
+//                     node in the expression tree
+//      <sequence-nr>: the sequence number of the corresponding instance
+//                     of type <primitive>
+//      <instance>:    (optional), some primitives have additional instance
+//                     names, for instance references to function arguments
+//                     have the name of the argument as their <instance>
+//      <compile_id>:  the sequence number of the invocation of the
+//                     function phylanx::execution_tree::compile
+//      <tag>:         the index into the vector of iterators, where the
+//                     iterator refers to the point of usage of the
+//                     primitive in the compiled source code
 //
 void print_instrumentation(
     char const* const name, int compile_id, std::string const& code,

--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -131,14 +131,14 @@ namespace phylanx { namespace execution_tree { namespace compiler
 #endif
         }
 
-        std::string get_newick_tree() const
+        topology get_expression_topology() const
         {
             primitive const* p = util::get_if<primitive>(&arg_);
             if (p != nullptr)
             {
-                return p->newick_tree(hpx::launch::sync) + ";";
+                return p->expression_topology(hpx::launch::sync);
             }
-            return ";";
+            return {};
         }
 
         primitive_argument_type arg_;

--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -131,6 +131,16 @@ namespace phylanx { namespace execution_tree { namespace compiler
 #endif
         }
 
+        std::string get_newick_tree() const
+        {
+            primitive const* p = util::get_if<primitive>(&arg_);
+            if (p != nullptr)
+            {
+                return p->newick_tree(hpx::launch::sync) + ";";
+            }
+            return ";";
+        }
+
         primitive_argument_type arg_;
 #if defined(_DEBUG)
         std::string name_;

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -10,10 +10,11 @@
 #include <phylanx/execution_tree/compiler/actors.hpp>
 #include <phylanx/execution_tree/primitives/access_argument.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
-#include <phylanx/execution_tree/primitives/define_variable.hpp>
 #include <phylanx/execution_tree/primitives/define_function.hpp>
+#include <phylanx/execution_tree/primitives/define_variable.hpp>
 #include <phylanx/execution_tree/primitives/variable.hpp>
 #include <phylanx/execution_tree/primitives/wrapped_function.hpp>
+#include <phylanx/execution_tree/primitives/wrapped_variable.hpp>
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/util.hpp>
@@ -169,7 +170,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         }
         function operator()(std::string && name) const
         {
-            return function{ast::nil{}, "always_nil: " + name};
+            return function{ast::nil{}, "always_nil# " + name};
         }
     };
 
@@ -207,7 +208,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         function operator()(std::size_t n, std::string const& name) const
         {
             std::string full_name =
-                "argument:" + std::to_string(sequence_number_) + ":" + name;
+                "argument#" + std::to_string(sequence_number_) + "#" + name;
 
             return function{
                     primitive(
@@ -221,26 +222,55 @@ namespace phylanx { namespace execution_tree { namespace compiler
         hpx::id_type locality_;
     };
 
-    // compose an external function
-    struct external_function : compiled_actor<external_function>
+    // compose an external variable
+    struct external_variable : compiled_actor<external_variable>
     {
-        // we must hold f by reference because functions can be recursive
+        // we must hold f by reference
         std::reference_wrapper<function const> f_;
+        std::size_t sequence_number_;
 
-        explicit external_function(function const& f,
+        explicit external_variable(function const& f,
+                std::size_t sequence_number,
                 hpx::id_type const& locality = hpx::find_here())
-          : compiled_actor<external_function>(locality)
+          : compiled_actor<external_variable>(locality)
+          ,sequence_number_(sequence_number)
           , f_(f)
         {}
 
         function compose(std::list<function> && elements,
             std::string const& name) const
         {
-            if (elements.empty())
-            {
-                return function{f_.get().arg_, name};
-            }
+            std::string full_name =
+                "variable#" + std::to_string(sequence_number_) + "#" + name;
+            return function{
+                    primitive(
+                        hpx::new_<primitives::wrapped_variable>(
+                            this->locality_, f_.get().arg_,
+                            full_name),
+                        full_name),
+                    full_name
+                };
+        }
+    };
 
+    // compose an external function
+    struct external_function : compiled_actor<external_function>
+    {
+        // we must hold f by reference because functions can be recursive
+        std::reference_wrapper<function const> f_;
+        std::size_t sequence_number_;
+
+        explicit external_function(function const& f,
+                std::size_t sequence_number,
+                hpx::id_type const& locality = hpx::find_here())
+          : compiled_actor<external_function>(locality)
+          , sequence_number_(sequence_number)
+          , f_(f)
+        {}
+
+        function compose(std::list<function> && elements,
+            std::string const& name) const
+        {
             arguments_type fargs;
             fargs.reserve(elements.size());
 
@@ -249,10 +279,15 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 fargs.push_back(arg.arg_);
             }
 
+            std::string full_name =
+                "function#" + std::to_string(sequence_number_) + "#" + name;
             return function{
-                    hpx::new_<primitives::wrapped_function>(
-                        this->locality_, f_.get().arg_, std::move(fargs), name),
-                    name
+                    primitive(
+                        hpx::new_<primitives::wrapped_function>(
+                            this->locality_, f_.get().arg_, std::move(fargs),
+                            full_name),
+                        full_name),
+                    full_name
                 };
         }
     };

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -230,7 +230,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         std::size_t sequence_number_;
 
         explicit external_variable(function const& f,
-                std::size_t sequence_number,
+                std::size_t sequence_number = std::size_t(-1),
                 hpx::id_type const& locality = hpx::find_here())
           : compiled_actor<external_variable>(locality)
           ,sequence_number_(sequence_number)
@@ -261,7 +261,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         std::size_t sequence_number_;
 
         explicit external_function(function const& f,
-                std::size_t sequence_number,
+                std::size_t sequence_number = std::size_t(-1),
                 hpx::id_type const& locality = hpx::find_here())
           : compiled_actor<external_function>(locality)
           , sequence_number_(sequence_number)

--- a/phylanx/execution_tree/compiler/parse_primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/parse_primitive_name.hpp
@@ -1,0 +1,56 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_EXECUTION_TREE_PARSE_PRIMITIVE_NAME_HPP)
+#define PHYLANX_EXECUTION_TREE_PARSE_PRIMITIVE_NAME_HPP
+
+#include <phylanx/config.hpp>
+
+#include <hpx/include/util.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace phylanx { namespace execution_tree { namespace compiler
+{
+    // The full name of every component is patterned after
+    //
+    //      /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag>
+    //
+    //  where:
+    //      <primitive>:   the name of primitive type representing the given
+    //                     node in the expression tree
+    //      <sequence-nr>: the sequence number of the corresponding instance
+    //                     of type <primitive>
+    //      <instance>:    (optional), some primitives have additional instance
+    //                     names, for instance references to function arguments
+    //                     have the name of the argument as their <instance>
+    //      <compile_id>:  the sequence number of the invocation of the
+    //                     function phylanx::execution_tree::compile
+    //      <tag>:         the index into the vector of iterators, where the
+    //                     iterator refers to the point of usage of the
+    //                     primitive in the compiled source code
+    struct primitive_name_parts
+    {
+        primitive_name_parts()
+          : sequence_number(-1)
+          , compile_id(-1)
+          , tag(-1)
+        {}
+
+        std::string primitive;
+        std::int64_t sequence_number;
+        std::string instance;
+        std::int64_t compile_id;
+        std::int64_t tag;
+    };
+
+    PHYLANX_EXPORT primitive_name_parts parse_primitive_name(
+        std::string const& name);
+}}}
+
+#endif
+
+

--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -52,5 +52,6 @@
 #include <phylanx/execution_tree/primitives/variable.hpp>
 #include <phylanx/execution_tree/primitives/while_operation.hpp>
 #include <phylanx/execution_tree/primitives/wrapped_function.hpp>
+#include <phylanx/execution_tree/primitives/wrapped_variable.hpp>
 
 #endif

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -74,6 +74,9 @@ namespace phylanx { namespace execution_tree
         hpx::future<bool> bind(std::vector<primitive_argument_type> const&);
         bool bind(hpx::launch::sync_policy,
             std::vector<primitive_argument_type> const&);
+
+        hpx::future<std::string> newick_tree() const;
+        std::string newick_tree(hpx::launch::sync_policy) const;
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -197,6 +200,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
         virtual bool bind(std::vector<primitive_argument_type> const& args);
 
+        std::string newick_tree_nonvirtual() const
+        {
+            return newick_tree();
+        }
+        virtual std::string newick_tree() const;
+
     public:
 
 #if defined(PHYLANX_DEBUG)
@@ -214,6 +223,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             base_primitive, eval_direct_nonvirtual, eval_direct_action);
         HPX_DEFINE_COMPONENT_ACTION(
             base_primitive, store_nonvirtual, store_action);
+        HPX_DEFINE_COMPONENT_ACTION(
+            base_primitive, newick_tree_nonvirtual, newick_tree_action);
 
     protected:
         static std::vector<primitive_argument_type> noargs;
@@ -234,6 +245,9 @@ HPX_REGISTER_ACTION_DECLARATION(
 HPX_REGISTER_ACTION_DECLARATION(
     phylanx::execution_tree::primitives::base_primitive::bind_action,
     phylanx_primitive_bind_action);
+HPX_REGISTER_ACTION_DECLARATION(
+    phylanx::execution_tree::primitives::base_primitive::newick_tree_action,
+    phylanx_primitive_newick_tree_action);
 
 namespace phylanx { namespace execution_tree
 {

--- a/phylanx/execution_tree/primitives/define_function.hpp
+++ b/phylanx/execution_tree/primitives/define_function.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -36,6 +36,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // value as returned by evaluating the given body.
         primitive_result_type eval_direct(
             std::vector<primitive_argument_type> const& args) const override;
+
+        // return the extended name for this function definition
+        std::string newick_tree() const;
 
         // Initialize the expression representing the function body, this has
         // to be done separately in order to support recursive functions.

--- a/phylanx/execution_tree/primitives/define_function.hpp
+++ b/phylanx/execution_tree/primitives/define_function.hpp
@@ -37,8 +37,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_result_type eval_direct(
             std::vector<primitive_argument_type> const& args) const override;
 
-        // return the extended name for this function definition
-        std::string newick_tree() const;
+        // return the topology for this function definition
+        topology expression_topology() const;
 
         // Initialize the expression representing the function body, this has
         // to be done separately in order to support recursive functions.

--- a/phylanx/execution_tree/primitives/define_variable.hpp
+++ b/phylanx/execution_tree/primitives/define_variable.hpp
@@ -41,6 +41,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::vector<primitive_argument_type> const& args) const override;
         void store(primitive_result_type && val) override;
 
+        // return the topology for this variable definition
+        topology expression_topology() const;
+
     protected:
         std::string extract_function_name() const;
 

--- a/phylanx/execution_tree/primitives/define_variable.hpp
+++ b/phylanx/execution_tree/primitives/define_variable.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/phylanx/execution_tree/primitives/wrapped_variable.hpp
+++ b/phylanx/execution_tree/primitives/wrapped_variable.hpp
@@ -3,8 +3,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_PRIMITIVES_WRAPPED_PRIMITIVE_OCT_22_2017_0111PM)
-#define PHYLANX_PRIMITIVES_WRAPPED_PRIMITIVE_OCT_22_2017_0111PM
+#if !defined(PHYLANX_PRIMITIVES_WRAPPED_VARIABLE_OCT_22_2017_0111PM)
+#define PHYLANX_PRIMITIVES_WRAPPED_VARIABLE_OCT_22_2017_0111PM
 
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
@@ -17,17 +17,16 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class HPX_COMPONENT_EXPORT wrapped_function
+    class HPX_COMPONENT_EXPORT wrapped_variable
       : public base_primitive
       , public hpx::components::locking_hook<
-          hpx::components::component_base<wrapped_function>>
+          hpx::components::component_base<wrapped_variable>>
     {
     public:
-        wrapped_function() = default;
+        wrapped_variable() = default;
+        wrapped_variable(primitive_argument_type target, std::string name);
 
-        wrapped_function(primitive_argument_type target, std::string name);
-        wrapped_function(primitive_argument_type target,
-            std::vector<primitive_argument_type>&& operands, std::string name);
+        void store(primitive_result_type && val);
 
         hpx::future<primitive_result_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
@@ -36,7 +35,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     private:
         primitive_argument_type target_;
-        std::vector<primitive_argument_type> args_;
         std::string name_;
     };
 }}}

--- a/phylanx/include/execution_tree.hpp
+++ b/phylanx/include/execution_tree.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -7,9 +7,10 @@
 #define PHYLANX_EXECUTION_TREE_HPP
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/compile.hpp>
 #include <phylanx/execution_tree/compiler/actors.hpp>
 #include <phylanx/execution_tree/compiler/compiler.hpp>
-#include <phylanx/execution_tree/compile.hpp>
+#include <phylanx/execution_tree/compiler/parse_primitive_name.hpp>
 #include <phylanx/execution_tree/primitives.hpp>
 
 #endif

--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/src/execution_tree/primitives/define_function.cpp
+++ b/src/execution_tree/primitives/define_function.cpp
@@ -95,25 +95,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
         body_ = std::move(body);
     }
 
-    std::string define_function::newick_tree() const
+    topology define_function::expression_topology() const
     {
         if (!valid(body_))
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
-                "define_function::name",
+                "define_function::expression_topology",
                 "expression representing the function body was not "
                     "initialized yet");
         }
 
-        std::string dependend_name;
-
         primitive const* p = util::get_if<primitive>(&body_);
         if (p != nullptr)
         {
-            dependend_name = p->newick_tree(hpx::launch::sync);
+            return p->expression_topology(hpx::launch::sync);
         }
 
-        return dependend_name;
+        return {};
     }
 }}}
 

--- a/src/execution_tree/primitives/define_function.cpp
+++ b/src/execution_tree/primitives/define_function.cpp
@@ -49,7 +49,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // created on.
         if (!valid(target_))
         {
-            if(!valid(body_))
+            if (!valid(body_))
             {
                 HPX_THROW_EXCEPTION(hpx::invalid_status,
                     "define_function::eval_direct",
@@ -84,7 +84,36 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     void define_function::set_body(primitive_argument_type&& body)
     {
+        if (valid(body_))
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "define_function::set_body",
+                "expression representing the function body was already "
+                    "initialized");
+        }
+
         body_ = std::move(body);
+    }
+
+    std::string define_function::newick_tree() const
+    {
+        if (!valid(body_))
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "define_function::name",
+                "expression representing the function body was not "
+                    "initialized yet");
+        }
+
+        std::string dependend_name;
+
+        primitive const* p = util::get_if<primitive>(&body_);
+        if (p != nullptr)
+        {
+            dependend_name = p->newick_tree(hpx::launch::sync);
+        }
+
+        return dependend_name;
     }
 }}}
 

--- a/src/execution_tree/primitives/define_variable.cpp
+++ b/src/execution_tree/primitives/define_variable.cpp
@@ -105,4 +105,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
         p->store(hpx::launch::sync, std::move(val));
     }
+
+    topology define_variable::expression_topology() const
+    {
+        if (!valid(body_))
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "define_variable::expression_topology",
+                "expression represented by the variable was not "
+                    "initialized yet");
+        }
+
+        primitive const* p = util::get_if<primitive>(&body_);
+        if (p != nullptr)
+        {
+            return p->expression_topology(hpx::launch::sync);
+        }
+
+        return {};
+    }
 }}}

--- a/src/execution_tree/primitives/identity.cpp
+++ b/src/execution_tree/primitives/identity.cpp
@@ -34,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     std::vector<match_pattern_type> const identity::match_data = {
-        hpx::util::make_tuple("identity1", "identity(_1)", &create<identity>)};
+        hpx::util::make_tuple("identity", "identity(_1)", &create<identity>)};
 
     ///////////////////////////////////////////////////////////////////////////
     identity::identity(std::vector<primitive_argument_type> && operands)
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "identity::identity_nd",
                         "input should be a scalar");
 
-                std::size_t dim = ops[0].scalar();
+                std::size_t dim = static_cast<std::size_t>(ops[0].scalar());
                 return operand_type{blaze::IdentityMatrix<double>(dim)};
             }
 

--- a/src/execution_tree/primitives/wrapped_function.cpp
+++ b/src/execution_tree/primitives/wrapped_function.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -23,30 +23,13 @@ HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
     "phylanx_primitive_component", hpx::components::factory_enabled)
 HPX_DEFINE_GET_COMPONENT_TYPE(wrapped_function_type::wrapped_type)
 
-HPX_REGISTER_ACTION(wrapped_function_type::set_target_direct_action,
-    phylanx_wrapped_function_set_target_action)
-
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    wrapped_function::wrapped_function(std::string name)
-      : name_(std::move(name))
-    {}
-
-    wrapped_function::wrapped_function(primitive_argument_type target)
-      : target_(std::move(target))
-    {}
-
     wrapped_function::wrapped_function(primitive_argument_type target,
             std::string name)
       : target_(std::move(target))
       , name_(std::move(name))
-    {}
-
-    wrapped_function::wrapped_function(primitive_argument_type target,
-            std::vector<primitive_argument_type>&& args)
-      : target_(std::move(target))
-      , args_(std::move(args))
     {}
 
     wrapped_function::wrapped_function(primitive_argument_type target,
@@ -72,11 +55,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return value_operand(target_, params);
-    }
-
-    void wrapped_function::set_target(primitive_argument_type target)
-    {
-        target_ = std::move(target);
     }
 
     bool wrapped_function::bind(
@@ -108,23 +86,3 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 }}}
 
-///////////////////////////////////////////////////////////////////////////////
-namespace phylanx { namespace execution_tree
-{
-    hpx::future<void> wrapped_function::set_target(
-        primitive_argument_type&& target)
-    {
-        using action_type =
-            primitives::wrapped_function::set_target_direct_action;
-        return hpx::async(
-            action_type(), this->primitive::get_id(), std::move(target));
-    }
-
-    void wrapped_function::set_target(hpx::launch::sync_policy,
-        primitive_argument_type&& target)
-    {
-        using action_type =
-            primitives::wrapped_function::set_target_direct_action;
-        action_type()(this->primitive::get_id(), std::move(target));
-    }
-}}

--- a/src/execution_tree/primitives/wrapped_variable.cpp
+++ b/src/execution_tree/primitives/wrapped_variable.cpp
@@ -1,0 +1,65 @@
+//  Copyright (c) 2017-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/wrapped_variable.hpp>
+
+#include <hpx/include/components.hpp>
+#include <hpx/include/lcos.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+typedef hpx::components::component<
+        phylanx::execution_tree::primitives::wrapped_variable
+    > wrapped_variable_type;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    wrapped_variable_type, phylanx_wrapped_variable_component,
+    "phylanx_primitive_component", hpx::components::factory_enabled)
+HPX_DEFINE_GET_COMPONENT_TYPE(wrapped_variable_type::wrapped_type)
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    wrapped_variable::wrapped_variable(primitive_argument_type target,
+            std::string name)
+      : target_(std::move(target))
+      , name_(std::move(name))
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_result_type> wrapped_variable::eval(
+        std::vector<primitive_argument_type> const& params) const
+    {
+        return value_operand(target_, params);
+    }
+
+    void wrapped_variable::store(primitive_result_type && val)
+    {
+        primitive* p = util::get_if<primitive>(&target_);
+        if (p != nullptr)
+        {
+            p->store(hpx::launch::sync, std::move(val));
+        }
+    }
+
+    bool wrapped_variable::bind(
+        std::vector<primitive_argument_type> const& params)
+    {
+        bool result = true;
+
+        primitive* p = util::get_if<primitive>(&target_);
+        if (p != nullptr)
+        {
+            result = p->bind(hpx::launch::sync, params) && result;
+        }
+
+        return result;
+    }
+}}}
+


### PR DESCRIPTION
This patch proposed to add the following additional facilities:

- Generate Newick tree from execution tree
- Parse primitive names into its parts


This PR is related to #125 