### PR TITLE
Simplify the way symbol information is exposed by the AST generator

### DIFF
--- a/phylanx/ast/detail/is_literal_value.hpp
+++ b/phylanx/ast/detail/is_literal_value.hpp
@@ -63,7 +63,7 @@ namespace phylanx { namespace ast { namespace detail
     }
     inline literal_value_type literal_value(unary_expr const& ue)
     {
-        return is_literal_value(ue.operand_);
+        return literal_value(ue.operand_);
     }
 
     inline bool is_literal_value(operation const& op)

--- a/phylanx/ast/generate_ast.hpp
+++ b/phylanx/ast/generate_ast.hpp
@@ -17,22 +17,9 @@ namespace phylanx { namespace ast
     /// Parse the given string and convert it into an instance of an AST
     PHYLANX_EXPORT ast::expression generate_ast(std::string const& input);
 
-    /// Parse the given string and convert it into an instance of an AST,
-    /// fill given vector with iterators, one for each tagged_id assigned
-    /// to one of the matched attributes.
-    PHYLANX_EXPORT ast::expression generate_ast(std::string const& input,
-        std::vector<std::string::const_iterator>& iters);
-
     /// Parse the given string and convert it into a list of AST instances
     PHYLANX_EXPORT std::vector<ast::expression> generate_asts(
         std::string const& input);
-
-    /// Parse the given string and convert it into a list of AST instances,
-    /// fill given vector with iterators, one for each tagged_id assigned
-    /// to one of the matched attributes.
-    PHYLANX_EXPORT std::vector<ast::expression> generate_asts(
-        std::string const& input,
-        std::vector<std::string::const_iterator>& iters);
 }}
 
 #endif

--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -402,7 +402,6 @@ namespace phylanx { namespace ast
         {
         }
 
-
     private:
         friend class hpx::serialization::access;
 

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -29,9 +29,9 @@ namespace phylanx { namespace execution_tree { namespace compiler
     //                     have the name of the argument as their <instance>
     //      <compile_id>:  the sequence number of the invocation of the
     //                     function phylanx::execution_tree::compile
-    //      <tag>:         the index into the vector of iterators, where the
-    //                     iterator refers to the point of usage of the
-    //                     primitive in the compiled source code
+    //      <tag>:         the position inside the compiled code block where the
+    //                     referring to the point of usage of the primitive in
+    //                     the compiled source code
     struct primitive_name_parts
     {
         primitive_name_parts()

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -241,19 +241,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
             base_primitive, eval_nonvirtual, eval_action);
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
             base_primitive, bind_nonvirtual, bind_action);
+        HPX_DEFINE_COMPONENT_DIRECT_ACTION(
+            base_primitive, expression_topology_nonvirtual,
+            expression_topology_action);
 #else
         HPX_DEFINE_COMPONENT_ACTION(
             base_primitive, eval_nonvirtual, eval_action);
         HPX_DEFINE_COMPONENT_ACTION(
             base_primitive, bind_nonvirtual, bind_action);
+        HPX_DEFINE_COMPONENT_ACTION(
+            base_primitive, expression_topology_nonvirtual,
+            expression_topology_action);
 #endif
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
             base_primitive, eval_direct_nonvirtual, eval_direct_action);
         HPX_DEFINE_COMPONENT_ACTION(
             base_primitive, store_nonvirtual, store_action);
-        HPX_DEFINE_COMPONENT_ACTION(
-            base_primitive, expression_topology_nonvirtual,
-            expression_topology_action);
 
     protected:
         static std::vector<primitive_argument_type> noargs;

--- a/phylanx/execution_tree/primitives/define_function.hpp
+++ b/phylanx/execution_tree/primitives/define_function.hpp
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::vector<primitive_argument_type> const& args) const override;
 
         // return the topology for this function definition
-        topology expression_topology() const;
+        topology expression_topology() const override;
 
         // Initialize the expression representing the function body, this has
         // to be done separately in order to support recursive functions.

--- a/phylanx/execution_tree/primitives/define_variable.hpp
+++ b/phylanx/execution_tree/primitives/define_variable.hpp
@@ -42,7 +42,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         void store(primitive_result_type && val) override;
 
         // return the topology for this variable definition
-        topology expression_topology() const;
+        topology expression_topology() const override;
 
     protected:
         std::string extract_function_name() const;

--- a/phylanx/execution_tree/primitives/wrapped_variable.hpp
+++ b/phylanx/execution_tree/primitives/wrapped_variable.hpp
@@ -26,7 +26,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         wrapped_variable() = default;
         wrapped_variable(primitive_argument_type target, std::string name);
 
-        void store(primitive_result_type && val);
+        void store(primitive_result_type && val) override;
 
         hpx::future<primitive_result_type> eval(
             std::vector<primitive_argument_type> const& params) const override;

--- a/src/ast/generate_ast.cpp
+++ b/src/ast/generate_ast.cpp
@@ -13,19 +13,176 @@
 
 #include <boost/spirit/include/qi.hpp>
 
+#include <algorithm>
 #include <sstream>
 #include <string>
 
 namespace phylanx { namespace ast
 {
-    ast::expression generate_ast(std::string const& input,
-        std::vector<std::string::const_iterator>& iters)
+    namespace detail
+    {
+        ///////////////////////////////////////////////////////////////////////
+        expression& replace_compile_ids(expression& ast,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+
+        template <typename Ast>
+        void replace_compile_ids(util::recursive_wrapper<Ast>& ast,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+
+        inline void replace_compile_ids(operand& op,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+        inline void replace_compile_ids(identifier& id,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+        inline void replace_compile_ids(unary_expr& ue,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+        inline void replace_compile_ids(primary_expr& pe,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+        inline void replace_compile_ids(operation& op,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+        inline void replace_compile_ids(function_call& fc,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin);
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Ast>
+        void replace_compile_ids(Ast const&,
+            std::vector<std::ptrdiff_t> const&,
+            std::string::const_iterator)
+        {
+        }
+
+        inline void replace_compile_ids(identifier& id,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            if (id.id >= 0)
+            {
+                id.id = std::distance(begin, iters[id.id]);
+            }
+        }
+
+        inline void replace_compile_ids(unary_expr& ue,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            if (ue.id >= 0)
+            {
+                ue.id = std::distance(begin, iters[ue.id]);
+            }
+            replace_compile_ids(ue.operand_, iters, begin);
+        }
+
+        inline void replace_compile_ids(primary_expr& pe,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            if (pe.id >= 0)
+            {
+                pe.id = std::distance(begin, iters[pe.id]);
+            }
+
+            switch (pe.index())
+            {
+            case 3:     // identifier
+                replace_compile_ids(util::get<3>(pe.get()), iters, begin);
+                break;
+
+            case 6:     // phylanx::util::recursive_wrapper<expression>
+                replace_compile_ids(util::get<6>(pe.get()).get(), iters, begin);
+                break;
+
+            case 7:     // phylanx::util::recursive_wrapper<function_call>
+                replace_compile_ids(util::get<7>(pe.get()).get(), iters, begin);
+                break;
+
+            case 8:     // phylanx::util::recursive_wrapper<std::vector<ast::expression>>
+                for (auto& ast : util::get<8>(pe.get()).get())
+                {
+                    replace_compile_ids(ast, iters, begin);
+                }
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        inline void replace_compile_ids(operand& op,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            switch (op.index())
+            {
+            case 1:     // phylanx::util::recursive_wrapper<primary_expr>
+                replace_compile_ids(util::get<1>(op.get()).get(), iters, begin);
+                break;
+
+            case 2:     // phylanx::util::recursive_wrapper<unary_expr>
+                replace_compile_ids(util::get<2>(op.get()).get(), iters, begin);
+                break;
+
+            default:
+                break;
+            }
+        }
+
+        inline void replace_compile_ids(operation& op,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            replace_compile_ids(op.operand_, iters, begin);
+        }
+
+        inline void replace_compile_ids(function_call& fc,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            replace_compile_ids(fc.function_name, iters, begin);
+            for (auto& arg : fc.args)
+            {
+                replace_compile_ids(arg, iters, begin);
+            }
+        }
+
+        template <typename Ast>
+        void replace_compile_ids(util::recursive_wrapper<Ast>& ast,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            replace_compile_ids(ast.get(), iters, begin);
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        expression& replace_compile_ids(expression& ast,
+            std::vector<std::string::const_iterator> const& iters,
+            std::string::const_iterator begin)
+        {
+            for (auto& op : ast.rest)
+            {
+                replace_compile_ids(op, iters, begin);
+            }
+            replace_compile_ids(ast.first, iters, begin);
+
+            return ast;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    ast::expression generate_ast(std::string const& input)
     {
         using iterator = std::string::const_iterator;
 
         iterator first = input.begin();
         iterator last = input.end();
 
+        std::vector<std::string::const_iterator> iters;
         std::stringstream strm;
         ast::parser::error_handler<iterator> error_handler(
             first, last, strm, iters);
@@ -49,24 +206,19 @@ namespace phylanx { namespace ast
                 "phylanx::ast::generate_ast", strm.str());
         }
 
-        return ast;
-    }
-
-    ast::expression generate_ast(std::string const& input)
-    {
-        std::vector<std::string::const_iterator> iters;
-        return generate_ast(input, iters);
+        // replace compile-tags with offsets against begin of input
+        return detail::replace_compile_ids(ast, iters, input.begin());
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::vector<ast::expression> generate_asts(std::string const& input,
-        std::vector<std::string::const_iterator>& iters)
+    std::vector<ast::expression> generate_asts(std::string const& input)
     {
         using iterator = std::string::const_iterator;
 
         iterator first = input.begin();
         iterator last = input.end();
 
+        std::vector<std::string::const_iterator> iters;
         std::stringstream strm;
         ast::parser::error_handler<iterator> error_handler(
             first, last, strm, iters);
@@ -90,13 +242,13 @@ namespace phylanx { namespace ast
                 "phylanx::ast::generate_asts", strm.str());
         }
 
-        return asts;
-    }
+        // replace compile-tags with offsets against begin of input
+        for (auto& ast : asts)
+        {
+            detail::replace_compile_ids(ast, iters, input.begin());
+        }
 
-    std::vector<ast::expression> generate_asts(std::string const& input)
-    {
-        std::vector<std::string::const_iterator> iters;
-        return generate_asts(input, iters);
+        return asts;
     }
 }}
 

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -258,7 +258,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             // get global name of the component created
             std::string full_name = name;
             std::int64_t id = ast::detail::tagged_id(name_expr);
-            if (id != 0)
+            if (id >= 0)
             {
                 full_name += annotation(id);
             }
@@ -322,7 +322,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             if (compiled_function* cf = env_.find(name))
             {
                 std::int64_t id = ast::detail::tagged_id(expr);
-                if (id != 0)
+                if (id >= 0)
                 {
                     name += annotation(id);
                 }
@@ -351,7 +351,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 }
 
                 std::int64_t id = ast::detail::tagged_id(expr);
-                if (id != 0)
+                if (id >= 0)
                 {
                     name += annotation(id);
                 }
@@ -414,7 +414,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
 
                 // get global name of the component created
                 std::int64_t id = ast::detail::tagged_id(expr);
-                if (id != 0)
+                if (id >= 0)
                 {
                     name += annotation(id);
                 }

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -182,9 +182,7 @@ namespace phylanx { namespace execution_tree
         return f.then(
             [this_name](hpx::future<topology> && f)
             {
-                topology t = f.get();
-                t.name_ = this_name;
-                return t;
+                return topology{{f.get()}, this_name};
             });
     }
 
@@ -216,7 +214,8 @@ namespace phylanx { namespace execution_tree
                 }
             }
 
-            if (!result.empty())
+            if (!result.empty() &&
+                !(result[0] == '(' && result[result.size()-1] == ')'))
             {
                 result = "(" + result + ")";
             }

--- a/tests/unit/execution_tree/CMakeLists.txt
+++ b/tests/unit/execution_tree/CMakeLists.txt
@@ -1,10 +1,11 @@
-# Copyright (c) 2017 Hartmut Kaiser
+# Copyright (c) 2017-2018 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
     compiler
+    expression_topology
     generate_tree
    )
 

--- a/tests/unit/execution_tree/expression_topology.cpp
+++ b/tests/unit/execution_tree/expression_topology.cpp
@@ -1,0 +1,39 @@
+//  Copyright (c) 2017-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+void test_expressiontree_topology(char const* code, char const* exprected)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+
+    auto f = phylanx::execution_tree::compile(
+        phylanx::ast::generate_ast(code), snippets);
+
+    auto topology = f.get_expression_topology();
+    std::string tree = phylanx::execution_tree::newick_tree(topology);
+
+    HPX_TEST_EQ(tree, std::string(exprected));
+}
+
+int main(int argc, char* argv[])
+{
+    test_expressiontree_topology(
+        "define(x, 42)",
+        "/phylanx/define-variable#0#x/0#7;");
+
+    test_expressiontree_topology(
+        "block(define(x, 42), define(y, x))",
+        "(/phylanx/define-variable#0#x/0#13,"
+            "(/phylanx/variable#0#x/0#31) "
+                "/phylanx/define-variable#1#y/0#28) "
+            "/phylanx/block#0/0#0;");
+
+    return hpx::util::report_errors();
+}
+


### PR DESCRIPTION
- this removes generate_ast() overloads that were taking the array of iterators
- flyby: fixing literal_value(unary_expr)
- flyby: expression_topology_action is direct in DEBUG
- flyby: fixing primitive name generation for id == 0
- flyby: fixing expression_topology, adding minimal test