### PR TITLE
Refactor primitives to new style (3)

### DIFF
--- a/phylanx/execution_tree/primitives/for_operation.hpp
+++ b/phylanx/execution_tree/primitives/for_operation.hpp
@@ -12,12 +12,15 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class for_operation : public primitive_component_base
+    class for_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<for_operation>
     {
     public:
         static match_pattern_type const match_data;
@@ -29,6 +32,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct iteration_for;
     };
 
     PHYLANX_EXPORT primitive create_for_operation(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/greater.hpp
+++ b/phylanx/execution_tree/primitives/greater.hpp
@@ -27,7 +27,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operand_type = ir::node_data<double>;
         using operands_type = std::vector<primitive_argument_type>;
 
-        hpx::future<primitive_argument_type> greater::eval(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args) const;
 

--- a/phylanx/execution_tree/primitives/greater.hpp
+++ b/phylanx/execution_tree/primitives/greater.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_GREATER_OCT_07_2017_0223PM)
 #define PHYLANX_PRIMITIVES_GREATER_OCT_07_2017_0223PM
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class greater : public primitive_component_base
+    class greater
+        : public primitive_component_base
+        , public std::enable_shared_from_this<greater>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> greater::eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct visit_greater;
+
+        primitive_argument_type greater0d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater0d2d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater0d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater1d0d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater1d1d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater1d2d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater1d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater2d0d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater2d1d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater2d2d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater2d(
+                operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type greater_all(
+                operand_type&& lhs, operand_type&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_greater(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/greater_equal.hpp
+++ b/phylanx/execution_tree/primitives/greater_equal.hpp
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class greater_equal : public primitive_component_base
+    class greater_equal
+        : public primitive_component_base
+        , public std::enable_shared_from_this<greater_equal>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct visit_greater_equal;
+
+        primitive_argument_type greater_equal0d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal0d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal1d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal1d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal1d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal2d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal2d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal2d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type greater_equal_all(
+            operand_type&& lhs, operand_type&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_greater_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/hstack_operation.hpp
+++ b/phylanx/execution_tree/primitives/hstack_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2018 Bibek Wagle
+// Copyright (c) 2018 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef PHYLANX_HSTACK_OPERATION_JAN13_1200_2018_H
 #define PHYLANX_HSTACK_OPERATION_JAN13_1200_2018_H
@@ -9,16 +9,30 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class hstack_operation : public primitive_component_base
+    class hstack_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<hstack_operation>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using storage1d_type = typename arg_type::storage1d_type;
+        using storage2d_type = typename arg_type::storage2d_type;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +43,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        primitive_argument_type hstack0d(args_type&& args) const;
+        primitive_argument_type hstack1d(args_type&& args) const;
+        primitive_argument_type hstack2d(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_hstack_operation(

--- a/phylanx/execution_tree/primitives/identity.hpp
+++ b/phylanx/execution_tree/primitives/identity.hpp
@@ -9,16 +9,29 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class identity : public primitive_component_base
+    class identity
+        : public primitive_component_base
+        , public std::enable_shared_from_this<identity>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using matrix_type = blaze::IdentityMatrix<double>;
+        using operands_type = std::vector<operand_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +42,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type identity_nd(operands_type&& ops) const;
     };
 
     PHYLANX_EXPORT primitive create_identity(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/inverse_operation.hpp
+++ b/phylanx/execution_tree/primitives/inverse_operation.hpp
@@ -1,7 +1,7 @@
-//   Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_INVERSE_OPERATION_OCT_09_2017_0154PM)
 #define PHYLANX_PRIMITIVES_INVERSE_OPERATION_OCT_09_2017_0154PM
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class inverse_operation : public primitive_component_base
+    class inverse_operation
+        : public primitive_component_base
+        , std::enable_shared_from_this<inverse_operation>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type inverse0d(operands_type && ops) const;
+        primitive_argument_type inverse2d(operands_type && ops) const;
     };
 
     PHYLANX_EXPORT primitive create_inverse_operation(

--- a/phylanx/execution_tree/primitives/inverse_operation.hpp
+++ b/phylanx/execution_tree/primitives/inverse_operation.hpp
@@ -21,7 +21,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     class inverse_operation
         : public primitive_component_base
-        , std::enable_shared_from_this<inverse_operation>
+        , public std::enable_shared_from_this<inverse_operation>
     {
     protected:
         using operand_type = ir::node_data<double>;

--- a/phylanx/execution_tree/primitives/less.hpp
+++ b/phylanx/execution_tree/primitives/less.hpp
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class less : public primitive_component_base
+    class less
+        : public primitive_component_base
+        , public std::enable_shared_from_this<less>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,35 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type less0d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less0d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less1d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less1d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less1d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less2d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less2d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less2d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_all(
+            operand_type&& lhs, operand_type&& rhs) const;
+
+    private:
+        struct visit_less;
     };
 
     PHYLANX_EXPORT primitive create_less(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/less_equal.hpp
+++ b/phylanx/execution_tree/primitives/less_equal.hpp
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class less_equal : public primitive_component_base
+    class less_equal
+        : public primitive_component_base
+        , public std::enable_shared_from_this<less_equal>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct visit_less_equal;
+
+        primitive_argument_type less_equal0d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal0d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal1d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal1d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal1d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal2d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal2d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal2d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type less_equal_all(
+            operand_type&& lhs, operand_type&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_less_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/row_slicing.hpp
+++ b/phylanx/execution_tree/primitives/row_slicing.hpp
@@ -48,7 +48,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
 
-        hpx::future<primitive_argument_type> row_slicing_operation::eval(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args) const;
 

--- a/phylanx/execution_tree/primitives/row_slicing.hpp
+++ b/phylanx/execution_tree/primitives/row_slicing.hpp
@@ -1,53 +1,74 @@
 // Copyright (c) 2017 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 #ifndef PHYLANX_ROW_SLICING_HPP
 #define PHYLANX_ROW_SLICING_HPP
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class row_slicing_operation : public primitive_component_base
+    /**
+    * @brief Row Slicing Primitive
+    *
+    * This primitive returns a slice of the original data.
+    * @param operands Vector of phylanx node data objects of
+    * size either three or four
+    *
+    * If used inside PhySL:
+    *
+    *      slice_row (input, row_start, row_stop, steps(optional) )
+    *
+    *          input : Scalar, Vector or a Matrix
+    *          row_start     : Starting index of the slice
+    *          row_stop      : Stopping index of the slice
+    *          steps          : Go from row_start to row_stop in steps
+    *  Note: Indices and steps can have negative values and negative values
+    *  indicate direction, similar to python.
+    *
+    */
+    class row_slicing_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<row_slicing_operation>
     {
+    protected:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using storage0d_type = typename arg_type::storage0d_type;
+        using storage1d_type = typename arg_type::storage1d_type;
+        using storage2d_type = typename arg_type::storage2d_type;
+
+        hpx::future<primitive_argument_type> row_slicing_operation::eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
         row_slicing_operation() = default;
-
-        /**
-        * @brief Row Slicing Primitive
-        *
-        * This primitive returns a slice of the original data.
-        * @param operands Vector of phylanx node data objects of
-        * size either three or four
-        *
-        * If used inside PhySL:
-        *
-        *      slice_row (input, row_start, row_stop, steps(optional) )
-        *
-        *          input : Scalar, Vector or a Matrix
-        *          row_start     : Starting index of the slice
-        *          row_stop      : Stopping index of the slice
-        *          steps          : Go from row_start to row_stop in steps
-        *  Note: Indices and steps can have negative vlaues and negative values
-        *  indicate direction, similar to python.
-        *
-        */
 
         row_slicing_operation(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        std::vector<int> create_list_row(
+            int start, int stop, int step, int array_length) const;
+        primitive_argument_type row_slicing0d(args_type&& args) const;
+        primitive_argument_type row_slicing1d(args_type&& args) const;
+        primitive_argument_type row_slicing2d(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_row_slicing_operation(

--- a/phylanx/execution_tree/primitives/slicing_operation.hpp
+++ b/phylanx/execution_tree/primitives/slicing_operation.hpp
@@ -30,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
 
-        hpx::future<primitive_argument_type> slicing_operation::eval(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args) const;
 

--- a/phylanx/execution_tree/primitives/slicing_operation.hpp
+++ b/phylanx/execution_tree/primitives/slicing_operation.hpp
@@ -9,16 +9,31 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class slicing_operation : public primitive_component_base
+    class slicing_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<slicing_operation>
     {
+    protected:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using storage0d_type = typename arg_type::storage0d_type;
+        using storage1d_type = typename arg_type::storage1d_type;
+        using storage2d_type = typename arg_type::storage2d_type;
+
+        hpx::future<primitive_argument_type> slicing_operation::eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -48,10 +63,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
         *  Quirks: In case the input is a vector, row_start, row_stop and row_steps
         *  determine the result. col_start, col_stop and col_step are ignored internally.
         *
-        *  Limitations: both row_steps and col_steps need to be provieded or omitted.
+        *  Limitations: both row_steps and col_steps need to be provided or omitted.
         *  Functionality for specifying only row_steps or col_steps is not present.
         *
-        *  Note: Indices and steps can have negative vlaues and negative values
+        *  Note: Indices and steps can have negative values and negative values
         *  indicate direction, similar to python.
         */
 
@@ -60,6 +75,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        std::vector<int> create_list_slice(
+            int start, int stop, int step, int array_length) const;
+        primitive_argument_type slicing0d(args_type&& args) const;
+        primitive_argument_type slicing1d(args_type&& args) const;
+        primitive_argument_type slicing2d(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_slicing_operation(

--- a/phylanx/execution_tree/primitives/vstack_operation.hpp
+++ b/phylanx/execution_tree/primitives/vstack_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2018 Bibek Wagle
+// Copyright (c) 2018 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef PHYLANX_VSTACK_OPERATION_JAN13_1200_2018_H
 #define PHYLANX_VSTACK_OPERATION_JAN13_1200_2018_H
@@ -9,16 +9,30 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class vstack_operation : public primitive_component_base
+    class vstack_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<vstack_operation>
     {
+    protected:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using storage1d_type = typename arg_type::storage1d_type;
+        using storage2d_type = typename arg_type::storage2d_type;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +43,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        primitive_argument_type vstack0d(args_type&& args) const;
+        primitive_argument_type vstack1d(args_type&& args) const;
+        primitive_argument_type vstack2d(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_vstack_operation(

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/greater.hpp>
@@ -47,523 +47,499 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type greater::greater0d1d(
+        operand_type&& lhs, operand_type&& rhs) const
     {
-        struct greater : std::enable_shared_from_this<greater>
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
         {
-            greater(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+            rhs = blaze::map(rhs.vector(),
+                [&](double x) { return (x > lhs.scalar()); });
+        }
+        else
+        {
+            rhs.vector() = blaze::map(rhs.vector(),
+                [&](double x) { return (x > lhs.scalar()); });
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<primitive_argument_type>;
-
-            primitive_argument_type greater0d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.vector(),
-                        [&](double x) { return (x > lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.vector() = blaze::map(rhs.vector(),
-                        [&](double x) { return (x > lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type greater0d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x > lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.matrix() = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x > lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type greater0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs.scalar() > rhs.scalar()});
-
-                case 1:
-                    return greater0d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return greater0d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater0d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type greater1d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(),
-                        [&](double x) { return (x > rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(),
-                        [&](double x) { return (x > rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type greater1d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater1d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x > y); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x > y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type greater1d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = lhs.vector();
-                auto cm = rhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater1d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x > y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x > y; });
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type greater1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return greater1d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return greater1d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return greater1d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater1d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type greater2d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x > rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x > rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type greater2d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = rhs.vector();
-                auto cm = lhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater2d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x > y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x > y; });
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type greater2d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto lhs_size = lhs.dimensions();
-                auto rhs_size = rhs.dimensions();
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater2d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                //       is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x > y); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x > y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type greater2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return greater2d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return greater2d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return greater2d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater2d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-        public:
-            primitive_argument_type greater_all(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_dims = lhs.num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return greater0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return greater1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return greater2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::greater_all",
-                        generate_error_message(
-                            "left hand side operand has unsupported number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-        protected:
-            struct visit_greater
-            {
-                template <typename T1, typename T2>
-                primitive_argument_type operator()(T1, T2) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_.name_, greater_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<primitive_argument_type>&&,
-                    ir::node_data<primitive_argument_type>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_.name_, greater_.codename_));
-                }
-
-                primitive_argument_type operator()(std::vector<ast::expression>&&,
-                    std::vector<ast::expression>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_.name_, greater_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ast::expression&&, ast::expression&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_.name_, greater_.codename_));
-                }
-
-                primitive_argument_type operator()(primitive&&, primitive&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_.name_, greater_.codename_));
-                }
-
-                template <typename T>
-                primitive_argument_type operator()(T && lhs, T && rhs) const
-                {
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs > rhs});
-                }
-
-                primitive_argument_type operator()(
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&,
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_.name_, greater_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<double>&& lhs, std::int64_t&& rhs) const
-                {
-                    if (lhs.num_dimensions() != 0)
-                    {
-                        return greater_.greater_all(
-                            std::move(lhs), operand_type(std::move(rhs)));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs[0] > rhs});
-                }
-
-                primitive_argument_type operator()(
-                    std::int64_t&& lhs, ir::node_data<double>&& rhs) const
-                {
-                    if (rhs.num_dimensions() != 0)
-                    {
-                        return greater_.greater_all(
-                            operand_type(std::move(lhs)), std::move(rhs));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs > rhs[0]});
-                }
-
-                primitive_argument_type operator()(
-                    operand_type&& lhs, operand_type&& rhs) const
-                {
-                    return greater_.greater_all(
-                        std::move(lhs), std::move(rhs));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be compared",
-                            greater_.name_, greater_.codename_));
-                }
-
-                greater const& greater_;
-            };
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "the greater primitive requires exactly two "
-                                "operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater::eval",
-                        generate_error_message(
-                            "the greater primitive requires that the "
-                                "arguments given by the operands array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops) -> primitive_argument_type
-                    {
-                        return primitive_argument_type(
-                            util::visit(visit_greater{*this_},
-                                std::move(ops[0].variant()),
-                                std::move(ops[1].variant())));
-                    }),
-                    detail::map_operands(
-                        operands, functional::literal_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
     }
 
-    // implement '>' for all possible combinations of lhs and rhs
+    primitive_argument_type greater::greater0d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            rhs = blaze::map(rhs.matrix(),
+                [&](double x) { return (x > lhs.scalar()); });
+        }
+        else
+        {
+            rhs.matrix() = blaze::map(rhs.matrix(),
+                [&](double x) { return (x > lhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type greater::greater0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs.scalar() > rhs.scalar()});
+
+        case 1:
+            return greater0d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return greater0d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater0d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type greater::greater1d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(),
+                [&](double x) { return (x > rhs.scalar()); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(),
+                [&](double x) { return (x > rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type greater::greater1d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater1d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x > y); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x > y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type greater::greater1d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = lhs.vector();
+        auto cm = rhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater1d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x > y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x > y; });
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type greater::greater1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return greater1d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return greater1d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return greater1d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater1d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type greater::greater2d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(),
+                [&](double x) { return (x > rhs.scalar()); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(),
+                [&](double x) { return (x > rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type greater::greater2d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = rhs.vector();
+        auto cm = lhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater2d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x > y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x > y; });
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type greater::greater2d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater2d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        //       is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x > y); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x > y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type greater::greater2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return greater2d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return greater2d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return greater2d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater2d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type greater::greater_all(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return greater0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return greater1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return greater2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::greater_all",
+                execution_tree::generate_error_message(
+                    "left hand side operand has unsupported number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    struct greater::visit_greater
+    {
+        template <typename T1, typename T2>
+        primitive_argument_type operator()(T1, T2) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    that_.name_, that_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<primitive_argument_type>&&,
+            ir::node_data<primitive_argument_type>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    that_.name_, that_.codename_));
+        }
+
+        primitive_argument_type operator()(std::vector<ast::expression>&&,
+            std::vector<ast::expression>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    that_.name_, that_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ast::expression&&, ast::expression&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    that_.name_, that_.codename_));
+        }
+
+        primitive_argument_type operator()(primitive&&, primitive&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    that_.name_, that_.codename_));
+        }
+
+        template <typename T>
+        primitive_argument_type operator()(T && lhs, T && rhs) const
+        {
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs > rhs});
+        }
+
+        primitive_argument_type operator()(
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&,
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    that_.name_, that_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<double>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return that_.greater_all(
+                    std::move(lhs), operand_type(std::move(rhs)));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs[0] > rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<double>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return that_.greater_all(
+                    operand_type(std::move(lhs)), std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs > rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            operand_type&& lhs, operand_type&& rhs) const
+        {
+            return that_.greater_all(
+                std::move(lhs), std::move(rhs));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be compared",
+                    that_.name_, that_.codename_));
+        }
+
+        greater const& that_;
+    };
+
+    hpx::future<primitive_argument_type> greater::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "the greater primitive requires exactly two "
+                        "operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater::eval",
+                execution_tree::generate_error_message(
+                    "the greater primitive requires that the "
+                        "arguments given by the operands array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type && ops) -> primitive_argument_type
+            {
+                return primitive_argument_type(
+                    util::visit(visit_greater{*this_},
+                        std::move(ops[0].variant()),
+                        std::move(ops[1].variant())));
+            }),
+            detail::map_operands(
+                operands, functional::literal_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Implement '>' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> greater::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::greater>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::greater>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -47,26 +47,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
-    {
-        struct greater_equal : std::enable_shared_from_this<greater_equal>
-        {
-            greater_equal(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<primitive_argument_type>;
-
-            primitive_argument_type greater_equal0d1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal0d1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 // TODO: SIMD functionality should be added, blaze implementation
                 // is not currently available
@@ -85,8 +67,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(rhs)});
             }
 
-            primitive_argument_type greater_equal0d2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal0d2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 // TODO: SIMD functionality should be added, blaze implementation
                 // is not currently available
@@ -105,8 +87,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(rhs)});
             }
 
-            primitive_argument_type greater_equal0d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal0d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t rhs_dims = rhs.num_dimensions();
                 switch(rhs_dims)
@@ -124,15 +106,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal0d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the operands have incompatible number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-            primitive_argument_type greater_equal1d0d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal1d0d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 // TODO: SIMD functionality should be added, blaze implementation
                 // is not currently available
@@ -151,8 +133,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type greater_equal1d1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal1d1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t lhs_size = lhs.dimension(0);
                 std::size_t rhs_size = rhs.dimension(0);
@@ -161,7 +143,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal1d1d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -183,8 +165,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type greater_equal1d2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal1d2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 auto cv = lhs.vector();
                 auto cm = rhs.matrix();
@@ -193,7 +175,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal1d2d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -221,8 +203,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(rhs)});
             }
 
-            primitive_argument_type greater_equal1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t rhs_dims = rhs.num_dimensions();
                 switch(rhs_dims)
@@ -239,15 +221,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal1d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the operands have incompatible number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-            primitive_argument_type greater_equal2d0d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal2d0d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t lhs_size = lhs.dimension(0);
                 std::size_t rhs_size = rhs.dimension(0);
@@ -269,8 +251,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type greater_equal2d1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal2d1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 auto cv = rhs.vector();
                 auto cm = lhs.matrix();
@@ -279,7 +261,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal2d1d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -307,8 +289,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type greater_equal2d2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal2d2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 auto lhs_size = lhs.dimensions();
                 auto rhs_size = rhs.dimensions();
@@ -317,7 +299,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal2d2d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -339,8 +321,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type greater_equal2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t rhs_dims = rhs.num_dimensions();
                 switch(rhs_dims)
@@ -357,16 +339,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal2d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the operands have incompatible number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-        public:
-            primitive_argument_type greater_equal_all(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type greater_equal::greater_equal_all(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t lhs_dims = lhs.num_dimensions();
                 switch (lhs_dims)
@@ -383,187 +364,182 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "greater_equal::greater_equal_all",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "left hand side operand has unsupported number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-        protected:
-            struct visit_greater_equal
+    struct greater_equal::visit_greater_equal
+    {
+        template <typename T1, typename T2>
+        primitive_argument_type operator()(T1, T2) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    greater_equal_.name_, greater_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<primitive_argument_type>&&,
+            ir::node_data<primitive_argument_type>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    greater_equal_.name_, greater_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(std::vector<ast::expression>&&,
+            std::vector<ast::expression>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    greater_equal_.name_, greater_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ast::expression&&, ast::expression&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    greater_equal_.name_, greater_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(primitive&&, primitive&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    greater_equal_.name_, greater_equal_.codename_));
+        }
+
+        template <typename T>
+        primitive_argument_type operator()(T && lhs, T && rhs) const
+        {
+            return primitive_argument_type(
+                    ir::node_data<bool>{lhs >= rhs});
+        }
+
+        primitive_argument_type operator()(
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&,
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    greater_equal_.name_, greater_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<double>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
             {
-                template <typename T1, typename T2>
-                primitive_argument_type operator()(T1, T2) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_equal_.name_, greater_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<primitive_argument_type>&&,
-                    ir::node_data<primitive_argument_type>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_equal_.name_, greater_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(std::vector<ast::expression>&&,
-                    std::vector<ast::expression>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_equal_.name_, greater_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ast::expression&&, ast::expression&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_equal_.name_, greater_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(primitive&&, primitive&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_equal_.name_, greater_equal_.codename_));
-                }
-
-                template <typename T>
-                primitive_argument_type operator()(T && lhs, T && rhs) const
-                {
-                    return primitive_argument_type(
-                            ir::node_data<bool>{lhs >= rhs});
-                }
-
-                primitive_argument_type operator()(
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&,
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            greater_equal_.name_, greater_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<double>&& lhs, std::int64_t&& rhs) const
-                {
-                    if (lhs.num_dimensions() != 0)
-                    {
-                        return greater_equal_.greater_equal_all(
-                            std::move(lhs), operand_type(std::move(rhs)));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs[0] >= rhs});
-                }
-
-                primitive_argument_type operator()(
-                    std::int64_t&& lhs, ir::node_data<double>&& rhs) const
-                {
-                    if (rhs.num_dimensions() != 0)
-                    {
-                        return greater_equal_.greater_equal_all(
-                            operand_type(std::move(lhs)), std::move(rhs));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs >= rhs[0]});
-                }
-
-                primitive_argument_type operator()(
-                    operand_type&& lhs, operand_type&& rhs) const
-                {
-                    return greater_equal_.greater_equal_all(
-                        std::move(lhs), std::move(rhs));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be compared",
-                            greater_equal_.name_, greater_equal_.codename_));
-                }
-
-                greater_equal const& greater_equal_;
-            };
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "the greater_equal primitive requires exactly two "
-                                "operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::eval",
-                        generate_error_message(
-                            "the greater_equal primitive requires that the "
-                                "arguments given by the operands array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops) -> primitive_argument_type
-                    {
-                        return primitive_argument_type(
-                            util::visit(visit_greater_equal{*this_},
-                                std::move(ops[0].variant()),
-                                std::move(ops[1].variant())));
-                    }),
-                    detail::map_operands(
-                        operands, functional::literal_operand{}, args,
-                        name_, codename_));
+                return greater_equal_.greater_equal_all(
+                    std::move(lhs), operand_type(std::move(rhs)));
             }
-        };
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs[0] >= rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<double>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return greater_equal_.greater_equal_all(
+                    operand_type(std::move(lhs)), std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs >= rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            operand_type&& lhs, operand_type&& rhs) const
+        {
+            return greater_equal_.greater_equal_all(
+                std::move(lhs), std::move(rhs));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be compared",
+                    greater_equal_.name_, greater_equal_.codename_));
+        }
+
+        greater_equal const& greater_equal_;
+    };
+
+    hpx::future<primitive_argument_type> greater_equal::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "the greater_equal primitive requires exactly two "
+                        "operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::eval",
+                execution_tree::generate_error_message(
+                    "the greater_equal primitive requires that the "
+                        "arguments given by the operands array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type && ops) -> primitive_argument_type
+            {
+                return primitive_argument_type(
+                    util::visit(visit_greater_equal{*this_},
+                        std::move(ops[0].variant()),
+                        std::move(ops[1].variant())));
+            }),
+            detail::map_operands(
+                operands, functional::literal_operand{}, args,
+                name_, codename_));
     }
 
-    // implement '>=' for all possible combinations of lhs and rhs
+    //////////////////////////////////////////////////////////////////////////
+    // Implement '>=' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> greater_equal::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::greater_equal>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::greater_equal>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/identity.cpp
+++ b/src/execution_tree/primitives/identity.cpp
@@ -49,85 +49,63 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail {
-        struct identity : std::enable_shared_from_this<identity>
-        {
-            identity(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+    primitive_argument_type identity::identity_nd(operands_type&& ops) const
+    {
+        if (ops[0].num_dimensions() != 0)
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "identity::identity_nd",
+                execution_tree::generate_error_message(
+                    "input should be a scalar",
+                    name_, codename_));
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using matrix_type = blaze::IdentityMatrix<double>;
-            using operands_type = std::vector<operand_type>;
-
-            primitive_argument_type identity_nd(operands_type&& ops) const
-            {
-                if (ops[0].num_dimensions() != 0)
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "identity::identity_nd",
-                        generate_error_message(
-                            "input should be a scalar",
-                            name_, codename_));
-
-                std::size_t dim = static_cast<std::size_t>(ops[0].scalar());
-                return primitive_argument_type{
-                    operand_type{blaze::IdentityMatrix<double>(dim)}};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
-            {
-                if (operands.size() > 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "identity::eval",
-                        generate_error_message(
-                            "the identity primitive requires"
-                                "at most one operand",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "identity::eval",
-                        generate_error_message(
-                            "the identity primitive requires that the "
-                                "arguments given by the operands array "
-                                "are valid",
-                            name_, codename_));
-                }
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type&& op0) -> primitive_argument_type
-                    {
-                        return this_->identity_nd(std::move(op0));
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        std::size_t dim = static_cast<std::size_t>(ops[0].scalar());
+        return primitive_argument_type{
+            operand_type{blaze::IdentityMatrix<double>(dim)}};
     }
 
+    hpx::future<primitive_argument_type> identity::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() > 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "identity::eval",
+                execution_tree::generate_error_message(
+                    "the identity primitive requires"
+                        "at most one operand",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "identity::eval",
+                execution_tree::generate_error_message(
+                    "the identity primitive requires that the "
+                        "arguments given by the operands array "
+                        "are valid",
+                    name_, codename_));
+        }
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type&& op0) -> primitive_argument_type
+            {
+                return this_->identity_nd(std::move(op0));
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> identity::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::identity>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::identity>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/inverse_operation.cpp
+++ b/src/execution_tree/primitives/inverse_operation.cpp
@@ -1,7 +1,7 @@
-//   Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/inverse_operation.hpp>
@@ -47,117 +47,97 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    hpx::future<primitive_argument_type> inverse_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
     {
-        struct inverse : std::enable_shared_from_this<inverse>
+        if (operands.size() != 1)
         {
-            inverse(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
-            {
-                if (operands.size() != 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "inverse_operation::eval",
-                        generate_error_message(
-                            "the inverse_operation primitive requires"
-                                "exactly one operand",
-                             name_, codename_));
-                }
-
-                if (!valid(operands[0]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "inverse_operation::eval",
-                        generate_error_message(
-                            "the inverse_operation primitive requires that "
-                                "the arguments given by the operands array "
-                                "is valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type&& ops) -> primitive_argument_type
-                    {
-                        std::size_t dims = ops[0].num_dimensions();
-                        switch (dims)
-                        {
-                        case 0:
-                            return this_->inverse0d(std::move(ops));
-
-                        case 2:
-                            return this_->inverse2d(std::move(ops));
-
-                        case 1: HPX_FALLTHROUGH;
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "inverse_operation::eval",
-                                generate_error_message(
-                                    "left hand side operand has unsupported "
-                                        "number of dimensions",
-                                    this_->name_, this_->codename_));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "inverse_operation::eval",
+                execution_tree::generate_error_message(
+                    "the inverse_operation primitive requires"
+                        "exactly one operand",
                         name_, codename_));
-            }
+        }
 
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<operand_type>;
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "inverse_operation::eval",
+                execution_tree::generate_error_message(
+                    "the inverse_operation primitive requires that "
+                        "the arguments given by the operands array "
+                        "is valid",
+                    name_, codename_));
+        }
 
-            primitive_argument_type inverse0d(operands_type && ops) const
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type&& ops) -> primitive_argument_type
             {
-                ops[0].scalar() = 1 / ops[0].scalar();
-                return primitive_argument_type{std::move(ops[0])};
-            }
-
-            primitive_argument_type inverse2d(operands_type && ops) const
-            {
-                if (ops[0].dimension(0) != ops[0].dimension(1))
+                std::size_t dims = ops[0].num_dimensions();
+                switch (dims)
                 {
+                case 0:
+                    return this_->inverse0d(std::move(ops));
+
+                case 2:
+                    return this_->inverse2d(std::move(ops));
+
+                case 1: HPX_FALLTHROUGH;
+                default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "inverse::inverse2d",
-                        generate_error_message(
-                            "matrices to inverse have to be quadratic",
-                            name_, codename_));
+                        "inverse_operation::eval",
+                        execution_tree::generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions",
+                            this_->name_, this_->codename_));
                 }
-
-                if (ops[0].is_ref())
-                {
-                    ops[0] = blaze::inv(ops[0].matrix());
-                }
-                else
-                {
-                    blaze::invert(ops[0].matrix_non_ref());
-                }
-                return primitive_argument_type{std::move(ops[0])};
-            }
-        };
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
     }
 
+    primitive_argument_type inverse_operation::inverse0d(
+        operands_type&& ops) const
+    {
+        ops[0].scalar() = 1 / ops[0].scalar();
+        return primitive_argument_type{std::move(ops[0])};
+    }
+
+    primitive_argument_type inverse_operation::inverse2d(
+        operands_type&& ops) const
+    {
+        if (ops[0].dimension(0) != ops[0].dimension(1))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "inverse::inverse2d",
+                execution_tree::generate_error_message(
+                    "matrices to inverse have to be quadratic",
+                    name_, codename_));
+        }
+
+        if (ops[0].is_ref())
+        {
+            ops[0] = blaze::inv(ops[0].matrix());
+        }
+        else
+        {
+            blaze::invert(ops[0].matrix_non_ref());
+        }
+        return primitive_argument_type{std::move(ops[0])};
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> inverse_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::inverse>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::inverse>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -47,522 +47,498 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type less::less0d1d(
+        operand_type&& lhs, operand_type&& rhs) const
     {
-        struct less : std::enable_shared_from_this<less>
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
         {
-            less(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+            rhs = blaze::map(rhs.vector(),
+                [&](double x) { return (x < lhs.scalar()); });
+        }
+        else
+        {
+            rhs.vector() = blaze::map(rhs.vector(),
+                [&](double x) { return (x < lhs.scalar()); });
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<primitive_argument_type>;
-
-            primitive_argument_type less0d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.vector(),
-                        [&](double x) { return (x < lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.vector() = blaze::map(rhs.vector(),
-                        [&](double x) { return (x < lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type less0d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x < lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.matrix() = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x < lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type less0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs.scalar() < rhs.scalar()});
-
-                case 1:
-                    return less0d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less0d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less0d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type less1d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(),
-                        [&](double x) { return (x < rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(),
-                        [&](double x) { return (x < rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less1d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less1d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x < y); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x < y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less1d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = lhs.vector();
-                auto cm = rhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less1d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x < y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x < y; });
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type less1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return less1d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return less1d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less1d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less1d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type less2d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x < rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x < rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less2d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = rhs.vector();
-                auto cm = lhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less2d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x < y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x < y; });
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less2d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto lhs_size = lhs.dimensions();
-                auto rhs_size = rhs.dimensions();
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less2d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                //       is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x < y); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x < y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return less2d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return less2d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less2d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less2d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-        public:
-            primitive_argument_type less_all(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_dims = lhs.num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return less0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return less1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::less_all",
-                        generate_error_message(
-                            "left hand side operand has unsupported number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-        protected:
-            struct visit_less
-            {
-                template <typename T1, typename T2>
-                primitive_argument_type operator()(T1, T2) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_.name_, less_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<primitive_argument_type>&&,
-                    ir::node_data<primitive_argument_type>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_.name_, less_.codename_));
-                }
-
-                primitive_argument_type operator()(std::vector<ast::expression>&&,
-                    std::vector<ast::expression>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_.name_, less_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ast::expression&&, ast::expression&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_.name_, less_.codename_));
-                }
-
-                primitive_argument_type operator()(primitive&&, primitive&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_.name_, less_.codename_));
-                }
-
-                template <typename T>
-                primitive_argument_type operator()(T && lhs, T && rhs) const
-                {
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs < rhs});
-                }
-
-                primitive_argument_type operator()(
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&,
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_.name_, less_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<double>&& lhs, std::int64_t&& rhs) const
-                {
-                    if (lhs.num_dimensions() != 0)
-                    {
-                        return less_.less_all(
-                            std::move(lhs), operand_type(std::move(rhs)));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs[0] < rhs});
-                }
-
-                primitive_argument_type operator()(
-                    std::int64_t&& lhs, ir::node_data<double>&& rhs) const
-                {
-                    if (rhs.num_dimensions() != 0)
-                    {
-                        return less_.less_all(
-                            operand_type(std::move(lhs)), std::move(rhs));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs < rhs[0]});
-                }
-
-                primitive_argument_type operator()(
-                    operand_type&& lhs, operand_type&& rhs) const
-                {
-                    return less_.less_all(
-                        std::move(lhs), std::move(rhs));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be compared",
-                            less_.name_, less_.codename_));
-                }
-
-                less const& less_;
-            };
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "the less primitive requires exactly two "
-                                "operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less::eval",
-                        generate_error_message(
-                            "the less primitive requires that the "
-                                "arguments given by the operands array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops) -> primitive_argument_type
-                    {
-                        return primitive_argument_type(
-                            util::visit(visit_less{*this_},
-                                std::move(ops[0].variant()),
-                                std::move(ops[1].variant())));
-                    }),
-                    detail::map_operands(
-                        operands, functional::literal_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
     }
 
-    // implement '<' for all possible combinations of lhs and rhs
+    primitive_argument_type less::less0d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            rhs = blaze::map(rhs.matrix(),
+                [&](double x) { return (x < lhs.scalar()); });
+        }
+        else
+        {
+            rhs.matrix() = blaze::map(rhs.matrix(),
+                [&](double x) { return (x < lhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type less::less0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs.scalar() < rhs.scalar()});
+
+        case 1:
+            return less0d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less0d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less0d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type less::less1d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(),
+                [&](double x) { return (x < rhs.scalar()); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(),
+                [&](double x) { return (x < rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less::less1d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less1d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x < y); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x < y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less::less1d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = lhs.vector();
+        auto cm = rhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less1d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x < y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x < y; });
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type less::less1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return less1d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return less1d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less1d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less1d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type less::less2d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(),
+                [&](double x) { return (x < rhs.scalar()); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(),
+                [&](double x) { return (x < rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less::less2d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = rhs.vector();
+        auto cm = lhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less2d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x < y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x < y; });
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less::less2d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less2d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        //       is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x < y); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x < y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less::less2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return less2d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return less2d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less2d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less2d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type less::less_all(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return less0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return less1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::less_all",
+                execution_tree::generate_error_message(
+                    "left hand side operand has unsupported number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    struct less::visit_less
+    {
+        template <typename T1, typename T2>
+        primitive_argument_type operator()(T1, T2) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_.name_, less_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<primitive_argument_type>&&,
+            ir::node_data<primitive_argument_type>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_.name_, less_.codename_));
+        }
+
+        primitive_argument_type operator()(std::vector<ast::expression>&&,
+            std::vector<ast::expression>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_.name_, less_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ast::expression&&, ast::expression&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_.name_, less_.codename_));
+        }
+
+        primitive_argument_type operator()(primitive&&, primitive&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_.name_, less_.codename_));
+        }
+
+        template <typename T>
+        primitive_argument_type operator()(T && lhs, T && rhs) const
+        {
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs < rhs});
+        }
+
+        primitive_argument_type operator()(
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&,
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_.name_, less_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<double>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return less_.less_all(
+                    std::move(lhs), operand_type(std::move(rhs)));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs[0] < rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<double>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return less_.less_all(
+                    operand_type(std::move(lhs)), std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs < rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            operand_type&& lhs, operand_type&& rhs) const
+        {
+            return less_.less_all(
+                std::move(lhs), std::move(rhs));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be compared",
+                    less_.name_, less_.codename_));
+        }
+
+        less const& less_;
+    };
+
+    hpx::future<primitive_argument_type> less::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "the less primitive requires exactly two "
+                        "operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less::eval",
+                execution_tree::generate_error_message(
+                    "the less primitive requires that the "
+                        "arguments given by the operands array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type && ops) -> primitive_argument_type
+            {
+                return primitive_argument_type(
+                    util::visit(visit_less{*this_},
+                        std::move(ops[0].variant()),
+                        std::move(ops[1].variant())));
+            }),
+            detail::map_operands(
+                operands, functional::literal_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Implement '<' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> less::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::less>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::less>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -47,523 +47,499 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type less_equal::less_equal0d1d(
+        operand_type&& lhs, operand_type&& rhs) const
     {
-        struct less_equal : std::enable_shared_from_this<less_equal>
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
         {
-            less_equal(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+            rhs = blaze::map(rhs.vector(),
+                [&](double x) { return (x <= lhs.scalar()); });
+        }
+        else
+        {
+            rhs.vector() = blaze::map(rhs.vector(),
+                [&](double x) { return (x <= lhs.scalar()); });
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<primitive_argument_type>;
-
-            primitive_argument_type less_equal0d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.vector(),
-                        [&](double x) { return (x <= lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.vector() = blaze::map(rhs.vector(),
-                        [&](double x) { return (x <= lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type less_equal0d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x <= lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.matrix() = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x <= lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type less_equal0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs.scalar() <= rhs.scalar()});
-
-                case 1:
-                    return less_equal0d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less_equal0d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal0d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type less_equal1d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(),
-                        [&](double x) { return (x <= rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(),
-                        [&](double x) { return (x <= rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less_equal1d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal1d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x <= y); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x <= y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less_equal1d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = lhs.vector();
-                auto cm = rhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal1d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x <= y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x <= y; });
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type less_equal1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return less_equal1d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return less_equal1d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less_equal1d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal1d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type less_equal2d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x <= rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x <= rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less_equal2d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = rhs.vector();
-                auto cm = lhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal2d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x <= y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x <= y; });
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less_equal2d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto lhs_size = lhs.dimensions();
-                auto rhs_size = rhs.dimensions();
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal2d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                //       is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x <= y); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x <= y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type less_equal2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return less_equal2d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return less_equal2d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less_equal2d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal2d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-        public:
-            primitive_argument_type less_equal_all(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_dims = lhs.num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return less_equal0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return less_equal1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return less_equal2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::less_equal_all",
-                        generate_error_message(
-                            "left hand side operand has unsupported number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-        protected:
-            struct visit_less_equal
-            {
-                template <typename T1, typename T2>
-                primitive_argument_type operator()(T1, T2) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_equal_.name_, less_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<primitive_argument_type>&&,
-                    ir::node_data<primitive_argument_type>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_equal_.name_, less_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(std::vector<ast::expression>&&,
-                    std::vector<ast::expression>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_equal_.name_, less_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ast::expression&&, ast::expression&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_equal_.name_, less_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(primitive&&, primitive&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_equal_.name_, less_equal_.codename_));
-                }
-
-                template <typename T>
-                primitive_argument_type operator()(T && lhs, T && rhs) const
-                {
-                    return primitive_argument_type(
-                            ir::node_data<bool>{lhs <= rhs});
-                }
-
-                primitive_argument_type operator()(
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&,
-                    util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            less_equal_.name_, less_equal_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<double>&& lhs, std::int64_t&& rhs) const
-                {
-                    if (lhs.num_dimensions() != 0)
-                    {
-                        return less_equal_.less_equal_all(
-                            std::move(lhs), operand_type(std::move(rhs)));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs[0] <= rhs});
-                }
-
-                primitive_argument_type operator()(
-                    std::int64_t&& lhs, ir::node_data<double>&& rhs) const
-                {
-                    if (rhs.num_dimensions() != 0)
-                    {
-                        return less_equal_.less_equal_all(
-                            operand_type(std::move(lhs)), std::move(rhs));
-                    }
-                    return primitive_argument_type(
-                            ir::node_data<bool>{lhs <= rhs[0]});
-                }
-
-                primitive_argument_type operator()(
-                    operand_type&& lhs, operand_type&& rhs) const
-                {
-                    return less_equal_.less_equal_all(
-                        std::move(lhs), std::move(rhs));
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be compared",
-                            less_equal_.name_, less_equal_.codename_));
-                }
-
-                less_equal const& less_equal_;
-            };
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "the less_equal primitive requires exactly two "
-                                "operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "less_equal::eval",
-                        generate_error_message(
-                            "the less_equal primitive requires that the "
-                                "arguments given by the operands array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops) -> primitive_argument_type
-                    {
-                        return primitive_argument_type(
-                            util::visit(visit_less_equal{*this_},
-                                std::move(ops[0].variant()),
-                                std::move(ops[1].variant())));
-                    }),
-                    detail::map_operands(
-                        operands, functional::literal_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
     }
 
-    // implement '<=' for all possible combinations of lhs and rhs
+    primitive_argument_type less_equal::less_equal0d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            rhs = blaze::map(rhs.matrix(),
+                [&](double x) { return (x <= lhs.scalar()); });
+        }
+        else
+        {
+            rhs.matrix() = blaze::map(rhs.matrix(),
+                [&](double x) { return (x <= lhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type less_equal::less_equal0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs.scalar() <= rhs.scalar()});
+
+        case 1:
+            return less_equal0d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less_equal0d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal0d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type less_equal::less_equal1d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(),
+                [&](double x) { return (x <= rhs.scalar()); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(),
+                [&](double x) { return (x <= rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less_equal::less_equal1d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal1d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x <= y); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x <= y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less_equal::less_equal1d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = lhs.vector();
+        auto cm = rhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal1d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x <= y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x <= y; });
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type less_equal::less_equal1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return less_equal1d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return less_equal1d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less_equal1d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal1d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type less_equal::less_equal2d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(),
+                [&](double x) { return (x <= rhs.scalar()); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(),
+                [&](double x) { return (x <= rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less_equal::less_equal2d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = rhs.vector();
+        auto cm = lhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal2d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x <= y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x <= y; });
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less_equal::less_equal2d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal2d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        //       is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x <= y); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x <= y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type less_equal::less_equal2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return less_equal2d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return less_equal2d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less_equal2d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal2d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type less_equal::less_equal_all(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return less_equal0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return less_equal1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return less_equal2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::less_equal_all",
+                execution_tree::generate_error_message(
+                    "left hand side operand has unsupported number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    struct less_equal::visit_less_equal
+    {
+        template <typename T1, typename T2>
+        primitive_argument_type operator()(T1, T2) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_equal_.name_, less_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<primitive_argument_type>&&,
+            ir::node_data<primitive_argument_type>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_equal_.name_, less_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(std::vector<ast::expression>&&,
+            std::vector<ast::expression>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_equal_.name_, less_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ast::expression&&, ast::expression&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_equal_.name_, less_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(primitive&&, primitive&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_equal_.name_, less_equal_.codename_));
+        }
+
+        template <typename T>
+        primitive_argument_type operator()(T && lhs, T && rhs) const
+        {
+            return primitive_argument_type(
+                    ir::node_data<bool>{lhs <= rhs});
+        }
+
+        primitive_argument_type operator()(
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&,
+            util::recursive_wrapper<
+                std::vector<primitive_argument_type>>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    less_equal_.name_, less_equal_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<double>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return less_equal_.less_equal_all(
+                    std::move(lhs), operand_type(std::move(rhs)));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs[0] <= rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<double>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return less_equal_.less_equal_all(
+                    operand_type(std::move(lhs)), std::move(rhs));
+            }
+            return primitive_argument_type(
+                    ir::node_data<bool>{lhs <= rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            operand_type&& lhs, operand_type&& rhs) const
+        {
+            return less_equal_.less_equal_all(
+                std::move(lhs), std::move(rhs));
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be compared",
+                    less_equal_.name_, less_equal_.codename_));
+        }
+
+        less_equal const& less_equal_;
+    };
+
+    hpx::future<primitive_argument_type> less_equal::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "the less_equal primitive requires exactly two "
+                        "operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "less_equal::eval",
+                execution_tree::generate_error_message(
+                    "the less_equal primitive requires that the "
+                        "arguments given by the operands array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type && ops) -> primitive_argument_type
+            {
+                return primitive_argument_type(
+                    util::visit(visit_less_equal{*this_},
+                        std::move(ops[0].variant()),
+                        std::move(ops[1].variant())));
+            }),
+            detail::map_operands(
+                operands, functional::literal_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Implement '<=' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> less_equal::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::less_equal>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::less_equal>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/row_slicing.cpp
+++ b/src/execution_tree/primitives/row_slicing.cpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2017-2018 Bibek Wagle
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Bibek Wagle
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/row_slicing.hpp>
@@ -52,249 +52,224 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    std::vector<int> row_slicing_operation::create_list_row(
+        int start, int stop, int step, int array_length) const
     {
-        struct slicing_row : std::enable_shared_from_this<slicing_row>
+        auto actual_start = 0;
+        auto actual_stop = 0;
+
+        if (start >= 0)
         {
-            slicing_row(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            actual_start = start;
+        }
+
+        if (start < 0)
+        {
+            actual_start = array_length + start;
+        }
+
+        if (stop >= 0)
+        {
+            actual_stop = stop;
+        }
+
+        if (stop < 0)
+        {
+            actual_stop = array_length + stop;
+        }
+
+        std::vector<int> result;
+
+        if (step > 0)
+        {
+            for (int i = actual_start; i < actual_stop; i += step)
             {
+                result.push_back(i);
             }
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using arg_type = ir::node_data<double>;
-            using args_type = std::vector<arg_type>;
-            using storage0d_type = typename arg_type::storage0d_type;
-            using storage1d_type = typename arg_type::storage1d_type;
-            using storage2d_type = typename arg_type::storage2d_type;
-
-            std::vector<int> create_list_row(
-                int start, int stop, int step, int array_length) const
+        if (step < 0)
+        {
+            for (int i = actual_start; i > actual_stop; i += step)
             {
-                auto actual_start = 0;
-                auto actual_stop = 0;
-
-                if (start >= 0)
-                {
-                    actual_start = start;
-                }
-
-                if (start < 0)
-                {
-                    actual_start = array_length + start;
-                }
-
-                if (stop >= 0)
-                {
-                    actual_stop = stop;
-                }
-
-                if (stop < 0)
-                {
-                    actual_stop = array_length + stop;
-                }
-
-                std::vector<int> result;
-
-                if (step > 0)
-                {
-                    for (int i = actual_start; i < actual_stop; i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
-
-                if (step < 0)
-                {
-                    for (int i = actual_start; i > actual_stop; i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
-
-                if (result.empty())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "row_slicing_operation::create_list_row",
-                        generate_error_message(
-                            "slicing will produce empty result, please "
-                                "check your parameters",
-                            name_, codename_));
-                }
-                return result;
+                result.push_back(i);
             }
+        }
 
-            primitive_argument_type row_slicing0d(args_type&& args) const
-            {
-                return primitive_argument_type{std::move(args[0])};
-            }
-
-            primitive_argument_type row_slicing1d(args_type&& args) const
-            {
-                auto row_start = args[1].scalar();
-                auto row_stop = args[2].scalar();
-                int step = 1;
-
-                if (args.size() == 4)
-                {
-                    step = args[3].scalar();
-
-                    if (step == 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                                "row_slicing_operation::row_slicing_operation",
-                            generate_error_message(
-                                "step can not be zero",
-                                name_, codename_));
-                    }
-                }
-
-                auto init_list =
-                    create_list_row(row_start, row_stop, step, args[0].size());
-
-                auto sv = blaze::elements(args[0].vector(), init_list);
-
-                if (sv.size() == 1)
-                {
-                    return primitive_argument_type{sv[0]};
-                }
-
-                storage1d_type v{sv};
-                return primitive_argument_type{
-                    ir::node_data<double>(std::move(v))};
-            }
-
-            primitive_argument_type row_slicing2d(args_type&& args) const
-            {
-                auto row_start = args[1].scalar();
-                auto row_stop = args[2].scalar();
-                auto num_matrix_rows = args[0].dimensions()[0];
-                auto num_matrix_cols = args[0].dimensions()[1];
-
-                int step = 1;
-
-                if (args.size() == 4)
-                {
-                    step = args[3].scalar();
-                    if (step == 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                                "row_slicing_operation::row_slicing_operation",
-                            generate_error_message(
-                                "step can not be zero",
-                                name_, codename_));
-                    }
-                }
-
-                auto init_list =
-                    create_list_row(row_start, row_stop, step, num_matrix_rows);
-
-                auto sm = blaze::rows(args[0].matrix(), init_list);
-
-                if (sm.rows() == 1)
-                {
-                    auto sv = blaze::trans(blaze::row(sm, 0));
-                    if (sv.size() == 1)
-                    {
-                        return primitive_argument_type{sv[0]};
-                    }
-
-                    storage1d_type v{sv};
-                    return primitive_argument_type{
-                        ir::node_data<double>{std::move(v)}};
-                }
-
-                storage2d_type m{sm};
-
-                return primitive_argument_type{
-                    ir::node_data<double>(std::move(m))};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 3 && operands.size() !=4)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "row_slicing_operation::row_slicing_operation",
-                        generate_error_message(
-                            "the row_slicing_operation primitive requires "
-                                "either three or four arguments",
-                            name_, codename_));
-                }
-
-                bool arguments_valid = true;
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        arguments_valid = false;
-                    }
-                }
-
-                if (!arguments_valid)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "row_slicing_operation::eval",
-                        generate_error_message(
-                            "the row_slicing_operation primitive requires "
-                                "that the arguments given by the operands "
-                                "array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type&& args) -> primitive_argument_type
-                    {
-                        std::size_t matrix_dims = args[0].num_dimensions();
-                        switch (matrix_dims)
-                        {
-                        case 0:
-                            return this_->row_slicing0d(std::move(args));
-
-                        case 1:
-                            return this_->row_slicing1d(std::move(args));
-
-                        case 2:
-                            return this_->row_slicing2d(std::move(args));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "row_slicing_operation::eval",
-                                generate_error_message(
-                                    "left hand side operand has unsupported "
-                                        "number of dimensions",
-                                    this_->name_, this_->codename_));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        if (result.empty())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "row_slicing_operation::create_list_row",
+                execution_tree::generate_error_message(
+                    "slicing will produce empty result, please "
+                        "check your parameters",
+                    name_, codename_));
+        }
+        return result;
     }
 
+    primitive_argument_type row_slicing_operation::row_slicing0d(args_type&& args) const
+    {
+        return primitive_argument_type{std::move(args[0])};
+    }
+
+    primitive_argument_type row_slicing_operation::row_slicing1d(args_type&& args) const
+    {
+        auto row_start = args[1].scalar();
+        auto row_stop = args[2].scalar();
+        int step = 1;
+
+        if (args.size() == 4)
+        {
+            step = args[3].scalar();
+
+            if (step == 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::"
+                        "row_slicing_operation::row_slicing_operation",
+                    execution_tree::generate_error_message(
+                        "step can not be zero",
+                        name_, codename_));
+            }
+        }
+
+        auto init_list =
+            create_list_row(row_start, row_stop, step, args[0].size());
+
+        auto sv = blaze::elements(args[0].vector(), init_list);
+
+        if (sv.size() == 1)
+        {
+            return primitive_argument_type{sv[0]};
+        }
+
+        storage1d_type v{sv};
+        return primitive_argument_type{
+            ir::node_data<double>(std::move(v))};
+    }
+
+    primitive_argument_type row_slicing_operation::row_slicing2d(args_type&& args) const
+    {
+        auto row_start = args[1].scalar();
+        auto row_stop = args[2].scalar();
+        auto num_matrix_rows = args[0].dimensions()[0];
+        auto num_matrix_cols = args[0].dimensions()[1];
+
+        int step = 1;
+
+        if (args.size() == 4)
+        {
+            step = args[3].scalar();
+            if (step == 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::"
+                        "row_slicing_operation::row_slicing_operation",
+                    execution_tree::generate_error_message(
+                        "step can not be zero",
+                        name_, codename_));
+            }
+        }
+
+        auto init_list =
+            create_list_row(row_start, row_stop, step, num_matrix_rows);
+
+        auto sm = blaze::rows(args[0].matrix(), init_list);
+
+        if (sm.rows() == 1)
+        {
+            auto sv = blaze::trans(blaze::row(sm, 0));
+            if (sv.size() == 1)
+            {
+                return primitive_argument_type{sv[0]};
+            }
+
+            storage1d_type v{sv};
+            return primitive_argument_type{
+                ir::node_data<double>{std::move(v)}};
+        }
+
+        storage2d_type m{sm};
+
+        return primitive_argument_type{
+            ir::node_data<double>(std::move(m))};
+    }
+
+    hpx::future<primitive_argument_type> row_slicing_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 3 && operands.size() !=4)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "row_slicing_operation::row_slicing_operation",
+                execution_tree::generate_error_message(
+                    "the row_slicing_operation primitive requires "
+                        "either three or four arguments",
+                    name_, codename_));
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "row_slicing_operation::eval",
+                execution_tree::generate_error_message(
+                    "the row_slicing_operation primitive requires "
+                        "that the arguments given by the operands "
+                        "array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](args_type&& args) -> primitive_argument_type
+            {
+                std::size_t matrix_dims = args[0].num_dimensions();
+                switch (matrix_dims)
+                {
+                case 0:
+                    return this_->row_slicing0d(std::move(args));
+
+                case 1:
+                    return this_->row_slicing1d(std::move(args));
+
+                case 2:
+                    return this_->row_slicing2d(std::move(args));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "row_slicing_operation::eval",
+                        execution_tree::generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions",
+                            this_->name_, this_->codename_));
+                }
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> row_slicing_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::slicing_row>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::slicing_row>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -51,277 +51,252 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    std::vector<int> slicing_operation::create_list_slice(
+        int start, int stop, int step, int array_length) const
     {
-        struct slicing : std::enable_shared_from_this<slicing>
+        auto actual_start = 0;
+        auto actual_stop = 0;
+
+        if (start >= 0)
         {
-            slicing(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            actual_start = start;
+        }
+
+        if (start < 0)
+        {
+            actual_start = array_length + start;
+        }
+
+        if (stop >= 0)
+        {
+            actual_stop = stop;
+        }
+
+        if (stop < 0)
+        {
+            actual_stop = array_length + stop;
+        }
+
+        std::vector<int> result;
+
+        if (step > 0)
+        {
+            for (int i = actual_start; i < actual_stop; i += step)
             {
+                result.push_back(i);
             }
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using arg_type = ir::node_data<double>;
-            using args_type = std::vector<arg_type>;
-            using storage0d_type = typename arg_type::storage0d_type;
-            using storage1d_type = typename arg_type::storage1d_type;
-            using storage2d_type = typename arg_type::storage2d_type;
-
-            std::vector<int> create_list_slice(
-                int start, int stop, int step, int array_length) const
+        if (step < 0)
+        {
+            for (int i = actual_start; i > actual_stop; i += step)
             {
-                auto actual_start = 0;
-                auto actual_stop = 0;
-
-                if (start >= 0)
-                {
-                    actual_start = start;
-                }
-
-                if (start < 0)
-                {
-                    actual_start = array_length + start;
-                }
-
-                if (stop >= 0)
-                {
-                    actual_stop = stop;
-                }
-
-                if (stop < 0)
-                {
-                    actual_stop = array_length + stop;
-                }
-
-                std::vector<int> result;
-
-                if (step > 0)
-                {
-                    for (int i = actual_start; i < actual_stop; i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
-
-                if (step < 0)
-                {
-                    for (int i = actual_start; i > actual_stop; i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
-
-                if (result.empty())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "slicing_operation::create_list_slice",
-                        generate_error_message(
-                            "slicing will produce empty result, please "
-                                "check your parameters",
-                            name_, codename_));
-                }
-                return result;
+                result.push_back(i);
             }
+        }
 
-            primitive_argument_type slicing0d(args_type&& args) const
-            {
-                return primitive_argument_type(std::move(args[0]));
-            }
-
-            primitive_argument_type slicing1d(args_type&& args) const
-            {
-                // return elements starting from row_start to row_stop.
-                // the values passed to col_stat and col_stop does not have an
-                // effect on the result.
-
-                auto row_start = args[1].scalar();
-                auto row_stop = args[2].scalar();
-                int step = 1;
-
-                if (args.size() == 7)
-                {
-                    step = args[3].scalar();
-
-                    if (step == 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                                "slicing_operation::slicing_operation",
-                            generate_error_message(
-                                "step can not be zero",
-                                name_, codename_));
-                    }
-                }
-
-                auto init_list = create_list_slice(
-                    row_start, row_stop, step, args[0].size());
-
-                auto sv = blaze::elements(args[0].vector(), init_list);
-
-                if (sv.size() == 1)
-                {
-                    return primitive_argument_type{sv[0]};
-                }
-
-                storage1d_type v{sv};
-                return primitive_argument_type{
-                    ir::node_data<double>(std::move(v))};
-            }
-
-            primitive_argument_type slicing2d(args_type&& args) const
-            {
-                auto row_start = args[1].scalar();
-                auto row_stop = args[2].scalar();
-                auto col_start = args[3].scalar();
-                auto col_stop = args[4].scalar();
-                auto num_matrix_rows = args[0].dimensions()[0];
-                auto num_matrix_cols = args[0].dimensions()[1];
-
-                int step_row = 1;
-                int step_col = 1;
-
-                if (args.size() == 7)
-                {
-                    step_row = args[3].scalar();
-                    step_col = args[6].scalar();
-                    col_start = args[4].scalar();
-                    col_stop = args[5].scalar();
-
-                    if (step_row == 0 || step_col == 0)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                                "row_slicing_operation::row_slicing_operation",
-                            generate_error_message(
-                                "step can not be zero",
-                                name_, codename_));
-                    }
-                }
-
-                auto init_list_row = create_list_slice(
-                    row_start, row_stop, step_row, num_matrix_rows);
-                auto init_list_col = create_list_slice(
-                    col_start, col_stop, step_col, num_matrix_cols);
-
-                blaze::DynamicMatrix<double> sm_row =
-                    blaze::rows(args[0].matrix(), init_list_row);
-                auto sm = blaze::columns(sm_row, init_list_col);
-
-                if (sm.rows() == 1)
-                {
-                    auto sv = blaze::trans(blaze::row(sm, 0));
-                    if (sv.size() == 1)
-                    {
-                        return primitive_argument_type{sv[0]};
-                    }
-
-                    storage1d_type v{sv};
-                    return primitive_argument_type{
-                        ir::node_data<double>{std::move(v)}};
-                }
-
-                if (sm.columns() == 1)
-                {
-                    auto sv = blaze::column(sm, 0);
-                    if (sv.size() == 1)
-                    {
-                        return primitive_argument_type{sv[0]};
-                    }
-
-                    storage1d_type v{sv};
-                    return primitive_argument_type{
-                        ir::node_data<double>{std::move(v)}};
-                }
-
-                storage2d_type m{sm};
-
-                return primitive_argument_type{
-                    ir::node_data<double>(std::move(m))};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 5 && operands.size() != 7)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "slicing_operation::slicing_operation",
-                        generate_error_message(
-                            "the slicing_operation primitive requires "
-                                "either five or seven arguments",
-                            name_, codename_));
-                }
-
-                bool arguments_valid = true;
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        arguments_valid = false;
-                    }
-                }
-
-                if (!arguments_valid)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "slicing_operation::eval",
-                        generate_error_message(
-                            "the slicing_operation primitive requires "
-                                "that the arguments given by the operands "
-                                "array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(
-                    hpx::util::unwrapping(
-                        [this_](args_type&& args) -> primitive_argument_type {
-                            std::size_t lhs_dims = args[0].num_dimensions();
-                            switch (lhs_dims)
-                            {
-                            case 0:
-                                return this_->slicing0d(std::move(args));
-
-                            case 1:
-                                return this_->slicing1d(std::move(args));
-
-                            case 2:
-                                return this_->slicing2d(std::move(args));
-
-                            default:
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "slicing_operation::eval",
-                                    generate_error_message(
-                                        "left hand side operand has unsupported "
-                                            "number of dimensions",
-                                        this_->name_, this_->codename_));
-                            }
-                        }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        if (result.empty())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "slicing_operation::create_list_slice",
+                execution_tree::generate_error_message(
+                    "slicing will produce empty result, please "
+                        "check your parameters",
+                    name_, codename_));
+        }
+        return result;
     }
 
+    primitive_argument_type slicing_operation::slicing0d(args_type&& args) const
+    {
+        return primitive_argument_type(std::move(args[0]));
+    }
+
+    primitive_argument_type slicing_operation::slicing1d(args_type&& args) const
+    {
+        // return elements starting from row_start to row_stop.
+        // the values passed to col_stat and col_stop does not have an
+        // effect on the result.
+
+        auto row_start = args[1].scalar();
+        auto row_stop = args[2].scalar();
+        int step = 1;
+
+        if (args.size() == 7)
+        {
+            step = args[3].scalar();
+
+            if (step == 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::"
+                        "slicing_operation::slicing_operation",
+                    execution_tree::generate_error_message(
+                        "step can not be zero",
+                        name_, codename_));
+            }
+        }
+
+        auto init_list = create_list_slice(
+            row_start, row_stop, step, args[0].size());
+
+        auto sv = blaze::elements(args[0].vector(), init_list);
+
+        if (sv.size() == 1)
+        {
+            return primitive_argument_type{sv[0]};
+        }
+
+        storage1d_type v{sv};
+        return primitive_argument_type{
+            ir::node_data<double>(std::move(v))};
+    }
+
+    primitive_argument_type slicing_operation::slicing2d(args_type&& args) const
+    {
+        auto row_start = args[1].scalar();
+        auto row_stop = args[2].scalar();
+        auto col_start = args[3].scalar();
+        auto col_stop = args[4].scalar();
+        auto num_matrix_rows = args[0].dimensions()[0];
+        auto num_matrix_cols = args[0].dimensions()[1];
+
+        int step_row = 1;
+        int step_col = 1;
+
+        if (args.size() == 7)
+        {
+            step_row = args[3].scalar();
+            step_col = args[6].scalar();
+            col_start = args[4].scalar();
+            col_stop = args[5].scalar();
+
+            if (step_row == 0 || step_col == 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::"
+                        "row_slicing_operation::row_slicing_operation",
+                    execution_tree::generate_error_message(
+                        "step can not be zero",
+                        name_, codename_));
+            }
+        }
+
+        auto init_list_row = create_list_slice(
+            row_start, row_stop, step_row, num_matrix_rows);
+        auto init_list_col = create_list_slice(
+            col_start, col_stop, step_col, num_matrix_cols);
+
+        blaze::DynamicMatrix<double> sm_row =
+            blaze::rows(args[0].matrix(), init_list_row);
+        auto sm = blaze::columns(sm_row, init_list_col);
+
+        if (sm.rows() == 1)
+        {
+            auto sv = blaze::trans(blaze::row(sm, 0));
+            if (sv.size() == 1)
+            {
+                return primitive_argument_type{sv[0]};
+            }
+
+            storage1d_type v{sv};
+            return primitive_argument_type{
+                ir::node_data<double>{std::move(v)}};
+        }
+
+        if (sm.columns() == 1)
+        {
+            auto sv = blaze::column(sm, 0);
+            if (sv.size() == 1)
+            {
+                return primitive_argument_type{sv[0]};
+            }
+
+            storage1d_type v{sv};
+            return primitive_argument_type{
+                ir::node_data<double>{std::move(v)}};
+        }
+
+        storage2d_type m{sm};
+
+        return primitive_argument_type{
+            ir::node_data<double>(std::move(m))};
+    }
+
+    hpx::future<primitive_argument_type> slicing_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 5 && operands.size() != 7)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "slicing_operation::slicing_operation",
+                execution_tree::generate_error_message(
+                    "the slicing_operation primitive requires "
+                        "either five or seven arguments",
+                    name_, codename_));
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "slicing_operation::eval",
+                execution_tree::generate_error_message(
+                    "the slicing_operation primitive requires "
+                        "that the arguments given by the operands "
+                        "array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(
+            hpx::util::unwrapping(
+                [this_](args_type&& args) -> primitive_argument_type {
+                    std::size_t lhs_dims = args[0].num_dimensions();
+                    switch (lhs_dims)
+                    {
+                    case 0:
+                        return this_->slicing0d(std::move(args));
+
+                    case 1:
+                        return this_->slicing1d(std::move(args));
+
+                    case 2:
+                        return this_->slicing2d(std::move(args));
+
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "slicing_operation::eval",
+                            execution_tree::generate_error_message(
+                                "left hand side operand has unsupported "
+                                    "number of dimensions",
+                                this_->name_, this_->codename_));
+                    }
+                }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> slicing_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::slicing>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::slicing>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/vstack_operation.cpp
+++ b/src/execution_tree/primitives/vstack_operation.cpp
@@ -49,192 +49,168 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type vstack_operation::vstack0d(args_type&& args) const
     {
-        struct vstack : std::enable_shared_from_this<vstack>
+        auto vec_size = args.size();
+        blaze::DynamicVector<double> temp(vec_size);
+
+        for (std::size_t i = 0; i < vec_size; ++i)
         {
-            vstack(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+            temp[i] = args[i].scalar();
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
+        blaze::DynamicMatrix<double> result(vec_size, 1);
+        blaze::column(result, 0) = temp;
 
-        protected:
-            using arg_type = ir::node_data<double>;
-            using args_type = std::vector<arg_type>;
-            using storage1d_type = typename arg_type::storage1d_type;
-            using storage2d_type = typename arg_type::storage2d_type;
-
-            primitive_argument_type vstack0d(args_type&& args) const
-            {
-                auto vec_size = args.size();
-                blaze::DynamicVector<double> temp(vec_size);
-
-                for (std::size_t i = 0; i < vec_size; ++i)
-                {
-                    temp[i] = args[i].scalar();
-                }
-
-                blaze::DynamicMatrix<double> result(vec_size, 1);
-                blaze::column(result, 0) = temp;
-
-                return primitive_argument_type{
-                    ir::node_data<double>{storage2d_type{std::move(result)}}};
-            }
-
-            primitive_argument_type vstack1d(args_type&& args) const
-            {
-                auto args_size = args.size();
-                arg_type& first = args[0];
-                std::size_t first_size = first.dimension(0);
-
-                for (std::size_t i = 1; i < args_size; ++i)
-                {
-                    if (args[i - 1].dimension(0) != args[i].dimension(0))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                                "vstack_operation::vstack_operation",
-                            generate_error_message(
-                                "the vstack_operation primitive requires "
-                                    "for the first dimension to be equal "
-                                    "for all vectors to be stacked",
-                                name_, codename_));
-                    }
-                }
-
-                blaze::DynamicMatrix<double> temp(args_size, first_size);
-                for (std::size_t i = 0; i < args_size; ++i)
-                {
-                    blaze::row(temp, i) = blaze::trans(args[i].vector());
-                }
-
-                return primitive_argument_type{
-                    ir::node_data<double>{storage2d_type{std::move(temp)}}};
-            }
-
-            primitive_argument_type vstack2d(args_type&& args) const
-            {
-                auto args_size = args.size();
-                auto total_rows = args[0].dimension(0);
-
-                for (std::size_t i = 1; i < args_size; ++i)
-                {
-                    if (args[i - 1].dimension(1) != args[i].dimension(1))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                                "vstack_operation::vstack_operation",
-                            generate_error_message(
-                                "the vstack_operation primitive requires "
-                                    "for the number of columns to be equal "
-                                    "for all matrices being stacked",
-                                name_, codename_));
-                    }
-
-                    total_rows += args[i].dimension(0);
-                }
-
-                blaze::DynamicMatrix<double> temp(
-                    total_rows, args[0].dimension(1));
-
-                auto step = 0;
-                for (std::size_t i = 0; i < args_size; ++i)
-                {
-                    auto num_rows = args[i].dimension(0);
-                    for (std::size_t j = 0; j < num_rows; ++j)
-                    {
-                        blaze::row(temp, j + step) =
-                            blaze::row(args[i].matrix(), j);
-                    }
-                    step = step + num_rows;
-                }
-
-                return primitive_argument_type{
-                    ir::node_data<double>{storage2d_type{std::move(temp)}}};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() < 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "vstack_operation::vstack_operation",
-                        generate_error_message(
-                            "the vstack_operation primitive requires at least "
-                                "two arguments",
-                            name_, codename_));
-                }
-
-                bool arguments_valid = true;
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        arguments_valid = false;
-                    }
-                }
-
-                if (!arguments_valid)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "vstack_operation::eval",
-                        generate_error_message(
-                            "the vstack_operation primitive requires "
-                                "that the arguments given by the operands "
-                                "array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type&& args) -> primitive_argument_type
-                    {
-                        std::size_t matrix_dims = args[0].num_dimensions();
-                        switch (matrix_dims)
-                        {
-                        case 0:
-                            return this_->vstack0d(std::move(args));
-
-                        case 1:
-                            return this_->vstack1d(std::move(args));
-
-                        case 2:
-                            return this_->vstack2d(std::move(args));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "vstack_operation::eval",
-                                generate_error_message(
-                                    "left hand side operand has unsupported "
-                                        "number of dimensions",
-                                    this_->name_, this_->codename_));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        return primitive_argument_type{
+            ir::node_data<double>{storage2d_type{std::move(result)}}};
     }
 
+    primitive_argument_type vstack_operation::vstack1d(args_type&& args) const
+    {
+        auto args_size = args.size();
+        arg_type& first = args[0];
+        std::size_t first_size = first.dimension(0);
+
+        for (std::size_t i = 1; i < args_size; ++i)
+        {
+            if (args[i - 1].dimension(0) != args[i].dimension(0))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::"
+                        "vstack_operation::vstack_operation",
+                    execution_tree::generate_error_message(
+                        "the vstack_operation primitive requires "
+                            "for the first dimension to be equal "
+                            "for all vectors to be stacked",
+                        name_, codename_));
+            }
+        }
+
+        blaze::DynamicMatrix<double> temp(args_size, first_size);
+        for (std::size_t i = 0; i < args_size; ++i)
+        {
+            blaze::row(temp, i) = blaze::trans(args[i].vector());
+        }
+
+        return primitive_argument_type{
+            ir::node_data<double>{storage2d_type{std::move(temp)}}};
+    }
+
+    primitive_argument_type vstack_operation::vstack2d(args_type&& args) const
+    {
+        auto args_size = args.size();
+        auto total_rows = args[0].dimension(0);
+
+        for (std::size_t i = 1; i < args_size; ++i)
+        {
+            if (args[i - 1].dimension(1) != args[i].dimension(1))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::"
+                        "vstack_operation::vstack_operation",
+                    execution_tree::generate_error_message(
+                        "the vstack_operation primitive requires "
+                            "for the number of columns to be equal "
+                            "for all matrices being stacked",
+                        name_, codename_));
+            }
+
+            total_rows += args[i].dimension(0);
+        }
+
+        blaze::DynamicMatrix<double> temp(
+            total_rows, args[0].dimension(1));
+
+        auto step = 0;
+        for (std::size_t i = 0; i < args_size; ++i)
+        {
+            auto num_rows = args[i].dimension(0);
+            for (std::size_t j = 0; j < num_rows; ++j)
+            {
+                blaze::row(temp, j + step) =
+                    blaze::row(args[i].matrix(), j);
+            }
+            step = step + num_rows;
+        }
+
+        return primitive_argument_type{
+            ir::node_data<double>{storage2d_type{std::move(temp)}}};
+    }
+
+    hpx::future<primitive_argument_type> vstack_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() < 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "vstack_operation::vstack_operation",
+                execution_tree::generate_error_message(
+                    "the vstack_operation primitive requires at least "
+                        "two arguments",
+                    name_, codename_));
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "vstack_operation::eval",
+                execution_tree::generate_error_message(
+                    "the vstack_operation primitive requires "
+                        "that the arguments given by the operands "
+                        "array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](args_type&& args) -> primitive_argument_type
+            {
+                std::size_t matrix_dims = args[0].num_dimensions();
+                switch (matrix_dims)
+                {
+                case 0:
+                    return this_->vstack0d(std::move(args));
+
+                case 1:
+                    return this_->vstack1d(std::move(args));
+
+                case 2:
+                    return this_->vstack2d(std::move(args));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "vstack_operation::eval",
+                        execution_tree::generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions",
+                            this_->name_, this_->codename_));
+                }
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> vstack_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::vstack>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::vstack>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}


### PR DESCRIPTION
This PR refactors the following primitives to the new primitive structure:

- [x] `for_operation`
- [x] `hstack_operation`
- [x] `vstack_operation`
- [x] `slicing_operation`
- [x] `row_slicing_operation`
- [x] `greater`
- [x] `greater_equal`
- [x] `identity`
- [x] `inverse_operation`
- [x] `less`
- [x] `less_equal`