### PR TITLE
Making sure arguments to user-facing functions are copied before passed to PhySL execution

### DIFF
--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -84,7 +84,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    struct function : actor<function>
+    struct function
     {
         function() = default;
 
@@ -106,35 +106,50 @@ namespace phylanx { namespace execution_tree { namespace compiler
             set_name(std::move(name));
         }
 
-        result_type call(arguments_type && args) const
+        template <typename ... Ts>
+        result_type operator()(Ts &&... ts) const
         {
             primitive const* p = util::get_if<primitive>(&arg_);
             if (p != nullptr)
             {
                 // user-facing functions need to copy all arguments
+                arguments_type keep_alive;
+                keep_alive.reserve(sizeof...(Ts));
+
+                int const sequencer_[] = {
+                    0, (keep_alive.emplace_back(
+                            extract_copy_value(std::forward<Ts>(ts))), 0)...
+                };
+                (void)sequencer_;
+
+                // construct argument-pack to use for actual call
                 arguments_type params;
-                params.reserve(args.size());
-                for (auto const& arg : args)
+                params.reserve(sizeof...(Ts));
+                for (auto const& arg : keep_alive)
                 {
-                    params.emplace_back(extract_copy_value(arg));
+                    params.emplace_back(extract_ref_value(arg));
                 }
+
                 return extract_copy_value(p->eval_direct(std::move(params)));
             }
+
             return arg_;
         }
+
         hpx::future<result_type> eval(arguments_type && args) const
         {
             primitive const* p = util::get_if<primitive>(&arg_);
             if (p != nullptr)
             {
                 // user-facing functions need to copy all arguments
-                arguments_type params;
-                params.reserve(args.size());
-                for (auto const& arg : args)
+                arguments_type keep_alive;
+                keep_alive.reserve(args.size());
+                for (auto && arg : std::move(args))
                 {
-                    params.emplace_back(extract_copy_value(arg));
+                    keep_alive.emplace_back(extract_copy_value(std::move(arg)));
                 }
-                return p->eval(std::move(params));
+
+                return p->eval(std::move(keep_alive));
             }
             return hpx::make_ready_future(arg_);
         }

--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -111,7 +111,14 @@ namespace phylanx { namespace execution_tree { namespace compiler
             primitive const* p = util::get_if<primitive>(&arg_);
             if (p != nullptr)
             {
-                return extract_copy_value(p->eval_direct(std::move(args)));
+                // user-facing functions need to copy all arguments
+                arguments_type params;
+                params.reserve(args.size());
+                for (auto const& arg : args)
+                {
+                    params.emplace_back(extract_copy_value(arg));
+                }
+                return extract_copy_value(p->eval_direct(std::move(params)));
             }
             return arg_;
         }
@@ -120,7 +127,14 @@ namespace phylanx { namespace execution_tree { namespace compiler
             primitive const* p = util::get_if<primitive>(&arg_);
             if (p != nullptr)
             {
-                return p->eval(std::move(args));
+                // user-facing functions need to copy all arguments
+                arguments_type params;
+                params.reserve(args.size());
+                for (auto const& arg : args)
+                {
+                    params.emplace_back(extract_copy_value(arg));
+                }
+                return p->eval(std::move(params));
             }
             return hpx::make_ready_future(arg_);
         }

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -100,9 +100,13 @@ namespace phylanx { namespace execution_tree
 
         hpx::future<primitive_argument_type> eval() const;
         hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> && args) const;
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const;
 
         primitive_argument_type eval_direct() const;
+        primitive_argument_type eval_direct(
+            std::vector<primitive_argument_type> && args) const;
         primitive_argument_type eval_direct(
             std::vector<primitive_argument_type> const& args) const;
 
@@ -133,6 +137,16 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT primitive_result_type value_operand_sync(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT primitive_result_type value_operand_sync(
+        primitive_argument_type const& val,
+        std::vector<primitive_argument_type> && args);
+    PHYLANX_EXPORT primitive_result_type value_operand_sync(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT primitive_result_type value_operand_sync(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> && args);
+
     PHYLANX_EXPORT primitive_result_type value_operand_ref_sync(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args);
@@ -344,11 +358,7 @@ namespace phylanx { namespace execution_tree
     template <typename T>
     primitive_argument_type extract_ref_value(ir::node_data<T> && val)
     {
-        if (val.is_ref())
-        {
-            return primitive_argument_type{std::move(val)};
-        }
-        return primitive_argument_type{val.ref()};
+        return primitive_argument_type{std::move(val)};
     }
 
     template <typename T>
@@ -434,6 +444,30 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT hpx::future<primitive_result_type> value_operand(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT hpx::future<primitive_result_type> value_operand(
+        primitive_argument_type const& val,
+        std::vector<primitive_argument_type> && args);
+    PHYLANX_EXPORT hpx::future<primitive_result_type> value_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT hpx::future<primitive_result_type> value_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> && args);
+
+    namespace functional
+    {
+        struct value_operand
+        {
+            template <typename T1, typename T2>
+            hpx::future<primitive_result_type> operator()(
+                T1&& t1, T2&& t2) const
+            {
+                return execution_tree::value_operand(
+                    std::forward<T1>(t1), std::forward<T2>(t2));
+            }
+        };
+    }
+
 // was declared above
 //     PHYLANX_EXPORT primitive_result_type value_operand_sync(
 //         primitive_argument_type const& val,
@@ -444,6 +478,30 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT hpx::future<primitive_result_type> literal_operand(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT hpx::future<primitive_result_type> literal_operand(
+        primitive_argument_type const& val,
+        std::vector<primitive_argument_type> && args);
+    PHYLANX_EXPORT hpx::future<primitive_result_type> literal_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT hpx::future<primitive_result_type> literal_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> && args);
+
+    namespace functional
+    {
+        struct literal_operand
+        {
+            template <typename T1, typename T2>
+            hpx::future<primitive_result_type> operator()(
+                T1&& t1, T2&& t2) const
+            {
+                return execution_tree::literal_operand(
+                    std::forward<T1>(t1), std::forward<T2>(t2));
+            }
+        };
+    }
+
     PHYLANX_EXPORT primitive_argument_type literal_operand_sync(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args);
@@ -453,6 +511,30 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
+        primitive_argument_type const& val,
+        std::vector<primitive_argument_type> && args);
+    PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> const& args);
+    PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> && args);
+
+    namespace functional
+    {
+        struct numeric_operand
+        {
+            template <typename T1, typename T2>
+            hpx::future<ir::node_data<double>> operator()(
+                T1&& t1, T2&& t2) const
+            {
+                return execution_tree::numeric_operand(
+                    std::forward<T1>(t1), std::forward<T2>(t2));
+            }
+        };
+    }
+
     PHYLANX_EXPORT ir::node_data<double> numeric_operand_sync(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args);

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -332,6 +332,44 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT primitive_result_type extract_copy_value(
         primitive_result_type && val);
 
+    template <typename T>
+    primitive_argument_type extract_ref_value(ir::node_data<T> const& val)
+    {
+        if (val.is_ref())
+        {
+            return primitive_argument_type{val};
+        }
+        return primitive_argument_type{val.ref()};
+    }
+    template <typename T>
+    primitive_argument_type extract_ref_value(ir::node_data<T> && val)
+    {
+        if (val.is_ref())
+        {
+            return primitive_argument_type{std::move(val)};
+        }
+        return primitive_argument_type{val.ref()};
+    }
+
+    template <typename T>
+    primitive_argument_type extract_copy_value(ir::node_data<T> const& val)
+    {
+        if (val.is_ref())
+        {
+            return primitive_argument_type{val.copy()};
+        }
+        return primitive_argument_type{val};
+    }
+    template <typename T>
+    primitive_argument_type extract_copy_value(ir::node_data<T> && val)
+    {
+        if (val.is_ref())
+        {
+            return primitive_argument_type{val.copy()};
+        }
+        return primitive_argument_type{std::move(val)};
+    }
+
     // Extract a literal type from a given primitive_argument_type, throw
     // if it doesn't hold one.
     PHYLANX_EXPORT primitive_result_type extract_literal_value(

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -513,7 +513,7 @@ namespace phylanx { namespace ir
                 "node_data object holds unsupported data type");
         }
 
-        custom_storage2d_type matrix()
+        custom_storage2d_type matrix() &
         {
             custom_storage2d_type* cm =
                 util::get_if<custom_storage2d_type>(&data_);
@@ -533,7 +533,7 @@ namespace phylanx { namespace ir
                 "phylanx::ir::node_data<T>::matrix()",
                 "node_data object holds unsupported data type");
         }
-        custom_storage2d_type matrix() const
+        custom_storage2d_type matrix() const&
         {
             custom_storage2d_type const* cm =
                 util::get_if<custom_storage2d_type>(&data_);
@@ -553,6 +553,12 @@ namespace phylanx { namespace ir
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "phylanx::ir::node_data<T>::matrix()",
                 "node_data object holds unsupported data type");
+        }
+        custom_storage2d_type matrix() &&
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::ir::node_data<T>::matrix()",
+                "node_data::matrix() shouldn't be called on an rvalue");
         }
 
         storage1d_type& vector_non_ref()
@@ -598,7 +604,7 @@ namespace phylanx { namespace ir
                 "node_data object holds unsupported data type");
         }
 
-        custom_storage1d_type vector()
+        custom_storage1d_type vector() &
         {
             custom_storage1d_type* cv =
                 util::get_if<custom_storage1d_type>(&data_);
@@ -615,7 +621,7 @@ namespace phylanx { namespace ir
                 "phylanx::ir::node_data<T>::vector()",
                 "node_data object holds unsupported data type");
         }
-        custom_storage1d_type vector() const
+        custom_storage1d_type vector() const&
         {
             custom_storage1d_type const* cv =
                 util::get_if<custom_storage1d_type>(&data_);
@@ -635,6 +641,12 @@ namespace phylanx { namespace ir
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "phylanx::ir::node_data<T>::vector()",
                 "node_data object holds unsupported data type");
+        }
+        custom_storage1d_type vector() &&
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::ir::node_data<T>::vector()",
+                "node_data::vector shouldn't be called on an rvalue");
         }
 
         storage0d_type& scalar()
@@ -741,7 +753,7 @@ namespace phylanx { namespace ir
         }
 
         /// Return a new instance of node_data referring to this instance.
-        node_data<T> ref() const
+        node_data<T> ref() const&
         {
             switch(data_.index())
             {
@@ -760,6 +772,12 @@ namespace phylanx { namespace ir
                 break;
             }
 
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::ir::node_data<T>::ref()",
+                "node_data object holds unsupported data type");
+        }
+        node_data<T> ref() &&
+        {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "phylanx::ir::node_data<T>::ref()",
                 "node_data object holds unsupported data type");

--- a/src/execution_tree/primitives/add_operation.cpp
+++ b/src/execution_tree/primitives/add_operation.cpp
@@ -390,9 +390,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type&& args) -> primitive_result_type
-                    {
+                return hpx::dataflow(
+                    hpx::util::unwrapping([this_](args_type&& args)
+                                              -> primitive_result_type {
                         std::size_t lhs_dims = args[0].num_dimensions();
                         switch (lhs_dims)
                         {
@@ -412,8 +412,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/column_slicing.cpp
+++ b/src/execution_tree/primitives/column_slicing.cpp
@@ -295,7 +295,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args));
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/console_output.cpp
+++ b/src/execution_tree/primitives/console_output.cpp
@@ -62,26 +62,29 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::vector<primitive_argument_type> const& args)
             {
                 auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type && args) -> primitive_result_type
-                    {
+                return hpx::dataflow(
+                    hpx::util::unwrapping([this_](args_type&& args)
+                                              -> primitive_result_type {
                         bool init = true;
                         for (auto const& arg : args)
                         {
-                            if(init)
+                            if (init)
+                            {
                                 init = false;
+                            }
                             else
-                                // Put spaces in the output
-                                // to match Python
+                            {
+                                // Put spaces in the output to match Python
                                 hpx::cout << ' ';
+                            }
                             hpx::cout << arg;
                         }
                         hpx::cout << std::endl;
 
                         return {};
                     }),
-                    detail::map_operands(operands, value_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::value_operand{}, args));
             }
 
         private:

--- a/src/execution_tree/primitives/cross_operation.cpp
+++ b/src/execution_tree/primitives/cross_operation.cpp
@@ -395,8 +395,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/debug_output.cpp
+++ b/src/execution_tree/primitives/debug_output.cpp
@@ -73,8 +73,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                         return {};
                     }),
-                    detail::map_operands(operands, value_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::value_operand{}, args));
             }
 
         private:

--- a/src/execution_tree/primitives/determinant.cpp
+++ b/src/execution_tree/primitives/determinant.cpp
@@ -99,8 +99,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
 
         protected:

--- a/src/execution_tree/primitives/div_operation.cpp
+++ b/src/execution_tree/primitives/div_operation.cpp
@@ -440,9 +440,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops) -> primitive_result_type
-                    {
+                return hpx::dataflow(
+                    hpx::util::unwrapping([this_](operands_type&& ops)
+                                              -> primitive_result_type {
                         std::size_t lhs_dims = ops[0].num_dimensions();
                         switch (lhs_dims)
                         {
@@ -462,8 +462,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/dot_operation.cpp
+++ b/src/execution_tree/primitives/dot_operation.cpp
@@ -218,8 +218,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -233,15 +233,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops)
+                    [this_](operands_type && ops) -> primitive_result_type
                     {
                         return primitive_result_type(
                             util::visit(visit_equal{*this_},
                                 std::move(ops[0].variant()),
                                 std::move(ops[1].variant())));
                     }),
-                    detail::map_operands(operands, literal_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::literal_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/exponential_operation.cpp
+++ b/src/execution_tree/primitives/exponential_operation.cpp
@@ -126,8 +126,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/extract_shape.cpp
+++ b/src/execution_tree/primitives/extract_shape.cpp
@@ -94,8 +94,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         return primitive_result_type{
                             std::int64_t(dims[std::size_t(args[1][0])])};
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -280,15 +280,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops)
+                    [this_](operands_type && ops) -> primitive_result_type
                     {
                         return primitive_result_type(
                             util::visit(visit_greater{*this_},
                                 std::move(ops[0].variant()),
                                 std::move(ops[1].variant())));
                     }),
-                    detail::map_operands(operands, literal_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::literal_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -282,15 +282,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops)
+                    [this_](operands_type && ops) -> primitive_result_type
                     {
                         return primitive_result_type(
                             util::visit(visit_greater_equal{*this_},
                                 std::move(ops[0].variant()),
                                 std::move(ops[1].variant())));
                     }),
-                    detail::map_operands(operands, literal_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::literal_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/hstack_operation.cpp
+++ b/src/execution_tree/primitives/hstack_operation.cpp
@@ -167,29 +167,30 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 auto this_ = this->shared_from_this();
-                return hpx::dataflow(
-                    hpx::util::unwrapping(
-                        [this_](args_type&& args) -> primitive_result_type {
-                            std::size_t matrix_dims = args[0].num_dimensions();
-                            switch (matrix_dims)
-                            {
-                            case 0:
-                                return this_->hstack0d(std::move(args));
+                return hpx::dataflow(hpx::util::unwrapping(
+                    [this_](args_type&& args) -> primitive_result_type
+                    {
+                        std::size_t matrix_dims = args[0].num_dimensions();
+                        switch (matrix_dims)
+                        {
+                        case 0:
+                            return this_->hstack0d(std::move(args));
 
-                            case 1:
-                                return this_->hstack1d(std::move(args));
+                        case 1:
+                            return this_->hstack1d(std::move(args));
 
-                            case 2:
-                                return this_->hstack2d(std::move(args));
+                        case 2:
+                            return this_->hstack2d(std::move(args));
 
-                            default:
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "hstack_operation::eval",
-                                    "left hand side operand has unsupported "
-                                    "number of dimensions");
-                            }
-                        }),
-                    detail::map_operands(operands, numeric_operand, args));
+                        default:
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "hstack_operation::eval",
+                                "left hand side operand has unsupported "
+                                "number of dimensions");
+                        }
+                    }),
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/identity.cpp
+++ b/src/execution_tree/primitives/identity.cpp
@@ -90,12 +90,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "arguments given by the operands array are valid");
                 }
                 auto this_ = this->shared_from_this();
-                return hpx::dataflow(
-                    hpx::util::unwrapping(
-                        [this_](operands_type&& op0) -> primitive_result_type {
-                            return this_->identity_nd(std::move(op0));
-                        }),
-                    detail::map_operands(operands, numeric_operand, args));
+                return hpx::dataflow(hpx::util::unwrapping(
+                    [this_](operands_type&& op0) -> primitive_result_type
+                    {
+                        return this_->identity_nd(std::move(op0));
+                    }),
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/inverse_operation.cpp
+++ b/src/execution_tree/primitives/inverse_operation.cpp
@@ -92,8 +92,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
 
         protected:

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -280,15 +280,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops)
+                    [this_](operands_type && ops) -> primitive_result_type
                     {
                         return primitive_result_type(
                             util::visit(visit_less{*this_},
                                 std::move(ops[0].variant()),
                                 std::move(ops[1].variant())));
                     }),
-                    detail::map_operands(operands, literal_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::literal_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -280,15 +280,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops)
+                    [this_](operands_type&& ops) -> primitive_result_type
                     {
                         return primitive_result_type(
                             util::visit(visit_less_equal{*this_},
                                 std::move(ops[0].variant()),
                                 std::move(ops[1].variant())));
                     }),
-                    detail::map_operands(operands, literal_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::literal_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -352,8 +352,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand , args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -242,15 +242,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops)
+                    [this_](operands_type && ops) -> primitive_result_type
                     {
                         return primitive_result_type(
                             util::visit(visit_not_equal{*this_},
                                 std::move(ops[0].variant()),
                                 std::move(ops[1].variant())));
                     }),
-                    detail::map_operands(operands, literal_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::literal_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/parallel_block_operation.cpp
+++ b/src/execution_tree/primitives/parallel_block_operation.cpp
@@ -67,11 +67,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
                     [this_](std::vector<primitive_result_type> && ops)
+                    ->  primitive_result_type
                     {
                         return ops.back();
                     }),
-                    detail::map_operands(operands, literal_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::literal_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/power_operation.cpp
+++ b/src/execution_tree/primitives/power_operation.cpp
@@ -133,8 +133,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/random.cpp
+++ b/src/execution_tree/primitives/random.cpp
@@ -101,8 +101,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
 
         protected:

--- a/src/execution_tree/primitives/row_slicing.cpp
+++ b/src/execution_tree/primitives/row_slicing.cpp
@@ -219,8 +219,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -445,8 +445,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/square_root_operation.cpp
+++ b/src/execution_tree/primitives/square_root_operation.cpp
@@ -101,28 +101,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 auto this_ = this->shared_from_this();
                 return hpx::dataflow(hpx::util::unwrapping(
                     [this_](operands_type&& ops) -> primitive_result_type
-                {
-
-                    switch (ops[0].num_dimensions())
                     {
-                    case 0:
-                        return this_->square_root_0d(std::move(ops));
 
-                    case 1:
-                        return this_->square_root_1d(std::move(ops));
+                        switch (ops[0].num_dimensions())
+                        {
+                        case 0:
+                            return this_->square_root_0d(std::move(ops));
 
-                    case 2:
-                        return this_->square_root_2d(std::move(ops));
+                        case 1:
+                            return this_->square_root_1d(std::move(ops));
 
-                    default:
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "square_root_operation::eval",
-                            "left hand side operand has unsupported "
-                            "number of dimensions");
-                    }
-                }),
-                    detail::map_operands(operands, numeric_operand, args)
-                    );
+                        case 2:
+                            return this_->square_root_2d(std::move(ops));
+
+                        default:
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "square_root_operation::eval",
+                                "left hand side operand has unsupported "
+                                "number of dimensions");
+                        }
+                    }),
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/string_output.cpp
+++ b/src/execution_tree/primitives/string_output.cpp
@@ -79,8 +79,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                         return primitive_result_type(strm.str());
                     }),
-                    detail::map_operands(operands, value_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::value_operand{}, args));
             }
 
         private:

--- a/src/execution_tree/primitives/sub_operation.cpp
+++ b/src/execution_tree/primitives/sub_operation.cpp
@@ -431,8 +431,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/transpose_operation.cpp
+++ b/src/execution_tree/primitives/transpose_operation.cpp
@@ -92,8 +92,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                     "number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
 
         protected:

--- a/src/execution_tree/primitives/unary_minus_operation.cpp
+++ b/src/execution_tree/primitives/unary_minus_operation.cpp
@@ -119,8 +119,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "operand has unsupported number of dimensions");
                         }
                     }),
-                    detail::map_operands(operands, numeric_operand, args)
-                );
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/execution_tree/primitives/vstack_operation.cpp
+++ b/src/execution_tree/primitives/vstack_operation.cpp
@@ -175,29 +175,30 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 auto this_ = this->shared_from_this();
-                return hpx::dataflow(
-                    hpx::util::unwrapping(
-                        [this_](args_type&& args) -> primitive_result_type {
-                            std::size_t matrix_dims = args[0].num_dimensions();
-                            switch (matrix_dims)
-                            {
-                            case 0:
-                                return this_->vstack0d(std::move(args));
+                return hpx::dataflow(hpx::util::unwrapping(
+                    [this_](args_type&& args) -> primitive_result_type
+                    {
+                        std::size_t matrix_dims = args[0].num_dimensions();
+                        switch (matrix_dims)
+                        {
+                        case 0:
+                            return this_->vstack0d(std::move(args));
 
-                            case 1:
-                                return this_->vstack1d(std::move(args));
+                        case 1:
+                            return this_->vstack1d(std::move(args));
 
-                            case 2:
-                                return this_->vstack2d(std::move(args));
+                        case 2:
+                            return this_->vstack2d(std::move(args));
 
-                            default:
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "vstack_operation::eval",
-                                    "left hand side operand has unsupported "
-                                    "number of dimensions");
-                            }
-                        }),
-                    detail::map_operands(operands, numeric_operand, args));
+                        default:
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "vstack_operation::eval",
+                                "left hand side operand has unsupported "
+                                "number of dimensions");
+                        }
+                    }),
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args));
             }
         };
     }

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -90,7 +90,7 @@ namespace phylanx { namespace ir
                 {
                     out << ", ";
                 }
-                out << std::to_string(r[i]);
+                out << r[i];
             }
             out << "]";
         }
@@ -103,7 +103,7 @@ namespace phylanx { namespace ir
         switch (dims)
         {
         case 0:
-            out << std::to_string(nd[0]);
+            out << nd[0];
             break;
 
         case 1: HPX_FALLTHROUGH;
@@ -114,6 +114,7 @@ namespace phylanx { namespace ir
         case 2: HPX_FALLTHROUGH;
         case 4:
             {
+                out << "[";
                 auto data = nd.matrix();
                 for (std::size_t row = 0; row != data.rows(); ++row)
                 {
@@ -122,6 +123,7 @@ namespace phylanx { namespace ir
                     detail::print_array(
                         out, blaze::row(data, row), data.columns());
                 }
+                out << "]";
             }
             break;
 

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -6,11 +6,13 @@
 set(tests
     cout_noargs_prints_nothing_159
     cout_prints_twice_155
+    define_looses_values_177
     negative_integral_value_131
    )
 
 set(cout_noargs_prints_nothing_FLAGS COMPONENT_DEPENDENCIES iostreams)
 set(cout_prints_twice_155_FLAGS COMPONENT_DEPENDENCIES iostreams)
+set(define_looses_values_177_FLAGS COMPONENT_DEPENDENCIES iostreams)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/tests/regressions/execution_tree/cout_prints_twice_155.cpp
+++ b/tests/regressions/execution_tree/cout_prints_twice_155.cpp
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
     HPX_TEST_EQ(hpx::init(argc, argv), 0);
 
     std::stringstream const& strm = hpx::get_consolestream();
-    HPX_TEST_EQ(strm.str(), std::string("hello: 42.000000\n"));
+    HPX_TEST_EQ(strm.str(), std::string("hello: 42\n"));
 
     return hpx::util::report_errors();
 }

--- a/tests/regressions/execution_tree/define_looses_values_177.cpp
+++ b/tests/regressions/execution_tree/define_looses_values_177.cpp
@@ -1,0 +1,61 @@
+//   Copyright (c) 2018 Bibek Wagle
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Fixing #177: Arguments are not being passed correctly to define
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+std::string const read_code = R"(block(
+    //
+    // display data
+    //
+    define(read, data_m, data_v, data_0,
+        block(
+            debug("Scalar Data Received = ", data_0),
+            debug("Vector Data Recieved = ", data_v),
+            debug("Matrix Data Recieved = ", data_m)
+        )
+    ),
+    read
+))";
+
+int hpx_main(int argc, char* argv[])
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+
+    blaze::DynamicVector<double> vec{1, 10, 11, 12, 13, 14, 15, 16};
+    blaze::DynamicMatrix<double> mat{{1, 10, 11}, {12, 13, 14}, {15, 16, 17}};
+
+    auto data_0d = phylanx::ir::node_data<double>{42.0};
+    auto data_vec = phylanx::ir::node_data<double>{std::move(vec)};
+    auto data_mat = phylanx::ir::node_data<double>{std::move(mat)};
+
+    auto func = phylanx::execution_tree::compile_and_run(read_code, snippets);
+
+    func(std::move(data_mat), std::move(data_vec), std::move(data_0d));
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+
+    std::stringstream const& strm = hpx::get_consolestream();
+    HPX_TEST_EQ(strm.str(), std::string(
+        "Scalar Data Received = 42\n"
+        "Vector Data Recieved = [1, 10, 11, 12, 13, 14, 15, 16]\n"
+        "Matrix Data Recieved = [[1, 10, 11], [12, 13, 14], [15, 16, 17]]\n"));
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -164,8 +164,8 @@ int main(int argc, char* argv[])
 
     test_expression(
         "1.0 / (1.0 + exp(-dot(A, B)))",
-            "1.000000\n"
-            "1.000000\n"
+            "1\n"
+            "1\n"
             "exp\n"
             "dot\n"
             "A\n"
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
         "'(true, 1, 1.0, A, A + B)",
             "true\n"
             "1\n"
-            "1.000000\n"
+            "1\n"
             "A\n"
             "A\n"
             "B\n"
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
         "'(true, 1, '(1.0, A, A + B))",
             "true\n"
             "1\n"
-            "1.000000\n"
+            "1\n"
             "A\n"
             "A\n"
             "B\n"

--- a/tests/unit/ast/to_string.cpp
+++ b/tests/unit/ast/to_string.cpp
@@ -10,9 +10,11 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
+
 #include <blaze/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -44,15 +46,9 @@ void test_primary_expr()
     blaze::DynamicVector<double> v = gen.generate(1007UL);
     phylanx::ast::primary_expr p3{
         phylanx::ir::node_data<double>{v}};
-    std::string expected("[");
-    for (std::size_t i = 0; i != v.size(); ++i)
-    {
-        if (i != 0)
-            expected += ", ";
-        expected += std::to_string(v[i]);
-    }
-    expected += "]";
-    test_to_string(p3, expected);
+    std::stringstream strm;
+    strm << p3;
+    test_to_string(p3, strm.str());
 
     phylanx::ast::primary_expr p4{"some string"};
     test_to_string(p4, "\"some string\"");

--- a/tests/unit/python/ast/python_builds_ast.py
+++ b/tests/unit/python/ast/python_builds_ast.py
@@ -3,10 +3,11 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import sys
 import phylanx.ast as ast
 import phylanx.util as util
-# A simple way to turn a python3 expression into a data structure (AST)
 
+# A simple way to turn a python3 expression into a data structure (AST)
 def oper(x):
     t = type(x)
     if t == ast.primary_expr:
@@ -82,7 +83,7 @@ expr = a1*a2*a0+a3*-a4
 #expr = (a1 + a2)+a3-a4
 
 # Convert the AST to a string and check the value
-if str(expr.value) == '(((3.140000 * "b") * "c") + ("d" * -"e"))':
+if str(expr.value) == '(((3.14 * "b") * "c") + ("d" * -"e"))':
     print("Success")
 else:
     print("Failure")


### PR DESCRIPTION

- flyby: fixed node_data printing
- flyby: added missing import

This fixes #177