### PR TITLE
Argmin & Argmax Primitives

### DIFF
--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -11,6 +11,8 @@
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
 #include <phylanx/execution_tree/primitives/and_operation.hpp>
 #include <phylanx/execution_tree/primitives/apply.hpp>
+#include <phylanx/execution_tree/primitives/argmax.hpp>
+#include <phylanx/execution_tree/primitives/argmin.hpp>
 #include <phylanx/execution_tree/primitives/block_operation.hpp>
 #include <phylanx/execution_tree/primitives/column_set.hpp>
 #include <phylanx/execution_tree/primitives/column_slicing.hpp>

--- a/phylanx/execution_tree/primitives/argmax.hpp
+++ b/phylanx/execution_tree/primitives/argmax.hpp
@@ -18,10 +18,12 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    /// \brief Implementation of argmax as a Phylanx primitive
-    /// This implementation is intended to behave like [NumPy implementation
-    /// of argmax]
+    /// \brief Implementation of argmax as a Phylanx primitive.
+    /// Returns the index of the largest element of argument a.
+    /// This implementation is intended to behave like [NumPy implementation of argmax]
     /// (https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.argmax.html).
+    /// \param a It may be a scalar value, vector, or matrix
+    /// \param axis The dimension along which the indices of the max value(s) should be found
     class argmax
         : public primitive_component_base
         , public std::enable_shared_from_this<argmax>
@@ -40,8 +42,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         argmax() = default;
 
-        /// \brief Calculates argmax of a node_data
-        /// \param args A scalar value, vector, or matrix
         argmax(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 

--- a/phylanx/execution_tree/primitives/argmax.hpp
+++ b/phylanx/execution_tree/primitives/argmax.hpp
@@ -22,20 +22,39 @@ namespace phylanx { namespace execution_tree { namespace primitives
     /// This implementation is intended to behave like [NumPy implementation
     /// of argmax]
     /// (https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.argmax.html).
-    class argmax : public primitive_component_base
+    class argmax
+        : public primitive_component_base
+        , public std::enable_shared_from_this<argmax>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using val_type = double;
+        using arg_type = ir::node_data<val_type>;
+        using args_type = std::vector<arg_type>;
+
     public:
         static match_pattern_type const match_data;
 
         argmax() = default;
 
-        /// \brief Calculates argmin of a node_data
+        /// \brief Calculates argmax of a node_data
         /// \param args A scalar value, vector, or matrix
         argmax(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type argmax0d(args_type && args) const;
+        primitive_argument_type argmax1d(args_type && args) const;
+        primitive_argument_type argmax2d_flatten(arg_type && arg_a) const;
+        primitive_argument_type argmax2d_x_axis(arg_type && arg_a) const;
+        primitive_argument_type argmax2d_y_axis(arg_type && arg_a) const;
+        primitive_argument_type argmax2d(args_type && args) const;
     };
 
     PHYLANX_EXPORT primitive create_argmax(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/argmax.hpp
+++ b/phylanx/execution_tree/primitives/argmax.hpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2018 Parsa Amini
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_ARGMAX)
+#define PHYLANX_PRIMITIVES_ARGMAX
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class argmax : public primitive_component_base
+    {
+    public:
+        static match_pattern_type const match_data;
+
+        argmax() = default;
+
+        argmax(std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& args) const override;
+    };
+
+    PHYLANX_EXPORT primitive create_argmax(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name = "", std::string const& codename = "");
+}}}
+
+#endif

--- a/phylanx/execution_tree/primitives/argmax.hpp
+++ b/phylanx/execution_tree/primitives/argmax.hpp
@@ -18,6 +18,10 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
+    /// \brief Implementation of argmax as a Phylanx primitive
+    /// This implementation is intended to behave like [NumPy implementation
+    /// of argmax]
+    /// (https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.argmax.html).
     class argmax : public primitive_component_base
     {
     public:
@@ -25,6 +29,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         argmax() = default;
 
+        /// \brief Calculates argmin of a node_data
+        /// \param args A scalar value, vector, or matrix
         argmax(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 

--- a/phylanx/execution_tree/primitives/argmin.hpp
+++ b/phylanx/execution_tree/primitives/argmin.hpp
@@ -18,10 +18,12 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    /// \brief Implementation of argmin as a Phylanx primitive
-    /// This implementation is intended to behave like [NumPy implementation
-    /// of argmin]
-    /// (https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.argmin.html).
+    /// \brief Implementation of argmin as a Phylanx primitive.
+    /// Returns the index of the smallest element of argument a.
+    /// This implementation is intended to behave like [NumPy implementation of argmax]
+    /// (https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.argmax.html).
+    /// \param a It may be a scalar value, vector, or matrix
+    /// \param axis The dimension along which the indices of the min value(s) should be found
     class argmin
         : public primitive_component_base
         , public std::enable_shared_from_this<argmin>
@@ -40,8 +42,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         argmin() = default;
 
-        /// \brief Calculates argmin of a node_data
-        /// \param args A scalar value, vector, or matrix
         argmin(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 

--- a/phylanx/execution_tree/primitives/argmin.hpp
+++ b/phylanx/execution_tree/primitives/argmin.hpp
@@ -1,0 +1,40 @@
+//  Copyright (c) 2018 Parsa Amini
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_ARGMIN)
+#define PHYLANX_PRIMITIVES_ARGMIN
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class argmin : public primitive_component_base
+    {
+    public:
+        static match_pattern_type const match_data;
+
+        argmin() = default;
+
+        argmin(std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& args) const override;
+    };
+
+    PHYLANX_EXPORT primitive create_argmin(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name = "", std::string const& codename = "");
+}}}
+
+#endif

--- a/phylanx/execution_tree/primitives/argmin.hpp
+++ b/phylanx/execution_tree/primitives/argmin.hpp
@@ -18,6 +18,10 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
+    /// \brief Implementation of argmax as a Phylanx primitive
+    /// This implementation is intended to behave like [NumPy implementation
+    /// of argmin]
+    /// (https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.argmin.html).
     class argmin : public primitive_component_base
     {
     public:
@@ -25,6 +29,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         argmin() = default;
 
+        /// \brief Calculates argmin of a node_data
+        /// \param args A scalar value, vector, or matrix
         argmin(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 

--- a/phylanx/execution_tree/primitives/argmin.hpp
+++ b/phylanx/execution_tree/primitives/argmin.hpp
@@ -18,12 +18,23 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    /// \brief Implementation of argmax as a Phylanx primitive
+    /// \brief Implementation of argmin as a Phylanx primitive
     /// This implementation is intended to behave like [NumPy implementation
     /// of argmin]
     /// (https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.argmin.html).
-    class argmin : public primitive_component_base
+    class argmin
+        : public primitive_component_base
+        , public std::enable_shared_from_this<argmin>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using val_type = double;
+        using arg_type = ir::node_data<val_type>;
+        using args_type = std::vector<arg_type>;
+
     public:
         static match_pattern_type const match_data;
 
@@ -36,6 +47,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type argmin0d(args_type && args) const;
+        primitive_argument_type argmin1d(args_type && args) const;
+        primitive_argument_type argmin2d_flatten(arg_type && arg_a) const;
+        primitive_argument_type argmin2d_x_axis(arg_type && arg_a) const;
+        primitive_argument_type argmin2d_y_axis(arg_type && arg_a) const;
+        primitive_argument_type argmin2d(args_type && args) const;
     };
 
     PHYLANX_EXPORT primitive create_argmin(hpx::id_type const& locality,

--- a/phylanx/util/matrix_iterators.hpp
+++ b/phylanx/util/matrix_iterators.hpp
@@ -7,6 +7,7 @@
 #if !defined(PHYLANX_MATRIX_ITERATORS)
 #define PHYLANX_MATRIX_ITERATORS
 
+#include <cstddef>
 #include <blaze/Math.h>
 
 namespace phylanx { namespace util

--- a/phylanx/util/matrix_iterators.hpp
+++ b/phylanx/util/matrix_iterators.hpp
@@ -1,0 +1,103 @@
+//  Copyright (c) 2018 Parsa Amini
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_MATRIX_ITERATORS)
+#define PHYLANX_MATRIX_ITERATORS
+
+#include <blaze/Math.h>
+
+namespace phylanx { namespace util
+{
+    template <typename T>
+    class matrix_row_iterator
+        : public hpx::util::iterator_facade<
+            matrix_row_iterator<T>,
+            blaze::Row<T>,
+            std::random_access_iterator_tag,
+            blaze::Row<T>>
+    {
+    public:
+        explicit matrix_row_iterator(T& t, const std::size_t index = 0)
+            : data_(t)
+            , index_(index)
+        {
+        }
+
+    private:
+        friend class hpx::util::iterator_core_access;
+
+        void increment()
+        {
+            ++index_;
+        }
+        void decrement()
+        {
+            --index_;
+        }
+        void advance(std::size_t n)
+        {
+            index_ += n;
+        }
+        bool equal(matrix_row_iterator const& other) const
+        {
+            return index_ == other.index_;
+        }
+        blaze::Row<T> dereference() const
+        {
+            return blaze::row(data_, index_);
+        }
+
+    private:
+        T & data_;
+        std::size_t index_;
+    };
+
+    template <typename T>
+    class matrix_column_iterator
+        : public hpx::util::iterator_facade<
+        matrix_column_iterator<T>,
+        blaze::Column<T>,
+        std::random_access_iterator_tag,
+        blaze::Column<T>>
+    {
+    public:
+        explicit matrix_column_iterator(T& t, const std::size_t index = 0)
+            : data_(t)
+            , index_(index)
+        {
+        }
+
+    private:
+        friend class hpx::util::iterator_core_access;
+
+        void increment()
+        {
+            ++index_;
+        }
+        void decrement()
+        {
+            --index_;
+        }
+        void advance(std::size_t n)
+        {
+            index_ += n;
+        }
+        bool equal(matrix_column_iterator const& other) const
+        {
+            return index_ == other.index_;
+        }
+        blaze::Column<T> dereference() const
+        {
+            return blaze::column(data_, index_);
+        }
+
+    private:
+        T & data_;
+        std::size_t index_;
+    };
+}}
+
+#endif

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -55,6 +55,8 @@ namespace phylanx { namespace execution_tree
 #endif
 
             // unary functions
+            primitives::argmin::match_data,
+            primitives::argmax::match_data,
             primitives::constant::match_data,
             primitives::determinant::match_data,
             primitives::enable_tracing::match_data,

--- a/src/execution_tree/primitives/argmax.cpp
+++ b/src/execution_tree/primitives/argmax.cpp
@@ -1,0 +1,363 @@
+//  Copyright (c) 2018 Parsa Amini
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/argmax.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/iterator_facade.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_argmax(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+    {
+        static std::string type("argmax");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const argmax::match_data =
+    {
+        hpx::util::make_tuple("argmax",
+            std::vector<std::string>{"argmax(_1, _2)"},
+            &create_argmax, &create_primitive<argmax>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    argmax::argmax(
+            std::vector<primitive_argument_type> && operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename T>
+        class matrix_row_iterator
+          : public hpx::util::iterator_facade<
+                matrix_row_iterator<T>,
+                blaze::Row<T>,
+                std::random_access_iterator_tag,
+                blaze::Row<T>>
+        {
+        public:
+            matrix_row_iterator(T& t, std::size_t index = 0)
+              : data_(t)
+              , index_(index)
+            {
+            }
+
+        private:
+            friend class hpx::util::iterator_core_access;
+
+            void increment()
+            {
+                ++index_;
+            }
+            void decrement()
+            {
+                --index_;
+            }
+            void advance(std::size_t n)
+            {
+                index_ += n;
+            }
+            bool equal(matrix_row_iterator const& other) const
+            {
+                return index_ == other.index_;
+            }
+            blaze::Row<T> dereference() const
+            {
+                return blaze::row(data_, index_);
+            }
+
+        private:
+            T& data_;
+            std::size_t index_;
+        };
+
+        template <typename T>
+        class matrix_column_iterator
+            : public hpx::util::iterator_facade<
+                matrix_column_iterator<T>,
+                blaze::Column<T>,
+                std::random_access_iterator_tag,
+                blaze::Column<T>>
+        {
+        public:
+            matrix_column_iterator(T& t, std::size_t index = 0)
+              : data_(t)
+              , index_(index)
+            {
+            }
+
+        private:
+            friend class hpx::util::iterator_core_access;
+
+            void increment()
+            {
+                ++index_;
+            }
+            void decrement()
+            {
+                --index_;
+            }
+            void advance(std::size_t n)
+            {
+                index_ += n;
+            }
+            bool equal(matrix_column_iterator const& other) const
+            {
+                return index_ == other.index_;
+            }
+            blaze::Column<T> dereference() const
+            {
+                return blaze::column(data_, index_);
+            }
+
+        private:
+            T& data_;
+            std::size_t index_;
+        };
+
+
+        struct argmax : std::enable_shared_from_this<argmax>
+        {
+            argmax(std::string const& name, std::string const& codename)
+              : name_(name)
+              , codename_(codename)
+            {}
+
+        protected:
+            std::string name_;
+            std::string codename_;
+
+        protected:
+            using arg_type = ir::node_data<double>;
+            using args_type = std::vector<arg_type>;
+
+            primitive_argument_type argmax0d(args_type && args) const
+            {
+                return 0ul;
+            }
+
+            ///////////////////////////////////////////////////////////////////////////
+            primitive_argument_type argmax1d(args_type && args) const
+            {
+                auto a = args[0].vector();
+                auto max_it = std::max_element(a.begin(), a.end());
+
+                return std::distance(a.begin(), max_it);
+            }
+
+            ///////////////////////////////////////////////////////////////////////////
+            primitive_argument_type argmax2d_flatten(arg_type && arg_a) const
+            {
+                auto a = arg_a.matrix();
+
+                matrix_row_iterator<decltype(a)> a_begin(a);
+                matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+
+                double global_max = 0.;
+                std::size_t global_index = 0ul;
+                std::size_t passed_rows = 0ul;
+                for (auto it = a_begin; it != a_end; ++it, ++passed_rows)
+                {
+                    auto local_max = std::max_element(it->begin(), it->end());
+                    auto local_max_val = *local_max;
+                    
+                    if (local_max_val > global_max)
+                    {
+                        global_max = local_max_val;
+                        auto index = std::distance(it->begin(), local_max) +
+                            passed_rows * it->size();
+                    }
+                }
+                return global_index;
+            }
+
+            primitive_argument_type argmax2d_x_axis(arg_type && arg_a) const
+            {
+                auto a = arg_a.matrix();
+
+                matrix_row_iterator<decltype(a)> a_begin(a);
+                matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+
+                std::vector<primitive_argument_type> result;
+                for (auto it = a_begin; it != a_end; ++it)
+                {
+                    auto local_max = std::max_element(it->begin(), it->end());
+                    auto index = std::distance(it->begin(), local_max);
+                    result.emplace_back(std::move(index));
+                }
+                return result;
+            }
+            primitive_argument_type argmax2d_y_axis(arg_type && arg_a) const
+            {
+
+                auto a = arg_a.matrix();
+
+                matrix_column_iterator<decltype(a)> a_begin(a);
+                matrix_column_iterator<decltype(a)> a_end(a, a.columns());
+
+                std::vector<primitive_argument_type> result;
+                for (auto it = a_begin; it != a_end; ++it)
+                {
+                    auto local_max = std::max_element(it->begin(), it->end());
+                    //auto index = std::distance(it->begin(), local_max);
+                    //result.emplace_back(std::move(index));
+                }
+                return result;
+            }
+
+            primitive_argument_type argmax2d(args_type && args) const
+            {
+                // `axis` is optional
+                if (args.size() == 1)
+                {
+                    // Option 1: Flatten and find max
+                    return argmax2d_flatten(std::move(args[0]));
+                }
+
+                // `axis` must be a scalar if provided
+                if (args[1].num_dimensions() != 0)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "argmax::argmax2d",
+                        generate_error_message(
+                            "operand axis must be a scalar", name_, codename_));
+                }
+                int axis = args[1].scalar();
+                // `axis` can only be -2, -1, 0, or 1
+                if (axis < -2 || axis > 1)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "argmax::argmax2d",
+                        generate_error_message(
+                            "operand axis can only be -2, -1, 0, or 1 for "
+                            "an a operand that is 2d",
+                            name_, codename_));
+                }
+                switch (axis)
+                {
+                // Option 2: Find max among rows
+                case -2: HPX_FALLTHROUGH;
+                case -0:
+                    return argmax2d_x_axis(std::move(args[0]));
+
+                // Option 3: Find max among columns
+                case -1: HPX_FALLTHROUGH;
+                case 1:
+                    return argmax2d_y_axis(std::move(args[0]));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "argmax::argmax2d",
+                        generate_error_message(
+                            "operand a has an invalid number of "
+                            "dimensions",
+                            name_, codename_));
+                }
+
+
+            }
+
+        public:
+            hpx::future<primitive_argument_type> eval(
+                std::vector<primitive_argument_type> const& operands,
+                std::vector<primitive_argument_type> const& args) const
+            {
+                if (operands.empty() || operands.size() > 2)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "argmax::eval",
+                        generate_error_message(
+                            "the argmax primitive requires exactly one or two "
+                                "operands",
+                            name_, codename_));
+                }
+
+                for (auto const& i : operands)
+                {
+                    if (!valid(i))
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "argmax::eval",
+                            generate_error_message(
+                                "the argmax primitive requires that the "
+                                "arguments given by the operands array are "
+                                "valid",
+                                name_, codename_));
+                    }
+                }
+
+
+                auto this_ = this->shared_from_this();
+                return hpx::dataflow(hpx::util::unwrapping(
+                    [this_](args_type&& args) -> primitive_argument_type
+                    {
+                        std::size_t a_dims = args[0].num_dimensions();
+                        switch (a_dims)
+                        {
+                        case 0:
+                            return this_->argmax0d(std::move(args));
+
+                        case 1:
+                            return this_->argmax1d(std::move(args));
+
+                        case 2:
+                            return this_->argmax2d(std::move(args));
+
+                        default:
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "argmax::eval",
+                                generate_error_message(
+                                    "operand a has an invalid "
+                                    "number of dimensions",
+                                this_->name_, this_->codename_));
+                        }
+                    }),
+                    // TODO: Check what value -1 is going to turn into.
+                    // node_data of doubles?
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args,
+                        name_, codename_));
+            }
+        };
+    }
+
+    hpx::future<primitive_argument_type> argmax::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return std::make_shared<detail::argmax>(name_, codename_)
+                ->eval(args, noargs);
+        }
+        return std::make_shared<detail::argmax>(name_, codename_)
+            ->eval(operands_, args);
+    }
+}}}

--- a/src/execution_tree/primitives/argmax.cpp
+++ b/src/execution_tree/primitives/argmax.cpp
@@ -47,296 +47,275 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     argmax::argmax(std::vector<primitive_argument_type>&& operands,
-        std::string const& name, std::string const& codename)
+            std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type argmax::argmax0d(args_type && args) const
     {
-        struct argmax : std::enable_shared_from_this<argmax>
+        // `axis` is optional
+        if (args.size() == 2)
         {
-            argmax(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {}
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using val_type = double;
-            using arg_type = ir::node_data<val_type>;
-            using args_type = std::vector<arg_type>;
-
-            primitive_argument_type argmax0d(args_type && args) const
+            // `axis` must be a scalar if provided
+            if (args[1].num_dimensions() != 0)
             {
-                // `axis` is optional
-                if (args.size() == 2)
-                {
-                    // `axis` must be a scalar if provided
-                    if (args[1].num_dimensions() != 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmax::argmax0d",
-                            generate_error_message(
-                                "operand axis must be a scalar", name_,
-                                codename_));
-                    }
-                    const int axis = args[1].scalar();
-                    // `axis` can only be -1 or 0
-                    if (axis < -1 || axis > 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmax::argmax0d",
-                            generate_error_message(
-                                "operand axis can only between -1 and 0 for "
-                                "an a operand that is 0d",
-                                name_, codename_));
-                    }
-                }
-
-                return 0ul;
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmax::argmax0d",
+                    execution_tree::generate_error_message(
+                        "operand axis must be a scalar", name_,
+                        codename_));
             }
-
-            ///////////////////////////////////////////////////////////////////////////
-            primitive_argument_type argmax1d(args_type && args) const
+            const int axis = args[1].scalar();
+            // `axis` can only be -1 or 0
+            if (axis < -1 || axis > 0)
             {
-                // `axis` is optional
-                if (args.size() == 2)
-                {
-                    // `axis` must be a scalar if provided
-                    if (args[1].num_dimensions() != 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmax::argmax1d",
-                            generate_error_message(
-                                "operand axis must be a scalar", name_,
-                                codename_));
-                    }
-                    const int axis = args[1].scalar();
-                    // `axis` can only be -1 or 0
-                    if (axis < -1 || axis > 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmax::argmax1d",
-                            generate_error_message(
-                                "operand axis can only between -1 and 0 for "
-                                "an a operand that is 1d",
-                                name_, codename_));
-                    }
-                }
-
-                auto a = args[0].vector();
-
-                // a should not be empty
-                if (a.size() == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmax1d",
-                        generate_error_message(
-                            "attempt to get argmax of an empty sequence",
-                            name_, codename_));
-                }
-
-                // Find the maximum value among the elements
-                const auto max_it = std::max_element(a.begin(), a.end());
-
-                // Return max's index
-                return std::distance(a.begin(), max_it);
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmax::argmax0d",
+                    execution_tree::generate_error_message(
+                        "operand axis can only between -1 and 0 for "
+                        "an a operand that is 0d",
+                        name_, codename_));
             }
+        }
 
-            ///////////////////////////////////////////////////////////////////////////
-            primitive_argument_type argmax2d_flatten(arg_type && arg_a) const
+        return 0ul;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type argmax::argmax1d(args_type && args) const
+    {
+        // `axis` is optional
+        if (args.size() == 2)
+        {
+            // `axis` must be a scalar if provided
+            if (args[1].num_dimensions() != 0)
             {
-                using phylanx::util::matrix_row_iterator;
-
-                auto a = arg_a.matrix();
-
-                const matrix_row_iterator<decltype(a)> a_begin(a);
-                const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
-
-                val_type global_max = 0.;
-                std::size_t global_index = 0ul;
-                std::size_t passed_rows = 0ul;
-                for (auto it = a_begin; it != a_end; ++it, ++passed_rows)
-                {
-                    const auto local_max = std::max_element(it->begin(), it->end());
-                    const auto local_max_val = *local_max;
-
-                    if (local_max_val > global_max)
-                    {
-                        global_max = local_max_val;
-                        global_index = std::distance(it->begin(), local_max) +
-                            passed_rows * it->size();
-                    }
-                }
-                return global_index;
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmax::argmax1d",
+                    execution_tree::generate_error_message(
+                        "operand axis must be a scalar", name_,
+                        codename_));
             }
-
-            primitive_argument_type argmax2d_x_axis(arg_type && arg_a) const
+            const int axis = args[1].scalar();
+            // `axis` can only be -1 or 0
+            if (axis < -1 || axis > 0)
             {
-                using phylanx::util::matrix_row_iterator;
-
-                auto a = arg_a.matrix();
-
-                const matrix_row_iterator<decltype(a)> a_begin(a);
-                const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
-
-                std::vector<primitive_argument_type> result;
-                for (auto it = a_begin; it != a_end; ++it)
-                {
-                    const auto local_max = std::max_element(it->begin(), it->end());
-                    std::int64_t index = std::distance(it->begin(), local_max);
-                    result.emplace_back(primitive_argument_type(index));
-                }
-                return result;
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmax::argmax1d",
+                    execution_tree::generate_error_message(
+                        "operand axis can only between -1 and 0 for "
+                        "an a operand that is 1d",
+                        name_, codename_));
             }
-            primitive_argument_type argmax2d_y_axis(arg_type && arg_a) const
+        }
+
+        auto a = args[0].vector();
+
+        // a should not be empty
+        if (a.size() == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmax::argmax1d",
+                execution_tree::generate_error_message(
+                    "attempt to get argmax of an empty sequence",
+                    name_, codename_));
+        }
+
+        // Find the maximum value among the elements
+        const auto max_it = std::max_element(a.begin(), a.end());
+
+        // Return max's index
+        return std::distance(a.begin(), max_it);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type argmax::argmax2d_flatten(arg_type && arg_a) const
+    {
+        using phylanx::util::matrix_row_iterator;
+
+        auto a = arg_a.matrix();
+
+        const matrix_row_iterator<decltype(a)> a_begin(a);
+        const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+
+        val_type global_max = 0.;
+        std::size_t global_index = 0ul;
+        std::size_t passed_rows = 0ul;
+        for (auto it = a_begin; it != a_end; ++it, ++passed_rows)
+        {
+            const auto local_max = std::max_element(it->begin(), it->end());
+            const auto local_max_val = *local_max;
+
+            if (local_max_val > global_max)
             {
-                using phylanx::util::matrix_column_iterator;
-
-                auto a = arg_a.matrix();
-
-                const matrix_column_iterator<decltype(a)> a_begin(a);
-                const matrix_column_iterator<decltype(a)> a_end(a, a.columns());
-
-                std::vector<primitive_argument_type> result;
-                for (auto it = a_begin; it != a_end; ++it)
-                {
-                    const auto local_max = std::max_element(it->begin(), it->end());
-                    std::int64_t index = std::distance(it->begin(), local_max);
-                    result.emplace_back(primitive_argument_type(index));
-                }
-                return result;
+                global_max = local_max_val;
+                global_index = std::distance(it->begin(), local_max) +
+                    passed_rows * it->size();
             }
+        }
+        return global_index;
+    }
 
-            primitive_argument_type argmax2d(args_type && args) const
+    primitive_argument_type argmax::argmax2d_x_axis(arg_type && arg_a) const
+    {
+        using phylanx::util::matrix_row_iterator;
+
+        auto a = arg_a.matrix();
+
+        const matrix_row_iterator<decltype(a)> a_begin(a);
+        const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+
+        std::vector<primitive_argument_type> result;
+        for (auto it = a_begin; it != a_end; ++it)
+        {
+            const auto local_max = std::max_element(it->begin(), it->end());
+            std::int64_t index = std::distance(it->begin(), local_max);
+            result.emplace_back(primitive_argument_type(index));
+        }
+        return result;
+    }
+    primitive_argument_type argmax::argmax2d_y_axis(arg_type && arg_a) const
+    {
+        using phylanx::util::matrix_column_iterator;
+
+        auto a = arg_a.matrix();
+
+        const matrix_column_iterator<decltype(a)> a_begin(a);
+        const matrix_column_iterator<decltype(a)> a_end(a, a.columns());
+
+        std::vector<primitive_argument_type> result;
+        for (auto it = a_begin; it != a_end; ++it)
+        {
+            const auto local_max = std::max_element(it->begin(), it->end());
+            std::int64_t index = std::distance(it->begin(), local_max);
+            result.emplace_back(primitive_argument_type(index));
+        }
+        return result;
+    }
+
+    primitive_argument_type argmax::argmax2d(args_type && args) const
+    {
+        // a should not be empty
+        if (args[0].matrix().rows() == 0 ||
+            args[0].matrix().columns() == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmax::argmax2d",
+                execution_tree::generate_error_message(
+                    "attempt to get argmax of an empty sequence",
+                    name_, codename_));
+        }
+
+        // `axis` is optional
+        if (args.size() == 1)
+        {
+            // Option 1: Flatten and find max
+            return argmax2d_flatten(std::move(args[0]));
+        }
+
+        // `axis` must be a scalar if provided
+        if (args[1].num_dimensions() != 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmax::argmax2d",
+                execution_tree::generate_error_message(
+                    "operand axis must be a scalar", name_, codename_));
+        }
+        const int axis = args[1].scalar();
+        // `axis` can only be -2, -1, 0, or 1
+        if (axis < -2 || axis > 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmax::argmax2d",
+                execution_tree::generate_error_message(
+                    "operand axis can only between -2 and 1 for an a "
+                    "operand that is 2d",
+                    name_, codename_));
+        }
+        switch (axis)
+        {
+        // Option 2: Find max among rows
+        case -2: HPX_FALLTHROUGH;
+        case 0:
+            return argmax2d_x_axis(std::move(args[0]));
+
+        // Option 3: Find max among columns
+        case -1: HPX_FALLTHROUGH;
+        case 1:
+            return argmax2d_y_axis(std::move(args[0]));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmax::argmax2d",
+                execution_tree::generate_error_message(
+                    "operand a has an invalid number of "
+                    "dimensions",
+                    name_, codename_));
+        }
+
+
+    }
+
+    hpx::future<primitive_argument_type> argmax::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.empty() || operands.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmax::eval",
+                execution_tree::generate_error_message(
+                    "the argmax primitive requires exactly one or two "
+                        "operands",
+                    name_, codename_));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
             {
-                // a should not be empty
-                if (args[0].matrix().rows() == 0 ||
-                    args[0].matrix().columns() == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmax2d",
-                        generate_error_message(
-                            "attempt to get argmax of an empty sequence",
-                            name_, codename_));
-                }
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmax::eval",
+                    execution_tree::generate_error_message(
+                        "the argmax primitive requires that the "
+                        "arguments given by the operands array are "
+                        "valid",
+                        name_, codename_));
+            }
+        }
 
-                // `axis` is optional
-                if (args.size() == 1)
-                {
-                    // Option 1: Flatten and find max
-                    return argmax2d_flatten(std::move(args[0]));
-                }
 
-                // `axis` must be a scalar if provided
-                if (args[1].num_dimensions() != 0)
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](args_type&& args) -> primitive_argument_type
+            {
+                std::size_t a_dims = args[0].num_dimensions();
+                switch (a_dims)
                 {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmax2d",
-                        generate_error_message(
-                            "operand axis must be a scalar", name_, codename_));
-                }
-                const int axis = args[1].scalar();
-                // `axis` can only be -2, -1, 0, or 1
-                if (axis < -2 || axis > 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmax2d",
-                        generate_error_message(
-                            "operand axis can only between -2 and 1 for an a "
-                            "operand that is 2d",
-                            name_, codename_));
-                }
-                switch (axis)
-                {
-                // Option 2: Find max among rows
-                case -2: HPX_FALLTHROUGH;
                 case 0:
-                    return argmax2d_x_axis(std::move(args[0]));
+                    return this_->argmax0d(std::move(args));
 
-                // Option 3: Find max among columns
-                case -1: HPX_FALLTHROUGH;
                 case 1:
-                    return argmax2d_y_axis(std::move(args[0]));
+                    return this_->argmax1d(std::move(args));
+
+                case 2:
+                    return this_->argmax2d(std::move(args));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmax2d",
-                        generate_error_message(
-                            "operand a has an invalid number of "
-                            "dimensions",
-                            name_, codename_));
-                }
-
-
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.empty() || operands.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "argmax::eval",
-                        generate_error_message(
-                            "the argmax primitive requires exactly one or two "
-                                "operands",
-                            name_, codename_));
+                        execution_tree::generate_error_message(
+                            "operand a has an invalid "
+                            "number of dimensions",
+                        this_->name_, this_->codename_));
                 }
-
-                for (auto const& i : operands)
-                {
-                    if (!valid(i))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmax::eval",
-                            generate_error_message(
-                                "the argmax primitive requires that the "
-                                "arguments given by the operands array are "
-                                "valid",
-                                name_, codename_));
-                    }
-                }
-
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type&& args) -> primitive_argument_type
-                    {
-                        std::size_t a_dims = args[0].num_dimensions();
-                        switch (a_dims)
-                        {
-                        case 0:
-                            return this_->argmax0d(std::move(args));
-
-                        case 1:
-                            return this_->argmax1d(std::move(args));
-
-                        case 2:
-                            return this_->argmax2d(std::move(args));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "argmax::eval",
-                                generate_error_message(
-                                    "operand a has an invalid "
-                                    "number of dimensions",
-                                this_->name_, this_->codename_));
-                        }
-                    }),
-                    // TODO: Check what value -1 is going to turn into.
-                    // node_data of doubles?
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+            }),
+            // TODO: Check what value -1 is going to turn into.
+            // node_data of doubles?
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
     }
 
     hpx::future<primitive_argument_type> argmax::eval(
@@ -344,10 +323,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::argmax>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::argmax>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/argmax.cpp
+++ b/src/execution_tree/primitives/argmax.cpp
@@ -85,7 +85,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     if (args[1].num_dimensions() != 0)
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmax::argmax2d",
+                            "argmax::argmax1d",
                             generate_error_message(
                                 "operand axis must be a scalar", name_,
                                 codename_));
@@ -95,7 +95,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     if (axis < -1 || axis > 0)
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmax::argmax2d",
+                            "argmax::argmax1d",
                             generate_error_message(
                                 "operand axis can only between -1 and 0 for "
                                 "an a operand that is 1d",
@@ -105,17 +105,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 auto a = args[0].vector();
 
+                // a should not be empty
                 if (a.size() == 0)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmax2d",
+                        "argmax::argmax1d",
                         generate_error_message(
                             "attempt to get argmax of an empty sequence",
                             name_, codename_));
                 }
 
+                // Find the maximum value among the elements
                 const auto max_it = std::max_element(a.begin(), a.end());
 
+                // Return max's index
                 return std::distance(a.begin(), max_it);
             }
 
@@ -125,15 +128,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 using phylanx::util::matrix_row_iterator;
 
                 auto a = arg_a.matrix();
-
-                if (a.rows() == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmax2d",
-                        generate_error_message(
-                            "attempt to get argmax of an empty sequence",
-                            name_, codename_));
-                }
 
                 const matrix_row_iterator<decltype(a)> a_begin(a);
                 const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
@@ -195,6 +189,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             primitive_argument_type argmax2d(args_type && args) const
             {
+                // a should not be empty
+                if (args[0].matrix().rows() == 0)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "argmax::argmax2d",
+                        generate_error_message(
+                            "attempt to get argmax of an empty sequence",
+                            name_, codename_));
+                }
+
                 // `axis` is optional
                 if (args.size() == 1)
                 {

--- a/src/execution_tree/primitives/argmin.cpp
+++ b/src/execution_tree/primitives/argmin.cpp
@@ -79,9 +79,47 @@ namespace phylanx { namespace execution_tree { namespace primitives
             ///////////////////////////////////////////////////////////////////////////
             primitive_argument_type argmin1d(args_type && args) const
             {
+                // `axis` is optional
+                if (args.size() == 2)
+                {
+                    // `axis` must be a scalar if provided
+                    if (args[1].num_dimensions() != 0)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "argmin::argmin1d",
+                            generate_error_message(
+                                "operand axis must be a scalar", name_,
+                                codename_));
+                    }
+                    const int axis = args[1].scalar();
+                    // `axis` can only be -1 or 0
+                    if (axis < -1 || axis > 0)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "argmin::argmin1d",
+                            generate_error_message(
+                                "operand axis can only between -1 and 0 for "
+                                "an a operand that is 1d",
+                                name_, codename_));
+                    }
+                }
+
                 auto a = args[0].vector();
+
+                // a should not be empty
+                if (a.size() == 0)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "argmin::argmin1d",
+                        generate_error_message(
+                            "attempt to get argmin of an empty sequence",
+                            name_, codename_));
+                }
+
+                // Find the minimum value among the elements
                 const auto min_it = std::min_element(a.begin(), a.end());
 
+                // Return min's index
                 return std::distance(a.begin(), min_it);
             }
 
@@ -152,6 +190,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             primitive_argument_type argmin2d(args_type && args) const
             {
+                // a should not be empty
+                if (args[0].matrix().rows() == 0)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "argmax::argmin2d",
+                        generate_error_message(
+                            "attempt to get argmax of an empty sequence",
+                            name_, codename_));
+                }
+
                 // `axis` is optional
                 if (args.size() == 1)
                 {

--- a/src/execution_tree/primitives/argmin.cpp
+++ b/src/execution_tree/primitives/argmin.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <string>
@@ -94,7 +95,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 const matrix_row_iterator<decltype(a)> a_begin(a);
                 const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
 
-                double global_min = std::numeric_limits<double>::max();
+                double global_min = (std::numeric_limits<double>::max)();
                 std::size_t global_index = 0ul;
                 std::size_t passed_rows = 0ul;
                 for (auto it = a_begin; it != a_end; ++it, ++passed_rows)
@@ -102,7 +103,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     const auto local_min = std::min_element(it->begin(), it->end());
                     const auto local_min_val = *local_min;
 
-                    if (local_min_val > global_min)
+                    if (local_min_val < global_min)
                     {
                         global_min = local_min_val;
                         global_index = std::distance(it->begin(), local_min) +
@@ -125,8 +126,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 for (auto it = a_begin; it != a_end; ++it)
                 {
                     const auto local_min = std::min_element(it->begin(), it->end());
-                    auto index = std::distance(it->begin(), local_min);
-                    result.emplace_back(index);
+                    std::int64_t index = std::distance(it->begin(), local_min);
+                    result.emplace_back(primitive_argument_type(index));
                 }
                 return result;
             }
@@ -143,8 +144,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 for (auto it = a_begin; it != a_end; ++it)
                 {
                     const auto local_min = std::min_element(it->begin(), it->end());
-                    auto index = std::distance(it->begin(), local_min);
-                    result.emplace_back(index);
+                    std::int64_t index = std::distance(it->begin(), local_min);
+                    result.emplace_back(primitive_argument_type(index));
                 }
                 return result;
             }
@@ -179,12 +180,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
                 switch (axis)
                 {
-                    // Option 2: Find min among rows
+                // Option 2: Find min among rows
                 case -2: HPX_FALLTHROUGH;
-                case -0:
+                case 0:
                     return argmin2d_x_axis(std::move(args[0]));
 
-                    // Option 3: Find min among columns
+                // Option 3: Find min among columns
                 case -1: HPX_FALLTHROUGH;
                 case 1:
                     return argmin2d_y_axis(std::move(args[0]));

--- a/src/execution_tree/primitives/argmin.cpp
+++ b/src/execution_tree/primitives/argmin.cpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2018 Parsa Amini
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/argmin.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_argmin(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+    {
+        static std::string type("argmin");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const argmin::match_data =
+    {
+        hpx::util::make_tuple("__argmin",
+            std::vector<std::string>{"argmin(_1, _2)"},
+            &create_argmin, &create_primitive<argmin>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    argmin::argmin(
+            std::vector<primitive_argument_type> && operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        struct argmin : std::enable_shared_from_this<argmin>
+        {
+            argmin(std::string const& name, std::string const& codename)
+              : name_(name)
+              , codename_(codename)
+            {}
+
+        protected:
+            std::string name_;
+            std::string codename_;
+
+        protected:
+            using arg_type = ir::node_data<double>;
+            using args_type = std::vector<arg_type>;
+
+        public:
+            hpx::future<primitive_argument_type> eval(
+                std::vector<primitive_argument_type> const& operands,
+                std::vector<primitive_argument_type> const& args) const
+            {
+                HPX_THROW_EXCEPTION(hpx::not_implemented,
+                    "argmin::eval",
+                    generate_error_message(
+                        "the argmin primitive is not implemented yet",
+                        name_, codename_));
+            }
+        };
+    }
+
+    hpx::future<primitive_argument_type> argmin::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return std::make_shared<detail::argmin>(name_, codename_)
+                ->eval(args, noargs);
+        }
+        return std::make_shared<detail::argmin>(name_, codename_)
+            ->eval(operands_, args);
+    }
+}}}

--- a/src/execution_tree/primitives/argmin.cpp
+++ b/src/execution_tree/primitives/argmin.cpp
@@ -42,300 +42,279 @@ namespace phylanx { namespace execution_tree { namespace primitives
     match_pattern_type const argmin::match_data =
     {
         hpx::util::make_tuple("argmin",
-        std::vector<std::string>{"argmin(_1, _2)"},
-        &create_argmin, &create_primitive<argmin>)
+            std::vector<std::string>{"argmin(_1, _2)"},
+            &create_argmin, &create_primitive<argmin>)
     };
 
     ///////////////////////////////////////////////////////////////////////////
     argmin::argmin(std::vector<primitive_argument_type>&& operands,
-        std::string const& name, std::string const& codename)
+            std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type argmin::argmin0d(args_type && args) const
     {
-        struct argmin : std::enable_shared_from_this<argmin>
+        // `axis` is optional
+        if (args.size() == 2)
         {
-            argmin(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {}
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using val_type = double;
-            using arg_type = ir::node_data<val_type>;
-            using args_type = std::vector<arg_type>;
-
-            primitive_argument_type argmin0d(args_type && args) const
+            // `axis` must be a scalar if provided
+            if (args[1].num_dimensions() != 0)
             {
-                // `axis` is optional
-                if (args.size() == 2)
-                {
-                    // `axis` must be a scalar if provided
-                    if (args[1].num_dimensions() != 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmin::argmin0d",
-                            generate_error_message(
-                                "operand axis must be a scalar", name_,
-                                codename_));
-                    }
-                    const int axis = args[1].scalar();
-                    // `axis` can only be -1 or 0
-                    if (axis < -1 || axis > 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmin::argmin0d",
-                            generate_error_message(
-                                "operand axis can only between -1 and 0 for "
-                                "an a operand that is 0d",
-                                name_, codename_));
-                    }
-                }
-
-                return 0ul;
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmin::argmin0d",
+                    execution_tree::generate_error_message(
+                        "operand axis must be a scalar", name_,
+                        codename_));
             }
-
-            ///////////////////////////////////////////////////////////////////////////
-            primitive_argument_type argmin1d(args_type && args) const
+            const int axis = args[1].scalar();
+            // `axis` can only be -1 or 0
+            if (axis < -1 || axis > 0)
             {
-                // `axis` is optional
-                if (args.size() == 2)
-                {
-                    // `axis` must be a scalar if provided
-                    if (args[1].num_dimensions() != 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmin::argmin1d",
-                            generate_error_message(
-                                "operand axis must be a scalar", name_,
-                                codename_));
-                    }
-                    const int axis = args[1].scalar();
-                    // `axis` can only be -1 or 0
-                    if (axis < -1 || axis > 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmin::argmin1d",
-                            generate_error_message(
-                                "operand axis can only between -1 and 0 for "
-                                "an a operand that is 1d",
-                                name_, codename_));
-                    }
-                }
-
-                auto a = args[0].vector();
-
-                // a should not be empty
-                if (a.size() == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmin::argmin1d",
-                        generate_error_message(
-                            "attempt to get argmin of an empty sequence",
-                            name_, codename_));
-                }
-
-                // Find the minimum value among the elements
-                const auto min_it = std::min_element(a.begin(), a.end());
-
-                // Return min's index
-                return std::distance(a.begin(), min_it);
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmin::argmin0d",
+                    execution_tree::generate_error_message(
+                        "operand axis can only between -1 and 0 for "
+                        "an a operand that is 0d",
+                        name_, codename_));
             }
+        }
 
-            ///////////////////////////////////////////////////////////////////////////
-            primitive_argument_type argmin2d_flatten(arg_type && arg_a) const
+        return 0ul;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type argmin::argmin1d(args_type && args) const
+    {
+        // `axis` is optional
+        if (args.size() == 2)
+        {
+            // `axis` must be a scalar if provided
+            if (args[1].num_dimensions() != 0)
             {
-                using phylanx::util::matrix_row_iterator;
-
-                auto a = arg_a.matrix();
-
-                const matrix_row_iterator<decltype(a)> a_begin(a);
-                const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
-
-                val_type global_min = (std::numeric_limits<val_type>::max)();
-                std::size_t global_index = 0ul;
-                std::size_t passed_rows = 0ul;
-                for (auto it = a_begin; it != a_end; ++it, ++passed_rows)
-                {
-                    const auto local_min = std::min_element(it->begin(), it->end());
-                    const auto local_min_val = *local_min;
-
-                    if (local_min_val < global_min)
-                    {
-                        global_min = local_min_val;
-                        global_index = std::distance(it->begin(), local_min) +
-                            passed_rows * it->size();
-                    }
-                }
-                return global_index;
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmin::argmin1d",
+                    execution_tree::generate_error_message(
+                        "operand axis must be a scalar", name_,
+                        codename_));
             }
-
-            primitive_argument_type argmin2d_x_axis(arg_type && arg_a) const
+            const int axis = args[1].scalar();
+            // `axis` can only be -1 or 0
+            if (axis < -1 || axis > 0)
             {
-                using phylanx::util::matrix_row_iterator;
-
-                auto a = arg_a.matrix();
-
-                const matrix_row_iterator<decltype(a)> a_begin(a);
-                const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
-
-                std::vector<primitive_argument_type> result;
-                for (auto it = a_begin; it != a_end; ++it)
-                {
-                    const auto local_min = std::min_element(it->begin(), it->end());
-                    std::int64_t index = std::distance(it->begin(), local_min);
-                    result.emplace_back(primitive_argument_type(index));
-                }
-                return result;
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmin::argmin1d",
+                    execution_tree::generate_error_message(
+                        "operand axis can only between -1 and 0 for "
+                        "an a operand that is 1d",
+                        name_, codename_));
             }
-            primitive_argument_type argmin2d_y_axis(arg_type && arg_a) const
+        }
+
+        auto a = args[0].vector();
+
+        // a should not be empty
+        if (a.size() == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmin::argmin1d",
+                execution_tree::generate_error_message(
+                    "attempt to get argmin of an empty sequence",
+                    name_, codename_));
+        }
+
+        // Find the minimum value among the elements
+        const auto min_it = std::min_element(a.begin(), a.end());
+
+        // Return min's index
+        return std::distance(a.begin(), min_it);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type argmin::argmin2d_flatten(arg_type && arg_a) const
+    {
+        using phylanx::util::matrix_row_iterator;
+
+        auto a = arg_a.matrix();
+
+        const matrix_row_iterator<decltype(a)> a_begin(a);
+        const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+
+        val_type global_min = (std::numeric_limits<val_type>::max)();
+        std::size_t global_index = 0ul;
+        std::size_t passed_rows = 0ul;
+        for (auto it = a_begin; it != a_end; ++it, ++passed_rows)
+        {
+            const auto local_min = std::min_element(it->begin(), it->end());
+            const auto local_min_val = *local_min;
+
+            if (local_min_val < global_min)
             {
-                using phylanx::util::matrix_column_iterator;
-
-                auto a = arg_a.matrix();
-
-                const matrix_column_iterator<decltype(a)> a_begin(a);
-                const matrix_column_iterator<decltype(a)> a_end(a, a.columns());
-
-                std::vector<primitive_argument_type> result;
-                for (auto it = a_begin; it != a_end; ++it)
-                {
-                    const auto local_min = std::min_element(it->begin(), it->end());
-                    std::int64_t index = std::distance(it->begin(), local_min);
-                    result.emplace_back(primitive_argument_type(index));
-                }
-                return result;
+                global_min = local_min_val;
+                global_index = std::distance(it->begin(), local_min) +
+                    passed_rows * it->size();
             }
+        }
+        return global_index;
+    }
 
-            primitive_argument_type argmin2d(args_type && args) const
+    primitive_argument_type argmin::argmin2d_x_axis(arg_type && arg_a) const
+    {
+        using phylanx::util::matrix_row_iterator;
+
+        auto a = arg_a.matrix();
+
+        const matrix_row_iterator<decltype(a)> a_begin(a);
+        const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+
+        std::vector<primitive_argument_type> result;
+        for (auto it = a_begin; it != a_end; ++it)
+        {
+            const auto local_min = std::min_element(it->begin(), it->end());
+            std::int64_t index = std::distance(it->begin(), local_min);
+            result.emplace_back(primitive_argument_type(index));
+        }
+        return result;
+    }
+    primitive_argument_type argmin::argmin2d_y_axis(arg_type && arg_a) const
+    {
+        using phylanx::util::matrix_column_iterator;
+
+        auto a = arg_a.matrix();
+
+        const matrix_column_iterator<decltype(a)> a_begin(a);
+        const matrix_column_iterator<decltype(a)> a_end(a, a.columns());
+
+        std::vector<primitive_argument_type> result;
+        for (auto it = a_begin; it != a_end; ++it)
+        {
+            const auto local_min = std::min_element(it->begin(), it->end());
+            std::int64_t index = std::distance(it->begin(), local_min);
+            result.emplace_back(primitive_argument_type(index));
+        }
+        return result;
+    }
+
+    primitive_argument_type argmin::argmin2d(args_type && args) const
+    {
+        // a should not be empty
+        if (args[0].matrix().rows() == 0 ||
+            args[0].matrix().columns() == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmin::argmin2d",
+                execution_tree::generate_error_message(
+                    "attempt to get argmin of an empty sequence",
+                    name_, codename_));
+        }
+
+        // `axis` is optional
+        if (args.size() == 1)
+        {
+            // Option 1: Flatten and find min
+            return argmin2d_flatten(std::move(args[0]));
+        }
+
+        // `axis` must be a scalar if provided
+        if (args[1].num_dimensions() != 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmin::argmin2d",
+                execution_tree::generate_error_message(
+                    "operand axis must be a scalar", name_, codename_));
+        }
+        const int axis = args[1].scalar();
+        // `axis` can only be -2, -1, 0, or 1
+        if (axis < -2 || axis > 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmin::argmin2d",
+                execution_tree::generate_error_message(
+                    "operand axis can only between -2 and 1 for an a "
+                    "operand that is 2d",
+                    name_, codename_));
+        }
+        switch (axis)
+        {
+        // Option 2: Find min among rows
+        case -2: HPX_FALLTHROUGH;
+        case 0:
+            return argmin2d_x_axis(std::move(args[0]));
+
+        // Option 3: Find min among columns
+        case -1: HPX_FALLTHROUGH;
+        case 1:
+            return argmin2d_y_axis(std::move(args[0]));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmin::argmin2d",
+                execution_tree::generate_error_message(
+                    "operand a has an invalid number of "
+                    "dimensions",
+                    name_, codename_));
+        }
+
+
+    }
+
+    hpx::future<primitive_argument_type> argmin::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.empty() || operands.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "argmin::eval",
+                execution_tree::generate_error_message(
+                    "the argmin primitive requires exactly one or two "
+                    "operands",
+                    name_, codename_));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
             {
-                // a should not be empty
-                if (args[0].matrix().rows() == 0 ||
-                    args[0].matrix().columns() == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmax::argmin2d",
-                        generate_error_message(
-                            "attempt to get argmax of an empty sequence",
-                            name_, codename_));
-                }
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "argmin::eval",
+                    execution_tree::generate_error_message(
+                        "the argmin primitive requires that the "
+                        "arguments given by the operands array are "
+                        "valid",
+                        name_, codename_));
+            }
+        }
 
-                // `axis` is optional
-                if (args.size() == 1)
-                {
-                    // Option 1: Flatten and find min
-                    return argmin2d_flatten(std::move(args[0]));
-                }
 
-                // `axis` must be a scalar if provided
-                if (args[1].num_dimensions() != 0)
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](args_type&& args) -> primitive_argument_type
+            {
+                std::size_t a_dims = args[0].num_dimensions();
+                switch (a_dims)
                 {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmin::argmin2d",
-                        generate_error_message(
-                            "operand axis must be a scalar", name_, codename_));
-                }
-                const int axis = args[1].scalar();
-                // `axis` can only be -2, -1, 0, or 1
-                if (axis < -2 || axis > 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmin::argmin2d",
-                        generate_error_message(
-                            "operand axis can only between -2 and 1 for an a "
-                            "operand that is 2d",
-                            name_, codename_));
-                }
-                switch (axis)
-                {
-                // Option 2: Find min among rows
-                case -2: HPX_FALLTHROUGH;
                 case 0:
-                    return argmin2d_x_axis(std::move(args[0]));
+                    return this_->argmin0d(std::move(args));
 
-                // Option 3: Find min among columns
-                case -1: HPX_FALLTHROUGH;
                 case 1:
-                    return argmin2d_y_axis(std::move(args[0]));
+                    return this_->argmin1d(std::move(args));
+
+                case 2:
+                    return this_->argmin2d(std::move(args));
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "argmin::argmin2d",
-                        generate_error_message(
-                            "operand a has an invalid number of "
-                            "dimensions",
-                            name_, codename_));
-                }
-
-
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.empty() || operands.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "argmin::eval",
-                        generate_error_message(
-                            "the argmin primitive requires exactly one or two "
-                            "operands",
-                            name_, codename_));
+                        execution_tree::generate_error_message(
+                            "operand a has an invalid "
+                            "number of dimensions",
+                            this_->name_, this_->codename_));
                 }
-
-                for (auto const& i : operands)
-                {
-                    if (!valid(i))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "argmin::eval",
-                            generate_error_message(
-                                "the argmin primitive requires that the "
-                                "arguments given by the operands array are "
-                                "valid",
-                                name_, codename_));
-                    }
-                }
-
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type&& args) -> primitive_argument_type
-                    {
-                        std::size_t a_dims = args[0].num_dimensions();
-                        switch (a_dims)
-                        {
-                        case 0:
-                            return this_->argmin0d(std::move(args));
-
-                        case 1:
-                            return this_->argmin1d(std::move(args));
-
-                        case 2:
-                            return this_->argmin2d(std::move(args));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "argmin::eval",
-                                generate_error_message(
-                                    "operand a has an invalid "
-                                    "number of dimensions",
-                                    this_->name_, this_->codename_));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
     }
 
     hpx::future<primitive_argument_type> argmin::eval(
@@ -343,10 +322,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::argmin>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::argmin>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -6,6 +6,8 @@
 set(tests
     add_operation
     and_operation
+    argmin
+    argmax
     block_operation
     column_set
     column_slicing

--- a/tests/unit/execution_tree/primitives/argmax.cpp
+++ b/tests/unit/execution_tree/primitives/argmax.cpp
@@ -10,11 +10,162 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
+
 #include <blaze/Math.h>
+
+void test_argmax_0d()
+{
+    int s1 = 10;
+
+    std::size_t expected = 0ul;
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(s1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmax(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_argmax_1d()
+{
+    blaze::DynamicVector<double> v1{ 1.0, 2.0, 3.0, 1.0 };
+
+    std::size_t expected = 2;
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmax(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_argmax_2d_flat()
+{
+    blaze::DynamicMatrix<double> m1{{ 1.0, 2.0, 3.0 }, { 4.0, 5.0, 6.0 }};
+
+    std::size_t expected = 5;
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmax(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_argmax_2d_x_axis()
+{
+    using arg_type = phylanx::execution_tree::primitive_argument_type;
+
+    blaze::DynamicMatrix<double> m1{ { 1.0, 2.0, 3.0 },{ 4.0, 5.0, 6.0 } };
+
+    std::vector<arg_type> expected{
+        arg_type{static_cast<std::int64_t>(2)},
+        arg_type{static_cast<std::int64_t>(2)}};
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(0));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmax(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs), std::move(rhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+    auto actual = phylanx::execution_tree::extract_list_value(f.get());
+
+    HPX_TEST_EQ(expected, actual);
+}
+
+void test_argmax_2d_y_axis()
+{
+    using arg_type = phylanx::execution_tree::primitive_argument_type;
+
+    blaze::DynamicMatrix<double> m1{ { 1.0, 2.0, 3.0 },{ 4.0, 5.0, 6.0 } };
+
+    std::vector<arg_type> expected{
+        arg_type{static_cast<std::int64_t>(1)},
+        arg_type{static_cast<std::int64_t>(1)},
+        arg_type{static_cast<std::int64_t>(1)}};
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmax(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs), std::move(rhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+    auto actual = phylanx::execution_tree::extract_list_value(f.get());
+
+    HPX_TEST_EQ(expected, actual);
+}
 
 int main(int argc, char* argv[])
 {
+    test_argmax_0d();
+    test_argmax_1d();
+    test_argmax_2d_flat();
+    test_argmax_2d_x_axis();
+    test_argmax_2d_y_axis();
+
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/argmax.cpp
+++ b/tests/unit/execution_tree/primitives/argmax.cpp
@@ -1,0 +1,20 @@
+//   Copyright (c) 2018 Parsa Amini
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <utility>
+#include <vector>
+#include <blaze/Math.h>
+
+int main(int argc, char* argv[])
+{
+    return hpx::util::report_errors();
+}

--- a/tests/unit/execution_tree/primitives/argmin.cpp
+++ b/tests/unit/execution_tree/primitives/argmin.cpp
@@ -10,11 +10,161 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstddef>
 #include <utility>
 #include <vector>
+
 #include <blaze/Math.h>
+
+void test_argmin_0d()
+{
+    int s1 = 10;
+
+    std::size_t expected = 0ul;
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(s1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmin(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_argmin_1d()
+{
+    blaze::DynamicVector<double> v1{ 1.0, 2.0, 3.0, -1.0 };
+
+    std::size_t expected = 3;
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmin(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_argmin_2d_flat()
+{
+    blaze::DynamicMatrix<double> m1{ { 1.0, 2.0, 3.0 },{ 4.0, 5.0, -6.0 } };
+
+    std::size_t expected = 5;
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmin(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_argmin_2d_x_axis()
+{
+    using arg_type = phylanx::execution_tree::primitive_argument_type;
+
+    blaze::DynamicMatrix<double> m1{ { 1.0, 2.0, -3.0 },{ 4.0, 5.0, -6.0 } };
+
+    std::vector<arg_type> expected{
+        arg_type{static_cast<std::int64_t>(2)},
+        arg_type{static_cast<std::int64_t>(2)}};
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(0));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmin(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs), std::move(rhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+    auto actual = phylanx::execution_tree::extract_list_value(f.get());
+
+    HPX_TEST_EQ(expected, actual);
+}
+
+void test_argmin_2d_y_axis()
+{
+    using arg_type = phylanx::execution_tree::primitive_argument_type;
+
+    blaze::DynamicMatrix<double> m1{ { 1.0, 2.0, 3.0 },{ 4.0, 5.0, 6.0 } };
+
+    std::vector<arg_type> expected{
+        arg_type{static_cast<std::int64_t>(0)},
+        arg_type{static_cast<std::int64_t>(0)},
+        arg_type{static_cast<std::int64_t>(0)} };
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive rhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_argmin(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs), std::move(rhs)
+    });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        p.eval();
+
+    auto actual = phylanx::execution_tree::extract_list_value(f.get());
+
+    HPX_TEST_EQ(expected, actual);
+}
 
 int main(int argc, char* argv[])
 {
+    test_argmin_0d();
+    test_argmin_1d();
+    test_argmin_2d_flat();
+    test_argmin_2d_x_axis();
+    test_argmin_2d_y_axis();
+
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/primitives/argmin.cpp
+++ b/tests/unit/execution_tree/primitives/argmin.cpp
@@ -11,6 +11,7 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <utility>
 #include <vector>
 

--- a/tests/unit/execution_tree/primitives/argmin.cpp
+++ b/tests/unit/execution_tree/primitives/argmin.cpp
@@ -1,0 +1,20 @@
+//   Copyright (c) 2018 Parsa Amini
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <utility>
+#include <vector>
+#include <blaze/Math.h>
+
+int main(int argc, char* argv[])
+{
+    return hpx::util::report_errors();
+}

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    matrix_iterators
     performance_data
     serialization_variant
    )

--- a/tests/unit/util/matrix_iterators.cpp
+++ b/tests/unit/util/matrix_iterators.cpp
@@ -1,0 +1,108 @@
+//  Copyright (c) 2018 Parsa Amini
+//  Copyright (c) 2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+
+#include <blaze/Math.h>
+
+void test_row_iterator_empty()
+{
+    blaze::DynamicMatrix<double> m1;
+
+    const phylanx::util::matrix_row_iterator<decltype(m1)> m1_begin(m1);
+    const phylanx::util::matrix_row_iterator<decltype(m1)> m1_end(
+        m1, m1.rows());
+
+    HPX_TEST(m1_begin == m1_end);
+}
+
+void test_row_iterator_iteration()
+{
+    blaze::DynamicMatrix<double> m1{{1, 2}, {3, 4}};
+
+    const phylanx::util::matrix_row_iterator<decltype(m1)> m1_begin(m1);
+    const phylanx::util::matrix_row_iterator<decltype(m1)> m1_end(
+        m1, m1.rows());
+
+    HPX_TEST(m1_begin != m1_end);
+
+    std::size_t count = 0ul;
+
+    for (auto it = m1_begin; it != m1_end; ++it)
+    {
+        ++count;
+    }
+
+    HPX_TEST_EQ(m1.rows(), count);
+}
+
+void test_row_iterator_dereference()
+{
+    blaze::DynamicMatrix<double> m1{{1, 2}, {3, 4}};
+
+    phylanx::util::matrix_row_iterator<decltype(m1)> it(m1, 1);
+
+    HPX_TEST(blaze::row(m1, 1) == *it);
+}
+
+void test_column_iterator_empty()
+{
+    blaze::DynamicMatrix<double> m1;
+
+    const phylanx::util::matrix_column_iterator<decltype(m1)> m1_begin(m1);
+    const phylanx::util::matrix_column_iterator<decltype(m1)> m1_end(
+        m1, m1.columns());
+
+    HPX_TEST(m1_begin == m1_end);
+}
+
+void test_column_iterator_iteration()
+{
+    blaze::DynamicMatrix<double> m1{{1, 2}, {3, 4}};
+
+    const phylanx::util::matrix_column_iterator<decltype(m1)> m1_begin(m1);
+    const phylanx::util::matrix_column_iterator<decltype(m1)> m1_end(
+        m1, m1.columns());
+
+    HPX_TEST(m1_begin != m1_end);
+
+    std::size_t count = 0ul;
+
+    for (auto it = m1_begin; it != m1_end; ++it)
+    {
+        ++count;
+    }
+
+    HPX_TEST_EQ(m1.columns(), count);
+}
+
+void test_column_iterator_dereference()
+{
+    blaze::DynamicMatrix<double> m1{{1, 2}, {3, 4}};
+
+    const phylanx::util::matrix_column_iterator<decltype(m1)> it(m1, 1);
+
+    HPX_TEST(blaze::column(m1, 1) == *it);
+}
+
+int main()
+{
+    test_row_iterator_empty();
+    test_row_iterator_iteration();
+    test_row_iterator_dereference();
+
+    test_column_iterator_empty();
+    test_column_iterator_iteration();
+    test_column_iterator_dereference();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This PR adds Argmin/Argmax primitives mentioned in #200.

It also includes iterators that allow iterating over `Row<T>`s and `Column<T>`s in a `Blaze::Matrix<T>`.