### PR TITLE
Refactor retrieve_counter_data

### DIFF
--- a/src/util/performance_data.cpp
+++ b/src/util/performance_data.cpp
@@ -31,14 +31,14 @@ namespace phylanx { namespace util
 
         // NOTE: primitive_instances are not verified
 
-        // Return value
-        std::map<std::string, std::vector<std::int64_t>> result;
-
-        // Reuse get_counter_values_array calls
+        // Querying for performance counters is relatively expensive and there
+        // is overlap, thus we can use futures
         //   key: primitive type
-        //   value: vector of performance counter values
-        std::map<std::string, std::vector<std::vector<std::int64_t>>>
-            counter_values_pile;
+        //   value: future of vector of performance counter values
+        std::map<std::string,
+            std::vector<
+            hpx::future<hpx::performance_counters::counter_values_array>>>
+            values_futures_pile;
 
         // Iterate through all provided primitive instances
         for (auto const& name : primitive_instances)
@@ -48,19 +48,14 @@ namespace phylanx { namespace util
                 phylanx::execution_tree::compiler::parse_primitive_name(name);
 
             // Performance counter values
-            std::vector<std::vector<std::int64_t>>& counter_values =
-                counter_values_pile[tags.primitive];
+            std::vector<
+                hpx::future<hpx::performance_counters::counter_values_array>>&
+                futures = values_futures_pile[tags.primitive];
 
-            if (counter_values.empty())
+            if (futures.empty())
             {
-                // Querying for performance counters is relatively expensive and there
-                // is overlap, thus we can use futures
-                std::vector<hpx::future<
-                    hpx::performance_counters::counter_values_array>>
-                    futures;
-
                 // Preallocate memory
-                counter_values.reserve(counter_name_last_parts.size());
+                futures.reserve(counter_name_last_parts.size());
 
                 // Iterate through the last parts of performance counter names
                 for (auto const& counter_name_last_part :
@@ -74,17 +69,53 @@ namespace phylanx { namespace util
                         counter_name, locality_id);
                     futures.push_back(counter.get_counter_values_array(false));
                 }
-
-                // We need the performance counter values. Wait until they are done
-                hpx::wait_all(futures);
-
-                // Collect the performance counter values
-                for (auto& f : futures)
-                {
-                    counter_values.push_back(f.get().values_);
-                }
             }
+        }
 
+        // We need the performance counter values. Wait until they are done
+        for (auto& entry : values_futures_pile)
+        {
+            hpx::wait_all(entry.second);
+        }
+
+        // Reuse get_counter_values_array calls
+        //   key: primitive type
+        //   value: vector of performance counter values
+        std::map<std::string, std::vector<std::vector<std::int64_t>>>
+            counter_values_pile;
+
+        // Collect the values from the futures
+        for (auto& values_futures : values_futures_pile)
+        {
+            // Performance counter values
+            std::vector<std::vector<std::int64_t>>& counter_values =
+                counter_values_pile[values_futures.first];
+
+            // Preallocate memory
+            counter_values.reserve(counter_name_last_parts.size());
+
+            // Collect the performance counter values
+            for (auto& f : values_futures.second)
+            {
+                counter_values.push_back(f.get().values_);
+            }
+        }
+
+        // Return value
+        std::map<std::string, std::vector<std::int64_t>> result;
+
+        // Iterate and collect the result from the futures
+        for (auto const& name : primitive_instances)
+        {
+            // Parse the primitive name
+            auto const tags =
+                phylanx::execution_tree::compiler::parse_primitive_name(name);
+
+            // Performance counter values
+            std::vector<std::vector<std::int64_t>>& counter_values =
+                counter_values_pile[tags.primitive];
+
+            // Collect the performance counter values
             std::vector<std::int64_t> data(counter_name_last_parts.size());
             for (unsigned int i = 0; i < counter_values.size(); ++i)
             {


### PR DESCRIPTION
This PR improves the use of futures in `phylanx::util::retrieve_counter_data()` to improve its performance.