### PR TITLE
Performance counter instrumentation for lra_csv_instrumented

### DIFF
--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -1,4 +1,5 @@
 //   Copyright (c) 2017-2018 Hartmut Kaiser
+//   Copyright (c) 2018 Parsa Amini
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
 //   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -101,13 +102,13 @@ std::string const lra_code = R"(block(
 std::pair<std::size_t, std::size_t> get_pos(std::string const& code,
     std::tuple<std::size_t, std::size_t, std::int64_t> const& tags)
 {
-    // column might be given directly, in that case line is given as well
+    // Column might be given directly, in that case line is given as well
     if (std::get<2>(tags) != -1)
     {
         return std::make_pair(std::get<1>(tags), std::get<2>(tags));
     }
 
-    // otherwise the given value is the offset into the code
+    // Otherwise the given value is the offset into the code
     std::size_t pos = std::get<1>(tags);
     std::size_t line = 1;
     std::size_t column = 1;
@@ -134,13 +135,13 @@ std::pair<std::size_t, std::size_t> get_pos(std::string const& code,
 std::size_t get_offset(std::string const& code,
     std::tuple<std::size_t, std::size_t, std::size_t> const& tags)
 {
-    // offset might be given directly
+    // Offset might be given directly
     if (std::get<2>(tags) == -1)
     {
         return std::get<1>(tags);
     }
 
-    // otherwise the given value is the line/column posiiton in the code
+    // Otherwise the given value is the line/column position in the code
     std::size_t offset = 0;
     std::size_t line = 1;
     std::size_t column = 0;
@@ -217,19 +218,19 @@ void print_instrumentation(
 
     for (auto const& e : entries)
     {
-        // extract compile_id and iterator index (tag) from the symbolic name
+        // Extract compile_id and iterator index (tag) from the symbolic name
         auto tags = extract_tags(e.first);
         if (std::get<0>(tags) != compile_id)
             continue;
 
-        // find real position of given symbol in source code
+        // Find real position of given symbol in source code
         if (std::get<1>(tags) >= 0)
         {
             auto pos = get_pos(code, tags);
             std::cout << e.first << ": " << name << "(" << pos.first << ", "
                       << pos.second << "): ";
 
-            // show the next (at max) 20 characters
+            // Show the next (at max) 20 characters
             auto offset = get_offset(code, tags);
             auto end = code.begin() + offset;
             for (int i = 0; end != code.end() && i != 20; ++end, ++i)
@@ -258,6 +259,46 @@ void print_instrumentation(
               << "\n\n";
 }
 
+void print_performance_counter_data_csv()
+{
+    std::cout << std::endl << "Primitive Performance Counter Data in CSV:";
+
+    // CSV Header
+    std::cout << std::endl
+              << "primitive_instance" << ","
+              << "count" << ","
+              << "time" << ","
+              << "direct_count" << ","
+              << "direct_time" << std::endl;
+
+    // List of existing primitive instances
+    std::vector<std::string> existing_primitive_instances;
+
+    // Retrieve all primitive instances
+    for (auto const& entry :
+        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*#*"))
+    {
+        existing_primitive_instances.push_back(entry.first);
+    }
+
+    // Print performance data
+    for (auto const& entry :
+        phylanx::util::retrieve_counter_data(existing_primitive_instances,
+            std::vector<std::string>{"count/eval", "time/eval",
+            "count/eval_direct", "time/eval_direct"},
+            hpx::find_here()))
+    {
+        std::cout << "\"" << entry.first << "\"";
+        for (auto const& counter_value : entry.second)
+        {
+            std::cout << "," << counter_value;
+        }
+        std::cout << std::endl;
+    }
+
+    std::cout << std::endl;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(boost::program_options::variables_map& vm)
 {
@@ -267,7 +308,7 @@ int hpx_main(boost::program_options::variables_map& vm)
         return hpx::finalize();
     }
 
-    // compile the given code
+    // Compile the given code
     phylanx::execution_tree::compiler::function_list snippets;
 
     auto read_x = phylanx::execution_tree::compile(
@@ -277,7 +318,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     auto lra = phylanx::execution_tree::compile(
         phylanx::ast::generate_ast(lra_code), snippets);
 
-    // print instrumentation information, if enabled
+    // Print instrumentation information, if enabled
     if (vm.count("instrument") != 0)
     {
         auto entries =
@@ -293,26 +334,32 @@ int hpx_main(boost::program_options::variables_map& vm)
     auto row_stop = vm["row_stop"].as<std::int64_t>();
     auto col_stop = vm["col_stop"].as<std::int64_t>();
 
-    // read the data from the files
+    // Read the data from the files
     auto x = read_x(vm["data_csv"].as<std::string>(), row_start, row_stop,
         col_start, col_stop);
     auto y = read_y(vm["data_csv"].as<std::string>(), row_start, row_stop);
 
-    // remaining command line options
+    // Remaining command line options
     auto alpha = vm["alpha"].as<double>();
     auto iterations = vm["num_iterations"].as<std::int64_t>();
     bool enable_output = vm.count("enable_output") != 0;
 
-    // time execution
+    // Measure execution time
     hpx::util::high_resolution_timer t;
 
-    // evaluate LRA using the read data
+    // Evaluate LRA using the read data
     auto result =
         lra(std::move(x), std::move(y), alpha, iterations, enable_output);
 
     auto elapsed = t.elapsed();
 
-    // make sure all counters are properly initialized, don't reset current
+    // Print performance counter data in CSV
+    if (vm.count("instrument") != 0)
+    {
+        print_performance_counter_data_csv();
+    }
+
+    // Make sure all counters are properly initialized, don't reset current
     // counter values
     hpx::reinit_active_counters(false);
 
@@ -325,7 +372,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
 int main(int argc, char* argv[])
 {
-    // command line handling
+    // Command line handling
     boost::program_options::options_description desc("usage: lra [options]");
     desc.add_options()
         ("enable_output,e", "enable progress output (default: false)")


### PR DESCRIPTION
This PR adds primitive performance counter information printed in CSV format to `lra_csv_instrumented`