### PR TITLE
Fixing shared library link on OSX

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -19,7 +19,7 @@ add_phylanx_source_group(
   TARGETS ${phylanx_SOURCES})
 
 ###############################################################################
-pybind11_add_module(phylanx_py ${phylanx_py_SOURCES} ${phylanx_py_HEADERS})
+pybind11_add_module(phylanx_py SHARED ${phylanx_py_SOURCES} ${phylanx_py_HEADERS})
 
 include_directories(${pybind11_INCLUDE_DIR}})
 


### PR DESCRIPTION
Based on the guidance from this thread:
https://cmake.org/Bug/bug_relationship_graph.php?bug_id=15126&graph=dependency
I added "SHARED" to the pybind11_add_module() call in python/src/CMakeLists.txt
because otherwise, the wrong linker flags are used and Clang complains.
CMake makes a distinction between shared object libraries and modules that
are loaded with dlopen() calls.

this manifested itself with this error message when linking Phylanx:
clang: error: invalid argument '-current_version 0.0.1' only allowed with '-dynamiclib'
Adding -dynamiclib caused a conflict with -bundle.  Removing -bundle made the
link work.