### PR TITLE
Shuffle Primitive

### DIFF
--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -59,6 +59,7 @@
 #include <phylanx/execution_tree/primitives/row_set.hpp>
 #include <phylanx/execution_tree/primitives/row_slicing.hpp>
 #include <phylanx/execution_tree/primitives/set_operation.hpp>
+#include <phylanx/execution_tree/primitives/shuffle_operation.hpp>
 #include <phylanx/execution_tree/primitives/slicing_operation.hpp>
 #include <phylanx/execution_tree/primitives/square_root_operation.hpp>
 #include <phylanx/execution_tree/primitives/store_operation.hpp>

--- a/phylanx/execution_tree/primitives/shuffle_operation.hpp
+++ b/phylanx/execution_tree/primitives/shuffle_operation.hpp
@@ -14,6 +14,7 @@
 #include <hpx/lcos/future.hpp>
 
 #include <memory>
+#include <random>
 #include <string>
 #include <vector>
 
@@ -52,6 +53,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::vector<primitive_argument_type> const& params) const override;
 
     private:
+        static std::mt19937 rand_machine;
+
         primitive_argument_type shuffle_1d(args_type && args) const;
         primitive_argument_type shuffle_2d(args_type && args) const;
     };

--- a/phylanx/execution_tree/primitives/shuffle_operation.hpp
+++ b/phylanx/execution_tree/primitives/shuffle_operation.hpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_SHUFFLE_OPERATION_HPP)
+#define PHYLANX_SHUFFLE_OPERATION_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    /// \brief Randomly shuffles the elements of a PhySL list or the rows of a
+    /// PhySL matrix in place. Unlike [NumPy shuffle](
+    /// https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.random.shuffle.html)
+    /// it returns the shuffled matrix or list
+    ///
+    /// \returns The PhySL matrix or PhySL list that was shuffled in place
+    ///
+    /// \param args Is either a matrix or list of any values to be
+    /// randomly shuffled
+    class shuffle_operation
+      : public primitive_component_base
+      , public std::enable_shared_from_this<shuffle_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+
+    public:
+        static match_pattern_type const match_data;
+
+        shuffle_operation() = default;
+
+        shuffle_operation(std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        primitive_argument_type shuffle_1d(args_type && args) const;
+        primitive_argument_type shuffle_2d(args_type && args) const;
+    };
+
+    PHYLANX_EXPORT primitive create_shuffle_operation(
+        hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name = "", std::string const& codename = "");
+}}}
+
+#endif

--- a/phylanx/execution_tree/primitives/shuffle_operation.hpp
+++ b/phylanx/execution_tree/primitives/shuffle_operation.hpp
@@ -22,7 +22,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     /// \brief Randomly shuffles the elements of a PhySL list or the rows of a
     /// PhySL matrix in place. Unlike [NumPy shuffle](
-    /// https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.random.shuffle.html)
+    /// https://docs.scipy.org/doc/numpy-1.14.0/reference/generated/numpy.random
+    /// .shuffle.html)
     /// it returns the shuffled matrix or list
     ///
     /// \returns The PhySL matrix or PhySL list that was shuffled in place

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
-//  Copyright (c) 2017 Parsa Amini
+// Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017 Parsa Amini
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_IR_NODE_DATA_AUG_26_2017_0924AM)
 #define PHYLANX_IR_NODE_DATA_AUG_26_2017_0924AM

--- a/phylanx/util/matrix_iterators.hpp
+++ b/phylanx/util/matrix_iterators.hpp
@@ -7,6 +7,7 @@
 #if !defined(PHYLANX_MATRIX_ITERATORS)
 #define PHYLANX_MATRIX_ITERATORS
 
+#include <algorithm>
 #include <cstddef>
 #include <utility>
 

--- a/phylanx/util/matrix_iterators.hpp
+++ b/phylanx/util/matrix_iterators.hpp
@@ -50,6 +50,10 @@ namespace phylanx { namespace util
         {
             return blaze::row(data_, index_);
         }
+        std::ptrdiff_t distance_to(matrix_row_iterator const& other) const
+        {
+            return other.index_ - index_;
+        }
 
     private:
         T & data_;
@@ -93,6 +97,10 @@ namespace phylanx { namespace util
         blaze::Column<T> dereference() const
         {
             return blaze::column(data_, index_);
+        }
+        std::ptrdiff_t distance_to(matrix_column_iterator const& other) const
+        {
+            return other.index_ - index_;
         }
 
     private:

--- a/phylanx/util/matrix_iterators.hpp
+++ b/phylanx/util/matrix_iterators.hpp
@@ -1,17 +1,45 @@
-//  Copyright (c) 2018 Parsa Amini
-//  Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_MATRIX_ITERATORS)
 #define PHYLANX_MATRIX_ITERATORS
 
 #include <cstddef>
+#include <utility>
+
 #include <blaze/Math.h>
+
+namespace blaze
+{
+    // BADBAD: This overload of swap is necessary to work around the problems
+    //         caused by matrix_row_iterator not being a real random access
+    //         iterator. Dereferencing matrix_row_iterator does not yield a
+    //         true reference but only a temporary blaze::Row holding true
+    //         references.
+    //
+    // A real fix for this problem is proposed in PR0022R0
+    // (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0022r0.html)
+    //
+    template <typename T>
+    HPX_FORCEINLINE
+        void swap(Row<T>&& x, Row<T>&& y)
+    {
+        for (auto a = x.begin(), b = y.begin(); a != x.end() && b != y.end();
+             ++a, ++b)
+        {
+            using std::iter_swap;
+
+            iter_swap(a, b);
+        }
+    }
+}
 
 namespace phylanx { namespace util
 {
+
     template <typename T>
     class matrix_row_iterator
         : public hpx::util::iterator_facade<

--- a/phylanx/util/matrix_iterators.hpp
+++ b/phylanx/util/matrix_iterators.hpp
@@ -7,40 +7,16 @@
 #if !defined(PHYLANX_MATRIX_ITERATORS)
 #define PHYLANX_MATRIX_ITERATORS
 
-#include <algorithm>
 #include <cstddef>
 #include <utility>
 
+#include <hpx/include/util.hpp>
+
 #include <blaze/Math.h>
-
-namespace blaze
-{
-    // BADBAD: This overload of swap is necessary to work around the problems
-    //         caused by matrix_row_iterator not being a real random access
-    //         iterator. Dereferencing matrix_row_iterator does not yield a
-    //         true reference but only a temporary blaze::Row holding true
-    //         references.
-    //
-    // A real fix for this problem is proposed in PR0022R0
-    // (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0022r0.html)
-    //
-    template <typename T>
-    HPX_FORCEINLINE
-        void swap(Row<T>&& x, Row<T>&& y)
-    {
-        for (auto a = x.begin(), b = y.begin(); a != x.end() && b != y.end();
-             ++a, ++b)
-        {
-            using std::iter_swap;
-
-            iter_swap(a, b);
-        }
-    }
-}
 
 namespace phylanx { namespace util
 {
-
+    // NOTE: These iterators are not swappable.
     template <typename T>
     class matrix_row_iterator
         : public hpx::util::iterator_facade<

--- a/phylanx/util/matrix_iterators.hpp
+++ b/phylanx/util/matrix_iterators.hpp
@@ -22,7 +22,7 @@ namespace phylanx { namespace util
     {
     public:
         explicit matrix_row_iterator(T& t, const std::size_t index = 0)
-            : data_(t)
+            : data_(&t)
             , index_(index)
         {
         }
@@ -34,29 +34,34 @@ namespace phylanx { namespace util
         {
             ++index_;
         }
+
         void decrement()
         {
             --index_;
         }
+
         void advance(std::size_t n)
         {
             index_ += n;
         }
+
         bool equal(matrix_row_iterator const& other) const
         {
             return index_ == other.index_;
         }
+
         blaze::Row<T> dereference() const
         {
-            return blaze::row(data_, index_);
+            return blaze::row(*data_, index_);
         }
+
         std::ptrdiff_t distance_to(matrix_row_iterator const& other) const
         {
             return other.index_ - index_;
         }
 
     private:
-        T & data_;
+        T* data_;
         std::size_t index_;
     };
 
@@ -70,7 +75,7 @@ namespace phylanx { namespace util
     {
     public:
         explicit matrix_column_iterator(T& t, const std::size_t index = 0)
-            : data_(t)
+            : data_(&t)
             , index_(index)
         {
         }
@@ -82,29 +87,34 @@ namespace phylanx { namespace util
         {
             ++index_;
         }
+
         void decrement()
         {
             --index_;
         }
+
         void advance(std::size_t n)
         {
             index_ += n;
         }
+
         bool equal(matrix_column_iterator const& other) const
         {
             return index_ == other.index_;
         }
+
         blaze::Column<T> dereference() const
         {
-            return blaze::column(data_, index_);
+            return blaze::column(*data_, index_);
         }
+
         std::ptrdiff_t distance_to(matrix_column_iterator const& other) const
         {
             return other.index_ - index_;
         }
 
     private:
-        T & data_;
+        T* data_;
         std::size_t index_;
     };
 }}

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -66,6 +66,7 @@ namespace phylanx { namespace execution_tree
             primitives::inverse_operation::match_data,
             primitives::power_operation::match_data,
             primitives::random::match_data,
+            primitives::shuffle_operation::match_data,
             primitives::square_root_operation::match_data,
             primitives::transpose_operation::match_data,
             // variadic operations

--- a/src/execution_tree/primitives/shuffle_operation.cpp
+++ b/src/execution_tree/primitives/shuffle_operation.cpp
@@ -44,6 +44,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    std::mt19937 shuffle_operation::rand_machine{std::random_device{}()};
+
     shuffle_operation::shuffle_operation(
             std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename)
@@ -54,7 +56,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     primitive_argument_type shuffle_operation::shuffle_1d(args_type && args) const
     {
         auto x = args[0].vector();
-        std::shuffle(x.begin(), x.end(), std::mt19937{std::random_device{}()});
+        std::shuffle(x.begin(), x.end(), rand_machine);
 
         return primitive_argument_type(std::move(x));
     }
@@ -64,7 +66,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto x = args[0].matrix();
         auto x_begin = util::matrix_row_iterator<decltype(x)>(x);
         auto x_end = util::matrix_row_iterator<decltype(x)>(x, x.rows());
-        std::shuffle(x_begin, x_end, std::mt19937{std::random_device{}()});
+        std::shuffle(x_begin, x_end, rand_machine);
 
         return primitive_argument_type(std::move(x));
     }

--- a/src/execution_tree/primitives/shuffle_operation.cpp
+++ b/src/execution_tree/primitives/shuffle_operation.cpp
@@ -27,6 +27,17 @@
 //////////////////////////////////////////////////////////////////////////
 namespace blaze
 {
+    namespace _row_swap
+    {
+        using std::swap;
+
+        template <typename T>
+        void check_swap() noexcept(
+            noexcept(swap(std::declval<typename T::BaseType&>(),
+                std::declval<typename T::BaseType&>())))
+        {}
+    }
+
     // BADBAD: This overload of swap is necessary to work around the problems
     //         caused by matrix_row_iterator not being a real random access
     //         iterator. Dereferencing matrix_row_iterator does not yield a
@@ -36,14 +47,16 @@ namespace blaze
     // A real fix for this problem is proposed in PR0022R0
     // (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0022r0.html)
     //
+    using std::iter_swap;
+
     template <typename T>
-    void swap(Row<T>&& x, Row<T>&& y)
+    void swap(Row<T>&& x, Row<T>&& y) noexcept(
+        noexcept(_row_swap::check_swap<T>()) &&
+        noexcept(*std::declval<typename T::Iterator>()))
     {
         for (auto a = x.begin(), b = y.begin(); a != x.end() && b != y.end();
             ++a, ++b)
         {
-            using std::iter_swap;
-
             iter_swap(a, b);
         }
     }

--- a/src/execution_tree/primitives/shuffle_operation.cpp
+++ b/src/execution_tree/primitives/shuffle_operation.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/shuffle_operation.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_shuffle_operation(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+    {
+        static std::string type("shuffle_operation");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const shuffle_operation::match_data =
+    {
+        hpx::util::make_tuple("shuffle_operation",
+            std::vector<std::string>{"shuffle_operation(__1)", "'(__1)"},
+            &create_shuffle_operation, &create_primitive<shuffle_operation>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    shuffle_operation::shuffle_operation(
+            std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type shuffle_operation::shuffle_1d(args_type && args) const
+    {
+        auto x = args[0].vector();
+        std::shuffle(x.begin(), x.end(), std::mt19937{std::random_device{}()});
+
+        return primitive_argument_type(std::move(x));
+    }
+
+    primitive_argument_type shuffle_operation::shuffle_2d(args_type&& args) const
+    {
+        auto x = args[0].matrix();
+        auto x_begin = util::matrix_row_iterator<decltype(x)>(x);
+        auto x_end = util::matrix_row_iterator<decltype(x)>(x, x.rows());
+        std::shuffle(x_begin, x_end, std::mt19937{ std::random_device{}() });
+
+        return primitive_argument_type(std::move(x));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> shuffle_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "shuffle_operation::eval",
+                execution_tree::generate_error_message(
+                    "the shuffle_operation primitive requires that "
+                    "the arguments given by the operands array "
+                    "are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(
+            hpx::util::unwrapping(
+                [this_](args_type&& args) -> primitive_argument_type {
+                    std::size_t lhs_dims = args[0].num_dimensions();
+                    switch (lhs_dims)
+                    {
+                    case 1:
+                        return this_->shuffle_1d(std::move(args));
+
+                    case 2:
+                        return this_->shuffle_2d(std::move(args));
+
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "shuffle_operation::eval",
+                            execution_tree::generate_error_message(
+                                "operand has an unsupported number of "
+                                "dimensions. Only possible values are: 1 or 2.",
+                                this_->name_, this_->codename_));
+                    }
+                }),
+            detail::map_operands(operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    hpx::future<primitive_argument_type> shuffle_operation::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return eval(args, noargs);
+        }
+        return eval(operands_, args);
+    }
+}}}

--- a/src/execution_tree/primitives/shuffle_operation.cpp
+++ b/src/execution_tree/primitives/shuffle_operation.cpp
@@ -17,11 +17,37 @@
 #include <cstddef>
 #include <memory>
 #include <numeric>
+#include <random>
 #include <string>
 #include <utility>
 #include <vector>
 
 #include <blaze/Math.h>
+
+//////////////////////////////////////////////////////////////////////////
+namespace blaze
+{
+    // BADBAD: This overload of swap is necessary to work around the problems
+    //         caused by matrix_row_iterator not being a real random access
+    //         iterator. Dereferencing matrix_row_iterator does not yield a
+    //         true reference but only a temporary blaze::Row holding true
+    //         references.
+    //
+    // A real fix for this problem is proposed in PR0022R0
+    // (http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0022r0.html)
+    //
+    template <typename T>
+    void swap(Row<T>&& x, Row<T>&& y)
+    {
+        for (auto a = x.begin(), b = y.begin(); a != x.end() && b != y.end();
+            ++a, ++b)
+        {
+            using std::iter_swap;
+
+            iter_swap(a, b);
+        }
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree { namespace primitives

--- a/src/execution_tree/primitives/shuffle_operation.cpp
+++ b/src/execution_tree/primitives/shuffle_operation.cpp
@@ -64,7 +64,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto x = args[0].matrix();
         auto x_begin = util::matrix_row_iterator<decltype(x)>(x);
         auto x_end = util::matrix_row_iterator<decltype(x)>(x, x.rows());
-        std::shuffle(x_begin, x_end, std::mt19937{ std::random_device{}() });
+        std::shuffle(x_begin, x_end, std::mt19937{std::random_device{}()});
 
         return primitive_argument_type(std::move(x));
     }

--- a/src/execution_tree/primitives/variable.cpp
+++ b/src/execution_tree/primitives/variable.cpp
@@ -53,7 +53,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (!operands_.empty())
         {
-            operands_[0] = extract_copy_value(operands_[0]);
+            operands_[0] = extract_copy_value(std::move(operands_[0]));
         }
     }
 

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -45,6 +45,7 @@ set(tests
     row_set
     row_slicing
     set_operation
+    shuffle_operation
     slicing_operation
     square_root_operation
     store_operation

--- a/tests/unit/execution_tree/primitives/shuffle_operation.cpp
+++ b/tests/unit/execution_tree/primitives/shuffle_operation.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+#include <blaze/Math.h>
+
+void test_shuffle_operation_1d()
+{
+    using op_type = blaze::DynamicVector<double>;
+
+    blaze::Rand<op_type> gen{};
+    op_type v1 = gen.generate(100ul);
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(v1));
+
+    phylanx::ir::node_data<double> v2_node =
+        phylanx::execution_tree::extract_numeric_value(lhs.eval_direct());
+    op_type v2 = v2_node.vector();
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_shuffle_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
+    auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
+    auto actual_val = actual.vector();
+
+    // Is it the same l-value?
+    HPX_TEST_EQ(actual_val, v2);
+
+    // Has it changed?
+    //HPX_TEST_NEQ(actual_val, v1);
+
+    // Is it the same size
+    //HPX_TEST_EQ(actual_val.size(), v1.size());
+
+    //// Does it contain all the elements?
+    //for (double const& i : v1)
+    //{
+    //    //HPX_TEST_NEQ(std::find(actual_val.begin(), actual_val.end(), i), -1);
+    //}
+}
+
+void test_shuffle_operation_2d()
+{
+    using op_type = blaze::DynamicMatrix<double>;
+    using phylanx::util::matrix_row_iterator;
+
+    blaze::Rand<op_type> gen{};
+    op_type m1 = gen.generate(20ul, 20ul);
+    op_type m2 = m1;
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_shuffle_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+                std::move(lhs)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
+    auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
+    auto actual_val = actual.matrix();
+
+    // Is it the same l-value?
+    //HPX_TEST_EQ(actual_val, m1);
+
+    // Has it changed?
+    HPX_TEST_NEQ(actual_val, m2);
+
+    // Is it the same size
+    HPX_TEST_EQ(actual_val.rows(), m2.rows());
+    HPX_TEST_EQ(actual_val.columns(), m2.columns());
+
+    // Does it contain all the elements?
+    auto m2_end = matrix_row_iterator<op_type>(m2, m2.rows());
+
+    //// Does it contain all the elements?
+    //for (auto it = matrix_row_iterator<op_type>(m2); it != m2_end; ++it)
+    //{
+    //    /*HPX_TEST_NEQ(
+    //        std::find_if(
+    //            matrix_row_iterator<decltype(actual_val)>(actual_val),
+    //            matrix_row_iterator<decltype(actual_val)>(
+    //                actual_val, actual_val.rows()),
+    //            [&it](auto x) { return *x == *it; }),
+    //        -1);*/
+    //}
+}
+
+int main(int argc, char* argv[])
+{
+    test_shuffle_operation_1d();
+
+    test_shuffle_operation_2d();
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/execution_tree/primitives/shuffle_operation.cpp
+++ b/tests/unit/execution_tree/primitives/shuffle_operation.cpp
@@ -29,7 +29,7 @@ void test_shuffle_operation_1d()
 
     phylanx::ir::node_data<double> v2_node =
         phylanx::execution_tree::extract_numeric_value(lhs.eval_direct());
-    op_type v2 = v2_node.vector();
+    auto v2 = v2_node.vector();
 
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_shuffle_operation(
@@ -41,20 +41,21 @@ void test_shuffle_operation_1d()
     auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
     auto actual_val = actual.vector();
 
-    // Is it the same l-value?
+    // Does it have the same value as the p?
     HPX_TEST_EQ(actual_val, v2);
 
     // Has it changed?
-    //HPX_TEST_NEQ(actual_val, v1);
+    HPX_TEST_NEQ(actual_val, v1);
 
     // Is it the same size
-    //HPX_TEST_EQ(actual_val.size(), v1.size());
+    HPX_TEST_EQ(actual_val.size(), v1.size());
 
-    //// Does it contain all the elements?
-    //for (double const& i : v1)
-    //{
-    //    //HPX_TEST_NEQ(std::find(actual_val.begin(), actual_val.end(), i), -1);
-    //}
+    // Does it contain all the elements?
+    for (double const& i : v1)
+    {
+        HPX_TEST(std::find(actual_val.begin(), actual_val.end(), i) !=
+            actual_val.end());
+    }
 }
 
 void test_shuffle_operation_2d()
@@ -64,11 +65,14 @@ void test_shuffle_operation_2d()
 
     blaze::Rand<op_type> gen{};
     op_type m1 = gen.generate(20ul, 20ul);
-    op_type m2 = m1;
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<double>(m1));
+
+    phylanx::ir::node_data<double> m2_node =
+        phylanx::execution_tree::extract_numeric_value(lhs.eval_direct());
+    auto m2 = m2_node.matrix(); // auto is CustomMatrix of with a lot of template args
 
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_shuffle_operation(
@@ -80,30 +84,30 @@ void test_shuffle_operation_2d()
     auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
     auto actual_val = actual.matrix();
 
-    // Is it the same l-value?
-    //HPX_TEST_EQ(actual_val, m1);
+    // Does it have the same value as the p?
+    HPX_TEST_EQ(actual_val, m2);
 
     // Has it changed?
-    HPX_TEST_NEQ(actual_val, m2);
+    HPX_TEST_NEQ(actual_val, m1);
 
     // Is it the same size
     HPX_TEST_EQ(actual_val.rows(), m2.rows());
     HPX_TEST_EQ(actual_val.columns(), m2.columns());
 
     // Does it contain all the elements?
-    auto m2_end = matrix_row_iterator<op_type>(m2, m2.rows());
+    auto m2_end = matrix_row_iterator<decltype(m2)>(m2, m2.rows());
 
-    //// Does it contain all the elements?
-    //for (auto it = matrix_row_iterator<op_type>(m2); it != m2_end; ++it)
-    //{
-    //    /*HPX_TEST_NEQ(
-    //        std::find_if(
-    //            matrix_row_iterator<decltype(actual_val)>(actual_val),
-    //            matrix_row_iterator<decltype(actual_val)>(
-    //                actual_val, actual_val.rows()),
-    //            [&it](auto x) { return *x == *it; }),
-    //        -1);*/
-    //}
+    // Does it contain all the elements?
+    for (auto it = matrix_row_iterator<decltype(m2)>(m2); it != m2_end; ++it)
+    {
+        auto val = *it;
+        auto actual_val_begin = matrix_row_iterator<decltype(actual_val)>(
+            actual_val);
+        auto actual_val_end = matrix_row_iterator<decltype(actual_val)>(
+            actual_val, actual_val.rows());
+
+        HPX_TEST(std::find(actual_val_begin, actual_val_end, val) != actual_val_end);
+    }
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This PR adds the shuffle primitive to Phylanx, which is the equivalent of `np.random.shuffle`. This primitive was mentioned in #200.

Also:
* Fixes a bug in variable primitive where unwanted copies were made during the assignment of a PhySL variable from PhySL Rvalue (`DynamicMatrix`)
* Updates matrix row & column iterator to make their instances copyable