### PR TITLE
Adding functionality to generate DOT string format from expression tree topology

### DIFF
--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -197,7 +197,11 @@ void print_instrumentation(
 
     std::cout << "Tree information for function: " << name << "\n";
     std::cout << phylanx::execution_tree::newick_tree(
-                     func.get_expression_topology())
+                     name, func.get_expression_topology())
+              << "\n\n";
+
+    std::cout << phylanx::execution_tree::dot_tree(
+                     name, func.get_expression_topology())
               << "\n\n";
 }
 

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -59,7 +59,14 @@ namespace phylanx { namespace execution_tree
         std::string name_;
     };
 
-    PHYLANX_EXPORT std::string newick_tree(topology const& t);
+    ///////////////////////////////////////////////////////////////////////////
+    // Generate Newick tree (string) format from given tree topology
+    PHYLANX_EXPORT std::string newick_tree(
+        std::string const& name, topology const& t);
+
+    // Generate Dot tree (string) format from given tree topology
+    PHYLANX_EXPORT std::string dot_tree(
+        std::string const& name, topology const& t);
 
     ///////////////////////////////////////////////////////////////////////////
     struct primitive_argument_type;

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -216,14 +216,14 @@ namespace phylanx { namespace execution_tree
                     }
                 }
 
-                if (!result.empty())
+                if (!result.empty() &&
+                    !(result[0] == '(' && result[result.size()-1] == ')'))
                 {
                     result = "(" + result + ")";
                 }
             }
 
-            if (!result.empty() &&
-                !(result[0] == '(' && result[result.size()-1] == ')'))
+            if (!t.name_.empty())
             {
                 if (!result.empty())
                 {

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -195,48 +195,83 @@ namespace phylanx { namespace execution_tree
 
     ///////////////////////////////////////////////////////////////////////////
     // traverse expression-tree topology and generate Newick representation
-    std::string newick_tree_helper(topology const& t)
+    namespace detail
     {
-        std::string result;
+        std::string newick_tree_helper(topology const& t)
+        {
+            std::string result;
+
+            if (!t.children_.empty())
+            {
+                bool first = true;
+                for (auto const& child : t.children_)
+                {
+                    std::string name = newick_tree_helper(child);
+                    if (!first && !name.empty())
+                    {
+                        result += ',';
+                    }
+                    first = false;
+                    if (!name.empty())
+                    {
+                        result += std::move(name);
+                    }
+                }
+
+                if (!result.empty())
+                {
+                    result = "(" + result + ")";
+                }
+            }
+
+            if (!t.name_.empty())
+            {
+                if (!result.empty())
+                {
+                    result += " ";
+                }
+                result += t.name_;
+            }
+
+            return result;
+        }
+    }
+
+    std::string newick_tree(std::string const& name, topology const& t)
+    {
+        return "(" + detail::newick_tree_helper(t) + ") " + name + ";";
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        std::string dot_tree_helper(topology const& t)
+        {
+            std::string result;
+
+            for (auto const& child : t.children_)
+            {
+                result += "    \"" + t.name_ + "\" -- \"" + child.name_ + "\";\n";
+                if (!child.children_.empty())
+                {
+                    result += dot_tree_helper(child);
+                }
+            }
+
+            return result;
+        }
+    }
+
+    std::string dot_tree(std::string const& name, topology const& t)
+    {
+        std::string result = "graph " + name + " {\n";
 
         if (!t.children_.empty())
         {
-            bool first = true;
-            for (auto const& child : t.children_)
-            {
-                std::string name = newick_tree_helper(child);
-                if (!first && !name.empty())
-                {
-                    result += ',';
-                }
-                first = false;
-                if (!name.empty())
-                {
-                    result += std::move(name);
-                }
-            }
-
-            if (!result.empty())
-            {
-                result = "(" + result + ")";
-            }
+            result += detail::dot_tree_helper(t);
         }
 
-        if (!t.name_.empty())
-        {
-            if (!result.empty())
-            {
-                result += " ";
-            }
-            result += t.name_;
-        }
-
-        return result;
-    }
-
-    std::string newick_tree(topology const& t)
-    {
-        return newick_tree_helper(t) + ";";
+        return result + "}\n";
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/tests/unit/execution_tree/expression_topology.cpp
+++ b/tests/unit/execution_tree/expression_topology.cpp
@@ -8,7 +8,8 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-void test_expressiontree_topology(char const* code, char const* exprected)
+void test_expressiontree_topology(char const* name,
+    char const* code, char const* expected)
 {
     phylanx::execution_tree::compiler::function_list snippets;
 
@@ -16,23 +17,23 @@ void test_expressiontree_topology(char const* code, char const* exprected)
         phylanx::ast::generate_ast(code), snippets);
 
     auto topology = f.get_expression_topology();
-    std::string tree = phylanx::execution_tree::newick_tree(topology);
+    std::string tree = phylanx::execution_tree::newick_tree(name, topology);
 
-    HPX_TEST_EQ(tree, std::string(exprected));
+    HPX_TEST_EQ(tree, std::string(expected));
 }
 
 int main(int argc, char* argv[])
 {
-    test_expressiontree_topology(
+    test_expressiontree_topology("test1",
         "define(x, 42)",
-        "/phylanx/define-variable#0#x/0#7;");
+            "(/phylanx/define-variable#0#x/0#7) test1;");
 
-    test_expressiontree_topology(
+    test_expressiontree_topology("test2",
         "block(define(x, 42), define(y, x))",
-        "(/phylanx/define-variable#0#x/0#13,"
+        "((/phylanx/define-variable#0#x/0#13,"
             "(/phylanx/variable#0#x/0#31) "
                 "/phylanx/define-variable#1#y/0#28) "
-            "/phylanx/block#0/0#0;");
+            "/phylanx/block#0/0#0) test2;");
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
- this fixes #153 

This also adds the name of the tree as an argument to the existing newick_tree() function