### PR TITLE
Fix the link in lra_csv_*

### DIFF
--- a/examples/algorithms/lra_csv.cpp
+++ b/examples/algorithms/lra_csv.cpp
@@ -13,7 +13,8 @@
 
 //////////////////////////////////////////////////////////////////////////////////
 // This example uses part of the breast cancer dataset from UCI Machine Learning
-// Repository. https://goo.gl/U2Uwz
+// Repository.
+//     https://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+(Diagnostic)
 //
 // A copy of the full dataset in CSV format (breast_cancer.csv), obtained from
 // scikit-learn datasets, is provided in the same folder as this example.

--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -22,7 +22,8 @@
 
 //////////////////////////////////////////////////////////////////////////////////
 // This example uses part of the breast cancer dataset from UCI Machine Learning
-// Repository. https://goo.gl/U2Uwz
+// Repository:
+//     https://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+(Diagnostic)
 //
 // A copy of the full dataset in CSV format (breast_cancer.csv), obtained from
 // scikit-learn datasets, is provided in the same folder as this example.


### PR DESCRIPTION
Current link refers to an irrelevant page:
```
$ curl -Is https://goo.gl/U2Uwz
```
```
HTTP/2 301
strict-transport-security: max-age=63072000; includeSubDomains; preload
content-type: text/html; charset=UTF-8
cache-control: no-cache, no-store, max-age=0, must-revalidate
pragma: no-cache
expires: Mon, 01 Jan 1990 00:00:00 GMT
date: Tue, 16 Jan 2018 18:12:06 GMT
location: http://www.cbsnews.com/video/watch/?id=7186319n
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
server: GSE
alt-svc: hq=":443"; ma=2592000; quic=51303431; quic=51303339; quic=51303338; quic=51303337; quic=51303335,quic=":443"; ma=2592000; v="41,39,38,37,35"
accept-ranges: none
vary: Accept-Encoding
```