### PR TITLE
Supporting direct positional (symbol) information in PhySL

### DIFF
--- a/phylanx/ast/detail/tagged_id.hpp
+++ b/phylanx/ast/detail/tagged_id.hpp
@@ -14,44 +14,44 @@
 namespace phylanx { namespace ast { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
-    inline std::int64_t tagged_id(identifier const& id);
+    inline tagged tagged_id(identifier const& id);
 
-    PHYLANX_EXPORT std::int64_t tagged_id(primary_expr const& pe);
-    PHYLANX_EXPORT std::int64_t tagged_id(unary_expr const& ue);
-    PHYLANX_EXPORT std::int64_t tagged_id(operand const& op);
+    PHYLANX_EXPORT tagged tagged_id(primary_expr const& pe);
+    PHYLANX_EXPORT tagged tagged_id(unary_expr const& ue);
+    PHYLANX_EXPORT tagged tagged_id(operand const& op);
 
-    inline std::int64_t tagged_id(operation const& op);
-    inline std::int64_t tagged_id(expression const& expr);
-    inline std::int64_t tagged_id(function_call const& fc);
+    inline tagged tagged_id(operation const& op);
+    inline tagged tagged_id(expression const& expr);
+    inline tagged tagged_id(function_call const& fc);
 
     template <typename Ast>
-    std::int64_t tagged_id(Ast const&)
+    tagged tagged_id(Ast const&)
     {
-        return 0;
+        return {};
     }
 
     template <typename Ast>
-    std::int64_t tagged_id(util::recursive_wrapper<Ast> const& ast)
+    tagged tagged_id(util::recursive_wrapper<Ast> const& ast)
     {
         return tagged_id(ast.get());
     }
 
-    inline std::int64_t tagged_id(identifier const& id)
+    inline tagged tagged_id(identifier const& id)
     {
-        return id.id;
+        return id;
     }
 
-    inline std::int64_t tagged_id(operation const& op)
+    inline tagged tagged_id(operation const& op)
     {
         return tagged_id(op.operand_);
     }
 
-    inline std::int64_t tagged_id(expression const& expr)
+    inline tagged tagged_id(expression const& expr)
     {
         return tagged_id(expr.first);
     }
 
-    inline std::int64_t tagged_id(function_call const& fc)
+    inline tagged tagged_id(function_call const& fc)
     {
         return tagged_id(fc.function_name);
     }

--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -48,21 +48,46 @@ namespace phylanx { namespace ast
     {
         tagged()
           : id(--next_id)
+          , col(-1)
         {}
 
         tagged(int tag)
           : id(tag)
+          , col(-1)
         {
         }
 
-        std::int64_t id; // Used to annotate the AST with the iterator position.
-                         // This id is used as a key to a map<int, Iterator>
-                         // (not really part of the AST.)
+        tagged(std::int64_t line, std::int64_t column)
+          : id(line)
+          , col(column)
+        {
+        }
+
+        std::int64_t id;    // Used to annotate the AST with the iterator position.
+                            // This id is used as a key to a map<int, Iterator>
+                            // (not really part of the AST.)
+                            // if 'col' != -1, then id represents the line number
+        std::int64_t col;   // if != -1, represents the column_offset
 
         // default-initialized tags are negative
         PHYLANX_EXPORT static std::int64_t next_id;
     };
 
+    inline bool operator==(tagged const& lhs, tagged const& rhs)
+    {
+        // if one of the col values is == -1 we consider the instances to be equal
+        if (lhs.col == -1 || rhs.col == -1)
+        {
+            return true;
+        }
+        return lhs.id == rhs.id && lhs.col == rhs.col;
+    }
+    inline bool operator!=(tagged const& lhs, tagged const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     enum class optoken
     {
         // precedence 1
@@ -178,6 +203,18 @@ namespace phylanx { namespace ast
         {
         }
 
+        identifier(
+            std::string const& name, std::int64_t line, std::int64_t column)
+          : tagged(line, column)
+          , name(name)
+        {
+        }
+        identifier(std::string&& name, std::int64_t line, std::int64_t column)
+          : tagged(line, column)
+          , name(std::move(name))
+        {
+        }
+
         std::string name;
 
     private:
@@ -191,7 +228,8 @@ namespace phylanx { namespace ast
 
     inline bool operator==(identifier const& lhs, identifier const& rhs)
     {
-        return lhs.name == rhs.name;
+        return lhs.name == rhs.name &&
+            static_cast<tagged const&>(lhs) == static_cast<tagged const&>(rhs);
     }
     inline bool operator!=(identifier const& lhs, identifier const& rhs)
     {
@@ -305,6 +343,17 @@ namespace phylanx { namespace ast
         PHYLANX_EXPORT void serialize(
             hpx::serialization::output_archive& ar, unsigned);
     };
+
+    inline bool operator==(primary_expr const& lhs, primary_expr const& rhs)
+    {
+        return static_cast<expr_node_type const&>(lhs) ==
+                static_cast<expr_node_type const&>(rhs) &&
+            static_cast<tagged const&>(lhs) == static_cast<tagged const&>(rhs);
+    }
+    inline bool operator!=(primary_expr const& lhs, primary_expr const& rhs)
+    {
+        return !(lhs == rhs);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     using operand_node_type = phylanx::ast::parser::extended_variant<

--- a/phylanx/ast/parser/annotation.hpp
+++ b/phylanx/ast/parser/annotation.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2001-2011 Joel de Guzman
-//  Copyright (c) 2001-2017 Hartmut Kaiser
+//  Copyright (c) 2001--2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -45,7 +45,7 @@ namespace phylanx { namespace ast { namespace parser
 
             bool operator()(ast::function_call& x) const
             {
-                if (x.function_name.id <= 0)
+                if (x.function_name.id < 0 && x.function_name.col == -1)
                 {
                     x.function_name.id = id;
                     return true;
@@ -55,13 +55,18 @@ namespace phylanx { namespace ast { namespace parser
 
             bool operator()(ast::identifier& x) const
             {
-                x.id = id;
+                if (x.id < 0 && x.col == -1)
+                {
+                    x.id = id;
+                    return true;
+                }
                 return false;
             }
 
             bool operator()(ast::primary_expr& x) const
             {
-                if (ast::detail::tagged_id(x) <= 0)
+                tagged t = ast::detail::tagged_id(x);
+                if (t.id < 0 && t.col == -1)
                 {
                     x.id = id;
                     return true;
@@ -71,7 +76,8 @@ namespace phylanx { namespace ast { namespace parser
 
             bool operator()(ast::unary_expr& x) const
             {
-                if (ast::detail::tagged_id(x) <= 0)
+                tagged t = ast::detail::tagged_id(x);
+                if (t.id < 0 && t.col == -1)
                 {
                     x.id = id;
                     return true;
@@ -131,7 +137,7 @@ namespace phylanx { namespace ast { namespace parser
 
         void operator()(ast::function_call& ast, Iterator pos) const
         {
-            if (ast.function_name.id <= 0)
+            if (ast.function_name.id < 0 && ast.function_name.col == -1)
             {
                 std::size_t id = iters.size();
                 iters.push_back(pos);
@@ -141,9 +147,12 @@ namespace phylanx { namespace ast { namespace parser
 
         void operator()(ast::identifier& ast, Iterator pos) const
         {
-            std::size_t id = iters.size();
-            iters.push_back(pos);
-            ast.id = static_cast<std::int64_t>(id);
+            if (ast.id < 0 && ast.col == -1)
+            {
+                std::size_t id = iters.size();
+                iters.push_back(pos);
+                ast.id = static_cast<std::int64_t>(id);
+            }
         }
     };
 }}}

--- a/phylanx/ast/parser/ast.hpp
+++ b/phylanx/ast/parser/ast.hpp
@@ -15,9 +15,17 @@
 #include <boost/fusion/include/adapt_struct.hpp>
 #include <boost/spirit/include/support_attributes.hpp>
 
+#include <cstdint>
 #include <list>
 #include <string>
 #include <vector>
+
+BOOST_FUSION_ADAPT_STRUCT(
+    phylanx::ast::identifier,
+    (std::string, name)
+    (std::int64_t, id)
+    (std::int64_t, col)
+)
 
 BOOST_FUSION_ADAPT_STRUCT(
     phylanx::ast::unary_expr,

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2001-2011 Joel de Guzman
-//  Copyright (c) 2001-2017 Hartmut Kaiser
+//  Copyright (c) 2001-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -44,6 +44,7 @@ namespace phylanx { namespace ast { namespace parser
         qi::alnum_type alnum;
         qi::bool_type bool_;
         qi::int_parser<std::int64_t> long_long;
+        qi::attr_type attr;
 
         using qi::on_error;
         using qi::on_success;
@@ -108,7 +109,7 @@ namespace phylanx { namespace ast { namespace parser
             ;
 
         function_call =
-                (identifier_name >> '(')
+                (identifier >> '(')
             >   argument_list
             >   ')'
             ;
@@ -121,10 +122,14 @@ namespace phylanx { namespace ast { namespace parser
 
         argument_list = -(expr % ',');
 
-        identifier = as<ast::identifier>()[identifier_name];
+        identifier =
+                identifier_name
+            >>  (('#' > long_long) | attr(std::int64_t(-1)))
+            >>  (('#' > long_long) | attr(std::int64_t(-1)))
+            ;
 
         identifier_name =
-                !lexeme[keywords >> !(alnum | '_')]
+               !lexeme[keywords >> !(alnum | '_')]
             >>  raw[lexeme[(alpha | '_') >> *(alnum | '_')]]
             ;
 
@@ -141,6 +146,8 @@ namespace phylanx { namespace ast { namespace parser
             (function_call)
             (argument_list)
             (identifier)
+            (identifier_name)
+            (string)
         );
 
         ///////////////////////////////////////////////////////////////////////

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -17,7 +17,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
 {
     // The full name of every component is patterned after
     //
-    //      /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag>
+    // /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag1>[#<tag2>]
     //
     //  where:
     //      <primitive>:   the name of primitive type representing the given
@@ -29,23 +29,47 @@ namespace phylanx { namespace execution_tree { namespace compiler
     //                     have the name of the argument as their <instance>
     //      <compile_id>:  the sequence number of the invocation of the
     //                     function phylanx::execution_tree::compile
-    //      <tag>:         the position inside the compiled code block where the
-    //                     referring to the point of usage of the primitive in
-    //                     the compiled source code
+    //      <tag1>:        if <tag2> == -1: the position inside the compiled code
+    //                     block where the referring to the point of usage of the
+    //                     primitive in the compiled source code
+    //                     if <tag2> != -1: the line number in the compiled code
+    //                     block where the referring to the point of usage of the
+    //                     primitive in the compiled source code
+    //      <tag2>:        (optional) if <tag2> != -1 or not given: the column
+    //                      offset in the given line (default: -1)
+    //
     struct primitive_name_parts
     {
         primitive_name_parts()
           : sequence_number(-1)
           , compile_id(-1)
-          , tag(-1)
+          , tag1(-1)
+          , tag2(-1)
         {}
 
         std::string primitive;
         std::int64_t sequence_number;
         std::string instance;
         std::int64_t compile_id;
-        std::int64_t tag;
+        std::int64_t tag1;
+        std::int64_t tag2;
     };
+
+    inline bool operator==(
+        primitive_name_parts const& lhs, primitive_name_parts const& rhs)
+    {
+        return lhs.primitive == rhs.primitive &&
+            lhs.sequence_number == rhs.sequence_number &&
+            lhs.instance == rhs.instance &&
+            lhs.compile_id == rhs.compile_id &&
+            lhs.tag1 == rhs.tag1 && lhs.tag2 == rhs.tag2;
+    }
+
+    inline bool operator!=(
+        primitive_name_parts const& lhs, primitive_name_parts const& rhs)
+    {
+        return !(lhs == rhs);
+    }
 
     // Split the given primitive name into its parts
     PHYLANX_EXPORT primitive_name_parts parse_primitive_name(

--- a/python/phylanx/util/__init__.py
+++ b/python/phylanx/util/__init__.py
@@ -61,6 +61,12 @@ def get_node(node,**kwargs):
     # if we can't find what we're looking for...
     return None
 
+def full_node_name(a, name):
+    return '%s#%d#%d' % (name, a.lineno, a.col_offset)
+
+def full_name(a):
+    return full_node_name(a, a.name)
+
 class Recompiler:
     def __init__(self):
         self.defs = {}
@@ -71,16 +77,16 @@ class Recompiler:
         if nm == "Num":
             return str(a.n)
         elif nm == "Str":
-            return '"'+a.s+'"'
+            return '"' + a.s + '"'
         elif nm == "Name":
-            return a.id
+            return full_node_name(a, a.id)
         elif nm == "Expr":
             args = [arg for arg in ast.iter_child_nodes(a)]
             s = ""
             if len(args)==1:
                 s += self.recompile(args[0])
             else:
-                raise Exception()
+                raise Exception('unexpected: expression has more than one sub-expression')
             return s
         elif nm == "Subscript":
             e = get_node(a,name="ExtSlice")
@@ -121,16 +127,16 @@ class Recompiler:
         elif nm == "FunctionDef":
             args = [arg for arg in ast.iter_child_nodes(a)]
             s = ""
-            s += "define("
-            s += a.name
-            s += ","
+            s += '%s(' % full_node_name(a, 'define')
+            s += full_name(a)
+            s += ", "
             for arg in ast.iter_child_nodes(args[0]):
-                s += arg.arg
-                s += ","
+                s += full_node_name(arg, arg.arg)
+                s += ", "
             if len(args)==2:
-                s += self.recompile(args[1],True)
+                s += self.recompile(args[1], True).strip(' ')
             else:
-                s += "block("
+                s += '%s(' % full_node_name(a, 'block')
                 #for aa in args[1:]:
                 sargs = args[1:]
                 for i in range(len(sargs)):
@@ -139,9 +145,9 @@ class Recompiler:
                         s += self.recompile(aa,True)
                     else:
                         s += self.recompile(aa,False)
-                        s += ","
+                        s += ", "
                 s += ")"
-            s += ")," + a.name
+            s += "), " + full_name(a)
             return s
         elif nm == "BinOp":
             args = [arg for arg in ast.iter_child_nodes(a)]
@@ -165,7 +171,7 @@ class Recompiler:
                 op = " ** "
                 priority = 3
             else:
-                raise Exception(nm2)
+                raise Exception('binary operation not supported: %s' % nm2)
             self.priority = priority
             term1 = self.recompile(args[0])
             self.priority = priority
@@ -182,7 +188,7 @@ class Recompiler:
             s = args[0].id+'('
             for n in range(1,len(args)):
                 if n > 1:
-                    s += ','
+                    s += ', '
                 s += self.recompile(args[n])
             s += ')'
             return s
@@ -220,7 +226,7 @@ class Recompiler:
                 tw = "block("
                 for aa in args[1:]:
                     s += tw
-                    tw = ","
+                    tw = ", "
                     s += self.recompile(aa)
                 s += ")"
             s += ")"
@@ -232,7 +238,7 @@ class Recompiler:
                 for j in range(len(a.body)):
                     aa = a.body[j]
                     if j > 0:
-                        s += ","
+                        s += ", "
                     if j + 1 == len(a.body):
                         s += self.recompile(aa,allowreturn)
                     else:
@@ -246,7 +252,7 @@ class Recompiler:
                 for j in range(len(a.orelse)):
                     aa = a.orelse[j]
                     if j > 0:
-                        s += ","
+                        s += ", "
                     if j + 1 == len(a.orelse):
                         s += self.recompile(aa,allowreturn)
                     else:
@@ -263,17 +269,19 @@ class Recompiler:
             sym = "?"
             nn = args[1].__class__.__name__
             if nn == "Lt":
-                sym = "<"
+                sym = " < "
             elif nn == "Gt":
-                sym = ">"
+                sym = " > "
             elif nn == "LtE":
-                sym = "<="
+                sym = " <= "
             elif nn == "GtE":
-                sym = ">="
+                sym = " >= "
             elif nn == "NotEq":
-                sym = "!="
+                sym = " != "
             elif nn == "Eq":
-                sym = "=="
+                sym = " == "
+            else:
+                raise Exception('boolean operation not supported: %s' % nn)
             return self.recompile(args[0])+sym+self.recompile(args[2])
         elif nm == "UnaryOp":
             args = [arg for arg in ast.iter_child_nodes(a)]
@@ -287,7 +295,7 @@ class Recompiler:
             else:
                 raise Exception(nm2)
         else:
-            raise Exception(nm)
+            raise Exception('unsupport AST node type: %s' % nm)
 
 def convert_to_phylanx_type(v):
     t = type(v)
@@ -315,7 +323,11 @@ class phyfun(object):
         # Create the AST
         tree = ast.parse(src)
         r = Recompiler()
-        self.__physl_src__ = "block(" + r.recompile(tree)+')\n'
+
+        assert len(tree.body) == 1
+
+        self.__physl_src__ = '%s(%s)\n' % (
+            full_node_name(tree.body[0], 'block'), r.recompile(tree))
 
     def __call__(self,*args):
         nargs = tuple(convert_to_phylanx_type(a) for a in args)

--- a/src/ast/detail/tagged_id.cpp
+++ b/src/ast/detail/tagged_id.cpp
@@ -15,31 +15,31 @@ namespace phylanx { namespace ast { namespace detail
     struct tagged_id_helper
     {
         template <typename Ast>
-        std::int64_t operator()(Ast const& ast) const
+        tagged operator()(Ast const& ast) const
         {
             return tagged_id(ast);
         }
     };
 
-    std::int64_t tagged_id(primary_expr const& pe)
+    tagged tagged_id(primary_expr const& pe)
     {
         if (pe.id >= 0)
         {
-            return pe.id;
+            return pe;
         }
         return visit(tagged_id_helper(), pe);
     }
 
-    std::int64_t tagged_id(unary_expr const& ue)
+    tagged tagged_id(unary_expr const& ue)
     {
         if (ue.id >= 0)
         {
-            return ue.id;
+            return ue;
         }
         return tagged_id(ue.operand_);
     }
 
-    std::int64_t tagged_id(operand const& op)
+    tagged tagged_id(operand const& op)
     {
         return visit(tagged_id_helper(), op);
     }

--- a/src/ast/generate_ast.cpp
+++ b/src/ast/generate_ast.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -64,7 +64,7 @@ namespace phylanx { namespace ast
             std::vector<std::string::const_iterator> const& iters,
             std::string::const_iterator begin)
         {
-            if (id.id >= 0)
+            if (id.id >= 0 && id.col == -1 && std::size_t(id.id) < iters.size())
             {
                 id.id = std::distance(begin, iters[id.id]);
             }
@@ -74,7 +74,7 @@ namespace phylanx { namespace ast
             std::vector<std::string::const_iterator> const& iters,
             std::string::const_iterator begin)
         {
-            if (ue.id >= 0)
+            if (ue.id >= 0 && ue.col == -1 && std::size_t(ue.id) < iters.size())
             {
                 ue.id = std::distance(begin, iters[ue.id]);
             }
@@ -85,7 +85,7 @@ namespace phylanx { namespace ast
             std::vector<std::string::const_iterator> const& iters,
             std::string::const_iterator begin)
         {
-            if (pe.id >= 0)
+            if (pe.id >= 0 && pe.col == -1 && std::size_t(pe.id) < iters.size())
             {
                 pe.id = std::distance(begin, iters[pe.id]);
             }

--- a/src/ast/node.cpp
+++ b/src/ast/node.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -117,25 +117,25 @@ namespace phylanx { namespace ast
     ///////////////////////////////////////////////////////////////////////////
     void identifier::serialize(hpx::serialization::output_archive& ar, unsigned)
     {
-        ar << name << id;
+        ar << name << id << col;
     }
 
     void identifier::serialize(hpx::serialization::input_archive& ar, unsigned)
     {
-        ar >> name >> id;
+        ar >> name >> id >> col;
     }
 
     ///////////////////////////////////////////////////////////////////////////
     void primary_expr::serialize(
         hpx::serialization::output_archive& ar, unsigned)
     {
-        ar << *static_cast<expr_node_type*>(this) << id;
+        ar << *static_cast<expr_node_type*>(this) << id << col;
     }
 
     void primary_expr::serialize(
         hpx::serialization::input_archive& ar, unsigned)
     {
-        ar >> *static_cast<expr_node_type*>(this) >> id;
+        ar >> *static_cast<expr_node_type*>(this) >> id >> col;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -152,12 +152,12 @@ namespace phylanx { namespace ast
     ///////////////////////////////////////////////////////////////////////////
     void unary_expr::serialize(hpx::serialization::output_archive& ar, unsigned)
     {
-        ar << operator_ << operand_ << id;
+        ar << operator_ << operand_ << id << col;
     }
 
     void unary_expr::serialize(hpx::serialization::input_archive& ar, unsigned)
     {
-        ar >> operator_ >> operand_ >> id;
+        ar >> operator_ >> operand_ >> id >> col;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -440,6 +440,10 @@ namespace phylanx { namespace ast
     std::ostream& operator<<(std::ostream& out, identifier const& id)
     {
         out << id.name;
+        if (id.id >= 0 && id.col != -1)
+        {
+            out << '#' << id.id << '#' << id.col;
+        }
         return out;
     }
 

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -207,11 +207,19 @@ namespace phylanx { namespace execution_tree { namespace compiler
         {}
 
     private:
-        std::string annotation(std::int64_t id)
+        std::string annotation(ast::tagged const& id)
         {
             // Note: the compile-id needs to be adjusted to be zero-based.
-            return "/" + std::to_string(snippets_.compile_id_ - 1) + "#" +
-                std::to_string(id);
+            std::string result = "/" +
+                std::to_string(snippets_.compile_id_ - 1) + "#" +
+                std::to_string(id.id);
+
+            if (id.col != -1)
+            {
+                result += '#' + std::to_string(id.col);
+            }
+
+            return result;
         }
 
         function handle_lambda(
@@ -256,8 +264,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
 
             // get global name of the component created
             std::string full_name = name;
-            std::int64_t id = ast::detail::tagged_id(name_expr);
-            if (id >= 0)
+            ast::tagged id = ast::detail::tagged_id(name_expr);
+            if (id.id >= 0)
             {
                 full_name += annotation(id);
             }
@@ -324,8 +332,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
         {
             if (compiled_function* cf = env_.find(name))
             {
-                std::int64_t id = ast::detail::tagged_id(expr);
-                if (id >= 0)
+                ast::tagged id = ast::detail::tagged_id(expr);
+                if (id.id >= 0)
                 {
                     name += annotation(id);
                 }
@@ -353,8 +361,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                         default_locality_));
                 }
 
-                std::int64_t id = ast::detail::tagged_id(expr);
-                if (id >= 0)
+                ast::tagged id = ast::detail::tagged_id(expr);
+                if (id.id >= 0)
                 {
                     name += annotation(id);
                 }
@@ -416,8 +424,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 name += "#" + std::to_string(sequence_number);
 
                 // get global name of the component created
-                std::int64_t id = ast::detail::tagged_id(expr);
-                if (id >= 0)
+                ast::tagged id = ast::detail::tagged_id(expr);
+                if (id.id >= 0)
                 {
                     name += annotation(id);
                 }

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -1,4 +1,4 @@
-//   Copyright (c) 2017 Hartmut Kaiser
+//   Copyright (c) 2017-2018 Hartmut Kaiser
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,6 +15,15 @@
 #include <string>
 #include <vector>
 
+///////////////////////////////////////////////////////////////////////////////
+template <typename Ast>
+void test_ast(std::string const& exprstr, Ast const& expected)
+{
+    phylanx::ast::expression expr = phylanx::ast::generate_ast(exprstr);
+    HPX_TEST_EQ(expr, phylanx::ast::expression(expected));
+}
+
+///////////////////////////////////////////////////////////////////////////////
 struct traverse_ast
 {
     traverse_ast(std::stringstream& strm)
@@ -115,10 +124,25 @@ void test_expression(std::string const& expr, std::string const& expected)
 
 int main(int argc, char* argv[])
 {
+    test_ast("A", phylanx::ast::identifier("A"));
+    test_ast("A#1#2", phylanx::ast::identifier("A", 1, 2));
+
+    test_ast("A()",
+        phylanx::ast::function_call(phylanx::ast::identifier("A")));
+    test_ast("A#1#2()",
+        phylanx::ast::function_call(phylanx::ast::identifier("A", 1, 2)));
+
     test_expression(
         "A + B",
             "A\n"
             "B\n"
+            "+\n"
+    );
+
+    test_expression(
+        "A#1#0 + B#1#5",
+            "A#1#0\n"
+            "B#1#5\n"
             "+\n"
     );
 
@@ -155,6 +179,13 @@ int main(int argc, char* argv[])
             "func\n"
             "A\n"
             "B\n"
+    );
+
+    test_expression(
+        "func#1#0(A#1#6, B#1#9)",
+            "func#1#0\n"
+            "A#1#6\n"
+            "B#1#9\n"
     );
 
     test_expression(

--- a/tests/unit/execution_tree/CMakeLists.txt
+++ b/tests/unit/execution_tree/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
     compiler
     expression_topology
     generate_tree
+    parse_primitive_name
    )
 
 foreach(test ${tests})

--- a/tests/unit/execution_tree/parse_primitive_name.cpp
+++ b/tests/unit/execution_tree/parse_primitive_name.cpp
@@ -1,0 +1,47 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+
+namespace pec = phylanx::execution_tree::compiler;
+
+void test_primitive_name(pec::primitive_name_parts const& expected_parts,
+    std::string const& expected_name)
+{
+    std::string name = pec::compose_primitive_name(expected_parts);
+    HPX_TEST_EQ(name, expected_name);
+
+    pec::primitive_name_parts parts = pec::parse_primitive_name(name);
+    HPX_TEST(parts == expected_parts);
+}
+
+int main(int argc, char* argv[])
+{
+    pec::primitive_name_parts parts;
+    parts.primitive = "add";
+    parts.sequence_number = 1;
+    parts.instance = "";
+    parts.compile_id = 2;
+    parts.tag1 = 3;
+    parts.tag2 = -1;
+
+    test_primitive_name(parts, "/phylanx/add#1/2#3");
+
+    parts.instance = "test";
+    test_primitive_name(parts, "/phylanx/add#1#test/2#3");
+
+    parts.tag2 = 4;
+    test_primitive_name(parts, "/phylanx/add#1#test/2#3#4");
+
+    parts.instance = "";
+    test_primitive_name(parts, "/phylanx/add#1/2#3#4");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/python/execution_tree/eval.py
+++ b/tests/unit/python/execution_tree/eval.py
@@ -1,4 +1,4 @@
-#  Copyright (c) 2017 Hartmut Kaiser
+#  Copyright (c) 2017-2018 Hartmut Kaiser
 #  Copyright (c) 2018 R. Tohid
 #  Copyright (c) 2018 Steven R. Brandt
 #
@@ -41,11 +41,20 @@ def fib(n):
     else:
         return fib(n-1)+fib(n-2)
 
+assert fib.__physl_src__ == \
+    'block#1#0(define#1#0(fib#1#0, n#1#8, ' + \
+        'if(n#2#7 < 2, n#3#15, ' + \
+            '(fib((n#5#19 - 1)) + fib((n#5#28 - 2))))' + \
+        '), fib#1#0)\n'
+
 assert fib(10)[0] == 55.0
 
 @phyfun
 def pass_str(a):
     return a
+
+assert pass_str.__physl_src__ == \
+    'block#1#0(define#1#0(pass_str#1#0, a#1#13, a#2#11), pass_str#1#0)\n'
 
 assert "foo" == str(pass_str("foo"))
 

--- a/tools/VS/ast.natvis
+++ b/tools/VS/ast.natvis
@@ -15,7 +15,8 @@
     <Type Name="phylanx::ast::identifier">
         <DisplayString>{name}</DisplayString>
         <Expand>
-            <Item Name="[tagged]" Condition="(id != 0)">id</Item>
+            <Item Name="[tagged]" Condition="(id != 0 &amp;&amp; col == -1)">id</Item>
+            <Item Name="[tagged]" Condition="(id != 0 &amp;&amp; col != -1)">id,col</Item>
             <Item Name="[name]">name</Item>
         </Expand>
     </Type>
@@ -31,7 +32,8 @@
         <DisplayString Condition="(var.impl_.index_ == 7)">function_call({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 8)">expression_list({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <Expand>
-            <Item Name="[tagged]" Condition="(id != 0)">id</Item>
+            <Item Name="[tagged]" Condition="(id != 0 &amp;&amp; col == -1)">id</Item>
+            <Item Name="[tagged]" Condition="(id != 0 &amp;&amp; col != -1)">id,col</Item>
             <Item Name="[nil]" Condition="(var.impl_.index_ == 0)">"nil"</Item>
             <Item Name="[bool]" Condition="(var.impl_.index_ == 1)">var.impl_.data_.tail_.head_.value</Item>
             <Item Name="[node_data]" Condition="(var.impl_.index_ == 2)">var.impl_.data_.tail_.tail_.head_.value</Item>
@@ -49,7 +51,6 @@
         <DisplayString Condition="(var.impl_.index_ == 1)">primary_expr({var.impl_.data_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 2)">unary_expr({var.impl_.data_.tail_.tail_.head_.value})</DisplayString>
         <Expand>
-            <Item Name="[tagged]" Condition="(id != 0)">id</Item>
             <Item Name="[nil]" Condition="(var.impl_.index_ == 0)">"nil"</Item>
             <Item Name="[primary_expr]" Condition="(var.impl_.index_ == 1)">var.impl_.data_.tail_.head_.value</Item>
             <Item Name="[unary_expr]" Condition="(var.impl_.index_ == 2)">var.impl_.data_.tail_.tail_.head_.value</Item>
@@ -59,6 +60,8 @@
     <Type Name="phylanx::ast::unary_expr">
         <DisplayString>{operator_}, {operand_}</DisplayString>
         <Expand>
+            <Item Name="[tagged]" Condition="(id != 0 &amp;&amp; col == -1)">id</Item>
+            <Item Name="[tagged]" Condition="(id != 0 &amp;&amp; col != -1)">id,col</Item>
             <Item Name="[operator]">operator_</Item>
             <Item Name="[operand]">operand_</Item>
         </Expand>


### PR DESCRIPTION
PhySL now allows for any symbol (identifier or function_call) to encode the line/column information
of the source code it was generated from: `<ident>#line#column`. This information is also encoded in the generated primitive names: 

    /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag1>[#<tag2>]

where `tag1` is either the offset as before (if `tag2` is missing), otherwise `tag1`/`tag2` encode the line/column.

- started to add positional information to PhySL generated from `@phyfun` decorator
- added test for facilities related to primitive_name
- flyby: fixing ast.natvis
