### PR TITLE
Making sure proper sequence numbers for primitives are generated

### DIFF
--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -188,7 +188,7 @@ std::tuple<std::size_t, std::size_t, std::size_t> extract_tags(
 // The symbolic names registered in AGAS that identify the created
 // primitive instances have the following structure:
 //
-// /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag1>[#<tag2>]
+// /phylanx/<primitive>$<sequence-nr>[$<instance>]/<compile_id>$<tag1>[$<tag2>]
 //
 //  where:
 //      <primitive>:   the name of primitive type representing the given

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -197,18 +197,17 @@ namespace phylanx { namespace execution_tree { namespace compiler
     // compose an argument selector
     struct argument
     {
-        argument(std::size_t sequence_number,
-                hpx::id_type const& locality = hpx::find_here())
-          : sequence_number_(sequence_number),
-            locality_(locality)
+        argument(hpx::id_type const& locality = hpx::find_here())
+          : locality_(locality)
         {
         }
 
         function operator()(std::size_t n, std::string const& name) const
         {
+            static std::size_t sequence_number = 0;
             static std::string type("access-argument");
             std::string full_name = type + "$" +
-                std::to_string(sequence_number_) + "$" + name;
+                std::to_string(sequence_number++) + "$" + name;
 
             return function{
                 primitive_argument_type{create_primitive_component(locality_,
@@ -216,7 +215,6 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 full_name};
         }
 
-        std::size_t sequence_number_;
         hpx::id_type locality_;
     };
 
@@ -225,22 +223,20 @@ namespace phylanx { namespace execution_tree { namespace compiler
     {
         // we must hold f by reference
         std::reference_wrapper<function const> f_;
-        std::size_t sequence_number_;
 
         explicit external_variable(function const& f,
-                std::size_t sequence_number = std::size_t(-1),
                 hpx::id_type const& locality = hpx::find_here())
           : compiled_actor<external_variable>(locality)
-          ,sequence_number_(sequence_number)
           , f_(f)
         {}
 
         function compose(std::list<function> && elements,
             std::string const& name) const
         {
+            static std::size_t sequence_number = 0;
             static std::string type("access-variable");
             std::string full_name = type + "$" +
-                std::to_string(sequence_number_) + "$" + name;
+                std::to_string(sequence_number++) + "$" + name;
 
             return function{
                 primitive_argument_type{create_primitive_component_with_name(

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -17,7 +17,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
 {
     // The full name of every component is patterned after
     //
-    // /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag1>[#<tag2>]
+    // /phylanx/<primitive>$<sequence-nr>[$<instance>]/<compile_id>$<tag1>[$<tag2>]
     //
     //  where:
     //      <primitive>:   the name of primitive type representing the given

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -186,16 +186,12 @@ namespace phylanx { namespace execution_tree { namespace compiler
             std::vector<ast::expression> const& args,
             ast::expression const& body) const
         {
-            static std::string argument_name("argument");
-
             std::size_t base_arg_num = env_.base_arg_num();
             environment env(&env_, args.size());
             for (std::size_t i = 0; i != args.size(); ++i)
             {
                 // get sequence number of this component
-                std::size_t sequence_number =
-                    snippets_.sequence_numbers_[argument_name]++;
-                argument arg(sequence_number, default_locality_);
+                argument arg(default_locality_);
 
                 HPX_ASSERT(ast::detail::is_identifier(args[i]));
                 env.define(ast::detail::identifier_name(args[i]),
@@ -235,15 +231,11 @@ namespace phylanx { namespace execution_tree { namespace compiler
             if (args.empty())
             {
                 // get sequence number of this component
-                static std::string variable("variable");
-                std::size_t sequence_number =
-                    snippets_.sequence_numbers_[variable]++;
-
-                env_.define(std::move(name),
-                    external_variable(f, sequence_number, default_locality_));
+                env_.define(
+                    std::move(name), external_variable(f, default_locality_));
 
                 static std::string define_variable("define-variable");
-                sequence_number =
+                std::size_t sequence_number =
                     snippets_.sequence_numbers_[define_variable]++;
 
                 // define variable
@@ -456,14 +448,11 @@ namespace phylanx { namespace execution_tree { namespace compiler
         function& f = snippets.snippets_.back();
 
         // get sequence number of this component
-        static std::string variable("variable");
-        std::size_t sequence_number = snippets.sequence_numbers_[variable]++;
-
-        env.define(std::move(name),
-            external_variable(f, sequence_number, default_locality));
+        env.define(std::move(name), external_variable(f, default_locality));
 
         static std::string define_variable("define-variable");
-        sequence_number = snippets.sequence_numbers_[define_variable]++;
+        std::size_t sequence_number =
+            snippets.sequence_numbers_[define_variable]++;
 
         f = primitive_variable{default_locality}(
                 std::move(body), define_variable + "$" +

--- a/src/performance_counters/register_counters.cpp
+++ b/src/performance_counters/register_counters.cpp
@@ -129,7 +129,7 @@ namespace phylanx { namespace performance_counters
         void reinit(bool reset) override
         {
             // Structure of primitives in symbolic namespace:
-            //     /phylanx/<primitive>#<sequence-nr>[#<instance>]/<compile_id>#<tag>
+            //     /phylanx/<primitive>$<sequence-nr>[$<instance>]/<compile_id>$<tag>
             auto entries = hpx::agas::find_symbols(hpx::launch::sync,
                 "/phylanx/" + extract_primitive_type() + "$*");
 

--- a/tests/unit/util/performance_data.cpp
+++ b/tests/unit/util/performance_data.cpp
@@ -44,12 +44,20 @@ char const* const fib_code = R"(block(
 
 std::map<std::string, std::vector<std::size_t>> expected_counts =
 {
-    { "access-variable$0", { 1, 0, } },
+    { "access-variable$0", { 9, 0, } },
     { "access-variable$1", { 0, 0, } },
-    { "access-variable$2", { 1, 0, } },
-    { "access-variable$3", { 0, 0, } },
-    { "access-variable$4", { 8, 0, } },
+    { "access-variable$2", { 8, 0, } },
+    { "access-variable$3", { 8, 0, } },
+    { "access-variable$4", { 0, 0, } },
     { "access-variable$5", { 8, 0, } },
+    { "access-variable$6", { 0, 0, } },
+    { "access-variable$7", { 8, 0, } },
+    { "access-variable$8", { 0, 0, } },
+    { "access-variable$9", { 8, 0, } },
+    { "access-variable$10", { 0, 0, } },
+    { "access-variable$11", { 8, 0, } },
+    { "access-variable$12", { 1, 0, } },
+    { "access-variable$13", { 1, 0, } },
     { "__add$0", { 8, 0, } },
     { "__add$1", { 8, 0, } },
     { "block$0", { 0, 1, } },
@@ -114,11 +122,11 @@ int main()
         auto const& expected_values = expected_counts[expected_key];
 
         HPX_TEST_EQ(
-            expected_values.size(), performance_counter_name_last_part.size());
+            entry.second.size(), performance_counter_name_last_part.size());
         HPX_TEST_EQ(entry.second[0], expected_values[0]);
-        HPX_TEST((entry.second[1] != 0) == (expected_values[0] != 0));
+        HPX_TEST_EQ(entry.second[1] != 0, expected_values[0] != 0);
         HPX_TEST_EQ(entry.second[2], expected_values[1]);
-        HPX_TEST((entry.second[3] != 0) == (expected_values[1] != 0));
+        HPX_TEST_EQ(entry.second[3] != 0, expected_values[1] != 0);
     }
 
     return hpx::util::report_errors();

--- a/tests/unit/util/performance_data.cpp
+++ b/tests/unit/util/performance_data.cpp
@@ -76,6 +76,9 @@ std::map<std::string, std::vector<std::size_t>> expected_counts =
     { "variable$5", { 0, 18, } },
 };
 
+const std::vector<std::string> performance_counter_name_last_part{
+    "count/eval", "time/eval", "count/eval_direct", "time/eval_direct"};
+
 int main()
 {
     // Compile the given code
@@ -99,8 +102,7 @@ int main()
 
     for (auto const& entry :
         phylanx::util::retrieve_counter_data(existing_primitive_instances,
-            std::vector<std::string>{"count/eval", "time/eval",
-                "count/eval_direct", "time/eval_direct"},
+            performance_counter_name_last_part,
             hpx::find_here()))
     {
         auto const tags =
@@ -111,7 +113,8 @@ int main()
             tags.primitive + "$" + std::to_string(tags.sequence_number));
         auto const& expected_values = expected_counts[expected_key];
 
-        HPX_TEST(!expected_values.empty());
+        HPX_TEST_EQ(
+            expected_values.size(), performance_counter_name_last_part.size());
         HPX_TEST_EQ(entry.second[0], expected_values[0]);
         HPX_TEST((entry.second[1] != 0) == (expected_values[0] != 0));
         HPX_TEST_EQ(entry.second[2], expected_values[1]);


### PR DESCRIPTION
Making sure sequence numbers generated for `access-variable` and `access-argument` primitives is unique.

This fixes #216