### PR TITLE
Refactor primitives to new style (2)

### DIFF
--- a/phylanx/execution_tree/primitives/constant.hpp
+++ b/phylanx/execution_tree/primitives/constant.hpp
@@ -49,7 +49,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             operand_type&& op, std::size_t dim) const;
         primitive_argument_type constant2d(operand_type&& op,
             operand_type::dimensions_type const& dim) const;
-
     };
 
     PHYLANX_EXPORT primitive create_constant(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/equal.hpp
+++ b/phylanx/execution_tree/primitives/equal.hpp
@@ -67,7 +67,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             operand_type&& lhs, operand_type&& rhs) const;
         primitive_argument_type equal_all(
             operand_type&& lhs, operand_type&& rhs) const;
-
     };
 
     PHYLANX_EXPORT primitive create_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/equal.hpp
+++ b/phylanx/execution_tree/primitives/equal.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_EQUAL_OCT_07_2017_0212PM)
 #define PHYLANX_PRIMITIVES_EQUAL_OCT_07_2017_0212PM
@@ -17,8 +17,18 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class equal : public primitive_component_base
+    class equal
+        : public primitive_component_base
+        , public std::enable_shared_from_this<equal>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<primitive_argument_type>;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +39,35 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct visit_equal;
+
+        primitive_argument_type equal0d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal0d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal1d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal1d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal1d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal2d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal2d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal2d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type equal_all(
+            operand_type&& lhs, operand_type&& rhs) const;
+
     };
 
     PHYLANX_EXPORT primitive create_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/exponential_operation.hpp
+++ b/phylanx/execution_tree/primitives/exponential_operation.hpp
@@ -21,7 +21,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     class exponential_operation
         : public primitive_component_base
-        , std::enable_shared_from_this<exponential_operation>
+        , public std::enable_shared_from_this<exponential_operation>
     {
     protected:
         hpx::future<primitive_argument_type> eval(

--- a/phylanx/execution_tree/primitives/exponential_operation.hpp
+++ b/phylanx/execution_tree/primitives/exponential_operation.hpp
@@ -1,7 +1,7 @@
-//   Copyright (c) 2017 Bibek Wagle
+// Copyright (c) 2017 Bibek Wagle
 //
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef PHYLANX_EXPONENTIAL_OPERATION_HPP_OCT031241PM
 #define PHYLANX_EXPONENTIAL_OPERATION_HPP_OCT031241PM
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class exponential_operation : public primitive_component_base
+    class exponential_operation
+        : public primitive_component_base
+        , std::enable_shared_from_this<exponential_operation>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type exponential0d(operands_type&& ops) const;
+        primitive_argument_type exponential1d(operands_type&& ops) const;
+        primitive_argument_type exponentialxd(operands_type&& ops) const;
     };
 
     PHYLANX_EXPORT primitive create_exponential_operation(

--- a/phylanx/execution_tree/primitives/extract_shape.hpp
+++ b/phylanx/execution_tree/primitives/extract_shape.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_EXTRACT_SHAPE_OCT_25_2017_1237PM)
 #define PHYLANX_PRIMITIVES_EXTRACT_SHAPE_OCT_25_2017_1237PM
@@ -9,16 +9,29 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class extract_shape : public primitive_component_base
+    class extract_shape
+        : public primitive_component_base
+        , public std::enable_shared_from_this<extract_shape>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args,
+            std::string const& name, std::string const& codename) const;
+
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +42,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        primitive_argument_type shape0d(args_type&& args) const;
+        primitive_argument_type shape1d(args_type&& args) const;
+        primitive_argument_type shape2d(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_extract_shape(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/file_write.hpp
+++ b/phylanx/execution_tree/primitives/file_write.hpp
@@ -39,7 +39,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::vector<primitive_argument_type> const& args) const override;
 
     private:
-        void write_to_file(primitive_argument_type const& val, std::string const filename) const;
+        void write_to_file(primitive_argument_type const& val,
+            std::string const& filename) const;
 
         std::string filename_;
         primitive_argument_type operand_;

--- a/phylanx/execution_tree/primitives/file_write.hpp
+++ b/phylanx/execution_tree/primitives/file_write.hpp
@@ -12,13 +12,21 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class file_write : public primitive_component_base
+    class file_write
+        : public primitive_component_base
+        , std::enable_shared_from_this<file_write>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +37,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        void write_to_file(primitive_argument_type const& val, std::string const filename) const;
+
+        std::string filename_;
+        primitive_argument_type operand_;
     };
 
     PHYLANX_EXPORT primitive create_file_write(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/file_write.hpp
+++ b/phylanx/execution_tree/primitives/file_write.hpp
@@ -20,7 +20,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     class file_write
         : public primitive_component_base
-        , std::enable_shared_from_this<file_write>
+        , public std::enable_shared_from_this<file_write>
     {
     protected:
         hpx::future<primitive_argument_type> eval(

--- a/phylanx/execution_tree/primitives/file_write_csv.hpp
+++ b/phylanx/execution_tree/primitives/file_write_csv.hpp
@@ -19,7 +19,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     class file_write_csv
         : public primitive_component_base
-        , std::enable_shared_from_this<file_write_csv>
+        , public std::enable_shared_from_this<file_write_csv>
     {
     protected:
         hpx::future<primitive_argument_type> eval(

--- a/phylanx/execution_tree/primitives/file_write_csv.hpp
+++ b/phylanx/execution_tree/primitives/file_write_csv.hpp
@@ -17,8 +17,14 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class file_write_csv : public primitive_component_base
+    class file_write_csv
+        : public primitive_component_base
+        , std::enable_shared_from_this<file_write_csv>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +35,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+    private:
+        void write_to_file_csv(ir::node_data<double> const& val,
+            std::string const& filename) const;
     };
 
     PHYLANX_EXPORT primitive create_file_write_csv(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/file_write_hdf5.hpp
+++ b/phylanx/execution_tree/primitives/file_write_hdf5.hpp
@@ -19,8 +19,15 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class file_write_hdf5 : public primitive_component_base
+    class file_write_hdf5
+        : public primitive_component_base
+        , public std::enable_shared_from_this<file_write_hdf5>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -31,6 +38,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        void write_to_file_hdf5(ir::node_data<double> const& val,
+            std::string const& filename, std::string const& dataset_name) const;
     };
 
     PHYLANX_EXPORT primitive create_file_write_hdf5(

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/equal.hpp>
@@ -47,357 +47,336 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type equal::equal0d1d(
+        operand_type&& lhs, operand_type&& rhs) const
     {
-        struct equal : std::enable_shared_from_this<equal>
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
         {
-            equal(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+            rhs = blaze::map(rhs.vector(),
+                [&](double x) { return (x == lhs.scalar()); });
+        }
+        else
+        {
+            rhs.vector() = blaze::map(rhs.vector(),
+                [&](double x) { return (x == lhs.scalar()); });
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
 
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<primitive_argument_type>;
+    primitive_argument_type equal::equal0d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            rhs = blaze::map(rhs.matrix(),
+                [&](double x) { return (x == lhs.scalar()); });
+        }
+        else
+        {
+            rhs.matrix() = blaze::map(rhs.matrix(),
+                [&](double x) { return (x == lhs.scalar()); });
+        }
 
-            primitive_argument_type equal0d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.vector(),
-                        [&](double x) { return (x == lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.vector() = blaze::map(rhs.vector(),
-                        [&](double x) { return (x == lhs.scalar()); });
-                }
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
+    primitive_argument_type equal::equal0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs.scalar() == rhs.scalar()});
 
-            primitive_argument_type equal0d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x == lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.matrix() = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x == lhs.scalar()); });
-                }
+        case 1:
+            return equal0d1d(std::move(lhs), std::move(rhs));
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
+        case 2:
+            return equal0d2d(std::move(lhs), std::move(rhs));
 
-            primitive_argument_type equal0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs.scalar() == rhs.scalar()});
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal0d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of dimensions",
+                    name_, codename_));
+        }
+    }
 
-                case 1:
-                    return equal0d1d(std::move(lhs), std::move(rhs));
+    primitive_argument_type equal::equal1d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(),
+                [&](double x) { return (x == rhs.scalar()); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(),
+                [&](double x) { return (x == rhs.scalar()); });
+        }
 
-                case 2:
-                    return equal0d2d(std::move(lhs), std::move(rhs));
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
 
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal0d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
+    primitive_argument_type equal::equal1d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
 
-            primitive_argument_type equal1d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(),
-                        [&](double x) { return (x == rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(),
-                        [&](double x) { return (x == rhs.scalar()); });
-                }
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal1d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x == y); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x == y); });
+        }
 
-            primitive_argument_type equal1d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
 
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal1d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+    primitive_argument_type equal::equal1d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = lhs.vector();
+        auto cm = rhs.matrix();
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x == y); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x == y); });
-                }
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal1d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
 
-            primitive_argument_type equal1d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = lhs.vector();
-                auto cm = rhs.matrix();
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x == y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
 
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal1d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x == y; });
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+    primitive_argument_type equal::equal1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return equal1d0d(std::move(lhs), std::move(rhs));
 
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x == y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
+        case 1:
+            return equal1d1d(std::move(lhs), std::move(rhs));
 
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x == y; });
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
+        case 2:
+            return equal1d2d(std::move(lhs), std::move(rhs));
 
-            primitive_argument_type equal1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return equal1d0d(std::move(lhs), std::move(rhs));
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal1d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
 
-                case 1:
-                    return equal1d1d(std::move(lhs), std::move(rhs));
+    primitive_argument_type equal::equal2d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
 
-                case 2:
-                    return equal1d2d(std::move(lhs), std::move(rhs));
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(),
+                [&](double x) { return (x == rhs.scalar()); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(),
+                [&](double x) { return (x == rhs.scalar()); });
+        }
 
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal1d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
 
-            primitive_argument_type equal2d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
+    primitive_argument_type equal::equal2d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = rhs.vector();
+        auto cm = lhs.matrix();
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x == rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x == rhs.scalar()); });
-                }
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal2d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
 
-            primitive_argument_type equal2d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = rhs.vector();
-                auto cm = lhs.matrix();
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x == y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
 
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal2d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x == y; });
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
 
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x == y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
+    primitive_argument_type equal::equal2d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
 
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x == y; });
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal2d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x == y); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x == y); });
+        }
 
-            primitive_argument_type equal2d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto lhs_size = lhs.dimensions();
-                auto rhs_size = rhs.dimensions();
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
 
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal2d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+    primitive_argument_type equal::equal2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return equal2d0d(std::move(lhs), std::move(rhs));
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x == y); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x == y); });
-                }
+        case 1:
+            return equal2d1d(std::move(lhs), std::move(rhs));
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        case 2:
+            return equal2d2d(std::move(lhs), std::move(rhs));
 
-            primitive_argument_type equal2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return equal2d0d(std::move(lhs), std::move(rhs));
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal2d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
 
-                case 1:
-                    return equal2d1d(std::move(lhs), std::move(rhs));
+    primitive_argument_type equal::equal_all(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return equal0d(std::move(lhs), std::move(rhs));
 
-                case 2:
-                    return equal2d2d(std::move(lhs), std::move(rhs));
+        case 1:
+            return equal1d(std::move(lhs), std::move(rhs));
 
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal2d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
+        case 2:
+            return equal2d(std::move(lhs), std::move(rhs));
 
-        public:
-            primitive_argument_type equal_all(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_dims = lhs.num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return equal0d(std::move(lhs), std::move(rhs));
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::equal_all",
+                execution_tree::generate_error_message(
+                    "left hand side operand has unsupported number "
+                        "of dimensions",
+                    name_, codename_));
+        }
+    }
 
-                case 1:
-                    return equal1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return equal2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::equal_all",
-                        generate_error_message(
-                            "left hand side operand has unsupported number "
-                                "of dimensions",
-                            name_, codename_));
-                }
-            }
-
-     protected:
-            struct visit_equal
+            struct equal::visit_equal
             {
                 template <typename T1, typename T2>
                 primitive_argument_type operator()(T1, T2) const
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "equal::eval",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "left hand side and right hand side are "
                                 "incompatible and can't be compared",
                             equal_.name_, equal_.codename_));
@@ -451,8 +430,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 equal const& equal_;
             };
 
-        public:
-            hpx::future<primitive_argument_type> eval(
+            hpx::future<primitive_argument_type> equal::eval(
                 std::vector<primitive_argument_type> const& operands,
                 std::vector<primitive_argument_type> const& args) const
             {
@@ -460,7 +438,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "equal::eval",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the equal primitive requires exactly two operands",
                             name_, codename_));
                 }
@@ -469,7 +447,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "equal::eval",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the equal primitive requires that the arguments "
                                 "given by the operands array are valid",
                             name_, codename_));
@@ -488,8 +466,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         operands, functional::literal_operand{}, args,
                         name_, codename_));
             }
-        };
-    }
 
     // implement '==' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> equal::eval(
@@ -497,10 +473,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::equal>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::equal>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/exponential_operation.cpp
+++ b/src/execution_tree/primitives/exponential_operation.cpp
@@ -51,13 +51,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive_argument_type exponential_operation::exponential0d(operands_type&& ops) const
+    primitive_argument_type exponential_operation::exponential0d(
+        operands_type&& ops) const
     {
         ops[0] = double(std::exp(ops[0].scalar()));
         return primitive_argument_type{std::move(ops[0])};
     }
 
-    primitive_argument_type exponential_operation::exponential1d(operands_type&& ops) const
+    primitive_argument_type exponential_operation::exponential1d(
+        operands_type&& ops) const
     {
         using vector_type = blaze::DynamicVector<double>;
 
@@ -66,7 +68,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             ir::node_data<double>(std::move(result))};
     }
 
-    primitive_argument_type exponential_operation::exponentialxd(operands_type&& ops) const
+    primitive_argument_type exponential_operation::exponentialxd(
+        operands_type&& ops) const
     {
         using matrix_type = blaze::DynamicMatrix<double>;
 

--- a/src/execution_tree/primitives/exponential_operation.cpp
+++ b/src/execution_tree/primitives/exponential_operation.cpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2017 Bibek Wagle
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017 Bibek Wagle
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/exponential_operation.hpp>
@@ -51,117 +51,93 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type exponential_operation::exponential0d(operands_type&& ops) const
     {
-        struct exp : std::enable_shared_from_this<exp>
-        {
-            exp(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        private:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<operand_type>;
-
-        protected:
-            primitive_argument_type exponential0d(operands_type&& ops) const
-            {
-                ops[0] = double(std::exp(ops[0].scalar()));
-                return primitive_argument_type{std::move(ops[0])};
-            }
-
-            primitive_argument_type exponential1d(operands_type&& ops) const
-            {
-                using vector_type = blaze::DynamicVector<double>;
-
-                vector_type result = blaze::exp(ops[0].vector());
-                return primitive_argument_type{
-                    ir::node_data<double>(std::move(result))};
-            }
-
-            primitive_argument_type exponentialxd(operands_type&& ops) const
-            {
-                using matrix_type = blaze::DynamicMatrix<double>;
-
-                matrix_type result = blaze::exp(ops[0].matrix());
-                return primitive_argument_type{
-                    ir::node_data<double>(std::move(result))};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "exponential_operation::eval",
-                        generate_error_message(
-                            "the exponential_operation primitive requires"
-                                "exactly one operand",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "exponential_operation::eval",
-                        generate_error_message(
-                            "the exponential_operation primitive requires "
-                                "that the arguments given by the operands "
-                                "array is valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type&& ops) -> primitive_argument_type
-                    {
-                        std::size_t dims = ops[0].num_dimensions();
-                        switch (dims)
-                        {
-                        case 0:
-                            return this_->exponential0d(std::move(ops));
-
-                        case 1:
-                            return this_->exponential1d(std::move(ops));
-
-                        case 2:
-                            return this_->exponentialxd(std::move(ops));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "exponential_operation::eval",
-                                generate_error_message(
-                                    "left hand side operand has unsupported "
-                                        "number of dimensions",
-                                    this_->name_, this_->codename_));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        ops[0] = double(std::exp(ops[0].scalar()));
+        return primitive_argument_type{std::move(ops[0])};
     }
 
-    // implement 'exp' for all possible combinations of lhs and rhs
+    primitive_argument_type exponential_operation::exponential1d(operands_type&& ops) const
+    {
+        using vector_type = blaze::DynamicVector<double>;
+
+        vector_type result = blaze::exp(ops[0].vector());
+        return primitive_argument_type{
+            ir::node_data<double>(std::move(result))};
+    }
+
+    primitive_argument_type exponential_operation::exponentialxd(operands_type&& ops) const
+    {
+        using matrix_type = blaze::DynamicMatrix<double>;
+
+        matrix_type result = blaze::exp(ops[0].matrix());
+        return primitive_argument_type{
+            ir::node_data<double>(std::move(result))};
+    }
+
+    hpx::future<primitive_argument_type> exponential_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "exponential_operation::eval",
+                execution_tree::generate_error_message(
+                    "the exponential_operation primitive requires"
+                        "exactly one operand",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "exponential_operation::eval",
+                execution_tree::generate_error_message(
+                    "the exponential_operation primitive requires "
+                        "that the arguments given by the operands "
+                        "array is valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type&& ops) -> primitive_argument_type
+            {
+                std::size_t dims = ops[0].num_dimensions();
+                switch (dims)
+                {
+                case 0:
+                    return this_->exponential0d(std::move(ops));
+
+                case 1:
+                    return this_->exponential1d(std::move(ops));
+
+                case 2:
+                    return this_->exponentialxd(std::move(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "exponential_operation::eval",
+                        execution_tree::generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions",
+                            this_->name_, this_->codename_));
+                }
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    // Implement 'exp' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> exponential_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::exp>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::exp>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -47,115 +47,89 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
-    namespace detail
+    void file_write::write_to_file(
+        primitive_argument_type const& val, std::string const filename) const
     {
-        struct file_write : std::enable_shared_from_this<file_write>
+        std::ofstream outfile(filename.c_str(),
+            std::ios::binary | std::ios::out | std::ios::trunc);
+        if (!outfile.is_open())
         {
-            file_write(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::eval",
+                execution_tree::generate_error_message(
+                    "couldn't open file: " + filename,
+                    name_, codename_));
+        }
+
+        std::vector<char> data = phylanx::util::serialize(val);
+        if (!outfile.write(data.data(), data.size()))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::eval",
+                execution_tree::generate_error_message(
+                    "couldn't read expected number of bytes from file: " +
+                        filename,
+                    name_, codename_));
+        }
+    }
+
+    hpx::future<primitive_argument_type> file_write::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::eval",
+                execution_tree::generate_error_message(
+                    "the file_write primitive requires exactly two "
+                    "operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::eval",
+                execution_tree::generate_error_message(
+                    "the file_write primitive requires that the "
+                    "given operands are valid",
+                    name_, codename_));
+        }
+
+        std::string filename =
+            string_operand_sync(operands[0], args, name_, codename_);
+
+        auto this_ = this->shared_from_this();
+        return literal_operand(operands[1], args, name_, codename_)
+            .then(hpx::util::unwrapping(
+                [this_, filename](primitive_argument_type && val)
+                ->  primitive_argument_type
+        {
+            if (!valid(val))
             {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "file_write::eval",
+                    execution_tree::generate_error_message(
+                        "the file_write primitive requires that the argument "
+                        "value given by the operand is non-empty",
+                        this_->name_, this_->codename_));
             }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            void write_to_file(primitive_argument_type const& val)
-            {
-                std::ofstream outfile(filename_.c_str(),
-                    std::ios::binary | std::ios::out | std::ios::trunc);
-                if (!outfile.is_open())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::eval",
-                        generate_error_message(
-                            "couldn't open file: " + filename_,
-                            name_, codename_));
-                }
-
-                std::vector<char> data = phylanx::util::serialize(val);
-                if (!outfile.write(data.data(), data.size()))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::eval",
-                        generate_error_message(
-                            "couldn't read expected number of bytes from "
-                                "file: " + filename_,
-                            name_, codename_));
-                }
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::"
-                            "eval",
-                        generate_error_message(
-                            "the file_write primitive requires exactly two "
-                                "operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::"
-                            "eval",
-                        generate_error_message(
-                            "the file_write primitive requires that the "
-                                "given operands are valid",
-                            name_, codename_));
-                }
-
-                filename_ =
-                    string_operand_sync(operands[0], args, name_, codename_);
-
-                auto this_ = this->shared_from_this();
-                return literal_operand(operands[1], args, name_, codename_)
-                    .then(hpx::util::unwrapping(
-                        [this_](primitive_argument_type && val)
-                        ->  primitive_argument_type
-                        {
-                            if (!valid(val))
-                            {
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "file_write::eval",
-                                    generate_error_message(
-                                        "the file_write primitive requires "
-                                            "that the argument value given "
-                                            "by the operand is non-empty",
-                                    this_->name_, this_->codename_));
-                            }
-
-                            this_->write_to_file(val);
-                            return primitive_argument_type(std::move(val));
-                        }));
-            }
-
-        private:
-            std::string filename_;
-            primitive_argument_type operand_;
-        };
+            this_->write_to_file(val, std::move(filename));
+            return primitive_argument_type(std::move(val));
+        }));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    // write data to given file and return content
+    // Write data to given file and return content
     hpx::future<primitive_argument_type> file_write::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::file_write>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::file_write>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -48,7 +48,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     void file_write::write_to_file(
-        primitive_argument_type const& val, std::string const filename) const
+        primitive_argument_type const& val, std::string const& filename) const
     {
         std::ofstream outfile(filename.c_str(),
             std::ios::binary | std::ios::out | std::ios::trunc);
@@ -103,7 +103,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return literal_operand(operands[1], args, name_, codename_)
             .then(hpx::util::unwrapping(
-                [this_, filename](primitive_argument_type && val)
+                [this_, &filename](primitive_argument_type && val)
                 ->  primitive_argument_type
         {
             if (!valid(val))

--- a/src/execution_tree/primitives/file_write.cpp
+++ b/src/execution_tree/primitives/file_write.cpp
@@ -103,8 +103,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return literal_operand(operands[1], args, name_, codename_)
             .then(hpx::util::unwrapping(
-                [this_, &filename](primitive_argument_type && val)
-                ->  primitive_argument_type
+                [this_, filename = std::move(filename)](
+                    primitive_argument_type && val) ->  primitive_argument_type
         {
             if (!valid(val))
             {

--- a/src/execution_tree/primitives/file_write_csv.cpp
+++ b/src/execution_tree/primitives/file_write_csv.cpp
@@ -135,8 +135,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return numeric_operand(operands[1], args, name_, codename_)
             .then(hpx::util::unwrapping(
-                [this_, &filename](ir::node_data<double> && val)
-                ->  primitive_argument_type
+                [this_, filename = std::move(filename)](
+                    ir::node_data<double> && val) ->  primitive_argument_type
                 {
                     this_->write_to_file_csv(val, std::move(filename));
                     return primitive_argument_type(std::move(val));

--- a/src/execution_tree/primitives/file_write_csv.cpp
+++ b/src/execution_tree/primitives/file_write_csv.cpp
@@ -47,121 +47,100 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     }
 
-    namespace detail
+    void file_write_csv::write_to_file_csv(
+        ir::node_data<double> const& val, std::string const& filename) const
     {
-        struct file_write_csv : std::enable_shared_from_this<file_write_csv>
+        std::ofstream outfile(
+            filename.c_str(), std::ios::out | std::ios::trunc);
+        if (!outfile.is_open())
         {
-            file_write_csv(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "file_write_csv::eval",
+                execution_tree::generate_error_message(
+                    "couldn't open file: " + filename,
+                    name_, codename_));
+        }
+
+        outfile << std::setprecision(
+            std::numeric_limits<long double>::digits10 + 1);
+        outfile << std::scientific;
+
+        switch (val.num_dimensions())
+        {
+        case 0:
+            outfile << val.scalar() << '\n';
+            break;
+
+        case 1:
             {
-            }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            void write_to_file_csv(ir::node_data<double> const& val)
-            {
-                std::ofstream outfile(
-                    filename_.c_str(), std::ios::out | std::ios::trunc);
-                if (!outfile.is_open())
+                auto v = val.vector();
+                for (std::size_t i = 0UL; i != v.size(); ++i)
                 {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "file_write_csv::eval",
-                        generate_error_message(
-                            "couldn't open file: " + filename_,
-                            name_, codename_));
-                }
-
-                outfile << std::setprecision(
-                    std::numeric_limits<long double>::digits10 + 1);
-                outfile << std::scientific;
-
-                switch (val.num_dimensions())
-                {
-                case 0:
-                    outfile << val.scalar() << '\n';
-                    break;
-
-                case 1:
+                    if (i != 0)
                     {
-                        auto v = val.vector();
-                        for (std::size_t i = 0UL; i != v.size(); ++i)
-                        {
-                            if (i != 0)
-                            {
-                                outfile << ',';
-                            }
-                            outfile << v[i];
-                        }
-                        outfile << '\n';
+                        outfile << ',';
                     }
-                    break;
-
-                case 2:
-                    {
-                        auto matrix = val.matrix();
-                        for (std::size_t i = 0UL; i != matrix.rows(); ++i)
-                        {
-                            outfile << matrix(i, 0);
-                            for (std::size_t j = 1UL; j != matrix.columns(); ++j)
-                            {
-                                outfile << ',' << matrix(i, j);
-                            }
-                            outfile << '\n';
-                        }
-                    }
-                    break;
+                    outfile << v[i];
                 }
+                outfile << '\n';
             }
+            break;
 
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
+        case 2:
             {
-                if (operands.size() != 2)
+                auto matrix = val.matrix();
+                for (std::size_t i = 0UL; i != matrix.rows(); ++i)
                 {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::"
-                            "file_write_csv",
-                        generate_error_message(
-                            "the file_write primitive requires exactly two "
-                                "operands",
-                            name_, codename_));
+                    outfile << matrix(i, 0);
+                    for (std::size_t j = 1UL; j != matrix.columns(); ++j)
+                    {
+                        outfile << ',' << matrix(i, j);
+                    }
+                    outfile << '\n';
                 }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::"
-                            "file_write_csv",
-                        generate_error_message("the file_write primitive "
-                            "requires that the given operands are valid",
-                            name_, codename_));
-                }
-
-                filename_ =
-                    string_operand_sync(operands[0], args, name_, codename_);
-
-                auto this_ = this->shared_from_this();
-                return numeric_operand(operands[1], args, name_, codename_)
-                    .then(hpx::util::unwrapping(
-                        [this_](ir::node_data<double> && val)
-                        ->  primitive_argument_type
-                        {
-                            this_->write_to_file_csv(val);
-                            return primitive_argument_type(std::move(val));
-                        }));
             }
+            break;
+        }
+    }
 
-        private:
-            std::string filename_;
-            primitive_argument_type operand_;
-        };
+    hpx::future<primitive_argument_type> file_write_csv::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::"
+                    "file_write_csv",
+                execution_tree::generate_error_message(
+                    "the file_write primitive requires exactly two "
+                        "operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::"
+                    "file_write_csv",
+                execution_tree::generate_error_message("the file_write primitive "
+                    "requires that the given operands are valid",
+                    name_, codename_));
+        }
+
+        std::string filename =
+            string_operand_sync(operands[0], args, name_, codename_);
+
+        auto this_ = this->shared_from_this();
+        return numeric_operand(operands[1], args, name_, codename_)
+            .then(hpx::util::unwrapping(
+                [this_, &filename](ir::node_data<double> && val)
+                ->  primitive_argument_type
+                {
+                    this_->write_to_file_csv(val, std::move(filename));
+                    return primitive_argument_type(std::move(val));
+                }));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -171,10 +150,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::file_write_csv>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::file_write_csv>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/file_write_hdf5.cpp
+++ b/src/execution_tree/primitives/file_write_hdf5.cpp
@@ -52,125 +52,102 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     }
 
-    namespace detail {
-        struct file_write_hdf5 : std::enable_shared_from_this<file_write_hdf5>
+    void file_write_hdf5::write_to_file_hdf5(ir::node_data<double> const& val,
+        std::string const& filename, std::string const& dataset_name) const
+    {
+        HighFive::File outfile(filename,
+            HighFive::File::ReadWrite | HighFive::File::Create |
+                HighFive::File::Truncate);
+
+        switch (val.num_dimensions())
         {
-            file_write_hdf5(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+        case 0:
             {
+                auto scalar = val.scalar();
+                HighFive::DataSet dataSet =
+                    outfile.createDataSet<double>(
+                        dataset_name, HighFive::DataSpace::From(scalar));
+                dataSet.write(scalar);
             }
+            break;
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            void write_to_file_hdf5(ir::node_data<double> const& val)
+        case 1:
             {
-                HighFive::File outfile(filename_,
-                    HighFive::File::ReadWrite | HighFive::File::Create |
-                        HighFive::File::Truncate);
-
-                switch (val.num_dimensions())
-                {
-                case 0:
-                    {
-                        auto scalar = val.scalar();
-                        HighFive::DataSet dataSet =
-                            outfile.createDataSet<double>(
-                                datasetName_, HighFive::DataSpace::From(scalar));
-                        dataSet.write(scalar);
-                    }
-                    break;
-
-                case 1:
-                    {
-                        auto vector = val.vector();
-                        std::vector<std::size_t> dims(1);
-                        dims[0] = vector.size();
-                        HighFive::DataSet dataSet =
-                            outfile.createDataSet<double>(
-                                datasetName_, HighFive::DataSpace(dims));
-                        dataSet.write(vector);
-                    }
-                    break;
-
-                case 2:
-                    {
-                        auto matrix = val.matrix();
-                        std::vector<std::size_t> dims(2);
-                        dims[0] = matrix.rows();
-                        dims[1] = matrix.columns();
-                        HighFive::DataSet dataSet =
-                            outfile.createDataSet<double>(
-                                datasetName_, HighFive::DataSpace(dims));
-                        dataSet.write(matrix);
-                    }
-                    break;
-                }
+                auto vector = val.vector();
+                std::vector<std::size_t> dims(1);
+                dims[0] = vector.size();
+                HighFive::DataSet dataSet =
+                    outfile.createDataSet<double>(
+                        dataset_name, HighFive::DataSpace(dims));
+                dataSet.write(vector);
             }
+            break;
 
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
+        case 2:
             {
-                if (operands.size() != 3)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::"
-                            "file_write_hdf5",
-                        generate_error_message(
-                            "the file_write primitive requires exactly "
-                                "three operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]) ||
-                    !valid(operands[2]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::file_write::"
-                            "file_write_hdf5",
-                        generate_error_message(
-                            "the file_write primitive requires that the "
-                                "given operands are valid",
-                            name_, codename_));
-                }
-
-                filename_ =
-                    string_operand_sync(operands[0], args, name_, codename_);
-                datasetName_ =
-                    string_operand_sync(operands[1], args, name_, codename_);
-
-                auto this_ = this->shared_from_this();
-                return numeric_operand(operands[2], args, name_, codename_)
-                    .then(hpx::util::unwrapping(
-                        [this_](ir::node_data<double>&& val)
-                        -> primitive_argument_type
-                        {
-                            if (!valid(val))
-                            {
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "file_write_hdf5::eval",
-                                    generate_error_message(
-                                        "the file_write_hdf5 primitive requires "
-                                            "that the argument value given by "
-                                            "the operand is non-empty",
-                                        this_->name_, this_->codename_));
-                            }
-
-                            this_->write_to_file_hdf5(val);
-                            return primitive_argument_type(std::move(val));
-                        }));
+                auto matrix = val.matrix();
+                std::vector<std::size_t> dims(2);
+                dims[0] = matrix.rows();
+                dims[1] = matrix.columns();
+                HighFive::DataSet dataSet =
+                    outfile.createDataSet<double>(
+                        dataset_name, HighFive::DataSpace(dims));
+                dataSet.write(matrix);
             }
+            break;
+        }
+    }
 
-        private:
-            std::string filename_;
-            std::string datasetName_;
-            primitive_argument_type operand_;
-        };
+    hpx::future<primitive_argument_type> file_write_hdf5::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::file_write_hdf5",
+                execution_tree::generate_error_message(
+                    "the file_write primitive requires exactly three operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]) ||
+            !valid(operands[2]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::file_write::file_write_hdf5",
+                execution_tree::generate_error_message(
+                    "the file_write primitive requires that the given operands "
+                    "are valid",
+                    name_, codename_));
+        }
+
+        std::string filename =
+            string_operand_sync(operands[0], args, name_, codename_);
+        std::string dataset_name =
+            string_operand_sync(operands[1], args, name_, codename_);
+
+        auto this_ = this->shared_from_this();
+        return numeric_operand(operands[2], args, name_, codename_)
+            .then(hpx::util::unwrapping(
+                [this_, &filename, &dataset_name](ir::node_data<double>&& val)
+                -> primitive_argument_type
+                {
+                    if (!valid(val))
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "file_write_hdf5::eval",
+                            execution_tree::generate_error_message(
+                                "the file_write_hdf5 primitive requires that "
+                                "the argument value given by the operand is "
+                                "non-empty",
+                                this_->name_, this_->codename_));
+                    }
+
+                    this_->write_to_file_hdf5(val, std::move(filename),
+                        std::move(dataset_name));
+                    return primitive_argument_type(std::move(val));
+                }));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -180,11 +157,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::file_write_hdf5>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::file_write_hdf5>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}
 

--- a/src/execution_tree/primitives/file_write_hdf5.cpp
+++ b/src/execution_tree/primitives/file_write_hdf5.cpp
@@ -130,8 +130,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return numeric_operand(operands[2], args, name_, codename_)
             .then(hpx::util::unwrapping(
-                [this_, &filename, &dataset_name](ir::node_data<double>&& val)
-                -> primitive_argument_type
+                [this_, filename = std::move(filename),
+                    dataset_name = std::move(dataset_name)](
+                    ir::node_data<double>&& val) -> primitive_argument_type
                 {
                     if (!valid(val))
                     {


### PR DESCRIPTION
This PR refactors the following primitives to the new primitive structure:

- [x] `equal`
- [x] `exponential_operation`
- [x] `extract_shape`
- [x] `file_write`
- [x] `file_write_csv`
- [x] `file_write_hdf5`