### PR TITLE
Renaming interpreter to physl

### DIFF
--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -276,7 +276,7 @@ void print_performance_counter_data_csv()
 
     // Retrieve all primitive instances
     for (auto const& entry :
-        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*#*"))
+        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*$*"))
     {
         existing_primitive_instances.push_back(entry.first);
     }

--- a/examples/interpreter/CMakeLists.txt
+++ b/examples/interpreter/CMakeLists.txt
@@ -5,7 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(example_programs
-    interpreter
+    physl
    )
 
 foreach(example_program ${example_programs})

--- a/examples/interpreter/factorial.physl
+++ b/examples/interpreter/factorial.physl
@@ -1,12 +1,14 @@
-//  Copyright (c) 2018 Parsa Amini
-//  Copyright (c) 2018 Hartmut Kaiser
-//
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-// Recursive Factorial example in PhySL
-// \param iterations Number of iterations
-// \returns the Factorial value after specified `iterations`
+#! /usr/bin/env physl
+#
+#  Copyright (c) 2018 Parsa Amini
+#  Copyright (c) 2018 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Recursive Factorial example in PhySL
+# \param iterations Number of iterations
+# \returns the Factorial value after specified `iterations`
 
 define(fact, arg0,
     if (arg0 <= 1,

--- a/examples/interpreter/fibonacci.physl
+++ b/examples/interpreter/fibonacci.physl
@@ -1,27 +1,27 @@
-//  Copyright (c) 2018 Parsa Amini
-//  Copyright (c) 2018 Hartmut Kaiser
-//
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-// Iterative Fibonacci example in PhySL
-// \param iterations Number of iterations
-// \returns the Fibonacci value after specified `iterations`
+#! /usr/bin/env physl
+#
+#  Copyright (c) 2018 Parsa Amini
+#  Copyright (c) 2018 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+# Iterative Fibonacci example in PhySL
+# \param iterations Number of iterations
+# \returns the Fibonacci value after specified `iterations`
 
 define(fibonacci, iterations,
     block(
+        define(result, if(iterations < 2, iterations, 0)),
         define(a, 1.0),
-        define(result, 0.0),
         define(b, 1.0),
-        define(tmp, 0.0),
         define(step, 2),
         while(
             step < iterations,
             block(
                 store(result, a + b),
-                store(tmp, b),
+                store(a, b),
                 store(b, result),
-                store(a, tmp),
                 store(step, step + 1)
             )
         ),

--- a/examples/interpreter/lra.physl
+++ b/examples/interpreter/lra.physl
@@ -1,32 +1,34 @@
-//  Copyright (c) 2018 Parsa Amini
-//  Copyright (c) 2018 Hartmut Kaiser
-//
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#! /usr/bin/env physl
+#
+#  Copyright (c) 2018 Parsa Amini
+#  Copyright (c) 2018 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#
+#
+# Linear Regression Algorithm example in PhySL
+# \param filepath
+# \param row_start
+# \param row_stop
+# \param col_start
+# \param col_stop
+# \param alpha
+# \param iterations
+# \param enable_output
+# \returns Calculated weights
 
-
-// Linear Regression Algorithm example in PhySL
-// \param filepath
-// \param row_start
-// \param row_stop
-// \param col_start
-// \param col_stop
-// \param alpha
-// \param iterations
-// \param enable_output
-// \returns Calculated weights
-
-// Read X-data from given CSV file
+# Read X-data from given CSV file
 define(read_x, filepath, row_start, row_stop, col_start, col_stop,
     slice(file_read_csv(filepath), row_start, row_stop, col_start, col_stop)
 )
 
-// Read Y-data from given CSV file
+# Read Y-data from given CSV file
 define(read_y, filepath, row_start, row_stop,
     slice(file_read_csv(filepath), row_start, row_stop, -1, 0)
 )
 
-// Logistic regression analysis algorithm
+# Logistic regression analysis algorithm
 define(lra, filepath, row_start, row_stop, col_start, col_stop, alpha,
             iterations, enable_output,
     block(

--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -73,7 +73,7 @@ void print_performance_counter_data_csv()
 
     // Retrieve all primitive instances
     for (auto const& entry :
-        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*#*"))
+        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*$*"))
     {
         existing_primitive_instances.push_back(entry.first);
     }
@@ -102,7 +102,7 @@ int handle_command_line(int argc, char* argv[], po::variables_map& vm)
     try
     {
         po::options_description cmdline_options(
-            "Usage: interpreter <physl_script> [options] [arguments...]");
+            "Usage: physl <physl_script> [options] [arguments...]");
         cmdline_options.add_options()
             ("help,h", "print out program usage")
             ("code,c", po::value<std::string>(),
@@ -151,8 +151,8 @@ int handle_command_line(int argc, char* argv[], po::variables_map& vm)
     }
     catch  (std::exception const& e)
     {
-        std::cerr << "command line handling: exception caught: " << e.what()
-                  << "\n";
+        std::cerr << "physl: command line handling: exception caught: "
+                  << e.what() << "\n";
         return -1;
     }
     return 0;
@@ -212,7 +212,7 @@ int main(int argc, char* argv[])
             phylanx::execution_tree::compiler::default_environment();
 
         phylanx::execution_tree::define_variable(
-            "sys_argv", snippets, env, args);
+            "sys_argv/0$0", snippets, env, args);
         auto const code = phylanx::execution_tree::compile(ast, snippets, env);
 
         // Re-init all performance counters to guarantee correct measurement
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
     }
     catch (std::exception const& e)
     {
-        std::cout << "exception caught:\n" << e.what() << "\n";
+        std::cout << "physl: exception caught:\n" << e.what() << "\n";
         return -1;
     }
 

--- a/examples/profiling/primitive_instrumentation.cpp
+++ b/examples/profiling/primitive_instrumentation.cpp
@@ -73,7 +73,7 @@ int hpx_main(boost::program_options::variables_map& vm)
 
     // Retrieve all primitive instances
     for (auto const& entry :
-        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*#*"))
+        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*$*"))
     {
         existing_primitive_instances.push_back(entry.first);
     }

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -131,8 +131,8 @@ namespace phylanx { namespace ast { namespace parser
 
         identifier =
                 identifier_name
-            >>  (('#' > long_long) | attr(std::int64_t(-1)))
-            >>  (('#' > long_long) | attr(std::int64_t(-1)))
+            >>  (('$' > long_long) | attr(std::int64_t(-1)))
+            >>  (('$' > long_long) | attr(std::int64_t(-1)))
             ;
 
         identifier_name =

--- a/phylanx/ast/parser/skipper.hpp
+++ b/phylanx/ast/parser/skipper.hpp
@@ -31,6 +31,7 @@ namespace phylanx { namespace ast { namespace parser
                     space                               // tab/space/cr/lf
                 |   "/*" >> *(char_ - "*/") >> "*/"     // C-style comments
                 |   "//" >> *(char_ - eol) >> eol       // C++-style comments
+                |   "#" >> *(char_ - eol) >> eol        // bash-style comments
                 ;
         }
 

--- a/phylanx/execution_tree/compile.hpp
+++ b/phylanx/execution_tree/compile.hpp
@@ -69,7 +69,7 @@ namespace phylanx { namespace execution_tree
         hpx::id_type const& default_locality = hpx::find_here());
 
     /// Add the given variable to the compilation environment
-    PHYLANX_EXPORT compiler::function define_variable(std::string const& name,
+    PHYLANX_EXPORT compiler::function define_variable(std::string name,
         compiler::function_list& snippets, compiler::environment& env,
         primitive_argument_type body,
         hpx::id_type const& default_locality = hpx::find_here());

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -174,7 +174,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         }
         function operator()(std::string && name) const
         {
-            return function{ast::nil{}, "always-nil# " + name};
+            return function{ast::nil{}, "always-nil$ " + name};
         }
     };
 
@@ -211,8 +211,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
 
         function operator()(std::size_t n, std::string const& name) const
         {
-            std::string full_name = "access-argument#" +
-                std::to_string(sequence_number_) + "#" + name;
+            std::string full_name = "access-argument$" +
+                std::to_string(sequence_number_) + "$" + name;
 
             return function{
                 primitive_argument_type{primitive{
@@ -243,8 +243,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
         function compose(std::list<function> && elements,
             std::string const& name) const
         {
-            std::string full_name = "access-variable#" +
-                std::to_string(sequence_number_) + "#" + name;
+            std::string full_name = "access-variable$" +
+                std::to_string(sequence_number_) + "$" + name;
 
 
             return function{
@@ -284,8 +284,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
             }
 
             // NOTE: Check the consistency of names: "function" vs "call-function"
-            std::string full_name = "call-function#" +
-                std::to_string(sequence_number_) + "#" + name;
+            std::string full_name = "call-function$" +
+                std::to_string(sequence_number_) + "$" + name;
 
 
             return function{
@@ -317,7 +317,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         {}
 
         template <typename F>
-        compiled_function* define(std::string const& name, F && f)
+        compiled_function* define(std::string name, F && f)
         {
             if (definitions_.find(name) != definitions_.end())
             {
@@ -326,14 +326,14 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     "given name was already defined: " + name);
             }
 
-            auto result = definitions_.emplace(
-                value_type(name, compiled_function(std::forward<F>(f))));
+            auto result = definitions_.emplace(value_type(
+                std::move(name), compiled_function(std::forward<F>(f))));
 
             if (!result.second)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::environment::define",
-                    "couldn't insert name into symbol table: " + name);
+                    "couldn't insert name into symbol table");
             }
 
             return &result.first->second;
@@ -388,7 +388,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         hpx::id_type const& default_locality);
 
     /// Add the given variable to the compilation environment
-    PHYLANX_EXPORT function define_variable(std::string const& name,
+    PHYLANX_EXPORT function define_variable(std::string name,
         function_list& snippets, environment& env, primitive_argument_type body,
         hpx::id_type const& default_locality);
 }}}

--- a/phylanx/execution_tree/primitives/apply.hpp
+++ b/phylanx/execution_tree/primitives/apply.hpp
@@ -15,7 +15,7 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class HPX_COMPONENT_EXPORT apply
+    class apply
       : public base_primitive
       , public hpx::components::component_base<apply>
     {
@@ -24,9 +24,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         apply() = default;
 
-        apply(std::vector<primitive_argument_type> && operands);
+        PHYLANX_EXPORT apply(std::vector<primitive_argument_type>&& operands);
 
-        primitive_argument_type eval_direct(
+        PHYLANX_EXPORT primitive_argument_type eval_direct(
             std::vector<primitive_argument_type> const& params) const override;
     };
 }}}

--- a/python/phylanx/util/__init__.py
+++ b/python/phylanx/util/__init__.py
@@ -114,7 +114,7 @@ def get_node(node,**kwargs):
     return None
 
 def full_node_name(a, name):
-    return '%s#%d#%d' % (name, a.lineno, a.col_offset)
+    return '%s$%d$%d' % (name, a.lineno, a.col_offset)
 
 def full_name(a):
     return full_node_name(a, a.name)

--- a/src/ast/node.cpp
+++ b/src/ast/node.cpp
@@ -442,7 +442,7 @@ namespace phylanx { namespace ast
         out << id.name;
         if (id.id >= 0 && id.col != -1)
         {
-            out << '#' << id.id << '#' << id.col;
+            out << '$' << id.id << '$' << id.col;
         }
         return out;
     }

--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace phylanx { namespace execution_tree
@@ -101,13 +102,13 @@ namespace phylanx { namespace execution_tree
 
     ///////////////////////////////////////////////////////////////////////////
     /// Add the given variable to the compilation environment
-    compiler::function define_variable(std::string const& name,
+    compiler::function define_variable(std::string name,
         compiler::function_list& snippets, compiler::environment& env,
         primitive_argument_type body,
         hpx::id_type const& default_locality)
     {
         return compiler::define_variable(
-            name, snippets, env, body, default_locality)();
+            std::move(name), snippets, env, body, default_locality)();
     }
 }}
 

--- a/src/execution_tree/compiler/primitive_name.cpp
+++ b/src/execution_tree/compiler/primitive_name.cpp
@@ -48,14 +48,14 @@ namespace phylanx { namespace execution_tree { namespace compiler
             {
                 start =
                         qi::lit("/phylanx/") >> primitive
-                    >   qi::lit('#') > qi::int_
-                    > ((qi::lit('#') > instance) | qi::attr(""))
-                    >   qi::lit('/') > qi::int_
-                    >   qi::lit('#') > qi::int_
-                    > ((qi::lit('#') > qi::int_) | qi::attr(-1))
+                    >>   qi::lit('$') >> qi::int_
+                    >> ((qi::lit('$') >> instance) | qi::attr(""))
+                    >>   qi::lit('/') >> qi::int_
+                    >>   qi::lit('$') >> qi::int_
+                    >> ((qi::lit('$') >> qi::int_) | qi::attr(-1))
                     ;
 
-                primitive = +(qi::char_ - qi::lit('#'));
+                primitive = +(qi::char_ - qi::lit('$'));
                 instance = +(qi::char_ - qi::lit('/'));
 
                 // Debugging support.
@@ -105,22 +105,22 @@ namespace phylanx { namespace execution_tree { namespace compiler
 
         std::string result("/phylanx/");
         result += parts.primitive;
-        result += "#" + std::to_string(
+        result += "$" + std::to_string(
             parts.sequence_number == -1 ? 0 : parts.sequence_number);
 
         if (!parts.instance.empty())
         {
-            result += "#" + parts.instance;
+            result += "$" + parts.instance;
         }
 
         result += "/" + std::to_string(
             parts.compile_id == -1 ? 0 : parts.compile_id);
-        result += "#" + std::to_string(parts.tag1 < 0 ? 0 : parts.tag1);
+        result += "$" + std::to_string(parts.tag1 < 0 ? 0 : parts.tag1);
 
         // column is optional
         if (parts.tag2 != -1)
         {
-            result += '#' + std::to_string(parts.tag2);
+            result += '$' + std::to_string(parts.tag2);
         }
 
         return result;

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -32,8 +32,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::primitives::"
-                    "access_argument::eval_direct",
-                "argument count out of bounds: " + std::to_string(argnum_));
+                "access_argument::eval_direct",
+                "argument count out of bounds, expected at least " +
+                    std::to_string(argnum_ + 1) + " argument(s) "
+                    "while only " + std::to_string(params.size()) +
+                    " argument(s) were supplied");
         }
         return value_operand_ref_sync(params[argnum_], params);
     }

--- a/src/performance_counters/register_counters.cpp
+++ b/src/performance_counters/register_counters.cpp
@@ -131,7 +131,7 @@ namespace phylanx { namespace performance_counters
             // Structure of primitives in symbolic namespace:
             //     /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag>
             auto entries = hpx::agas::find_symbols(hpx::launch::sync,
-                "/phylanx/" + extract_primitive_type() + "#*");
+                "/phylanx/" + extract_primitive_type() + "$*");
 
             // TODO: Only keep entries that live on this locality.
             // This will be a problem when Phylanx becomes distributed.

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -129,11 +129,11 @@ void test_expression(std::string const& expr, std::string const& expected)
 int main(int argc, char* argv[])
 {
     test_ast("A", phylanx::ast::identifier("A"));
-    test_ast("A#1#2", phylanx::ast::identifier("A", 1, 2));
+    test_ast("A$1$2", phylanx::ast::identifier("A", 1, 2));
 
     test_ast("A()",
         phylanx::ast::function_call(phylanx::ast::identifier("A")));
-    test_ast("A#1#2()",
+    test_ast("A$1$2()",
         phylanx::ast::function_call(phylanx::ast::identifier("A", 1, 2)));
 
     test_expression(
@@ -144,9 +144,9 @@ int main(int argc, char* argv[])
     );
 
     test_expression(
-        "A#1#0 + B#1#5",
-            "A#1#0\n"
-            "B#1#5\n"
+        "A$1$0 + B$1$5",
+            "A$1$0\n"
+            "B$1$5\n"
             "+\n"
     );
 
@@ -186,10 +186,10 @@ int main(int argc, char* argv[])
     );
 
     test_expression(
-        "func#1#0(A#1#6, B#1#9)",
-            "func#1#0\n"
-            "A#1#6\n"
-            "B#1#9\n"
+        "func$1$0(A$1$6, B$1$9)",
+            "func$1$0\n"
+            "A$1$6\n"
+            "B$1$9\n"
     );
 
     test_expression(

--- a/tests/unit/execution_tree/expression_topology.cpp
+++ b/tests/unit/execution_tree/expression_topology.cpp
@@ -34,26 +34,26 @@ int main(int argc, char* argv[])
 {
     test_expressiontree_topology("test1",
         "define(x, 42)",
-            "(/phylanx/define-variable#0#x/0#7) test1;",
+            "(/phylanx/define-variable$0$x/0$7) test1;",
             "graph test1 {\n"
-            "    \"/phylanx/define-variable#0#x/0#7\";\n"
+            "    \"/phylanx/define-variable$0$x/0$7\";\n"
             "}\n");
 
     test_expressiontree_topology("test2",
         "block(define(x, 42), define(y, x))",
-            "((/phylanx/define-variable#0#x/0#13,"
-                "(/phylanx/access-variable#0#x/0#31) "
-                    "/phylanx/define-variable#1#y/0#28) "
-                "/phylanx/block#0/0#0) test2;",
+            "((/phylanx/define-variable$0$x/0$13,"
+                "(/phylanx/access-variable$0$x/0$31) "
+                    "/phylanx/define-variable$1$y/0$28) "
+                "/phylanx/block$0/0$0) test2;",
             "graph test2 {\n"
-            "    \"/phylanx/block#0/0#0\" -- "
-                    "\"/phylanx/define-variable#0#x/0#13\";\n"
-            "    \"/phylanx/define-variable#0#x/0#13\";\n"
-            "    \"/phylanx/block#0/0#0\" -- "
-                    "\"/phylanx/define-variable#1#y/0#28\";\n"
-            "    \"/phylanx/define-variable#1#y/0#28\" -- "
-                    "\"/phylanx/access-variable#0#x/0#31\";\n"
-            "    \"/phylanx/access-variable#0#x/0#31\";\n"
+            "    \"/phylanx/block$0/0$0\" -- "
+                    "\"/phylanx/define-variable$0$x/0$13\";\n"
+            "    \"/phylanx/define-variable$0$x/0$13\";\n"
+            "    \"/phylanx/block$0/0$0\" -- "
+                    "\"/phylanx/define-variable$1$y/0$28\";\n"
+            "    \"/phylanx/define-variable$1$y/0$28\" -- "
+                    "\"/phylanx/access-variable$0$x/0$31\";\n"
+            "    \"/phylanx/access-variable$0$x/0$31\";\n"
             "}\n");
 
     return hpx::util::report_errors();

--- a/tests/unit/execution_tree/instrumentation.cpp
+++ b/tests/unit/execution_tree/instrumentation.cpp
@@ -25,7 +25,7 @@ void test_unary_expr()
     auto f = phylanx::execution_tree::compile(
         phylanx::ast::generate_ast(code, iterators), snippets);
 
-    auto entries = hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*");
+    auto entries = hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*$*");
 
 }
 

--- a/tests/unit/execution_tree/parse_primitive_name.cpp
+++ b/tests/unit/execution_tree/parse_primitive_name.cpp
@@ -32,16 +32,16 @@ int main(int argc, char* argv[])
     parts.tag1 = 3;
     parts.tag2 = -1;
 
-    test_primitive_name(parts, "/phylanx/add#1/2#3");
+    test_primitive_name(parts, "/phylanx/add$1/2$3");
 
     parts.instance = "test";
-    test_primitive_name(parts, "/phylanx/add#1#test/2#3");
+    test_primitive_name(parts, "/phylanx/add$1$test/2$3");
 
     parts.tag2 = 4;
-    test_primitive_name(parts, "/phylanx/add#1#test/2#3#4");
+    test_primitive_name(parts, "/phylanx/add$1$test/2$3$4");
 
     parts.instance = "";
-    test_primitive_name(parts, "/phylanx/add#1/2#3#4");
+    test_primitive_name(parts, "/phylanx/add$1/2$3$4");
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/performance_counters/primitive_counter.cpp
+++ b/tests/unit/performance_counters/primitive_counter.cpp
@@ -134,7 +134,7 @@ int main()
 
         // Verify the number of primitive instances in lra
         auto entries = hpx::agas::find_symbols(
-            hpx::launch::sync, "/phylanx/" + name + "#*");
+            hpx::launch::sync, "/phylanx/" + name + "$*");
         HPX_TEST_EQ(expected_counts[name], entries.size());
 
         // Time performance counters

--- a/tests/unit/python/execution_tree/eval.py
+++ b/tests/unit/python/execution_tree/eval.py
@@ -42,10 +42,10 @@ def fib(n):
         return fib(n-1)+fib(n-2)
 
 assert fib.__physl_src__ == \
-    'block#1#0(define#1#0(fib#1#0, n#1#8, ' + \
-        'if(n#2#7 < 2, n#3#15, ' + \
-            '(fib((n#5#19 - 1)) + fib((n#5#28 - 2))))' + \
-        '), fib#1#0)\n'
+    'block$1$0(define$1$0(fib$1$0, n$1$8, ' + \
+        'if(n$2$7 < 2, n$3$15, ' + \
+            '(fib((n$5$19 - 1)) + fib((n$5$28 - 2))))' + \
+        '), fib$1$0)\n'
 
 assert fib(10)[0] == 55.0
 
@@ -54,7 +54,7 @@ def pass_str(a):
     return a
 
 assert pass_str.__physl_src__ == \
-    'block#1#0(define#1#0(pass_str#1#0, a#1#13, a#2#11), pass_str#1#0)\n'
+    'block$1$0(define$1$0(pass_str$1$0, a$1$13, a$2$11), pass_str$1$0)\n'
 
 assert "foo" == str(pass_str("foo"))
 

--- a/tests/unit/util/performance_data.cpp
+++ b/tests/unit/util/performance_data.cpp
@@ -44,38 +44,38 @@ char const* const fib_code = R"(block(
 
 std::map<std::string, std::vector<std::size_t>> expected_counts =
 {
-    { "access-variable#0", { 1, 0, } },
-    { "access-variable#1", { 0, 0, } },
-    { "access-variable#1", { 0, 0, } },
-    { "access-variable#2", { 1, 0, } },
-    { "access-variable#2", { 1, 0, } },
-    { "access-variable#2", { 1, 0, } },
-    { "access-variable#3", { 0, 0, } },
-    { "access-variable#3", { 0, 0, } },
-    { "access-variable#3", { 0, 0, } },
-    { "access-variable#4", { 8, 0, } },
-    { "access-variable#4", { 8, 0, } },
-    { "access-variable#5", { 8, 0, } },
-    { "access-variable#5", { 8, 0, } },
-    { "access-variable#5", { 8, 0, } },
-    { "__add#0", { 8, 0, } },
-    { "__add#1", { 8, 0, } },
-    { "block#0", { 0, 1, } },
-    { "block#1", { 0, 1, } },
-    { "block#2", { 8, 0, } },
-    { "define-variable#0", { 2, 0, } },
-    { "define-variable#1", { 9, 0, } },
-    { "define-variable#2", { 10, 0, } },
-    { "define-variable#3", { 17, 0, } },
-    { "define-variable#4", { 9, 0, } },
-    { "define-variable#5", { 18, 0, } },
-    { "__lt#0", { 9, 0, } },
-    { "store#0", { 8, 0, } },
-    { "store#1", { 8, 0, } },
-    { "store#2", { 8, 0, } },
-    { "store#3", { 8, 0, } },
-    { "store#4", { 8, 0, } },
-    { "while#0", { 1, 0, } },
+    { "access-variable$0", { 1, 0, } },
+    { "access-variable$1", { 0, 0, } },
+    { "access-variable$1", { 0, 0, } },
+    { "access-variable$2", { 1, 0, } },
+    { "access-variable$2", { 1, 0, } },
+    { "access-variable$2", { 1, 0, } },
+    { "access-variable$3", { 0, 0, } },
+    { "access-variable$3", { 0, 0, } },
+    { "access-variable$3", { 0, 0, } },
+    { "access-variable$4", { 8, 0, } },
+    { "access-variable$4", { 8, 0, } },
+    { "access-variable$5", { 8, 0, } },
+    { "access-variable$5", { 8, 0, } },
+    { "access-variable$5", { 8, 0, } },
+    { "__add$0", { 8, 0, } },
+    { "__add$1", { 8, 0, } },
+    { "block$0", { 0, 1, } },
+    { "block$1", { 0, 1, } },
+    { "block$2", { 8, 0, } },
+    { "define-variable$0", { 2, 0, } },
+    { "define-variable$1", { 9, 0, } },
+    { "define-variable$2", { 10, 0, } },
+    { "define-variable$3", { 17, 0, } },
+    { "define-variable$4", { 9, 0, } },
+    { "define-variable$5", { 18, 0, } },
+    { "__lt$0", { 9, 0, } },
+    { "store$0", { 8, 0, } },
+    { "store$1", { 8, 0, } },
+    { "store$2", { 8, 0, } },
+    { "store$3", { 8, 0, } },
+    { "store$4", { 8, 0, } },
+    { "while$0", { 1, 0, } },
 };
 
 int main()
@@ -94,7 +94,7 @@ int main()
 
     // Retrieve all primitive instances
     for (auto const& entry :
-        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*#*"))
+        hpx::agas::find_symbols(hpx::launch::sync, "/phylanx/*$*"))
     {
         existing_primitive_instances.push_back(entry.first);
     }
@@ -110,7 +110,7 @@ int main()
                 entry.first);
 
         std::string const expected_key(
-            tags.primitive + "#" + std::to_string(tags.sequence_number));
+            tags.primitive + "$" + std::to_string(tags.sequence_number));
         auto const& expected_values = expected_counts[expected_key];
 
         HPX_TEST(!expected_values.empty());


### PR DESCRIPTION
- Changing delimiter in primitive names from '#' to '$'
- PhySL comments now may begin with '#'
- Adding shebang support to example PhySL scripts

This relies on https://github.com/STEllAR-GROUP/hpx/pull/3162 being merged