### PR TITLE
Adding make_list and make_vector primitives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 phylanx_setup_hpx()
 phylanx_setup_blaze()
 phylanx_setup_pybind11()
-phylanx_setup_hdf5()
+phylanx_setup_highfive()
 
 phylanx_include(GitCommit)
 

--- a/cmake/Phylanx_HighFive.cmake
+++ b/cmake/Phylanx_HighFive.cmake
@@ -4,14 +4,30 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 # setup HighFive/HDF5 as a dependency
-macro(phylanx_setup_hdf5)
+macro(phylanx_setup_highfive)
+
+    set(PHYLANX_HDF5_LIBRARIES)
     if(PHYLANX_WITH_HIGHFIVE)
 
-        find_package(HDF5)
+        # try to find cmake built HDF5 libraries
+        find_package(HDF5 NAMES hdf5 COMPONENTS C shared NO_MODULE QUIET)
         if(NOT HDF5_FOUND)
-            phylanx_warn("The HDF5 libraries could not be found, please set HDF5_DIR to help locating it.")
-            set(PHYLANX_WITH_HIGHFIVE OFF)
-        else()
+            find_package(HDF5) # NAMES hdf5 COMPONENTS C static NO_MODULE QUIET)
+            if(NOT HDF5_FOUND)
+                phylanx_warn("The HDF5 libraries could not be found, please set HDF5_DIR to help locating it.")
+                set(PHYLANX_WITH_HIGHFIVE OFF)
+            endif()
+        endif()
+
+        if(HDF5_FOUND)
+            include_directories(${HDF5_INCLUDE_DIR})
+            foreach(comp ${HDF5_VALID_COMPONENTS})
+                string(TOUPPER ${comp} comp_uc)
+                if(HDF5_C_${comp_uc}_LIBRARY)
+                    link_libraries(${HDF5_C_${comp_uc}_LIBRARY})
+                    set(PHYLANX_HDF5_LIBRARIES "${PHYLANX_HDF5_LIBRARIES}" "${HDF5_C_${comp_uc}_LIBRARY}")
+                endif()
+            endforeach()
             phylanx_info("HDF5 library version: " ${HDF5_VERSION})
 
             find_package(HighFive NO_MODULE NO_CMAKE_PACKAGE_REGISTRY)

--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -45,6 +45,7 @@
 #include <phylanx/execution_tree/primitives/less_equal.hpp>
 #include <phylanx/execution_tree/primitives/linearmatrix.hpp>
 #include <phylanx/execution_tree/primitives/linspace.hpp>
+#include <phylanx/execution_tree/primitives/make_vector.hpp>
 #include <phylanx/execution_tree/primitives/mul_operation.hpp>
 #include <phylanx/execution_tree/primitives/not_equal.hpp>
 #include <phylanx/execution_tree/primitives/or_operation.hpp>

--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -45,6 +45,7 @@
 #include <phylanx/execution_tree/primitives/less_equal.hpp>
 #include <phylanx/execution_tree/primitives/linearmatrix.hpp>
 #include <phylanx/execution_tree/primitives/linspace.hpp>
+#include <phylanx/execution_tree/primitives/make_list.hpp>
 #include <phylanx/execution_tree/primitives/make_vector.hpp>
 #include <phylanx/execution_tree/primitives/mul_operation.hpp>
 #include <phylanx/execution_tree/primitives/not_equal.hpp>

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -217,6 +217,13 @@ namespace phylanx { namespace execution_tree
                 std::vector<primitive_argument_type>>{std::move(val)}}
         {}
 
+        primitive_argument_type(argument_value_type const& val)
+          : argument_value_type{val}
+        {}
+        primitive_argument_type(argument_value_type&& val)
+          : argument_value_type{std::move(val)}
+        {}
+
         inline primitive_argument_type operator()() const;
 
         inline primitive_argument_type
@@ -657,6 +664,35 @@ namespace phylanx { namespace execution_tree
         std::vector<primitive_argument_type> const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT hpx::future<std::vector<primitive_argument_type>> list_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> const& args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT hpx::future<std::vector<primitive_argument_type>> list_operand(
+        primitive_argument_type const& val,
+        std::vector<primitive_argument_type> && args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT hpx::future<std::vector<primitive_argument_type>> list_operand(
+        primitive_argument_type && val,
+        std::vector<primitive_argument_type> && args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    namespace functional
+    {
+        struct list_operand
+        {
+            template <typename... Ts>
+            hpx::future<std::vector<primitive_argument_type>> operator()(
+                Ts&&... ts) const
+            {
+                return execution_tree::list_operand(std::forward<Ts>(ts)...);
+            }
+        };
+    }
+
     PHYLANX_EXPORT std::vector<primitive_argument_type> list_operand_sync(
         primitive_argument_type const& val,
         std::vector<primitive_argument_type> const& args,

--- a/phylanx/execution_tree/primitives/make_list.hpp
+++ b/phylanx/execution_tree/primitives/make_list.hpp
@@ -3,13 +3,12 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_MAKE_VECTOR_FEB_24_2018_0720PM)
-#define PHYLANX_MAKE_VECTOR_FEB_24_2018_0720PM
+#if !defined(PHYLANX_MAKE_LIST_FEB_25_2018_1030AM)
+#define PHYLANX_MAKE_LIST_FEB_25_2018_1030AM
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
-#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
@@ -19,16 +18,10 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class make_vector
+    class make_list
       : public primitive_component_base
-      , public std::enable_shared_from_this<make_vector>
+      , public std::enable_shared_from_this<make_list>
     {
-    private:
-        using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
-        using storage1d_type = typename arg_type::storage1d_type;
-        using storage2d_type = typename arg_type::storage2d_type;
-
     protected:
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
@@ -37,23 +30,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     public:
         static match_pattern_type const match_data;
 
-        make_vector() = default;
+        make_list() = default;
 
         ///
-        /// \brief Creates a (Blaze) vector by concatenating its arguments
+        /// \brief Creates a PhySL list by concatenating its arguments
         ///
-        /// \param args Is a (possibly empty) list of either zero- or
-        ///             one-dimensional numerical values to be concatenated
-        ///             in order.
+        /// \param args Is a (possibly empty) list of any values to be
+        ///             concatenated into a PhySL list in order.
         ///
-        make_vector(std::vector<primitive_argument_type>&& operands,
+        make_list(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
     };
 
-    PHYLANX_EXPORT primitive create_make_vector(
+    PHYLANX_EXPORT primitive create_make_list(
         hpx::id_type const& locality,
         std::vector<primitive_argument_type>&& operands,
         std::string const& name = "", std::string const& codename = "");

--- a/phylanx/execution_tree/primitives/make_vector.hpp
+++ b/phylanx/execution_tree/primitives/make_vector.hpp
@@ -1,0 +1,54 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_MAKE_VECTOR_FEB_24_2018_0720PM)
+#define PHYLANX_MAKE_VECTOR_FEB_24_2018_0720PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class make_vector
+      : public primitive_component_base
+      , public std::enable_shared_from_this<make_vector>
+    {
+    private:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using storage1d_type = typename arg_type::storage1d_type;
+        using storage2d_type = typename arg_type::storage2d_type;
+
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+    public:
+        static match_pattern_type const match_data;
+
+        make_vector() = default;
+
+        make_vector(std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& params) const override;
+    };
+
+    PHYLANX_EXPORT primitive create_make_vector(
+        hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name = "", std::string const& codename = "");
+}}}
+
+#endif

--- a/phylanx/execution_tree/primitives/primitive_component.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component.hpp
@@ -31,7 +31,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public hpx::components::component_base<primitive_component>
     {
     private:
-        PHYLANX_EXPORT static std::unique_ptr<primitive_component_base>
+        PHYLANX_EXPORT static std::shared_ptr<primitive_component_base>
         create_primitive(std::string const& type,
             std::vector<primitive_argument_type>&& params,
             std::string const& name, std::string const& codename);
@@ -107,7 +107,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
     private:
-        std::unique_ptr<primitive_component_base> primitive_;
+        std::shared_ptr<primitive_component_base> primitive_;
 
         // Performance counter data
         mutable std::int64_t eval_count_;

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -74,7 +74,7 @@ namespace phylanx { namespace execution_tree
         std::string const&, std::string const&);
 
     using primitive_factory_function_type =
-        std::unique_ptr<primitives::primitive_component_base> (*)(
+        std::shared_ptr<primitives::primitive_component_base> (*)(
             std::vector<primitive_argument_type>&&, std::string const&,
             std::string const&);
 
@@ -102,12 +102,12 @@ namespace phylanx { namespace execution_tree
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Primitive>
-    std::unique_ptr<primitives::primitive_component_base>
+    std::shared_ptr<primitives::primitive_component_base>
     create_primitive(std::vector<primitive_argument_type>&& args,
         std::string const& name, std::string const& codename)
     {
-        return std::unique_ptr<primitives::primitive_component_base>{
-            new Primitive(std::move(args), name, codename)};
+        return std::static_pointer_cast<primitives::primitive_component_base>(
+            std::make_shared<Primitive>(std::move(args), name, codename));
     }
 }}
 

--- a/phylanx/include/util.hpp
+++ b/phylanx/include/util.hpp
@@ -8,6 +8,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/util/performance_data.hpp>
+#include <phylanx/util/repr_manip.hpp>
 #include <phylanx/util/serialization/ast.hpp>
 #include <phylanx/util/serialization/blaze.hpp>
 #include <phylanx/util/serialization/variant.hpp>

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -26,8 +26,80 @@
 
 namespace phylanx { namespace ir
 {
+    ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    class PHYLANX_EXPORT node_data
+    class PHYLANX_EXPORT node_data;
+
+    namespace detail
+    {
+        /// \cond NOINTERNAL
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename T>
+        class node_data_iterator
+          : public hpx::util::iterator_facade<node_data_iterator<T>,
+                T,
+                std::random_access_iterator_tag,
+                T const&,
+                std::ptrdiff_t,
+                T const*>
+        {
+        private:
+            using base_type =
+                hpx::util::iterator_facade<node_data_iterator<T>,
+                    T,
+                    std::random_access_iterator_tag,
+                    T const&,
+                    std::ptrdiff_t,
+                    T const*>;
+
+        public:
+            node_data_iterator(node_data<T> const& nd, std::size_t index = 0)
+              : nd_(nd), index_(index)
+            {
+            }
+
+        private:
+            friend class hpx::util::iterator_core_access;
+
+            typename base_type::reference dereference() const
+            {
+                return nd_[index_];
+            }
+
+            bool equal(node_data_iterator const& x) const
+            {
+                return &nd_ == &x.nd_ && index_ == x.index_;
+            }
+
+            void advance(typename base_type::difference_type n)
+            {
+                index_ += n;
+            }
+
+            void increment()
+            {
+                ++index_;
+            }
+
+            void decrement()
+            {
+                --index_;
+            }
+
+            typename base_type::difference_type distance_to(
+                node_data_iterator const& y) const
+            {
+                return y.index_ - index_;
+            }
+
+            node_data<T> const& nd_;
+            std::size_t index_;
+        };
+    }
+
+    template <typename T>
+    class node_data
     {
     private:
         static void increment_copy_construction_count();
@@ -179,6 +251,9 @@ namespace phylanx { namespace ir
         T& operator[](dimensions_type const& indicies);
         T const& operator[](dimensions_type const& indicies) const;
 
+        T& at(std::size_t index1, std::size_t index2);
+        T const& at(std::size_t index1, std::size_t index2) const;
+
         std::size_t size() const;
 
         storage2d_type& matrix_non_ref();
@@ -224,6 +299,14 @@ namespace phylanx { namespace ir
         {
             return !bool(*this);
         }
+
+        using const_iterator = detail::node_data_iterator<T>;
+
+        const_iterator begin() const;
+        const_iterator end() const;
+
+        const_iterator cbegin() const;
+        const_iterator cend() const;
 
     private:
         /// \cond NOINTERNAL

--- a/phylanx/util/repr_manip.hpp
+++ b/phylanx/util/repr_manip.hpp
@@ -1,0 +1,21 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_REPR_MANIP_HPP)
+#define PHYLANX_UTIL_REPR_MANIP_HPP
+
+#include <phylanx/config.hpp>
+
+#include <iosfwd>
+
+namespace phylanx { namespace util
+{
+    PHYLANX_EXPORT std::ostream& repr(std::ostream& stream);
+    PHYLANX_EXPORT std::ostream& norepr(std::ostream& stream);
+    PHYLANX_EXPORT bool is_repr(std::ostream& stream);
+}}
+
+#endif
+

--- a/phylanx/util/serialization/ast.hpp
+++ b/phylanx/util/serialization/ast.hpp
@@ -16,14 +16,18 @@ namespace phylanx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT std::vector<char> serialize(ir::node_data<double> const&);
+    PHYLANX_EXPORT std::vector<char> serialize(ir::node_data<bool> const&);
 
     namespace detail
     {
         PHYLANX_EXPORT void unserialize(
             std::vector<char> const&, ir::node_data<double>&);
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ir::node_data<bool>&);
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    PHYLANX_EXPORT std::vector<char> serialize(ast::nil);
     PHYLANX_EXPORT std::vector<char> serialize(ast::optoken);
     PHYLANX_EXPORT std::vector<char> serialize(ast::identifier const&);
     PHYLANX_EXPORT std::vector<char> serialize(ast::primary_expr const&);
@@ -39,6 +43,8 @@ namespace phylanx { namespace util
 
     namespace detail
     {
+        PHYLANX_EXPORT void unserialize(
+            std::vector<char> const&, ast::nil&);
         PHYLANX_EXPORT void unserialize(
             std::vector<char> const&, ast::optoken&);
         PHYLANX_EXPORT void unserialize(

--- a/python/phylanx/ir/__init__.py
+++ b/python/phylanx/ir/__init__.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2018 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+try:
+    from _phylanx.ir import *
+
+except Exception:
+    from _phylanxd.ir import *

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,8 @@ target_link_libraries(phylanx_component
   blaze::blaze ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 
 if(PHYLANX_WITH_HIGHFIVE)
-  target_link_libraries(phylanx_component HighFive)
+  target_link_libraries(phylanx_component
+    HighFive ${PHYLANX_HDF5_LIBRARIES})
   set_property(TARGET phylanx_component APPEND
     PROPERTY COMPILE_DEFINITIONS
     "PHYLANX_HAVE_HIGHFIVE")

--- a/src/ast/node.cpp
+++ b/src/ast/node.cpp
@@ -7,6 +7,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
+#include <phylanx/util/repr_manip.hpp>
 
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/util.hpp>
@@ -428,6 +429,10 @@ namespace phylanx { namespace ast
 
     std::ostream& operator<<(std::ostream& out, nil)
     {
+        if (util::is_repr(out))
+        {
+            out << "<nil>";
+        }
         return out;
     }
 
@@ -453,26 +458,32 @@ namespace phylanx { namespace ast
         {
             void operator()(bool ast) const
             {
-                out_ << (ast ? "true" : "false");
+                out_ << std::boolalpha << ast;
             }
 
             void operator()(std::string const& ast) const
             {
-                out_ << "\"";
+                if (util::is_repr(out_))
+                {
+                    out_ << "\"";
+                }
                 for (char c : ast)
                 {
                     switch (c)
                     {
                     case '\b':  out_ << "\\\b"; break;
-                    case '\n':  out_ << "\\\n"; break;
-                    case '\r':  out_ << "\\\r"; break;
-                    case '\t':  out_ << "\\\t"; break;
+                    case '\n':  out_ << "\\n"; break;
+                    case '\r':  out_ << "\\r"; break;
+                    case '\t':  out_ << "\\t"; break;
                     case '\\':  out_ << "\\\\"; break;
                     case '\"':  out_ << "\\\""; break;
                     default:    out_ << c;
                     }
                 }
-                out_ << "\"";
+                if (util::is_repr(out_))
+                {
+                    out_ << "\"";
+                }
             }
 
             template <typename Ast>

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -24,6 +24,7 @@ namespace phylanx { namespace execution_tree
             primitives::debug_output::match_data,
             primitives::define_variable::match_data_define,
             primitives::hstack_operation::match_data,
+            primitives::make_vector::match_data,
             primitives::parallel_block_operation::match_data,
             primitives::row_slicing_operation::match_data,
             primitives::slicing_operation::match_data,

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -24,6 +24,7 @@ namespace phylanx { namespace execution_tree
             primitives::debug_output::match_data,
             primitives::define_variable::match_data_define,
             primitives::hstack_operation::match_data,
+            primitives::make_list::match_data,
             primitives::make_vector::match_data,
             primitives::parallel_block_operation::match_data,
             primitives::row_slicing_operation::match_data,

--- a/src/execution_tree/primitives/hstack_operation.cpp
+++ b/src/execution_tree/primitives/hstack_operation.cpp
@@ -152,13 +152,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::vector<primitive_argument_type> const& operands,
                 std::vector<primitive_argument_type> const& args) const
             {
-                if (operands.size() != 2)
+                if (operands.size() < 2)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "phylanx::execution_tree::primitives::"
                             "hstack_operation::hstack_operation",
                         generate_error_message(
-                            "the hstack_operation primitive requires exactly "
+                            "the hstack_operation primitive requires at least "
                                 "two arguments",
                             name_, codename_));
                 }

--- a/src/execution_tree/primitives/make_list.cpp
+++ b/src/execution_tree/primitives/make_list.cpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/make_list.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_make_list(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+    {
+        static std::string type("make_list");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const make_list::match_data =
+    {
+        hpx::util::make_tuple("make_list",
+            std::vector<std::string>{"make_list(__1)", "'(__1)"},
+            &create_make_list, &create_primitive<make_list>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    make_list::make_list(
+            std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> make_list::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "make_list::eval",
+                execution_tree::generate_error_message(
+                    "the make_list primitive requires that "
+                        "the arguments given by the operands array "
+                        "are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](std::vector<primitive_argument_type> && args)
+            ->  primitive_argument_type
+            {
+                return primitive_argument_type{std::move(args)};
+            }),
+            detail::map_operands(
+                operands, functional::value_operand{}, args,
+                name_, codename_));
+    }
+
+    hpx::future<primitive_argument_type> make_list::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return eval(args, noargs);
+        }
+        return eval(operands_, args);
+    }
+}}}

--- a/src/execution_tree/primitives/make_vector.cpp
+++ b/src/execution_tree/primitives/make_vector.cpp
@@ -1,0 +1,115 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/make_vector.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_make_vector(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+    {
+        static std::string type("make_vector");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const make_vector::match_data =
+    {
+        hpx::util::make_tuple("make_vector",
+            std::vector<std::string>{"make_vector(__1)"},
+            &create_make_vector, &create_primitive<make_vector>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    make_vector::make_vector(
+            std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> make_vector::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "make_vector::eval",
+                execution_tree::generate_error_message(
+                    "the make_vector primitive requires that "
+                        "the arguments given by the operands array "
+                        "are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](args_type&& args) -> primitive_argument_type
+            {
+                std::size_t vec_size = args.size();
+                blaze::DynamicVector<double> temp(vec_size);
+
+                for (std::size_t i = 0; i != vec_size; ++i)
+                {
+                    if (args[i].num_dimensions() != 0)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "make_vector::eval",
+                            execution_tree::generate_error_message(
+                                "the make_vector primitive requires that "
+                                    "all arguments evaluate to zero-"
+                                    "dimensional values",
+                                this_->name_, this_->codename_));
+                    }
+                    temp[i] = args[i].scalar();
+                }
+
+                return primitive_argument_type{
+                    ir::node_data<double>{storage1d_type{std::move(temp)}}};
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    hpx::future<primitive_argument_type> make_vector::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return eval(args, noargs);
+        }
+        return eval(operands_, args);
+    }
+}}}

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -82,7 +82,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     /////////////////////////////////////////////////////////////////////////
-    std::unique_ptr<primitive_component_base>
+    std::shared_ptr<primitive_component_base>
     primitive_component::create_primitive(std::string const& type,
         std::vector<primitive_argument_type>&& args, std::string const& name,
         std::string const& codename)

--- a/src/execution_tree/primitives/string_output.cpp
+++ b/src/execution_tree/primitives/string_output.cpp
@@ -5,10 +5,6 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/string_output.hpp>
-#include <phylanx/ir/node_data.hpp>
-#include <phylanx/util/serialization/ast.hpp>
-#include <phylanx/util/serialization/execution_tree.hpp>
-#include <phylanx/util/variant.hpp>
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/src/execution_tree/primitives/vstack_operation.cpp
+++ b/src/execution_tree/primitives/vstack_operation.cpp
@@ -163,13 +163,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::vector<primitive_argument_type> const& operands,
                 std::vector<primitive_argument_type> const& args) const
             {
-                if (operands.size() != 2)
+                if (operands.size() < 2)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "phylanx::execution_tree::primitives::"
                             "vstack_operation::vstack_operation",
                         generate_error_message(
-                            "the vstack_operation primitive requires exactly "
+                            "the vstack_operation primitive requires at least "
                                 "two arguments",
                             name_, codename_));
                 }

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -433,6 +433,31 @@ namespace phylanx { namespace ir
     }
 
     template <typename T>
+    T& node_data<T>::at(std::size_t index1, std::size_t index2)
+    {
+        switch(data_.index())
+        {
+        case 0:
+            return scalar();
+
+        case 1: HPX_FALLTHROUGH;
+        case 3:
+            return vector()[index1];
+
+        case 2: HPX_FALLTHROUGH;
+        case 4:
+            return matrix()(index1, index2);
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::at()",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
     T const& node_data<T>::operator[](std::size_t index) const
     {
         switch(data_.index())
@@ -488,6 +513,31 @@ namespace phylanx { namespace ir
     }
 
     template <typename T>
+    T const& node_data<T>::at(std::size_t index1, std::size_t index2) const
+    {
+        switch(data_.index())
+        {
+        case 0:
+            return scalar();
+
+        case 1: HPX_FALLTHROUGH;
+        case 3:
+            return vector()[index1];
+
+        case 2: HPX_FALLTHROUGH;
+        case 4:
+            return matrix()(index1, index2);
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::at()",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
     std::size_t node_data<T>::size() const
     {
         switch(data_.index())
@@ -513,6 +563,30 @@ namespace phylanx { namespace ir
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::ir::node_data<T>::operator[]()",
             "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    typename node_data<T>::const_iterator node_data<T>::begin() const
+    {
+        return const_iterator(*this, 0);
+    }
+
+    template <typename T>
+    typename node_data<T>::const_iterator  node_data<T>::end() const
+    {
+        return const_iterator(*this, size());
+    }
+
+    template <typename T>
+    typename node_data<T>::const_iterator  node_data<T>::cbegin() const
+    {
+        return const_iterator(*this, 0);
+    }
+
+    template <typename T>
+    typename node_data<T>::const_iterator  node_data<T>::cend() const
+    {
+        return const_iterator(*this, size());
     }
 
     template <typename T>

--- a/src/util/repr_manip.cpp
+++ b/src/util/repr_manip.cpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/util/repr_manip.hpp>
+
+#include <iostream>
+
+namespace phylanx { namespace util
+{
+    namespace detail
+    {
+        int get_repr_manip_index()
+        {
+            static int const index = std::ios_base::xalloc();
+            return index;
+        }
+    }
+
+    std::ostream& repr(std::ostream& stream)
+    {
+        stream.iword(detail::get_repr_manip_index()) = 1;
+        return stream;
+    }
+
+    std::ostream& norepr(std::ostream& stream)
+    {
+        stream.iword(detail::get_repr_manip_index()) = 0;
+        return stream;
+    }
+
+
+    bool is_repr(std::ostream& stream)
+    {
+        return stream.iword(detail::get_repr_manip_index()) != 0;
+    }
+}}
+

--- a/src/util/serialization/ast.cpp
+++ b/src/util/serialization/ast.cpp
@@ -16,7 +16,8 @@
 namespace phylanx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
+    namespace detail
+    {
         template <typename Ast>
         std::vector<char> serialize(Ast const& input)
         {
@@ -34,9 +35,19 @@ namespace phylanx { namespace util
         }
     }
 
+    std::vector<char> serialize(ir::node_data<bool> const& ast)
+    {
+        return detail::serialize(ast);
+    }
+
     std::vector<char> serialize(ir::node_data<double> const& ast)
     {
         return detail::serialize(ast);
+    }
+
+    std::vector<char> serialize(ast::nil ast)
+    {
+        return std::vector<char>{};
     }
 
     std::vector<char> serialize(ast::optoken ast)
@@ -103,6 +114,16 @@ namespace phylanx { namespace util
             std::vector<char> const& input, ir::node_data<double>& ast)
         {
             detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(
+            std::vector<char> const& input, ir::node_data<bool>& ast)
+        {
+            detail::unserialize_helper(input, ast);
+        }
+
+        void unserialize(std::vector<char> const& input, ast::nil& ast)
+        {
         }
 
         void unserialize(std::vector<char> const& input, ast::optoken& ast)

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -8,8 +8,10 @@ set(tests
     cout_prints_twice_155
     define_loses_values_177
     expression_topology_213
+    list_of_variables_244
     negative_integral_value_131
     out_of_scope_variable_232
+    vector_of_variables_244
    )
 
 set(cout_noargs_prints_nothing_FLAGS COMPONENT_DEPENDENCIES iostreams)

--- a/tests/regressions/execution_tree/define_loses_values_177.cpp
+++ b/tests/regressions/execution_tree/define_loses_values_177.cpp
@@ -22,8 +22,8 @@ std::string const read_code = R"(block(
     define(read, data_m, data_v, data_0,
         block(
             debug("Scalar Data Received = ", data_0),
-            debug("Vector Data Recieved = ", data_v),
-            debug("Matrix Data Recieved = ", data_m)
+            debug("Vector Data Received = ", data_v),
+            debug("Matrix Data Received = ", data_m)
         )
     ),
     read
@@ -54,8 +54,8 @@ int main(int argc, char* argv[])
     std::stringstream const& strm = hpx::get_consolestream();
     HPX_TEST_EQ(strm.str(), std::string(
         "Scalar Data Received = 42\n"
-        "Vector Data Recieved = [1, 10, 11, 12, 13, 14, 15, 16]\n"
-        "Matrix Data Recieved = [[1, 10, 11], [12, 13, 14], [15, 16, 17]]\n"));
+        "Vector Data Received = [1, 10, 11, 12, 13, 14, 15, 16]\n"
+        "Matrix Data Received = [[1, 10, 11], [12, 13, 14], [15, 16, 17]]\n"));
 
     return hpx::util::report_errors();
 }

--- a/tests/regressions/execution_tree/list_of_variables_244.cpp
+++ b/tests/regressions/execution_tree/list_of_variables_244.cpp
@@ -1,0 +1,47 @@
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Fixing #244: Can not create a list or a vector of previously defined variables
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <sstream>
+
+std::string const code = R"(block(
+    define(f, a, block(
+        define(b, 6),
+        define(lst1, make_list(a, b, 42)),
+        debug(lst1),
+        define(lst2, make_list(make_vector(a, b), lst1, "string")),
+        debug(lst2)
+    )),
+    f
+))";
+
+int hpx_main(int argc, char* argv[])
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(code, snippets);
+
+    f(5.0);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+
+    std::stringstream const& strm = hpx::get_consolestream();
+    HPX_TEST_EQ(strm.str(),
+        std::string("'(5, 6, 42)\n'([5, 6], '(5, 6, 42), string)\n"));
+
+    return hpx::util::report_errors();
+}

--- a/tests/regressions/execution_tree/vector_of_variables_244.cpp
+++ b/tests/regressions/execution_tree/vector_of_variables_244.cpp
@@ -1,0 +1,46 @@
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Fixing #244: Can not create a list or a vector of previously defined variables
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <sstream>
+
+std::string const code = R"(block(
+    define(f, a, block(
+        define(b, 6),
+        define(vec1, make_vector(a, b, 42)),
+        debug(vec1),
+        define(vec2, make_vector(a, vec1, b)),
+        debug(vec2)
+    )),
+    f
+))";
+
+int hpx_main(int argc, char* argv[])
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(code, snippets);
+
+    f(5.0);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+
+    std::stringstream const& strm = hpx::get_consolestream();
+    HPX_TEST_EQ(strm.str(), std::string("[5, 6, 42]\n[5, 5, 6, 42, 6]\n"));
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/ast/to_string.cpp
+++ b/tests/unit/ast/to_string.cpp
@@ -51,7 +51,7 @@ void test_primary_expr()
     test_to_string(p3, strm.str());
 
     phylanx::ast::primary_expr p4{"some string"};
-    test_to_string(p4, "\"some string\"");
+    test_to_string(p4, "some string");
 
     phylanx::ast::primary_expr p5{std::uint64_t(42)};
     test_to_string(p5, "42");
@@ -71,7 +71,7 @@ void test_operand()
 
     phylanx::ast::primary_expr p3{"some string"};
     phylanx::ast::operand op3(std::move(p3));
-    test_to_string(op3, "\"some string\"");
+    test_to_string(op3, "some string");
 
     phylanx::ast::primary_expr p4{std::uint64_t(42)};
     phylanx::ast::operand op4(std::move(p4));

--- a/tests/unit/python/ast/python_builds_ast.py
+++ b/tests/unit/python/ast/python_builds_ast.py
@@ -101,7 +101,7 @@ a4 = Val("e")
 expr = a1 * a2 * a0 + a3 * -a4
 
 # Convert the AST to a string and check the value
-if str(expr.value) == '(((3.14 * "b") * "c") + ("d" * -"e"))':
+if str(expr.value) == '(((3.14 * b) * c) + (d * -e))':
     print("Success")
 else:
     print("Failure")

--- a/tests/unit/python/execution_tree/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/CMakeLists.txt
@@ -5,9 +5,9 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-  eval
-  for
-  make_array
+    eval
+    for
+    make_array
    )
 
 foreach(test ${tests})
@@ -15,14 +15,28 @@ foreach(test ${tests})
 
   add_phylanx_python_unit_test("execution_tree" ${test}
     SCRIPT ${script}
-    FOLDER "Tests/Python/Unit/Execution_Tree"
+    FOLDER "Tests/Python/Unit/ExecutionTree"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
     ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
 
   add_phylanx_pseudo_target(tests.unit.python_execution_tree.${test}_py)
-  add_phylanx_pseudo_dependencies(tests.unit.python_execution_tree tests.unit.python_execution_tree.${test}_py)
-  add_phylanx_pseudo_dependencies(tests.unit.python_execution_tree.${test}_py ${test}_test_py)
+  add_phylanx_pseudo_dependencies(
+    tests.unit.python_execution_tree tests.unit.python_execution_tree.${test}_py)
+  add_phylanx_pseudo_dependencies(
+    tests.unit.python_execution_tree.${test}_py ${test}_test_py)
 
+endforeach()
+
+set(subdirs
+    primitives
+   )
+
+foreach(subdir ${subdirs})
+  add_phylanx_pseudo_target(tests.unit.python_execution_tree.python_${subdir})
+  add_subdirectory(${subdir})
+  add_phylanx_pseudo_dependencies(
+    tests.unit.python_execution_tree 
+    tests.unit.python_execution_tree.python_${subdir})
 endforeach()
 

--- a/tests/unit/python/execution_tree/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(subdir ${subdirs})
   add_phylanx_pseudo_target(tests.unit.python_execution_tree.python_${subdir})
   add_subdirectory(${subdir})
   add_phylanx_pseudo_dependencies(
-    tests.unit.python_execution_tree 
+    tests.unit.python_execution_tree
     tests.unit.python_execution_tree.python_${subdir})
 endforeach()
 

--- a/tests/unit/python/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/primitives/CMakeLists.txt
@@ -1,0 +1,30 @@
+# Copyright (c) 2017 Hartmut Kaiser
+# Copyright (c) 2018 Steven R. Brandt
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    make_vector
+   )
+
+foreach(test ${tests})
+  set(script ${test}.py)
+
+  add_phylanx_python_unit_test("primitives" ${test}
+    SCRIPT ${script}
+    FOLDER "Tests/Python/Unit/ExecutionTree/Primitives"
+    DEPENDS phylanx_py python_setup
+    WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+
+  add_phylanx_pseudo_target(tests.unit.python_execution_tree.python_primitives.${test}_py)
+  add_phylanx_pseudo_dependencies(
+    tests.unit.python_execution_tree.python_primitives
+    tests.unit.python_execution_tree.python_primitives.${test}_py)
+  add_phylanx_pseudo_dependencies(
+    tests.unit.python_execution_tree.python_primitives.${test}_py
+    ${test}_test_py)
+
+endforeach()
+

--- a/tests/unit/python/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/primitives/CMakeLists.txt
@@ -5,6 +5,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    make_list
     make_vector
    )
 

--- a/tests/unit/python/execution_tree/primitives/make_list.py
+++ b/tests/unit/python/execution_tree/primitives/make_list.py
@@ -1,0 +1,53 @@
+#  Copyright (c) 2018 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import phylanx
+from phylanx.util import *
+
+
+@phyfun
+def test_make_list_empty():
+    return make_list()
+
+
+@phyfun
+def test_make_list_one():
+    return make_list(42)
+
+
+@phyfun
+def test_make_list_literals():
+    return make_list(1, 2, 3, 4)
+
+
+@phyfun
+def test_make_list():
+    a = 1
+    b = 2
+    c = 3
+    return make_list(a, b, c)
+
+
+@phyfun
+def test_make_list2():
+    a = 1
+    b = 2
+    c = 3
+    return make_list(a, make_list(a, b, c), c)
+
+
+@phyfun
+def test_make_list_arg(l):
+    a = 1
+    c = 3
+    return make_list(a, l, c)
+
+
+assert test_make_list_empty() == []
+assert test_make_list_one() == [42]
+assert test_make_list_literals() == [1, 2, 3, 4]
+assert test_make_list() == [1, 2, 3]
+assert test_make_list2() == [1, [1, 2, 3], 3]
+assert test_make_list_arg([1, 2, 3]) == [1, [1, 2, 3], 3]

--- a/tests/unit/python/execution_tree/primitives/make_vector.py
+++ b/tests/unit/python/execution_tree/primitives/make_vector.py
@@ -1,0 +1,35 @@
+#  Copyright (c) 2018 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+from phylanx.util import *
+
+
+@phyfun
+def test_make_vector_empty():
+    return make_vector()
+
+
+@phyfun
+def test_make_vector_one():
+    return make_vector(42)
+
+
+@phyfun
+def test_make_vector_literals():
+    returnmake_vector(1, 2, 3, 4)
+
+
+@phyfun
+def test_make_vector():
+    a = 1
+    b = 2
+    c = 3
+    return test_make_vector(a, b, c)
+
+
+assert test_make_vector_empty() == []
+assert test_make_vector_one() == [42]
+assert test_make_vector_literals() == [1, 2, 3, 4]
+assert test_make_vector() == [1, 2, 3]

--- a/tests/unit/python/execution_tree/primitives/make_vector.py
+++ b/tests/unit/python/execution_tree/primitives/make_vector.py
@@ -3,6 +3,7 @@
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+import phylanx
 from phylanx.util import *
 
 
@@ -18,7 +19,7 @@ def test_make_vector_one():
 
 @phyfun
 def test_make_vector_literals():
-    returnmake_vector(1, 2, 3, 4)
+    return make_vector(1, 2, 3, 4)
 
 
 @phyfun
@@ -26,10 +27,19 @@ def test_make_vector():
     a = 1
     b = 2
     c = 3
-    return test_make_vector(a, b, c)
+    return make_vector(a, b, c)
+
+
+@phyfun
+def test_make_vector2():
+    a = 1
+    b = 2
+    c = 3
+    return make_vector(a, make_vector(a, b, c), c)
 
 
 assert test_make_vector_empty() == []
 assert test_make_vector_one() == [42]
 assert test_make_vector_literals() == [1, 2, 3, 4]
 assert test_make_vector() == [1, 2, 3]
+assert test_make_vector2() == [1, 1, 2, 3, 3]


### PR DESCRIPTION
This fixes #244

This also includes:
- adding `make_vector` primitive allowing to dynamically compose `blaze::DynamicVector` in PhySL (also supports concatenating vectors)
- change primitive_component to use shared_ptr instead of unique_ptr allowing for  a simpler way of implementing primitives
- adding `make_list` primitive to create PhySL lists
- flyby: re-add iterator interface for `node_data<T>`
- flyby: clean up python bindings
  - fixing bindings for recursive_wrapper allowing for direct exposure of `std::vector<>` based types
  - exposing `phylanx::execution_tree::primitive_argument_type` (as a variant) to python
  - exposing `node_data<T>` to python
  - exposing `phylanx::ast::nil` to python
- flyby: more fixes to HighFive/HDF5 build system
- flyby: allow more than 2 arguments for hstack and vstack primitives