### PR TITLE
Single element extraction via slicing

### DIFF
--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -112,7 +112,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     auto sv = blaze::subvector(
                         arg0, arg0.size() + col_start, -col_start + col_stop);
 
-                    if(sv.size() ==1)
+                    if(sv.size() == 1)
                     {
                         storage0d_type v{sv[0]};
                         return ir::node_data<double>{std::move(v)};
@@ -125,7 +125,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 auto sv =
                     blaze::subvector(arg0, col_start, col_stop - col_start);
 
-                if(sv.size() ==1)
+                if(sv.size() == 1)
                 {
                     storage0d_type v{sv[0]};
                     return ir::node_data<double>{std::move(v)};
@@ -196,7 +196,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 num_matrix_rows, 1),
                             0);
 
-                        if(sv.size() ==1)
+                        if(sv.size() == 1)
                         {
                             storage0d_type v{sv[0]};
                             return ir::node_data<double>{std::move(v)};
@@ -222,7 +222,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             num_matrix_rows, 1),
                         0);
 
-                    if(sv.size() ==1)
+                    if(sv.size() == 1)
                     {
                         storage0d_type v{sv[0]};
                         return ir::node_data<double>{std::move(v)};

--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -102,6 +102,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "col_stop can not be negative if col_start is positive");
                 }
 
+                using storage0d_type = typename arg_type::storage0d_type;
                 using storage1d_type = typename arg_type::storage1d_type;
 
                 auto arg0 = args[0].vector();
@@ -111,12 +112,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     auto sv = blaze::subvector(
                         arg0, arg0.size() + col_start, -col_start + col_stop);
 
+                    if(sv.size() ==1)
+                    {
+                        storage0d_type v{sv[0]};
+                        return ir::node_data<double>{std::move(v)};
+                    }
+
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};
                 }
 
                 auto sv =
                     blaze::subvector(arg0, col_start, col_stop - col_start);
+
+                if(sv.size() ==1)
+                {
+                    storage0d_type v{sv[0]};
+                    return ir::node_data<double>{std::move(v)};
+                }
 
                 storage1d_type v{sv};
                 return ir::node_data<double>(std::move(v));
@@ -163,6 +176,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "negative");
                 }
 
+                using storage0d_type = typename arg_type::storage0d_type;
                 using storage1d_type = typename arg_type::storage1d_type;
                 using storage2d_type = typename arg_type::storage2d_type;
 
@@ -181,6 +195,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 0, num_cols + col_start,
                                 num_matrix_rows, 1),
                             0);
+
+                        if(sv.size() ==1)
+                        {
+                            storage0d_type v{sv[0]};
+                            return ir::node_data<double>{std::move(v)};
+                        }
 
                         storage1d_type v{sv};
                         return ir::node_data<double>{std::move(v)};
@@ -201,6 +221,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             0, col_start,
                             num_matrix_rows, 1),
                         0);
+
+                    if(sv.size() ==1)
+                    {
+                        storage0d_type v{sv[0]};
+                        return ir::node_data<double>{std::move(v)};
+                    }
 
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -100,6 +100,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 using storage1d_type = typename arg_type::storage1d_type;
+                using storage0d_type = typename arg_type::storage0d_type;
 
                 auto arg0 = args[0].vector();
 
@@ -110,10 +111,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};
+
+                    if(sv.size() ==1)
+                    {
+                        storage0d_type v{sv[0]};
+                        return ir::node_data<double>{std::move(v)};
+                    }
                 }
 
                 auto sv =
                     blaze::subvector(arg0, col_start, col_stop - col_start);
+
+                if(sv.size() ==1)
+                {
+                    storage0d_type v{sv[0]};
+                    return ir::node_data<double>{std::move(v)};
+                }
 
                 storage1d_type v{sv};
                 return ir::node_data<double>{std::move(v)};
@@ -174,6 +187,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "col_start/row_start is positive");
                 }
 
+                using storage0d_type = typename arg_type::storage0d_type;
                 using storage1d_type = typename arg_type::storage1d_type;
                 using storage2d_type = typename arg_type::storage2d_type;
 
@@ -194,6 +208,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 1, -col_start + col_stop),
                             0));
 
+                        if(sv.size() ==1)
+                        {
+                            storage0d_type v{sv[0]};
+                            return ir::node_data<double>{std::move(v)};
+                        }
+
                         storage1d_type v{sv};
                         return ir::node_data<double>{std::move(v)};
                     }
@@ -204,6 +224,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 row_start, num_cols + col_start,
                                 row_stop - row_start, 1),
                             0);
+
+                        if(sv.size() ==1)
+                        {
+                            storage0d_type v{sv[0]};
+                            return ir::node_data<double>{std::move(v)};
+                        }
 
                         storage1d_type v{sv};
                         return ir::node_data<double>{std::move(v)};
@@ -232,6 +258,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 1, col_stop - col_start),
                             0));
 
+                        if(sv.size() ==1)
+                        {
+                            storage0d_type v{sv[0]};
+                            return ir::node_data<double>{std::move(v)};
+                        }
+
                         storage1d_type v{sv};
                         return ir::node_data<double>{std::move(v)};
                     }
@@ -242,6 +274,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 num_rows + row_start, col_start,
                                 -row_start + row_stop, 1),
                             0);
+
+                        if(sv.size() ==1)
+                        {
+                            storage0d_type v{sv[0]};
+                            return ir::node_data<double>{std::move(v)};
+                        }
 
                         storage1d_type v{sv};
                         return ir::node_data<double>{std::move(v)};
@@ -271,6 +309,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 1, -col_start + col_stop),
                             0));
 
+                        if(sv.size() ==1)
+                        {
+                            storage0d_type v{sv[0]};
+                            return ir::node_data<double>{std::move(v)};
+                        }
+
                         storage1d_type v{sv};
                         return ir::node_data<double>{std::move(v)};
                     }
@@ -281,6 +325,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 num_rows + row_start, num_cols + col_start,
                                 -row_start + row_stop, 1),
                             0);
+
+                        if(sv.size() ==1)
+                        {
+                            storage0d_type v{sv[0]};
+                            return ir::node_data<double>{std::move(v)};
+                        }
 
                         storage1d_type v{sv};
                         return ir::node_data<double>{std::move(v)};
@@ -304,6 +354,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             1, col_stop - col_start),
                         0));
 
+                    if(sv.size() ==1)
+                    {
+                        storage0d_type v{sv[0]};
+                        return ir::node_data<double>{std::move(v)};
+                    }
+
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};
                 }
@@ -314,6 +370,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             row_start, col_start,
                             row_stop - row_start, 1),
                         0);
+
+                    if(sv.size() ==1)
+                    {
+                        storage0d_type v{sv[0]};
+                        return ir::node_data<double>{std::move(v)};
+                    }
 
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -112,7 +112,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     storage1d_type v{sv};
                     return ir::node_data<double>{std::move(v)};
 
-                    if(sv.size() ==1)
+                    if(sv.size() == 1)
                     {
                         storage0d_type v{sv[0]};
                         return ir::node_data<double>{std::move(v)};
@@ -122,7 +122,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 auto sv =
                     blaze::subvector(arg0, col_start, col_stop - col_start);
 
-                if(sv.size() ==1)
+                if(sv.size() == 1)
                 {
                     storage0d_type v{sv[0]};
                     return ir::node_data<double>{std::move(v)};
@@ -208,7 +208,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 1, -col_start + col_stop),
                             0));
 
-                        if(sv.size() ==1)
+                        if(sv.size() == 1)
                         {
                             storage0d_type v{sv[0]};
                             return ir::node_data<double>{std::move(v)};
@@ -225,7 +225,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 row_stop - row_start, 1),
                             0);
 
-                        if(sv.size() ==1)
+                        if(sv.size() == 1)
                         {
                             storage0d_type v{sv[0]};
                             return ir::node_data<double>{std::move(v)};
@@ -258,7 +258,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 1, col_stop - col_start),
                             0));
 
-                        if(sv.size() ==1)
+                        if(sv.size() == 1)
                         {
                             storage0d_type v{sv[0]};
                             return ir::node_data<double>{std::move(v)};
@@ -275,7 +275,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 -row_start + row_stop, 1),
                             0);
 
-                        if(sv.size() ==1)
+                        if(sv.size() == 1)
                         {
                             storage0d_type v{sv[0]};
                             return ir::node_data<double>{std::move(v)};
@@ -309,7 +309,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 1, -col_start + col_stop),
                             0));
 
-                        if(sv.size() ==1)
+                        if(sv.size() == 1)
                         {
                             storage0d_type v{sv[0]};
                             return ir::node_data<double>{std::move(v)};
@@ -326,7 +326,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 -row_start + row_stop, 1),
                             0);
 
-                        if(sv.size() ==1)
+                        if(sv.size() == 1)
                         {
                             storage0d_type v{sv[0]};
                             return ir::node_data<double>{std::move(v)};
@@ -354,7 +354,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             1, col_stop - col_start),
                         0));
 
-                    if(sv.size() ==1)
+                    if(sv.size() == 1)
                     {
                         storage0d_type v{sv[0]};
                         return ir::node_data<double>{std::move(v)};
@@ -371,7 +371,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             row_stop - row_start, 1),
                         0);
 
-                    if(sv.size() ==1)
+                    if(sv.size() == 1)
                     {
                         storage0d_type v{sv[0]};
                         return ir::node_data<double>{std::move(v)};

--- a/tests/unit/execution_tree/primitives/column_slicing.cpp
+++ b/tests/unit/execution_tree/primitives/column_slicing.cpp
@@ -214,7 +214,7 @@ void test_column_slicing_operation_1d_single_slice_negative_index()
         });
 
     auto sm = blaze::subvector(v1, 1002, 1);
-    auto expected = sm;
+    auto expected = sm[0];
 
     hpx::future<phylanx::execution_tree::primitive_result_type> f =
         slice.eval();

--- a/tests/unit/execution_tree/primitives/slicing_operation.cpp
+++ b/tests/unit/execution_tree/primitives/slicing_operation.cpp
@@ -653,6 +653,142 @@ void test_row_slicing_operation_from_end_single_row()
                 phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_single_element_slicing_operation_from_end_row()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(6.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(7.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 96, 6, 1, 1);
+    auto expected = blaze::trans(blaze::row(sm,0))[0];
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_single_element_slicing_operation_from_end_column()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(0.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(1.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-5.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(-4.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+
+    auto sm = blaze::submatrix(m1, 0, 96, 1, 1);
+    auto expected = blaze::column(sm,0)[0];
+
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+
+void test_single_element_slicing_operation()
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> m1 = gen.generate(101UL, 101UL);
+
+    phylanx::execution_tree::primitive input_matrix =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive row_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(10.0));
+
+    phylanx::execution_tree::primitive row_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(11.0));
+
+    phylanx::execution_tree::primitive col_start =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(14.0));
+
+    phylanx::execution_tree::primitive col_stop =
+            hpx::new_<phylanx::execution_tree::primitives::variable>(
+                    hpx::find_here(), phylanx::ir::node_data<double>(15.0));
+
+    phylanx::execution_tree::primitive slice =
+            hpx::new_<phylanx::execution_tree::primitives::slicing_operation>(
+                    hpx::find_here(),
+                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                            std::move(input_matrix), std::move(row_start),
+                            std::move(row_stop), std::move(col_start),
+                            std::move(col_stop)
+                    });
+
+    auto sm = blaze::submatrix(m1, 10, 14, 1, 1);
+    auto expected = sm(0,0);
+
+    hpx::future<phylanx::execution_tree::primitive_result_type> f =
+            slice.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+                phylanx::execution_tree::extract_numeric_value(f.get()));
+}
 
 int main(int argc, char* argv[])
 {
@@ -673,6 +809,11 @@ int main(int argc, char* argv[])
 
     test_col_slicing_operation_from_end_single_column();
     test_row_slicing_operation_from_end_single_row();
+
+    test_single_element_slicing_operation_from_end_row();
+    test_single_element_slicing_operation_from_end_column();
+
+    test_single_element_slicing_operation();
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
This pull request makes sure if a single element is extracted via slicing, a double is returned and not a vector of double. 