### PR TITLE
Instrument Primitive Performance Information

### DIFF
--- a/cmake/Phylanx_SetupCompilerFlags.cmake
+++ b/cmake/Phylanx_SetupCompilerFlags.cmake
@@ -61,6 +61,8 @@ macro(phylanx_setup_compiler_flags)
       phylanx_add_compile_flag(/wd4244)
       # warning C4167: conversion from 'size_t' to 'int', possible loss of data
       phylanx_add_compile_flag(/wd4267)
+	  # warning C4552: '*': operator has no effect; expected operator with side-effect
+	  phylanx_add_compile_flag(/wd4552)
 
       # Runtime type information
       phylanx_add_target_compile_option(-GR)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@
 set(subdirs
     algorithms
     ast
-	profiling
+    profiling
    )
 
 foreach(subdir ${subdirs})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(subdirs
     algorithms
     ast
+	profiling
    )
 
 foreach(subdir ${subdirs})

--- a/examples/profiling/CMakeLists.txt
+++ b/examples/profiling/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) 2018 Parsa Amini
+# Copyright (c) 2018 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(example_programs
+    primitive_instrumentation
+   )
+
+foreach(example_program ${example_programs})
+
+  set(${example_program}_FLAGS DEPENDENCIES iostreams_component)
+
+  set(sources ${example_program}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_phylanx_executable(${example_program}
+                     SOURCES ${sources}
+                     ${${example_program}_FLAGS}
+                     FOLDER "Examples/Profiling")
+
+  # add a custom target for this example
+  add_phylanx_pseudo_target(examples.prof_.${example_program})
+
+  # make pseudo-targets depend on master pseudo-target
+  add_phylanx_pseudo_dependencies(examples.prof_
+                              examples.prof_.${example_program})
+
+  # add dependencies to pseudo-target
+  add_phylanx_pseudo_dependencies(examples.prof_.${example_program}
+                              ${example_program}_exe)
+endforeach()
+

--- a/examples/profiling/CMakeLists.txt
+++ b/examples/profiling/CMakeLists.txt
@@ -23,14 +23,14 @@ foreach(example_program ${example_programs})
                      FOLDER "Examples/Profiling")
 
   # add a custom target for this example
-  add_phylanx_pseudo_target(examples.prof_.${example_program})
+  add_phylanx_pseudo_target(examples.profiling_.${example_program})
 
   # make pseudo-targets depend on master pseudo-target
-  add_phylanx_pseudo_dependencies(examples.prof_
-                              examples.prof_.${example_program})
+  add_phylanx_pseudo_dependencies(examples.profiling_
+                              examples.profiling_.${example_program})
 
   # add dependencies to pseudo-target
-  add_phylanx_pseudo_dependencies(examples.prof_.${example_program}
+  add_phylanx_pseudo_dependencies(examples.profiling_.${example_program}
                               ${example_program}_exe)
 endforeach()
 

--- a/examples/profiling/primitive_instrumentation.cpp
+++ b/examples/profiling/primitive_instrumentation.cpp
@@ -10,79 +10,31 @@
 #include <hpx/include/agas.hpp>
 #include <hpx/runtime_fwd.hpp>
 
-#include <cstddef>
-#include <cstdint>
 #include <iostream>
-#include <map>
-#include <vector>
 #include <string>
 #include <utility>
 
-#include <boost/program_options.hpp>
-#include <blaze/Math.h>
-
-//////////////////////////////////////////////////////////////////////////////////
-// This example uses part of the breast cancer dataset from UCI Machine Learning
-// Repository:
-//     https://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+(Diagnostic)
-//
-// A copy of the full dataset in CSV format (breast_cancer.csv), obtained from
-// scikit-learn datasets, is provided in the same folder as this example.
-//
-// The layout of the data in the provided CSV file used by the example
-// is as follows:
-// 30 features per line followed by the classification
-// 569 lines of data
-//
-// This example also demonstrates how the generated primitives can be introspected
-// and linked back to the source code.
-//
-/////////////////////////////////////////////////////////////////////////////////
-
-std::string const read_x_code = R"(block(
-    //
-    // Read X-data from given CSV file
-    //
-    define(read_x, filepath, row_start, row_stop, col_start, col_stop,
-        slice(file_read_csv(filepath), row_start, row_stop, col_start, col_stop)
-    ),
-    read_x
-))";
-
-std::string const read_y_code = R"(block(
-    //
-    // Read Y-data from given CSV file
-    //
-    define(read_y, filepath, row_start, row_stop,
-        slice(file_read_csv(filepath), row_start, row_stop, -1, 0)
-    ),
-    read_y
-))";
-
 ///////////////////////////////////////////////////////////////////////////////
-std::string const lra_code = R"(block(
+char const* const lra_code = R"(block(
     //
     // Logistic regression analysis algorithm
     //
-    //   x: [N, M]
-    //   y: [N]
-    //
-    define(lra, x, y, alpha, iterations, enable_output,
+    //   x: [30, 2]
+    //   y: [30]
+    define(lra, x, y, alpha,
         block(
-            define(weights, constant(0.0, shape(x, 1))),            // weights: [M]
-            define(transx, transpose(x)),                           // transx:  [M, N]
+            define(weights, constant(0.0, shape(x, 1))),     // weights: [2]
+            define(transx, transpose(x)),                    // transx:  [2, 30]
             define(pred, constant(0.0, shape(x, 0))),
             define(error, constant(0.0, shape(x, 0))),
             define(gradient, constant(0.0, shape(x, 1))),
             define(step, 0),
             while(
-                step < iterations,
+                step < 10,
                 block(
-                    if(enable_output, cout("step: ", step, ", ", weights)),
-                    // exp(-dot(x, weights)): [N], pred: [N]
                     store(pred, 1.0 / (1.0 + exp(-dot(x, weights)))),
-                    store(error, pred - y),                         // error: [N]
-                    store(gradient, dot(transx, error)),            // gradient: [M]
+                    store(error, pred - y),                  // error: [30]
+                    store(gradient, dot(transx, error)),     // gradient: [2]
                     parallel_block(
                         store(weights, weights - (alpha * gradient)),
                         store(step, step + 1)
@@ -96,205 +48,132 @@ std::string const lra_code = R"(block(
 ))";
 
 ///////////////////////////////////////////////////////////////////////////////
-// Find the line/column position in the source code from a given iterator
-// pointing into it.
-//
-std::pair<std::size_t, std::size_t> get_pos(std::string const& code,
-    std::int64_t pos)
+int hpx_main()
 {
-    std::size_t line = 1;
-    std::size_t column = 1;
-
-    for (std::int64_t i = 0; i != pos && i != code.size(); ++i)
-    {
-        if (code[i] == '\r' || code[i] == '\n')    // CR/LF
-        {
-            ++line;
-            column = 1;
-        }
-        else
-        {
-            ++column;
-        }
-    }
-
-    return std::make_pair(line, column);
-}
-
-// Extract the compile_id/tag pair from a given primitive instance name.
-//
-// The compile_id is a sequence number tracking invocations of the
-// function phylanx::execution_tree::compile (needed to link back to the
-// concrete source code compiled).
-//
-// The tag is an index into the array of iterators filled by
-// phylanx::ast::generate_ast. It allows to find the iterator referring
-// to the construct in the source code a particular primitive instance was
-// created by.
-//
-std::pair<std::size_t, std::int64_t> extract_tags(std::string const& name)
-{
-    auto data = phylanx::execution_tree::compiler::parse_primitive_name(name);
-    return std::make_pair(data.compile_id, data.tag);
-}
-
-// The symbolic names registered in AGAS that identify the created
-// primitive instances have the following structure:
-//
-//      /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag>
-//
-//  where:
-//      <primitive>:   the name of primitive type representing the given
-//                     node in the expression tree
-//      <sequence-nr>: the sequence number of the corresponding instance
-//                     of type <primitive>
-//      <instance>:    (optional), some primitives have additional instance
-//                     names, for instance references to function arguments
-//                     have the name of the argument as their <instance>
-//      <compile_id>:  the sequence number of the invocation of the
-//                     function phylanx::execution_tree::compile
-//      <tag>:         the position inside the compiled code block where the
-//                     referring to the point of usage of the primitive in
-//                     the compiled source code
-//
-void print_instrumentation(
-    char const* const name, int compile_id, std::string const& code,
-    phylanx::execution_tree::compiler::function const& func,
-    std::map<std::string, hpx::id_type> const& entries)
-{
-    std::cout << "Instrumentation information for function: " << name << "\n";
-
-    for (auto const& e : entries)
-    {
-        // extract compile_id and iterator index (tag) from the symbolic name
-        auto tags = extract_tags(e.first);
-        if (tags.first != compile_id)
-            continue;
-
-        // find real position of given symbol in source code
-        if (tags.second >= 0)
-        {
-            auto pos = get_pos(code, tags.second);
-            std::cout << e.first << ": " << name << "(" << pos.first << ", "
-                      << pos.second << "): ";
-
-            // show the next (at max) 20 characters
-            auto end = code.begin() + tags.second;
-            for (int i = 0; end != code.end() && i != 20; ++end, ++i)
-            {
-                if (*end == '\n' || *end == '\r')
-                    break;
-            }
-            std::cout << std::string(code.begin() + tags.second, end) << " ...\n";
-        }
-        else
-        {
-            std::cout << e.first << "\n";
-        }
-    }
-
-    std::cout << "\n";
-
-    std::cout << "Tree information for function: " << name << "\n";
-    std::cout << phylanx::execution_tree::newick_tree(
-                     name, func.get_expression_topology())
-              << "\n\n";
-
-    std::cout << phylanx::execution_tree::dot_tree(
-                     name, func.get_expression_topology())
-              << "\n\n";
-}
-
-///////////////////////////////////////////////////////////////////////////////
-int hpx_main(boost::program_options::variables_map& vm)
-{
-    if (vm.count("data_csv") == 0)
-    {
-        std::cerr << "Please specify '--data_csv=data-file'";
-        return hpx::finalize();
-    }
-
     // compile the given code
     phylanx::execution_tree::compiler::function_list snippets;
 
-    auto read_x = phylanx::execution_tree::compile_and_run(
-        phylanx::ast::generate_ast(read_x_code), snippets);
-    auto read_y = phylanx::execution_tree::compile_and_run(
-        phylanx::ast::generate_ast(read_y_code), snippets);
     auto lra = phylanx::execution_tree::compile_and_run(
         phylanx::ast::generate_ast(lra_code), snippets);
 
     // print instrumentation information, if enabled
-    if (vm.count("instrument") != 0)
-    {
-        auto entries =
-            hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*");
+    auto entries =
+        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*");
 
-        print_instrumentation("read_x", 0, read_x_code, read_x, entries);
-        print_instrumentation("read_y", 1, read_y_code, read_y, entries);
-        print_instrumentation("lra", 2, lra_code, lra, entries);
-    }
+    // LRA arguments
 
-    auto row_start = vm["row_start"].as<std::int64_t>();
-    auto col_start = vm["col_start"].as<std::int64_t>();
-    auto row_stop = vm["row_stop"].as<std::int64_t>();
-    auto col_stop = vm["col_stop"].as<std::int64_t>();
+    blaze::DynamicMatrix<double> v1{ { 15.04, 16.74 },{ 13.82, 24.49 },
+    { 12.54, 16.32 },{ 23.09, 19.83 },{ 9.268, 12.87 },{ 9.676, 13.14 },
+    { 12.22, 20.04 },{ 11.06, 17.12 },{ 16.3 , 15.7 },{ 15.46, 23.95 },
+    { 11.74, 14.69 },{ 14.81, 14.7 },{ 13.4 , 20.52 },{ 14.58, 13.66 },
+    { 15.05, 19.07 },{ 11.34, 18.61 },{ 18.31, 20.58 },{ 19.89, 20.26 },
+    { 12.88, 18.22 },{ 12.75, 16.7 },{ 9.295, 13.9 },{ 24.63, 21.6 },
+    { 11.26, 19.83 },{ 13.71, 18.68 },{ 9.847, 15.68 },{ 8.571, 13.1 },
+    { 13.46, 18.75 },{ 12.34, 12.27 },{ 13.94, 13.17 },{ 12.07, 13.44 } };
 
-    // read the data from the files
-    auto x = read_x(vm["data_csv"].as<std::string>(), row_start, row_stop,
-        col_start, col_stop);
-    auto y = read_y(vm["data_csv"].as<std::string>(), row_start, row_stop);
+    blaze::DynamicVector<double> v2{ 1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0,
+        1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1 };
+    auto x = phylanx::ir::node_data<double>{ v1 };
+    auto y = phylanx::ir::node_data<double>{ v2 };
+    auto alpha = phylanx::ir::node_data<double>{ 1e-5 };
+    bool enable_output = true;
 
-    // remaining command line options
-    auto alpha = vm["alpha"].as<double>();
-    auto iterations = vm["num_iterations"].as<std::int64_t>();
-    bool enable_output = vm.count("enable_output") != 0;
-
-    // time execution
+    // Time execution
     hpx::util::high_resolution_timer t;
 
-    // evaluate LRA using the read data
-    auto result =
-        lra(std::move(x), std::move(y), alpha, iterations, enable_output);
+    // Evaluate LRA using the read data
+    auto result = lra(x, y, alpha);
+
+    // CSV Header
+    std::cout << "primitive" << ","
+        << "sequence_number" << ","
+        << "instance_id" << ","
+        << "compile_id" << ","
+        << "tag1" << ","
+        << "tag2" << ","
+        << "count" << ","
+        << "time" << ","
+        << "direct_count" << ","
+        << "direct_time"
+        << std::endl;
+
+    // Complement performance data from primitive performance counters with
+    // information in their AGAS names
+    for (auto const& pattern :
+        phylanx::execution_tree::get_all_known_patterns())
+    {
+        std::string const& name = hpx::util::get<0>(pattern);
+
+        std::string count_pc_name(
+            "/phylanx{locality#0/total}/primitives/" + name + "/count/eval");
+        hpx::performance_counters::performance_counter count_pc(
+            count_pc_name);
+        auto count_pc_values =
+            count_pc.get_counter_values_array(hpx::launch::sync, false);
+
+        std::string time_pc_name(
+            "/phylanx{locality#0/total}/primitives/" + name + "/time/eval");
+        hpx::performance_counters::performance_counter time_pc(time_pc_name);
+        auto time_pc_values =
+            time_pc.get_counter_values_array(hpx::launch::sync, false);
+
+        std::string direct_count_pc_name(
+            "/phylanx{locality#0/total}/primitives/" + name +
+            "/count/eval_direct");
+        hpx::performance_counters::performance_counter direct_count_pc(
+            direct_count_pc_name);
+        auto direct_count_pc_values =
+            direct_count_pc.get_counter_values_array(hpx::launch::sync, false);
+
+        std::string direct_time_pc_name(
+            "/phylanx{locality#0/total}/primitives/" + name +
+            "/time/eval_direct");
+        hpx::performance_counters::performance_counter direct_time_pc(
+            direct_time_pc_name);
+        auto direct_time_pc_values =
+            direct_time_pc.get_counter_values_array(hpx::launch::sync, false);
+
+        // Query AGAS for primitives
+        auto entries = hpx::agas::find_symbols(
+            hpx::launch::sync, "/phylanx/" + name + "#*");
+
+        for (auto const& e : entries)
+        {
+            // Parse the primitive name
+            auto tags = phylanx::execution_tree::compiler::parse_primitive_name(
+                e.first);
+
+            // HACK: block 0 does not appear in AGAS
+            if (name == "block" &&
+                (tags.sequence_number == 0 ||
+                    tags.sequence_number == count_pc_values.values_.size()))
+            {
+                continue;
+            }
+
+            std::cout << "\"" << name << "\"" << ","
+                << tags.sequence_number << ","
+                << tags.instance << ","
+                << tags.compile_id << ","
+                << tags.tag1 << ","
+                << tags.tag2 << ","
+                << count_pc_values.values_[tags.sequence_number] << ","
+                << time_pc_values.values_[tags.sequence_number] << ","
+                << direct_count_pc_values.values_[tags.sequence_number] << ","
+                << direct_time_pc_values.values_[tags.sequence_number]
+                << std::endl;
+        }
+    }
 
     auto elapsed = t.elapsed();
 
-    std::cout << "Result: \n"
-              << phylanx::execution_tree::extract_numeric_value(result) << "\n"
-              << "Calculated in: " << elapsed << " seconds\n";
+    // Make sure all counters are properly initialized, don't reset current counter values
+    hpx::reinit_active_counters(false);
 
     return hpx::finalize();
 }
 
 int main(int argc, char* argv[])
 {
-    // command line handling
-    boost::program_options::options_description desc("usage: lra [options]");
-    desc.add_options()
-        ("enable_output,e", "enable progress output (default: false)")
-        ("instrument,i", "print instrumentation information (default: false)")
-        ("num_iterations,n",
-            boost::program_options::value<std::int64_t>()->default_value(750),
-            "number of iterations (default: 750)")
-        ("alpha,a",
-            boost::program_options::value<double>()->default_value(1e-5),
-            "alpha (default: 1e-5)")
-        ("data_csv",
-            boost::program_options::value<std::string>(),
-            "file name for reading data")
-        ("row_start",
-            boost::program_options::value<std::int64_t>()->default_value(0),
-            "row_start (default: 0)")
-        ("col_start",
-            boost::program_options::value<std::int64_t>()->default_value(0),
-            "col_start (default: 0)")
-        ("row_stop",
-            boost::program_options::value<std::int64_t>()->default_value(569),
-            "row_stop (default: 569)")
-        ("col_stop",
-            boost::program_options::value<std::int64_t>()->default_value(30),
-            "col_stop (default: 30)")
-        ;
-
-    return hpx::init(desc, argc, argv);
+    return hpx::init(argc, argv);
 }

--- a/examples/profiling/primitive_instrumentation.cpp
+++ b/examples/profiling/primitive_instrumentation.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/agas.hpp>
 #include <hpx/runtime_fwd.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <string>
@@ -61,17 +62,17 @@ char const* const lra_code = R"(block(
 std::map<std::string, std::vector<std::int64_t>> retrieve_counter_data(
     std::vector<std::string> const& primitive_instances,
     hpx::naming::id_type locality_id,
-    std::vector<std::string> counter_name_last_parts)
+    std::vector<std::string>
+        counter_name_last_parts)
 {
-    namespace pc = hpx::performance_counters;
-
     // Return value
     std::map<std::string, std::vector<std::int64_t>> result;
 
     // Reuse get_counter_values_array calls
     //   key: primitive type
-    //   value: vector of counter_values_array instance
-    std::map<std::string, std::vector<pc::counter_values_array>> pc_values;
+    //   value: vector of performance counter values
+    std::map<std::string, std::vector<std::vector<std::int64_t>>>
+        counter_values_pile;
 
     // Iterate through all provided primitive instances
     for (auto const& name : primitive_instances)
@@ -83,8 +84,8 @@ std::map<std::string, std::vector<std::int64_t>> retrieve_counter_data(
         // TODO: Ensure counter_name_last_part has at least one entry
 
         // Performance counter values
-        std::vector<pc::counter_values_array> &counter_values =
-            pc_values[tags.primitive];
+        std::vector<std::vector<std::int64_t>>& counter_values =
+            counter_values_pile[tags.primitive];
         if (counter_values.empty())
         {
             // Iterate through the last parts of performance counter names
@@ -96,16 +97,18 @@ std::map<std::string, std::vector<std::int64_t>> retrieve_counter_data(
                 std::string counter_name("/phylanx/primitives/" +
                     tags.primitive + "/" + counter_name_last_part);
                 // The actual performance counter
-                pc::performance_counter counter(counter_name, locality_id);
+                hpx::performance_counters::performance_counter counter(
+                    counter_name, locality_id);
                 counter_values.push_back(
-                    counter.get_counter_values_array(hpx::launch::sync, false));
+                    counter.get_counter_values_array(hpx::launch::sync, false)
+                        .values_);
             }
         }
 
         // HACK: block 0 does not appear in AGAS
         if (tags.primitive == "block" &&
             (tags.sequence_number == 0 ||
-                tags.sequence_number == counter_values[0].values_.size()))
+                tags.sequence_number == counter_values[0].size()))
         {
             continue;
         }
@@ -113,7 +116,7 @@ std::map<std::string, std::vector<std::int64_t>> retrieve_counter_data(
         std::vector<std::int64_t> data(counter_name_last_parts.size());
         for (int i = 0; i < counter_values.size(); ++i)
         {
-            data[i] = counter_values[i].values_[tags.sequence_number];
+            data[i] = counter_values[i][tags.sequence_number];
         }
 
         result[name] = data;

--- a/examples/profiling/primitive_instrumentation.cpp
+++ b/examples/profiling/primitive_instrumentation.cpp
@@ -91,8 +91,6 @@ std::map<std::string, std::vector<std::int64_t>> retrieve_counter_data(
             // Iterate through the last parts of performance counter names
             for (auto const& counter_name_last_part : counter_name_last_parts)
             {
-                // NOTE: Reuse the get_counter_values_array call?
-                //
                 // Construct the name of the counter
                 std::string counter_name("/phylanx/primitives/" +
                     tags.primitive + "/" + counter_name_last_part);
@@ -103,14 +101,6 @@ std::map<std::string, std::vector<std::int64_t>> retrieve_counter_data(
                     counter.get_counter_values_array(hpx::launch::sync, false)
                         .values_);
             }
-        }
-
-        // HACK: block 0 does not appear in AGAS
-        if (tags.primitive == "block" &&
-            (tags.sequence_number == 0 ||
-                tags.sequence_number == counter_values[0].size()))
-        {
-            continue;
         }
 
         std::vector<std::int64_t> data(counter_name_last_parts.size());
@@ -131,7 +121,7 @@ int hpx_main()
     // compile the given code
     phylanx::execution_tree::compiler::function_list snippets;
 
-    auto lra = phylanx::execution_tree::compile_and_run(
+    auto lra = phylanx::execution_tree::compile(
         phylanx::ast::generate_ast(lra_code), snippets);
 
     // print instrumentation information, if enabled

--- a/examples/profiling/primitive_instrumentation.cpp
+++ b/examples/profiling/primitive_instrumentation.cpp
@@ -1,0 +1,300 @@
+//   Copyright (c) 2018 Parsa Amini
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/agas.hpp>
+#include <hpx/runtime_fwd.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <vector>
+#include <string>
+#include <utility>
+
+#include <boost/program_options.hpp>
+#include <blaze/Math.h>
+
+//////////////////////////////////////////////////////////////////////////////////
+// This example uses part of the breast cancer dataset from UCI Machine Learning
+// Repository:
+//     https://archive.ics.uci.edu/ml/datasets/Breast+Cancer+Wisconsin+(Diagnostic)
+//
+// A copy of the full dataset in CSV format (breast_cancer.csv), obtained from
+// scikit-learn datasets, is provided in the same folder as this example.
+//
+// The layout of the data in the provided CSV file used by the example
+// is as follows:
+// 30 features per line followed by the classification
+// 569 lines of data
+//
+// This example also demonstrates how the generated primitives can be introspected
+// and linked back to the source code.
+//
+/////////////////////////////////////////////////////////////////////////////////
+
+std::string const read_x_code = R"(block(
+    //
+    // Read X-data from given CSV file
+    //
+    define(read_x, filepath, row_start, row_stop, col_start, col_stop,
+        slice(file_read_csv(filepath), row_start, row_stop, col_start, col_stop)
+    ),
+    read_x
+))";
+
+std::string const read_y_code = R"(block(
+    //
+    // Read Y-data from given CSV file
+    //
+    define(read_y, filepath, row_start, row_stop,
+        slice(file_read_csv(filepath), row_start, row_stop, -1, 0)
+    ),
+    read_y
+))";
+
+///////////////////////////////////////////////////////////////////////////////
+std::string const lra_code = R"(block(
+    //
+    // Logistic regression analysis algorithm
+    //
+    //   x: [N, M]
+    //   y: [N]
+    //
+    define(lra, x, y, alpha, iterations, enable_output,
+        block(
+            define(weights, constant(0.0, shape(x, 1))),            // weights: [M]
+            define(transx, transpose(x)),                           // transx:  [M, N]
+            define(pred, constant(0.0, shape(x, 0))),
+            define(error, constant(0.0, shape(x, 0))),
+            define(gradient, constant(0.0, shape(x, 1))),
+            define(step, 0),
+            while(
+                step < iterations,
+                block(
+                    if(enable_output, cout("step: ", step, ", ", weights)),
+                    // exp(-dot(x, weights)): [N], pred: [N]
+                    store(pred, 1.0 / (1.0 + exp(-dot(x, weights)))),
+                    store(error, pred - y),                         // error: [N]
+                    store(gradient, dot(transx, error)),            // gradient: [M]
+                    parallel_block(
+                        store(weights, weights - (alpha * gradient)),
+                        store(step, step + 1)
+                    )
+                )
+            ),
+            weights
+        )
+    ),
+    lra
+))";
+
+///////////////////////////////////////////////////////////////////////////////
+// Find the line/column position in the source code from a given iterator
+// pointing into it.
+//
+std::pair<std::size_t, std::size_t> get_pos(std::string const& code,
+    std::int64_t pos)
+{
+    std::size_t line = 1;
+    std::size_t column = 1;
+
+    for (std::int64_t i = 0; i != pos && i != code.size(); ++i)
+    {
+        if (code[i] == '\r' || code[i] == '\n')    // CR/LF
+        {
+            ++line;
+            column = 1;
+        }
+        else
+        {
+            ++column;
+        }
+    }
+
+    return std::make_pair(line, column);
+}
+
+// Extract the compile_id/tag pair from a given primitive instance name.
+//
+// The compile_id is a sequence number tracking invocations of the
+// function phylanx::execution_tree::compile (needed to link back to the
+// concrete source code compiled).
+//
+// The tag is an index into the array of iterators filled by
+// phylanx::ast::generate_ast. It allows to find the iterator referring
+// to the construct in the source code a particular primitive instance was
+// created by.
+//
+std::pair<std::size_t, std::int64_t> extract_tags(std::string const& name)
+{
+    auto data = phylanx::execution_tree::compiler::parse_primitive_name(name);
+    return std::make_pair(data.compile_id, data.tag);
+}
+
+// The symbolic names registered in AGAS that identify the created
+// primitive instances have the following structure:
+//
+//      /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag>
+//
+//  where:
+//      <primitive>:   the name of primitive type representing the given
+//                     node in the expression tree
+//      <sequence-nr>: the sequence number of the corresponding instance
+//                     of type <primitive>
+//      <instance>:    (optional), some primitives have additional instance
+//                     names, for instance references to function arguments
+//                     have the name of the argument as their <instance>
+//      <compile_id>:  the sequence number of the invocation of the
+//                     function phylanx::execution_tree::compile
+//      <tag>:         the position inside the compiled code block where the
+//                     referring to the point of usage of the primitive in
+//                     the compiled source code
+//
+void print_instrumentation(
+    char const* const name, int compile_id, std::string const& code,
+    phylanx::execution_tree::compiler::function const& func,
+    std::map<std::string, hpx::id_type> const& entries)
+{
+    std::cout << "Instrumentation information for function: " << name << "\n";
+
+    for (auto const& e : entries)
+    {
+        // extract compile_id and iterator index (tag) from the symbolic name
+        auto tags = extract_tags(e.first);
+        if (tags.first != compile_id)
+            continue;
+
+        // find real position of given symbol in source code
+        if (tags.second >= 0)
+        {
+            auto pos = get_pos(code, tags.second);
+            std::cout << e.first << ": " << name << "(" << pos.first << ", "
+                      << pos.second << "): ";
+
+            // show the next (at max) 20 characters
+            auto end = code.begin() + tags.second;
+            for (int i = 0; end != code.end() && i != 20; ++end, ++i)
+            {
+                if (*end == '\n' || *end == '\r')
+                    break;
+            }
+            std::cout << std::string(code.begin() + tags.second, end) << " ...\n";
+        }
+        else
+        {
+            std::cout << e.first << "\n";
+        }
+    }
+
+    std::cout << "\n";
+
+    std::cout << "Tree information for function: " << name << "\n";
+    std::cout << phylanx::execution_tree::newick_tree(
+                     name, func.get_expression_topology())
+              << "\n\n";
+
+    std::cout << phylanx::execution_tree::dot_tree(
+                     name, func.get_expression_topology())
+              << "\n\n";
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(boost::program_options::variables_map& vm)
+{
+    if (vm.count("data_csv") == 0)
+    {
+        std::cerr << "Please specify '--data_csv=data-file'";
+        return hpx::finalize();
+    }
+
+    // compile the given code
+    phylanx::execution_tree::compiler::function_list snippets;
+
+    auto read_x = phylanx::execution_tree::compile_and_run(
+        phylanx::ast::generate_ast(read_x_code), snippets);
+    auto read_y = phylanx::execution_tree::compile_and_run(
+        phylanx::ast::generate_ast(read_y_code), snippets);
+    auto lra = phylanx::execution_tree::compile_and_run(
+        phylanx::ast::generate_ast(lra_code), snippets);
+
+    // print instrumentation information, if enabled
+    if (vm.count("instrument") != 0)
+    {
+        auto entries =
+            hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*");
+
+        print_instrumentation("read_x", 0, read_x_code, read_x, entries);
+        print_instrumentation("read_y", 1, read_y_code, read_y, entries);
+        print_instrumentation("lra", 2, lra_code, lra, entries);
+    }
+
+    auto row_start = vm["row_start"].as<std::int64_t>();
+    auto col_start = vm["col_start"].as<std::int64_t>();
+    auto row_stop = vm["row_stop"].as<std::int64_t>();
+    auto col_stop = vm["col_stop"].as<std::int64_t>();
+
+    // read the data from the files
+    auto x = read_x(vm["data_csv"].as<std::string>(), row_start, row_stop,
+        col_start, col_stop);
+    auto y = read_y(vm["data_csv"].as<std::string>(), row_start, row_stop);
+
+    // remaining command line options
+    auto alpha = vm["alpha"].as<double>();
+    auto iterations = vm["num_iterations"].as<std::int64_t>();
+    bool enable_output = vm.count("enable_output") != 0;
+
+    // time execution
+    hpx::util::high_resolution_timer t;
+
+    // evaluate LRA using the read data
+    auto result =
+        lra(std::move(x), std::move(y), alpha, iterations, enable_output);
+
+    auto elapsed = t.elapsed();
+
+    std::cout << "Result: \n"
+              << phylanx::execution_tree::extract_numeric_value(result) << "\n"
+              << "Calculated in: " << elapsed << " seconds\n";
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // command line handling
+    boost::program_options::options_description desc("usage: lra [options]");
+    desc.add_options()
+        ("enable_output,e", "enable progress output (default: false)")
+        ("instrument,i", "print instrumentation information (default: false)")
+        ("num_iterations,n",
+            boost::program_options::value<std::int64_t>()->default_value(750),
+            "number of iterations (default: 750)")
+        ("alpha,a",
+            boost::program_options::value<double>()->default_value(1e-5),
+            "alpha (default: 1e-5)")
+        ("data_csv",
+            boost::program_options::value<std::string>(),
+            "file name for reading data")
+        ("row_start",
+            boost::program_options::value<std::int64_t>()->default_value(0),
+            "row_start (default: 0)")
+        ("col_start",
+            boost::program_options::value<std::int64_t>()->default_value(0),
+            "col_start (default: 0)")
+        ("row_stop",
+            boost::program_options::value<std::int64_t>()->default_value(569),
+            "row_stop (default: 569)")
+        ("col_stop",
+            boost::program_options::value<std::int64_t>()->default_value(30),
+            "col_stop (default: 30)")
+        ;
+
+    return hpx::init(desc, argc, argv);
+}

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -283,7 +283,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 fargs.push_back(arg.arg_);
             }
 
-            std::string full_name = "function#" +
+            // NOTE: Check the consistency of names: "function" vs "call-function"
+            std::string full_name = "call-function#" +
                 std::to_string(sequence_number_) + "#" + name;
 
 

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -303,8 +303,9 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 return f;
             }
 
+            // NOTE: Check the consistency of names: "function" vs "call-function"
             // get sequence number of this component
-            static std::string function_("function");
+            static std::string function_("call-function");
             std::size_t sequence_number =
                 snippets_.sequence_numbers_[function_]++;
 


### PR DESCRIPTION
This PR demonstrates how to complement primitive performance counter information with information inside AGAS to produce and prints that information in CSV.

> **Note**:
> This PR includes a temporary workaround that needs to be removed after #190 is resolved.