### PR TITLE
Check environment variables when HPX_DIR is not explicitly set

### DIFF
--- a/cmake/Phylanx_SetupHPX.cmake
+++ b/cmake/Phylanx_SetupHPX.cmake
@@ -9,6 +9,9 @@ macro(phylanx_setup_hpx)
     set(HPX_DIR ${HPX_ROOT}/lib/cmake/HPX)
   endif()
 
+  if(NOT HPX_DIR AND EXISTS "$ENV{HPX_DIR}")
+    set(HPX_DIR $ENV{HPX_DIR})
+  endif()
   if(EXISTS "${HPX_DIR}")
     find_package(HPX REQUIRED NO_CMAKE_PACKAGE_REGISTRY)
 


### PR DESCRIPTION
This fixes #243 by checking the environment variable `HPX_DIR` in case `-DHPX_DIR` is not explicitly set in the CMake command.