### PR TITLE
Refactor primitives to new style (4)

### DIFF
--- a/phylanx/execution_tree/primitives/if_conditional.hpp
+++ b/phylanx/execution_tree/primitives/if_conditional.hpp
@@ -13,13 +13,21 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class if_conditional : public primitive_component_base
+    class if_conditional
+        : public primitive_component_base
+        , public std::enable_shared_from_this<if_conditional>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 

--- a/phylanx/execution_tree/primitives/linearmatrix.hpp
+++ b/phylanx/execution_tree/primitives/linearmatrix.hpp
@@ -1,7 +1,7 @@
-//   Copyright (c) 2018 R. Tohid
+// Copyright (c) 2018 R. Tohid
 //
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_LINEARMATRIX_FEB_04_2018_0331PM)
 #define PHYLANX_PRIMITIVES_LINEARMATRIX_FEB_04_2018_0331PM
@@ -9,16 +9,29 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class linearmatrix : public primitive_component_base
+    class linearmatrix
+        : public primitive_component_base
+        , public std::enable_shared_from_this<linearmatrix>
     {
+    protected:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using matrix_type = blaze::DynamicMatrix<double>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +42,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type linmatrix(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_linearmatrix(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/linspace.hpp
+++ b/phylanx/execution_tree/primitives/linspace.hpp
@@ -27,7 +27,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///    stop: the last value of the sequence. It will be ignored if the
     ///    number of samples is less than 2.
     ///    num_samples: number of samples in the sequence.
-    ///    
+    ///
     class linspace
         : public primitive_component_base
         , public std::enable_shared_from_this<linspace>

--- a/phylanx/execution_tree/primitives/linspace.hpp
+++ b/phylanx/execution_tree/primitives/linspace.hpp
@@ -1,7 +1,7 @@
-//   Copyright (c) 2018 R. Tohid
-//
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright (c) 2018 R. Tohid
+// 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_LINSPACE_JAN_22_2018_0931AM)
 #define PHYLANX_PRIMITIVES_LINSPACE_JAN_22_2018_0931AM
@@ -9,46 +9,48 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    /**
-     * @brief Linear space of evenly distributed numbers over the given interval.
-     *
-     * @author R. Tohid
-     * @version 0.0.1
-     * @date 2018
-     */
-    class linspace : public primitive_component_base
+    ///
+    /// \brief Creates a linear space of evenly spaced numbers over the given interval.
+    ///
+    /// \param args Is a vector with exactly three elements (in order):
+    ///    start: the first value of the sequence.
+    ///    stop: the last value of the sequence. It will be ignored if the
+    ///    number of samples is less than 2.
+    ///    num_samples: number of samples in the sequence.
+    ///    
+    class linspace
+        : public primitive_component_base
+        , public std::enable_shared_from_this<linspace>
     {
+    protected:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using vector_type = blaze::DynamicVector<double>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
-
-        /**
-         * @brief Default constructor.
-         */
-        linspace() = default;
-
-        /**
-         * @brief Creates a linear space of evenly spaced numbers over the given interval.
-         *
-         * @param args Is a vector with exactly three elements (in order):
-         *
-         * start: the first value of the sequence.\n
-         * stop: the last value of the sequence. It will be ignored if the number of
-         * samples is less than 2.\n
-         * num_samples: number of samples in the sequence.
-         */
         linspace(std::vector<primitive_argument_type>&& args,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type linspace1d(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_linspace(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/linspace.hpp
+++ b/phylanx/execution_tree/primitives/linspace.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2018 R. Tohid
-// 
+//
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/phylanx/execution_tree/primitives/mul_operation.hpp
+++ b/phylanx/execution_tree/primitives/mul_operation.hpp
@@ -22,7 +22,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     class mul_operation
         : public primitive_component_base
-        , std::enable_shared_from_this<mul_operation>
+        , public std::enable_shared_from_this<mul_operation>
     {
     protected:
         using operand_type = ir::node_data<double>;

--- a/phylanx/execution_tree/primitives/mul_operation.hpp
+++ b/phylanx/execution_tree/primitives/mul_operation.hpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
-//  Copyright (c) 2017 Alireza Kheirkhahan
+// Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017 Alireza Kheirkhahan
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_MUL_OPERATION_SEP_25_2017_0900PM)
 #define PHYLANX_PRIMITIVES_MUL_OPERATION_SEP_25_2017_0900PM
@@ -10,16 +10,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class mul_operation : public primitive_component_base
+    class mul_operation
+        : public primitive_component_base
+        , std::enable_shared_from_this<mul_operation>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -30,6 +42,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type mul0d(operands_type && ops) const;
+        primitive_argument_type mul0d0d(operands_type && ops) const;
+        primitive_argument_type mul0d1d(operands_type && ops) const;
+        primitive_argument_type mul0d2d(operands_type && ops) const;
+        primitive_argument_type mul1d(operands_type && ops) const;
+        primitive_argument_type mul1d0d(operands_type && ops) const;
+        primitive_argument_type mul1d1d(operands_type && ops) const;
+        primitive_argument_type mul1d2d(operands_type && ops) const;
+        primitive_argument_type mul2d(operands_type && ops) const;
+        primitive_argument_type mul2d0d(operands_type && ops) const;
+        primitive_argument_type mul2d1d(operands_type && ops) const;
+        primitive_argument_type mul2d2d(operands_type && ops) const;
     };
 
     PHYLANX_EXPORT primitive create_mul_operation(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/not_equal.hpp
+++ b/phylanx/execution_tree/primitives/not_equal.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_NOT_EQUAL_OCT_07_2017_0212PM)
 #define PHYLANX_PRIMITIVES_NOT_EQUAL_OCT_07_2017_0212PM
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class not_equal : public primitive_component_base
+    class not_equal
+        : public primitive_component_base
+        , public std::enable_shared_from_this<not_equal>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct visit_not_equal;
+
+        primitive_argument_type not_equal0d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal0d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal1d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal1d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal1d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal2d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal2d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal2d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type not_equal_all(
+            operand_type&& lhs, operand_type&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_not_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/or_operation.hpp
+++ b/phylanx/execution_tree/primitives/or_operation.hpp
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class or_operation : public primitive_component_base
+    class or_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<or_operation>
     {
+    protected:
+        using operand_type = ir::node_data<bool>;
+        using operands_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct visit_or_operation;
+
+        primitive_argument_type or_operation0d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation0d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation1d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation1d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation1d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation2d0d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation2d1d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation2d2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_operation2d(
+            operand_type&& lhs, operand_type&& rhs) const;
+        primitive_argument_type or_all(
+            operand_type&& lhs, operand_type&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_or_operation(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/parallel_block_operation.hpp
+++ b/phylanx/execution_tree/primitives/parallel_block_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_PARALLEL_BLOCK_OPERATION_OCT_08_2017_0807PM)
 #define PHYLANX_PRIMITIVES_PARALLEL_BLOCK_OPERATION_OCT_08_2017_0807PM

--- a/phylanx/execution_tree/primitives/parallel_block_operation.hpp
+++ b/phylanx/execution_tree/primitives/parallel_block_operation.hpp
@@ -9,16 +9,26 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class parallel_block_operation : public primitive_component_base
+    class parallel_block_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<parallel_block_operation>
     {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args,
+            std::string const& name, std::string const& codename) const;
+
     public:
         static match_pattern_type const match_data;
 

--- a/phylanx/execution_tree/primitives/power_operation.hpp
+++ b/phylanx/execution_tree/primitives/power_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017 Parsa Amini
+// Copyright (c) 2017-2018 Parsa Amini
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_POWER_OPERATION)
 #define PHYLANX_PRIMITIVES_POWER_OPERATION
@@ -9,16 +9,24 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class power_operation : public primitive_component_base
+    class power_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<power_operation>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +37,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type power0d(operands_type && ops) const;
+        primitive_argument_type power1d(operands_type && ops) const;
+        primitive_argument_type power2d(operands_type && ops) const;
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
     };
 
     PHYLANX_EXPORT primitive create_power_operation(

--- a/phylanx/execution_tree/primitives/row_set.hpp
+++ b/phylanx/execution_tree/primitives/row_set.hpp
@@ -20,15 +20,15 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
 
-    /// 
+    ///
     /// \brief Row Set Primitive
-    /// 
+    ///
     /// This primitive returns a sets value to specific row.
     /// \param operands Vector of phylanx node data objects of
     /// size five
-    /// 
+    ///
     /// If used inside PhySL:
-    /// 
+    ///
     ///      set_row (input, col_start, col_stop, steps, value )
     /// 
     ///          input         : Vector or a Matrix
@@ -39,7 +39,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     /// 
     ///  Note: Indices and steps can have negative values and negative values
     ///  indicate direction, similar to python.
-    /// 
+    ///
     class row_set_operation
         : public primitive_component_base
         , public std::enable_shared_from_this<row_set_operation>

--- a/phylanx/execution_tree/primitives/row_set.hpp
+++ b/phylanx/execution_tree/primitives/row_set.hpp
@@ -13,6 +13,8 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -30,13 +32,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
     /// If used inside PhySL:
     ///
     ///      set_row (input, col_start, col_stop, steps, value )
-    /// 
+    ///
     ///          input         : Vector or a Matrix
     ///          row_start     : Starting index of the set
     ///          row_stop      : Stopping index of the set
     ///          steps         : Go from row_start to row_stop in steps
     ///          value         : The value to set
-    /// 
+    ///
     ///  Note: Indices and steps can have negative values and negative values
     ///  indicate direction, similar to python.
     ///

--- a/phylanx/execution_tree/primitives/row_set.hpp
+++ b/phylanx/execution_tree/primitives/row_set.hpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef PHYLANX_ROW_SET_HPP
 #define PHYLANX_ROW_SET_HPP
@@ -9,41 +9,57 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class row_set_operation : public primitive_component_base
+
+    /// 
+    /// \brief Row Set Primitive
+    /// 
+    /// This primitive returns a sets value to specific row.
+    /// \param operands Vector of phylanx node data objects of
+    /// size five
+    /// 
+    /// If used inside PhySL:
+    /// 
+    ///      set_row (input, col_start, col_stop, steps, value )
+    /// 
+    ///          input         : Vector or a Matrix
+    ///          row_start     : Starting index of the set
+    ///          row_stop      : Stopping index of the set
+    ///          steps         : Go from row_start to row_stop in steps
+    ///          value         : The value to set
+    /// 
+    ///  Note: Indices and steps can have negative values and negative values
+    ///  indicate direction, similar to python.
+    /// 
+    class row_set_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<row_set_operation>
     {
+    protected:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+
+        using storage0d_type = typename arg_type::storage0d_type;
+        using storage1d_type = typename arg_type::storage1d_type;
+        using storage2d_type = typename arg_type::storage2d_type;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
         row_set_operation() = default;
-
-         /**
-         * @brief Row Set Primitive
-         *
-         * This primitive returns a sets value to specific row.
-         * @param operands Vector of phylanx node data objects of
-         * size five
-         *
-         * If used inside PhySL:
-         *
-         *      set_row (input, col_start, col_stop, steps, value )
-         *
-         *          input         : Vector or a Matrix
-         *          row_start     : Starting index of the set
-         *          row_stop      : Stopping index of the set
-         *          steps         : Go from row_start to row_stop in steps
-         *          value         : The value to set
-         *
-         *  Note: Indices and steps can have negative vlaues and negative values
-         *  indicate direction, similar to python.
-         */
 
         row_set_operation(
             std::vector<primitive_argument_type>&& operands,
@@ -51,6 +67,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        bool check_row_set_parameters(std::int64_t start, std::int64_t stop,
+            std::int64_t step, std::size_t array_length) const;
+        std::vector<std::int64_t> create_list_row_set(std::int64_t start,
+            std::int64_t stop, std::int64_t step,
+            std::int64_t array_length) const;
+        primitive_argument_type row_set0d(args_type&& args) const;
+        primitive_argument_type row_set1d(args_type&& args) const;
+        primitive_argument_type row_set2d(args_type&& args) const;
     };
 
     PHYLANX_EXPORT primitive create_row_set_operation(

--- a/phylanx/execution_tree/primitives/row_slicing.hpp
+++ b/phylanx/execution_tree/primitives/row_slicing.hpp
@@ -18,25 +18,25 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    /**
-    * @brief Row Slicing Primitive
-    *
-    * This primitive returns a slice of the original data.
-    * @param operands Vector of phylanx node data objects of
-    * size either three or four
-    *
-    * If used inside PhySL:
-    *
-    *      slice_row (input, row_start, row_stop, steps(optional) )
-    *
-    *          input : Scalar, Vector or a Matrix
-    *          row_start     : Starting index of the slice
-    *          row_stop      : Stopping index of the slice
-    *          steps          : Go from row_start to row_stop in steps
-    *  Note: Indices and steps can have negative values and negative values
-    *  indicate direction, similar to python.
-    *
-    */
+    ///
+    /// \brief Row Slicing Primitive
+    /// 
+    /// This primitive returns a slice of the original data.
+    /// \param operands Vector of phylanx node data objects of
+    /// size either three or four
+    /// 
+    /// If used inside PhySL:
+    /// 
+    ///      slice_row (input, row_start, row_stop, steps(optional) )
+    /// 
+    ///          input : Scalar, Vector or a Matrix
+    ///          row_start     : Starting index of the slice
+    ///          row_stop      : Stopping index of the slice
+    ///          steps          : Go from row_start to row_stop in steps
+    ///  Note: Indices and steps can have negative values and negative values
+    ///  indicate direction, similar to python.
+    /// 
+    /// 
     class row_slicing_operation
         : public primitive_component_base
         , public std::enable_shared_from_this<row_slicing_operation>

--- a/phylanx/execution_tree/primitives/row_slicing.hpp
+++ b/phylanx/execution_tree/primitives/row_slicing.hpp
@@ -20,22 +20,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///
     /// \brief Row Slicing Primitive
-    /// 
+    ///
     /// This primitive returns a slice of the original data.
     /// \param operands Vector of phylanx node data objects of
     /// size either three or four
-    /// 
+    ///
     /// If used inside PhySL:
-    /// 
+    ///
     ///      slice_row (input, row_start, row_stop, steps(optional) )
-    /// 
+    ///
     ///          input : Scalar, Vector or a Matrix
     ///          row_start     : Starting index of the slice
     ///          row_stop      : Stopping index of the slice
     ///          steps          : Go from row_start to row_stop in steps
     ///  Note: Indices and steps can have negative values and negative values
     ///  indicate direction, similar to python.
-    /// 
+    ///
     class row_slicing_operation
         : public primitive_component_base
         , public std::enable_shared_from_this<row_slicing_operation>

--- a/phylanx/execution_tree/primitives/row_slicing.hpp
+++ b/phylanx/execution_tree/primitives/row_slicing.hpp
@@ -36,7 +36,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///  Note: Indices and steps can have negative values and negative values
     ///  indicate direction, similar to python.
     /// 
-    /// 
     class row_slicing_operation
         : public primitive_component_base
         , public std::enable_shared_from_this<row_slicing_operation>

--- a/phylanx/execution_tree/primitives/set_operation.hpp
+++ b/phylanx/execution_tree/primitives/set_operation.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/phylanx/execution_tree/primitives/set_operation.hpp
+++ b/phylanx/execution_tree/primitives/set_operation.hpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2018 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef PHYLANX_SET_OPERATION_1153_02182018_HPP
 #define PHYLANX_SET_OPERATION_1153_02182018_HPP
@@ -17,45 +17,66 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class set_operation : public primitive_component_base
+    ///
+    /// \brief Set Primitive
+    /// 
+    /// This primitive sets new value to  a slice of the original data.
+    /// \param operands Vector of phylanx node data objects of
+    /// size eight
+    /// 
+    /// If used inside PhySL:
+    /// 
+    ///      slice (input, row_start, row_stop, row_steps
+    ///                , col_start, col_stop, col_steps , value_to_set
+    ///          )
+    /// 
+    ///          input         : Vector or a Matrix
+    ///          row_start     : Starting index of the slice (row)
+    ///          row_stop      : Stopping index of the slice (row)
+    ///          row_steps     : Go from row_start to row_stop in row_steps
+    ///          col_start     : Starting index of the slice (column)
+    ///          col_stop      : Stopping index of the slice (column)
+    ///          col_steps     : Go from col_start to col_stop in steps
+    ///          value_to_set  : value to set to the referenced region in the input
+    /// 
+    /// 
+    ///  Note: Indices and steps can have negative vlaues and negative values
+    ///  indicate direction, similar to python.
+    /// 
+    class set_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<set_operation>
     {
+    protected:
+        using arg_type = ir::node_data<double>;
+        using args_type = std::vector<arg_type>;
+        using storage0d_type = typename arg_type::storage0d_type;
+        using storage1d_type = typename arg_type::storage1d_type;
+        using storage2d_type = typename arg_type::storage2d_type;
+
     public:
         static match_pattern_type const match_data;
 
         set_operation() = default;
-
-        /**
-        * @brief Set Primitive
-        *
-        * This primitive sets new value to  a slice of the original data.
-        * @param operands Vector of phylanx node data objects of
-        * size eight
-        *
-        * If used inside PhySL:
-        *
-        *      slice (input, row_start, row_stop, row_steps
-        *                , col_start, col_stop, col_steps , value_to_set
-        *          )
-        *
-        *          input         : Vector or a Matrix
-        *          row_start     : Starting index of the slice (row)
-        *          row_stop      : Stopping index of the slice (row)
-        *          row_steps     : Go from row_start to row_stop in row_steps
-        *          col_start     : Starting index of the slice (column)
-        *          col_stop      : Stopping index of the slice (column)
-        *          col_steps     : Go from col_start to col_stop in steps
-        *          value_to_set  : value to set to the referenced region in the input
-        *
-        *
-        *  Note: Indices and steps can have negative vlaues and negative values
-        *  indicate direction, similar to python.
-        */
 
         set_operation(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        bool check_set_parameters(std::int64_t start, std::int64_t stop,
+            std::int64_t step, std::size_t array_length) const;
+        std::vector<std::int64_t> create_list_set(std::int64_t start,
+            std::int64_t stop, std::int64_t step,
+            std::size_t array_length) const;
+        primitive_argument_type set0d(args_type&& args) const;
+        primitive_argument_type set1d(args_type&& args) const;
+        primitive_argument_type set2d(args_type&& args) const;
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
     };
 
     PHYLANX_EXPORT primitive create_set_operation(

--- a/phylanx/execution_tree/primitives/set_operation.hpp
+++ b/phylanx/execution_tree/primitives/set_operation.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -19,17 +20,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///
     /// \brief Set Primitive
-    /// 
+    ///
     /// This primitive sets new value to  a slice of the original data.
     /// \param operands Vector of phylanx node data objects of
     /// size eight
-    /// 
+    ///
     /// If used inside PhySL:
-    /// 
+    ///
     ///      slice (input, row_start, row_stop, row_steps
     ///                , col_start, col_stop, col_steps , value_to_set
     ///          )
-    /// 
+    ///
     ///          input         : Vector or a Matrix
     ///          row_start     : Starting index of the slice (row)
     ///          row_stop      : Stopping index of the slice (row)
@@ -38,11 +39,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///          col_stop      : Stopping index of the slice (column)
     ///          col_steps     : Go from col_start to col_stop in steps
     ///          value_to_set  : value to set to the referenced region in the input
-    /// 
-    /// 
+    ///
     ///  Note: Indices and steps can have negative values and negative values
     ///  indicate direction, similar to python.
-    /// 
+    ///
     class set_operation
         : public primitive_component_base
         , public std::enable_shared_from_this<set_operation>

--- a/phylanx/execution_tree/primitives/set_operation.hpp
+++ b/phylanx/execution_tree/primitives/set_operation.hpp
@@ -40,7 +40,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///          value_to_set  : value to set to the referenced region in the input
     /// 
     /// 
-    ///  Note: Indices and steps can have negative vlaues and negative values
+    ///  Note: Indices and steps can have negative values and negative values
     ///  indicate direction, similar to python.
     /// 
     class set_operation

--- a/phylanx/execution_tree/primitives/slicing_operation.hpp
+++ b/phylanx/execution_tree/primitives/slicing_operation.hpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2017 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #ifndef PHYLANX_SLICING_OPERATION_1153_10242017_HPP
 #define PHYLANX_SLICING_OPERATION_1153_10242017_HPP

--- a/phylanx/execution_tree/primitives/square_root_operation.hpp
+++ b/phylanx/execution_tree/primitives/square_root_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017 Parsa Amini
+// Copyright (c) 2017 Parsa Amini
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_SQUARE_ROOT_OPERATION)
 #define PHYLANX_PRIMITIVES_SQUARE_ROOT_OPERATION
@@ -9,16 +9,29 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class square_root_operation : public primitive_component_base
+    class square_root_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<square_root_operation>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args,
+            std::string const& name, std::string const& codename) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +42,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type square_root_0d(operands_type && ops) const;
+        primitive_argument_type square_root_1d(operands_type && ops) const;
+        primitive_argument_type square_root_2d(operands_type && ops) const;
     };
 
     PHYLANX_EXPORT primitive create_square_root_operation(

--- a/phylanx/execution_tree/primitives/store_operation.hpp
+++ b/phylanx/execution_tree/primitives/store_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017 Alireza kheirkhahan
+// Copyright (c) 2017 Alireza kheirkhahan
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_STORE_PRIMITIVE_OCT_05_2017_0204PM)
 #define PHYLANX_PRIMITIVES_STORE_PRIMITIVE_OCT_05_2017_0204PM

--- a/phylanx/execution_tree/primitives/store_operation.hpp
+++ b/phylanx/execution_tree/primitives/store_operation.hpp
@@ -12,12 +12,15 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx {namespace execution_tree { namespace primitives
 {
-    class store_operation : public primitive_component_base
+    class store_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<store_operation>
     {
     public:
         static match_pattern_type const match_data;
@@ -29,6 +32,9 @@ namespace phylanx {namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct store;
     };
 
     PHYLANX_EXPORT primitive create_store_operation(

--- a/phylanx/execution_tree/primitives/string_output.hpp
+++ b/phylanx/execution_tree/primitives/string_output.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2018 Hartmut Kaiser
-//
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Copyright (c) 2018 Hartmut Kaiser
+// 
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_STRING_OUTPUT_JAN_18_2018_0105PM)
 #define PHYLANX_PRIMITIVES_STRING_OUTPUT_JAN_18_2018_0105PM
@@ -9,16 +9,27 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class string_output : public primitive_component_base
+    class string_output
+        : public primitive_component_base
+        , public std::enable_shared_from_this<string_output>
     {
+    protected:
+        using args_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 

--- a/phylanx/execution_tree/primitives/string_output.hpp
+++ b/phylanx/execution_tree/primitives/string_output.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2018 Hartmut Kaiser
-// 
+//
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/phylanx/execution_tree/primitives/sub_operation.hpp
+++ b/phylanx/execution_tree/primitives/sub_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017 Bibek Wagle
+// Copyright (c) 2017 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_SUB_OPERATION_SEP_15_2017_1035AM)
 #define PHYLANX_PRIMITIVES_SUB_OPERATION_SEP_15_2017_1035AM
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class sub_operation : public primitive_component_base
+    class sub_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<sub_operation>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,25 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        struct sub0dnd_simd;
+        struct subnd0d_simd;
+
+        primitive_argument_type sub0d0d(operands_type && ops) const;
+        primitive_argument_type sub0d1d(operands_type && ops) const;
+        primitive_argument_type sub0d2d(operands_type && ops) const;
+        primitive_argument_type sub0d(operands_type && ops) const;
+        ///////////////////////////////////////////////////////////
+        primitive_argument_type sub1d0d(operands_type && ops) const;
+        primitive_argument_type sub1d1d(operands_type && ops) const;
+        primitive_argument_type sub1d2d(operands_type&& ops) const;
+        primitive_argument_type sub1d(operands_type && ops) const;
+        ///////////////////////////////////////////////////////////
+        primitive_argument_type sub2d0d(operands_type && ops) const;
+        primitive_argument_type sub2d1d(operands_type&& ops) const;
+        primitive_argument_type sub2d2d(operands_type && ops) const;
+        primitive_argument_type sub2d(operands_type && ops) const;
     };
 
     PHYLANX_EXPORT primitive create_sub_operation(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/transpose_operation.hpp
+++ b/phylanx/execution_tree/primitives/transpose_operation.hpp
@@ -1,7 +1,7 @@
-//   Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_TRANSPOSE_OPERATION_OCT_09_2017_0146PM)
 #define PHYLANX_PRIMITIVES_TRANSPOSE_OPERATION_OCT_09_2017_0146PM
@@ -17,8 +17,19 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class transpose_operation : public primitive_component_base
+    class transpose_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<transpose_operation>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args,
+            std::string const& name, std::string const& codename) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +40,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type transpose0d1d(operands_type&& ops) const;
+        primitive_argument_type transpose2d(operands_type && ops) const;
     };
 
     PHYLANX_EXPORT primitive create_transpose_operation(

--- a/phylanx/execution_tree/primitives/unary_minus_operation.hpp
+++ b/phylanx/execution_tree/primitives/unary_minus_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_UNARY_MINUS_OPERATION_OCT_10_2017_0248PM)
 #define PHYLANX_PRIMITIVES_UNARY_MINUS_OPERATION_OCT_10_2017_0248PM
@@ -9,16 +9,29 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class unary_minus_operation : public primitive_component_base
+    class unary_minus_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<unary_minus_operation>
     {
+    protected:
+        using operand_type = ir::node_data<double>;
+        using operands_type = std::vector<operand_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args,
+            std::string const& name, std::string const& codename) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +42,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        primitive_argument_type neg0d(operands_type&& ops) const;
+        primitive_argument_type neg1d(operands_type&& ops) const;
+        primitive_argument_type neg2d(operands_type&& ops) const;
     };
 
     PHYLANX_EXPORT primitive create_unary_minus_operation(

--- a/phylanx/execution_tree/primitives/unary_not_operation.hpp
+++ b/phylanx/execution_tree/primitives/unary_not_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_UNARY_NOT_OPERATION_OCT_10_2017_0310PM)
 #define PHYLANX_PRIMITIVES_UNARY_NOT_OPERATION_OCT_10_2017_0310PM
@@ -9,16 +9,28 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class unary_not_operation : public primitive_component_base
+    class unary_not_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<unary_not_operation>
     {
+    protected:
+        using operand_type = ir::node_data<bool>;
+        using operands_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
     public:
         static match_pattern_type const match_data;
 
@@ -29,6 +41,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        struct visit_unary_not;
+
+        primitive_argument_type unary_not_all(operand_type&& ops) const;
     };
 
     PHYLANX_EXPORT primitive create_unary_not_operation(

--- a/phylanx/execution_tree/primitives/while_operation.hpp
+++ b/phylanx/execution_tree/primitives/while_operation.hpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_WHILE_OPERATION_OCT_06_2017_1127AM)
 #define PHYLANX_PRIMITIVES_WHILE_OPERATION_OCT_06_2017_1127AM
@@ -12,12 +12,15 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class while_operation : public primitive_component_base
+    class while_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<while_operation>
     {
     public:
         static match_pattern_type const match_data;
@@ -29,6 +32,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
+
+    private:
+        struct iteration;
     };
 
     PHYLANX_EXPORT primitive create_while_operation(

--- a/src/execution_tree/primitives/linearmatrix.cpp
+++ b/src/execution_tree/primitives/linearmatrix.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2018 R. Tohid
+// Copyright (c) 2018 R. Tohid
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/linearmatrix.hpp>
@@ -47,130 +47,107 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type linearmatrix::linmatrix(args_type&& args) const
     {
-        struct linearmatrix : std::enable_shared_from_this<linearmatrix>
+
+        if (5 != args.size())
         {
-            linearmatrix(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "linearmatrix::linmatrix",
+                execution_tree::generate_error_message(
+                    "linearmatrix primitive requires five "
+                        "arguments.",
+                    name_, codename_));
+        }
+
+        std::size_t nx = extract_integer_value(args[0]);
+        std::size_t ny = extract_integer_value(args[1]);
+        double base_value = args[2].scalar();
+        double dx = args[3].scalar();
+        double dy = args[4].scalar();
+
+        if (nx < 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "detail::linearmatrix",
+                execution_tree::generate_error_message(
+                    "the size of matrix in dimension x must at "
+                        "least be one.",
+                    name_, codename_));
+        }
+
+        if (ny < 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "detail::linearmatrix",
+                execution_tree::generate_error_message(
+                    "the size of matrix in dimension y must at "
+                        "least be one.",
+                    name_, codename_));
+        }
+
+        matrix_type result{nx, ny};
+
+        for(int x = 0; x < nx; x++)
+        {
+            for(int y = 0; y < ny; y++)
             {
+                result(x, y) = base_value + dx * x + dy * y;
             }
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using arg_type = ir::node_data<double>;
-            using args_type = std::vector<arg_type>;
-            using matrix_type = blaze::DynamicMatrix<double>;
-
-            primitive_argument_type linmatrix(args_type&& args) const
-            {
-
-                if (5 != args.size())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "linearmatrix::linmatrix",
-                        generate_error_message(
-                            "linearmatrix primitive requires five "
-                                "arguments.",
-                            name_, codename_));
-                }
-
-                std::size_t nx = extract_integer_value(args[0]);
-                std::size_t ny = extract_integer_value(args[1]);
-                double base_value = args[2].scalar();
-                double dx = args[3].scalar();
-                double dy = args[4].scalar();
-
-                if (nx < 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "detail::linearmatrix",
-                        generate_error_message(
-                            "the size of matrix in dimension x must at "
-                                "least be one.",
-                            name_, codename_));
-                }
-
-                if (ny < 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "detail::linearmatrix",
-                        generate_error_message(
-                            "the size of matrix in dimension y must at "
-                                "least be one.",
-                            name_, codename_));
-                }
-
-                matrix_type result{nx, ny};
-
-                for(int x = 0; x < nx; x++)
-                {
-                    for(int y = 0; y < ny; y++)
-                    {
-                        result(x, y) = base_value + dx * x + dy * y;
-                    }
-                }
-
-                return arg_type{std::move(result)};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
-            {
-                if (operands.size() != 5)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "linearmatrix",
-                        generate_error_message(
-                            "the linearmatrix primitive requires exactly "
-                                "five arguments.",
-                            name_, codename_));
-                }
-
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "linearmatrix::eval",
-                            generate_error_message(
-                                "at least one of the arguments passed to "
-                                    "linearmatrix is not valid.",
-                                name_, codename_));
-                    }
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type&& args) -> primitive_argument_type
-                    {
-                        return this_->linmatrix(std::move(args));
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        return arg_type{std::move(result)};
     }
 
+    hpx::future<primitive_argument_type> linearmatrix::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 5)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "linearmatrix",
+                execution_tree::generate_error_message(
+                    "the linearmatrix primitive requires exactly "
+                        "five arguments.",
+                    name_, codename_));
+        }
+
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "linearmatrix::eval",
+                    execution_tree::generate_error_message(
+                        "at least one of the arguments passed to "
+                            "linearmatrix is not valid.",
+                        name_, codename_));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](args_type&& args) -> primitive_argument_type
+            {
+                return this_->linmatrix(std::move(args));
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> linearmatrix::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::linearmatrix>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::linearmatrix>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/linspace.cpp
+++ b/src/execution_tree/primitives/linspace.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2018 R. Tohid
+// Copyright (c) 2018 R. Tohid
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/linspace.hpp>
@@ -45,109 +45,86 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type linspace::linspace1d(args_type&& args) const
     {
-        struct linspace : std::enable_shared_from_this<linspace>
+        double start = args[0][0];
+        double stop = args[1][0];
+        double num_samples = args[2][0];
+
+        if (num_samples < 1)
         {
-            linspace(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "detail::linspace1d",
+                execution_tree::generate_error_message(
+                    "the linspace primitive requires at least one "
+                    "interval",
+                    name_, codename_));
+        }
+
+        if (1 == num_samples)
+        {
+            vector_type result{ start };
+            return primitive_argument_type{ arg_type{std::move(result)} };
+        }
+        else
+        {
+            auto result = vector_type(num_samples);
+            double dx = (stop - start) / (num_samples - 1);
+            for (std::size_t i = 0; i < num_samples; i++)
             {
+                result[i] = start + dx * i;
             }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using arg_type = ir::node_data<double>;
-            using args_type = std::vector<arg_type>;
-            using vector_type = blaze::DynamicVector<double>;
-
-            primitive_argument_type linspace1d(args_type&& args) const
-            {
-                double start = args[0][0];
-                double stop = args[1][0];
-                double num_samples = args[2][0];
-
-                if (num_samples < 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "detail::linspace1d",
-                        generate_error_message(
-                            "the linspace primitive requires at least one "
-                                "interval",
-                            name_, codename_));
-                }
-
-                if (1 == num_samples)
-                {
-                    vector_type result{start};
-                    return primitive_argument_type{arg_type{std::move(result)}};
-                }
-                else
-                {
-                    auto result = vector_type(num_samples);
-                    double dx = (stop - start) / (num_samples - 1);
-                    for (std::size_t i = 0; i < num_samples; i++)
-                    {
-                        result[i] = start + dx * i;
-                    }
-                    return primitive_argument_type{arg_type{std::move(result)}};
-                }
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
-            {
-                if (operands.size() != 3)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::linspace",
-                        generate_error_message(
-                            "the linspace primitive requires exactly three "
-                                "arguments.",
-                            name_, codename_));
-                }
-
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "linspace::eval",
-                            generate_error_message(
-                                "at least one of the arguments passed to "
-                                    "linspace is not valid.",
-                                name_, codename_));
-                    }
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](args_type&& args) -> primitive_argument_type
-                    {
-                        return this_->linspace1d(std::move(args));
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+            return primitive_argument_type{ arg_type{std::move(result)} };
+        }
     }
 
+    hpx::future<primitive_argument_type> linspace::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::linspace",
+                execution_tree::generate_error_message(
+                    "the linspace primitive requires exactly three "
+                    "arguments.",
+                    name_, codename_));
+        }
+
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "linspace::eval",
+                    execution_tree::generate_error_message(
+                        "at least one of the arguments passed to "
+                        "linspace is not valid.",
+                        name_, codename_));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](args_type&& args) -> primitive_argument_type
+        {
+            return this_->linspace1d(std::move(args));
+        }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> linspace::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::linspace>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::linspace>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/mul_operation.cpp
+++ b/src/execution_tree/primitives/mul_operation.cpp
@@ -1,9 +1,9 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
-//  Copyright (c) 2017 Alireza Kheirkhahan
-//  Copyright (c) 2017 Parsa Amini
+// Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017 Alireza Kheirkhahan
+// Copyright (c) 2017-2018 Parsa Amini
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/mul_operation.hpp>
@@ -50,473 +50,450 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type mul_operation::mul0d(operands_type && ops) const
     {
-        struct mul : std::enable_shared_from_this<mul>
+        switch (ops[1].num_dimensions())
         {
-            mul(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+        case 0:
+            return mul0d0d(std::move(ops));
 
-        protected:
-            std::string name_;
-            std::string codename_;
+        case 1:
+            return mul0d1d(std::move(ops));
 
-        private:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<operand_type>;
+        case 2:
+            return mul0d2d(std::move(ops));
 
-        private:
-            primitive_argument_type mul0d(operands_type && ops) const
-            {
-                switch (ops[1].num_dimensions())
-                {
-                case 0:
-                    return mul0d0d(std::move(ops));
-
-                case 1:
-                    return mul0d1d(std::move(ops));
-
-                case 2:
-                    return mul0d2d(std::move(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul0d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type mul0d0d(operands_type && ops) const
-            {
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                if (ops.size() == 2)
-                {
-                    lhs.scalar() *= rhs.scalar();
-                    return primitive_argument_type{ std::move(lhs) };
-                }
-
-                return primitive_argument_type{
-                    std::accumulate(
-                        ops.begin() + 1, ops.end(), std::move(lhs),
-                        [this](operand_type& result, operand_type const& curr)
-                        {
-                            if (curr.num_dimensions() != 0)
-                            {
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "mul_operation::mul0d0d",
-                                    generate_error_message(
-                                        "all operands must be scalars",
-                                        name_, codename_));
-                            }
-                            result.scalar() *= curr.scalar();
-                            return std::move(result);
-                        })
-                    };
-            }
-
-            primitive_argument_type mul0d1d(operands_type && ops) const
-            {
-                if (ops.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul0d1d",
-                        generate_error_message(
-                            "can't handle more than two operands",
-                            name_, codename_));
-                }
-
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                if (ops[1].is_ref())
-                {
-                    rhs = rhs.vector() * lhs.scalar();
-                }
-                else
-                {
-                    rhs.vector() *= lhs.scalar();
-                }
-                return primitive_argument_type{ std::move(rhs) };
-            }
-
-            primitive_argument_type mul0d2d(operands_type && ops) const
-            {
-
-                if (ops.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul0d2d",
-                        generate_error_message(
-                            "can't handle more than two operands",
-                            name_, codename_));
-                }
-
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                if (ops[1].is_ref())
-                {
-                    rhs = rhs.matrix() * lhs.scalar();
-                }
-                else
-                {
-                    rhs.matrix() *= lhs.scalar();
-                }
-                return primitive_argument_type{ std::move(rhs) };
-            }
-
-            ///////////////////////////////////////////////////////////////////
-            primitive_argument_type mul1d(operands_type && ops) const
-            {
-                switch (ops[1].num_dimensions())
-                {
-                case 0:
-                    return mul1d0d(std::move(ops));
-
-                case 1:
-                    return mul1d1d(std::move(ops));
-
-                case 2:
-                    return mul1d2d(std::move(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul1d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type mul1d0d(operands_type && ops) const
-            {
-                if (ops.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul1d0d",
-                        generate_error_message(
-                            "can't handle more than two operands",
-                            name_, codename_));
-                }
-
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                if (ops[0].is_ref())
-                {
-                    lhs = lhs.vector() * rhs.scalar();
-                }
-                else
-                {
-                    lhs.vector() *= rhs.scalar();
-                }
-                return primitive_argument_type{std::move(lhs)};
-            }
-
-            primitive_argument_type mul1d1d(operands_type && ops) const
-            {
-                if (ops.size() == 2)
-                {
-                    if (ops[0].is_ref())
-                    {
-                        ops[0] = ops[0].vector() * ops[1].vector();
-                    }
-                    else
-                    {
-                        ops[0].vector() *= ops[1].vector();
-                    }
-                    return primitive_argument_type{ std::move(ops[0]) };
-                }
-
-                return primitive_argument_type{
-                    std::accumulate(
-                        ops.begin() + 1, ops.end(), std::move(ops[0]),
-                        [this](operand_type& result, operand_type const& curr)
-                        ->  operand_type
-                        {
-                            if (curr.num_dimensions() != 1)
-                            {
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "mul_operation::mul1d1d",
-                                    generate_error_message(
-                                        "all operands must be vectors",
-                                        name_, codename_));
-                            }
-
-                            if (result.is_ref())
-                            {
-                                result = result.vector() * curr.vector();
-                            }
-                            else
-                            {
-                                result.vector() *= curr.vector();
-                            }
-                            return std::move(result);
-                        })
-                    };
-            }
-
-            primitive_argument_type mul1d2d(operands_type && ops) const
-            {
-                if (ops.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul1d2d",
-                        generate_error_message(
-                            "can't handle more than two operands",
-                            name_, codename_));
-                }
-
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                auto cv = lhs.vector();
-                auto cm = rhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul1d2d",
-                        "vector size does not match number of matrix columns");
-                }
-
-                // TODO: Blaze does not support broadcasting
-                if (rhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cv.size()};
-                    for (std::size_t i = 0; i < cm.rows(); ++i)
-                    {
-                        blaze::row(m, i) = blaze::trans(cv) * blaze::row(cm, i);
-                    }
-                    return primitive_argument_type{std::move(m)};
-                }
-
-                for (std::size_t i = 0; i < rhs.matrix().rows(); ++i)
-                {
-                    blaze::row(cm, i) = blaze::trans(cv) * blaze::row(cm, i);
-                }
-                return primitive_argument_type{std::move(rhs)};
-            }
-
-            primitive_argument_type mul2d(operands_type && ops) const
-            {
-                switch (ops[1].num_dimensions())
-                {
-                case 0:
-                    return mul2d0d(std::move(ops));
-
-                case 1:
-                    return mul2d1d(std::move(ops));
-
-                case 2:
-                    return mul2d2d(std::move(ops));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul2d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type mul2d0d(operands_type && ops) const
-            {
-                if (ops.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul2d0d",
-                        generate_error_message(
-                            "can't handle more than two operands",
-                            name_, codename_));
-                }
-
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                if (lhs.is_ref())
-                {
-                    lhs = lhs.matrix() * rhs.scalar();
-                }
-                else
-                {
-                    lhs.matrix() *= rhs.scalar();
-                }
-                return primitive_argument_type{std::move(lhs)};
-            }
-
-            primitive_argument_type mul2d1d(operands_type && ops) const
-            {
-                if (ops.size() > 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul2d1d",
-                        generate_error_message(
-                            "can't handle more than two operands",
-                            name_, codename_));
-                }
-
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                auto cv = rhs.vector();
-                auto cm = lhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul2d1d",
-                        "vector size does not match number of matrix columns");
-                }
-
-                // TODO: Blaze does not support broadcasting
-                if (lhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cv.size()};
-                    for (std::size_t i = 0; i < cm.rows(); ++i)
-                    {
-                        blaze::row(m, i) = blaze::row(cm, i) * blaze::trans(cv);
-                    }
-                    return primitive_argument_type{std::move(m)};
-                }
-
-                for (std::size_t i = 0; i < cm.rows(); ++i)
-                {
-                    blaze::row(cm, i) *= blaze::trans(cv);
-                }
-                return primitive_argument_type{std::move(lhs)};
-            }
-
-            primitive_argument_type mul2d2d(operands_type && ops) const
-            {
-                if (ops.size() == 2)
-                {
-                    if (ops[0].is_ref())
-                    {
-                        ops[0] = ops[0].matrix() % ops[1].matrix();
-                    }
-                    else
-                    {
-                        ops[0].matrix() %= ops[1].matrix();
-                    }
-                    return primitive_argument_type{std::move(ops[0])};
-                }
-
-                return primitive_argument_type{
-                    std::accumulate(
-                        ops.begin() + 1, ops.end(), std::move(ops[0]),
-                        [this](operand_type& result, operand_type const& curr)
-                        ->  operand_type
-                        {
-                            if (curr.num_dimensions() != 2)
-                            {
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "mul_operation::mul2d2d",
-                                    generate_error_message(
-                                        "all operands must be matrices",
-                                        name_, codename_));
-                            }
-
-                            if (result.is_ref())
-                            {
-                                result = result.matrix() % curr.matrix();
-                            }
-                            else
-                            {
-                                result.matrix() %= curr.matrix();
-                            }
-                            return std::move(result);
-                        })
-                    };
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() < 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul_operation",
-                        generate_error_message(
-                            "the mul_operation primitive requires at least "
-                                "two operands",
-                            name_, codename_));
-                }
-
-                bool arguments_valid = true;
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        arguments_valid = false;
-                    }
-                }
-
-                if (!arguments_valid)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "mul_operation::mul_operation",
-                        generate_error_message(
-                            "the mul_operation primitive requires that "
-                                "the arguments given by the operands array "
-                                "are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type&& ops) -> primitive_argument_type
-                    {
-                        std::size_t lhs_dims = ops[0].num_dimensions();
-                        switch (lhs_dims)
-                        {
-                        case 0:
-                            return this_->mul0d(std::move(ops));
-
-                        case 1:
-                            return this_->mul1d(std::move(ops));
-
-                        case 2:
-                            return this_->mul2d(std::move(ops));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "mul_operation::eval",
-                                generate_error_message(
-                                    "left hand side operand has unsupported "
-                                        "number of dimensions",
-                                    this_->name_, this_->codename_));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul0d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
     }
 
-    // implement '*' for all possible combinations of lhs and rhs
+    primitive_argument_type mul_operation::mul0d0d(operands_type && ops) const
+    {
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        if (ops.size() == 2)
+        {
+            lhs.scalar() *= rhs.scalar();
+            return primitive_argument_type{ std::move(lhs) };
+        }
+
+        return primitive_argument_type{
+            std::accumulate(
+                ops.begin() + 1, ops.end(), std::move(lhs),
+                [this](operand_type& result, operand_type const& curr)
+                {
+                    if (curr.num_dimensions() != 0)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "mul_operation::mul0d0d",
+                            execution_tree::generate_error_message(
+                                "all operands must be scalars",
+                                name_, codename_));
+                    }
+                    result.scalar() *= curr.scalar();
+                    return std::move(result);
+                })
+            };
+    }
+
+    primitive_argument_type mul_operation::mul0d1d(operands_type && ops) const
+    {
+        if (ops.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul0d1d",
+                execution_tree::generate_error_message(
+                    "can't handle more than two operands",
+                    name_, codename_));
+        }
+
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        if (ops[1].is_ref())
+        {
+            rhs = rhs.vector() * lhs.scalar();
+        }
+        else
+        {
+            rhs.vector() *= lhs.scalar();
+        }
+        return primitive_argument_type{ std::move(rhs) };
+    }
+
+    primitive_argument_type mul_operation::mul0d2d(operands_type && ops) const
+    {
+
+        if (ops.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul0d2d",
+                execution_tree::generate_error_message(
+                    "can't handle more than two operands",
+                    name_, codename_));
+        }
+
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        if (ops[1].is_ref())
+        {
+            rhs = rhs.matrix() * lhs.scalar();
+        }
+        else
+        {
+            rhs.matrix() *= lhs.scalar();
+        }
+        return primitive_argument_type{ std::move(rhs) };
+    }
+
+    ///////////////////////////////////////////////////////////////////
+    primitive_argument_type mul_operation::mul1d(operands_type && ops) const
+    {
+        switch (ops[1].num_dimensions())
+        {
+        case 0:
+            return mul1d0d(std::move(ops));
+
+        case 1:
+            return mul1d1d(std::move(ops));
+
+        case 2:
+            return mul1d2d(std::move(ops));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul1d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type mul_operation::mul1d0d(operands_type && ops) const
+    {
+        if (ops.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul1d0d",
+                execution_tree::generate_error_message(
+                    "can't handle more than two operands",
+                    name_, codename_));
+        }
+
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        if (ops[0].is_ref())
+        {
+            lhs = lhs.vector() * rhs.scalar();
+        }
+        else
+        {
+            lhs.vector() *= rhs.scalar();
+        }
+        return primitive_argument_type{std::move(lhs)};
+    }
+
+    primitive_argument_type mul_operation::mul1d1d(operands_type && ops) const
+    {
+        if (ops.size() == 2)
+        {
+            if (ops[0].is_ref())
+            {
+                ops[0] = ops[0].vector() * ops[1].vector();
+            }
+            else
+            {
+                ops[0].vector() *= ops[1].vector();
+            }
+            return primitive_argument_type{ std::move(ops[0]) };
+        }
+
+        return primitive_argument_type{
+            std::accumulate(
+                ops.begin() + 1, ops.end(), std::move(ops[0]),
+                [this](operand_type& result, operand_type const& curr)
+                ->  operand_type
+                {
+                    if (curr.num_dimensions() != 1)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "mul_operation::mul1d1d",
+                            execution_tree::generate_error_message(
+                                "all operands must be vectors",
+                                name_, codename_));
+                    }
+
+                    if (result.is_ref())
+                    {
+                        result = result.vector() * curr.vector();
+                    }
+                    else
+                    {
+                        result.vector() *= curr.vector();
+                    }
+                    return std::move(result);
+                })
+            };
+    }
+
+    primitive_argument_type mul_operation::mul1d2d(operands_type && ops) const
+    {
+        if (ops.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul1d2d",
+                execution_tree::generate_error_message(
+                    "can't handle more than two operands",
+                    name_, codename_));
+        }
+
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        auto cv = lhs.vector();
+        auto cm = rhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul1d2d",
+                "vector size does not match number of matrix columns");
+        }
+
+        // TODO: Blaze does not support broadcasting
+        if (rhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cv.size()};
+            for (std::size_t i = 0; i < cm.rows(); ++i)
+            {
+                blaze::row(m, i) = blaze::trans(cv) * blaze::row(cm, i);
+            }
+            return primitive_argument_type{std::move(m)};
+        }
+
+        for (std::size_t i = 0; i < rhs.matrix().rows(); ++i)
+        {
+            blaze::row(cm, i) = blaze::trans(cv) * blaze::row(cm, i);
+        }
+        return primitive_argument_type{std::move(rhs)};
+    }
+
+    primitive_argument_type mul_operation::mul2d(operands_type && ops) const
+    {
+        switch (ops[1].num_dimensions())
+        {
+        case 0:
+            return mul2d0d(std::move(ops));
+
+        case 1:
+            return mul2d1d(std::move(ops));
+
+        case 2:
+            return mul2d2d(std::move(ops));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul2d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type mul_operation::mul2d0d(operands_type && ops) const
+    {
+        if (ops.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul2d0d",
+                execution_tree::generate_error_message(
+                    "can't handle more than two operands",
+                    name_, codename_));
+        }
+
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        if (lhs.is_ref())
+        {
+            lhs = lhs.matrix() * rhs.scalar();
+        }
+        else
+        {
+            lhs.matrix() *= rhs.scalar();
+        }
+        return primitive_argument_type{std::move(lhs)};
+    }
+
+    primitive_argument_type mul_operation::mul2d1d(operands_type && ops) const
+    {
+        if (ops.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul2d1d",
+                execution_tree::generate_error_message(
+                    "can't handle more than two operands",
+                    name_, codename_));
+        }
+
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        auto cv = rhs.vector();
+        auto cm = lhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul2d1d",
+                "vector size does not match number of matrix columns");
+        }
+
+        // TODO: Blaze does not support broadcasting
+        if (lhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cv.size()};
+            for (std::size_t i = 0; i < cm.rows(); ++i)
+            {
+                blaze::row(m, i) = blaze::row(cm, i) * blaze::trans(cv);
+            }
+            return primitive_argument_type{std::move(m)};
+        }
+
+        for (std::size_t i = 0; i < cm.rows(); ++i)
+        {
+            blaze::row(cm, i) *= blaze::trans(cv);
+        }
+        return primitive_argument_type{std::move(lhs)};
+    }
+
+    primitive_argument_type mul_operation::mul2d2d(operands_type && ops) const
+    {
+        if (ops.size() == 2)
+        {
+            if (ops[0].is_ref())
+            {
+                ops[0] = ops[0].matrix() % ops[1].matrix();
+            }
+            else
+            {
+                ops[0].matrix() %= ops[1].matrix();
+            }
+            return primitive_argument_type{std::move(ops[0])};
+        }
+
+        return primitive_argument_type{
+            std::accumulate(
+                ops.begin() + 1, ops.end(), std::move(ops[0]),
+                [this](operand_type& result, operand_type const& curr)
+                ->  operand_type
+                {
+                    if (curr.num_dimensions() != 2)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "mul_operation::mul2d2d",
+                            execution_tree::generate_error_message(
+                                "all operands must be matrices",
+                                name_, codename_));
+                    }
+
+                    if (result.is_ref())
+                    {
+                        result = result.matrix() % curr.matrix();
+                    }
+                    else
+                    {
+                        result.matrix() %= curr.matrix();
+                    }
+                    return std::move(result);
+                })
+            };
+    }
+
+    hpx::future<primitive_argument_type> mul_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() < 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul_operation",
+                execution_tree::generate_error_message(
+                    "the mul_operation primitive requires at least "
+                        "two operands",
+                    name_, codename_));
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "mul_operation::mul_operation",
+                execution_tree::generate_error_message(
+                    "the mul_operation primitive requires that "
+                        "the arguments given by the operands array "
+                        "are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type&& ops) -> primitive_argument_type
+            {
+                std::size_t lhs_dims = ops[0].num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return this_->mul0d(std::move(ops));
+
+                case 1:
+                    return this_->mul1d(std::move(ops));
+
+                case 2:
+                    return this_->mul2d(std::move(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "mul_operation::eval",
+                        execution_tree::generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions",
+                            this_->name_, this_->codename_));
+                }
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Implement '*' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> mul_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::mul>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::mul>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/not_equal.hpp>
@@ -47,461 +47,437 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type not_equal::not_equal0d1d(
+        operand_type&& lhs, operand_type&& rhs) const
     {
-        struct not_equal : std::enable_shared_from_this<not_equal>
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
         {
-            not_equal(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
+            rhs = blaze::map(rhs.vector(),
+                [&](double x) { return (x != lhs.scalar()); });
+        }
+        else
+        {
+            rhs.vector() = blaze::map(rhs.vector(),
+                [&](double x) { return (x != lhs.scalar()); });
+        }
 
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<primitive_argument_type>;
-
-            primitive_argument_type not_equal0d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.vector(),
-                        [&](double x) { return (x != lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.vector() = blaze::map(rhs.vector(),
-                        [&](double x) { return (x != lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type not_equal0d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x != lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.matrix() = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x != lhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type not_equal0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs.scalar() != rhs.scalar()});
-
-                case 1:
-                    return not_equal0d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return not_equal0d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal0d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type not_equal1d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(),
-                        [&](double x) { return (x != rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(),
-                        [&](double x) { return (x != rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type not_equal1d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal1d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x != y); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x != y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type not_equal1d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = lhs.vector();
-                auto cm = rhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal1d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x != y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x != y; });
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
-            primitive_argument_type not_equal1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return not_equal1d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return not_equal1d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return not_equal1d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal1d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-            primitive_argument_type not_equal2d0d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x != rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x != rhs.scalar()); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type not_equal2d1d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = rhs.vector();
-                auto cm = lhs.matrix();
-
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal2d1d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
-
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x != y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
-
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x != y; });
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type not_equal2d2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto lhs_size = lhs.dimensions();
-                auto rhs_size = rhs.dimensions();
-
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal2d2d",
-                        generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
-
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x != y); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x != y); });
-                }
-
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
-
-            primitive_argument_type not_equal2d(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return not_equal2d0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return not_equal2d1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return not_equal2d2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal2d",
-                        generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
-
-        public:
-            primitive_argument_type not_equal_all(
-                operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_dims = lhs.num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return not_equal0d(std::move(lhs), std::move(rhs));
-
-                case 1:
-                    return not_equal1d(std::move(lhs), std::move(rhs));
-
-                case 2:
-                    return not_equal2d(std::move(lhs), std::move(rhs));
-
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::not_equal_all",
-                        generate_error_message(
-                            "left hand side operand has unsupported number "
-                                "of dimensions",
-                            name_, codename_));
-                }
-            }
-
-     protected:
-            struct visit_not_equal
-            {
-                template <typename T1, typename T2>
-                primitive_argument_type operator()(T1, T2) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are "
-                                "incompatible and can't be compared",
-                            not_equal_.name_, not_equal_.codename_));
-                }
-
-                template <typename T>
-                primitive_argument_type operator()(T && lhs, T && rhs) const
-                {
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs != rhs});
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<double>&& lhs, std::int64_t&& rhs) const
-                {
-                    if (lhs.num_dimensions() != 0)
-                    {
-                        return not_equal_.not_equal_all(
-                            std::move(lhs), operand_type(std::move(rhs)));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs[0] != rhs});
-                }
-
-                primitive_argument_type operator()(
-                    std::int64_t&& lhs, ir::node_data<double>&& rhs) const
-                {
-                    if (rhs.num_dimensions() != 0)
-                    {
-                        return not_equal_.not_equal_all(
-                            operand_type(std::move(lhs)), std::move(rhs));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs != rhs[0]});
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
-                {
-                    return not_equal_.not_equal_all(
-                        ir::node_data<double>(std::move(lhs)),
-                        ir::node_data<double>(std::move(rhs)));
-                }
-
-                primitive_argument_type operator()(
-                    operand_type&& lhs, operand_type&& rhs) const
-                {
-                    return not_equal_.not_equal_all(std::move(lhs), std::move(rhs));
-                }
-
-                not_equal const& not_equal_;
-            };
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::eval",
-                        generate_error_message(
-                            "the not_equal primitive requires exactly two operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "not_equal::eval",
-                        generate_error_message(
-                            "the not_equal primitive requires that the arguments "
-                                "given by the operands array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops) -> primitive_argument_type
-                    {
-                        return primitive_argument_type(
-                            util::visit(visit_not_equal{*this_},
-                                std::move(ops[0].variant()),
-                                std::move(ops[1].variant())));
-                    }),
-                    detail::map_operands(
-                        operands, functional::literal_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
     }
 
-    // implement '!=' for all possible combinations of lhs and rhs
+    primitive_argument_type not_equal::not_equal0d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            rhs = blaze::map(rhs.matrix(),
+                [&](double x) { return (x != lhs.scalar()); });
+        }
+        else
+        {
+            rhs.matrix() = blaze::map(rhs.matrix(),
+                [&](double x) { return (x != lhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type not_equal::not_equal0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs.scalar() != rhs.scalar()});
+
+        case 1:
+            return not_equal0d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return not_equal0d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal0d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type not_equal::not_equal1d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(),
+                [&](double x) { return (x != rhs.scalar()); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(),
+                [&](double x) { return (x != rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type not_equal::not_equal1d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal1d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x != y); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x != y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type not_equal::not_equal1d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = lhs.vector();
+        auto cm = rhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal1d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x != y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x != y; });
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(rhs)});
+    }
+
+    primitive_argument_type not_equal::not_equal1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return not_equal1d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return not_equal1d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return not_equal1d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal1d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type not_equal::not_equal2d0d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(),
+                [&](double x) { return (x != rhs.scalar()); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(),
+                [&](double x) { return (x != rhs.scalar()); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type not_equal::not_equal2d1d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto cv = rhs.vector();
+        auto cm = lhs.matrix();
+
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal2d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x != y; });
+            return primitive_argument_type(
+                ir::node_data<bool>{std::move(m)});
+        }
+
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x != y; });
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type not_equal::not_equal2d2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
+
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal2d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
+
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x != y); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x != y); });
+        }
+
+        return primitive_argument_type(
+            ir::node_data<bool>{std::move(lhs)});
+    }
+
+    primitive_argument_type not_equal::not_equal2d(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return not_equal2d0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return not_equal2d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return not_equal2d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal2d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
+
+    primitive_argument_type not_equal::not_equal_all(
+        operand_type&& lhs, operand_type&& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return not_equal0d(std::move(lhs), std::move(rhs));
+
+        case 1:
+            return not_equal1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return not_equal2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::not_equal_all",
+                execution_tree::generate_error_message(
+                    "left hand side operand has unsupported number "
+                        "of dimensions",
+                    name_, codename_));
+        }
+    }
+
+    struct not_equal::visit_not_equal
+    {
+        template <typename T1, typename T2>
+        primitive_argument_type operator()(T1, T2) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are "
+                        "incompatible and can't be compared",
+                    not_equal_.name_, not_equal_.codename_));
+        }
+
+        template <typename T>
+        primitive_argument_type operator()(T && lhs, T && rhs) const
+        {
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs != rhs});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<double>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return not_equal_.not_equal_all(
+                    std::move(lhs), operand_type(std::move(rhs)));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs[0] != rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<double>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return not_equal_.not_equal_all(
+                    operand_type(std::move(lhs)), std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs != rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        {
+            return not_equal_.not_equal_all(
+                ir::node_data<double>(std::move(lhs)),
+                ir::node_data<double>(std::move(rhs)));
+        }
+
+        primitive_argument_type operator()(
+            operand_type&& lhs, operand_type&& rhs) const
+        {
+            return not_equal_.not_equal_all(std::move(lhs), std::move(rhs));
+        }
+
+        not_equal const& not_equal_;
+    };
+
+    hpx::future<primitive_argument_type> not_equal::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::eval",
+                execution_tree::generate_error_message(
+                    "the not_equal primitive requires exactly two operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "not_equal::eval",
+                execution_tree::generate_error_message(
+                    "the not_equal primitive requires that the arguments "
+                        "given by the operands array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type && ops) -> primitive_argument_type
+            {
+                return primitive_argument_type(
+                    util::visit(visit_not_equal{*this_},
+                        std::move(ops[0].variant()),
+                        std::move(ops[1].variant())));
+            }),
+            detail::map_operands(
+                operands, functional::literal_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Implement '!=' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> not_equal::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::not_equal>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::not_equal>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/or_operation.cpp
+++ b/src/execution_tree/primitives/or_operation.cpp
@@ -48,26 +48,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
-    {
-        struct or_operation : std::enable_shared_from_this<or_operation>
-        {
-            or_operation(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<bool>;
-            using operands_type = std::vector<primitive_argument_type>;
-
-            primitive_argument_type or_operation0d1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation0d1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 // TODO: SIMD functionality should be added, blaze implementation
                 // is not currently available
@@ -78,8 +60,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(rhs)});
             }
 
-            primitive_argument_type or_operation0d2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation0d2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 // TODO: SIMD functionality should be added, blaze implementation
                 // is not currently available
@@ -90,8 +72,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(rhs)});
             }
 
-            primitive_argument_type or_operation0d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation0d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t rhs_dims = rhs.num_dimensions();
                 switch (rhs_dims)
@@ -109,15 +91,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_operation0d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the operands have incompatible number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-            primitive_argument_type or_operation1d0d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation1d0d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 // TODO: SIMD functionality should be added, blaze implementation
                 // is not currently available
@@ -128,8 +110,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type or_operation1d1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation1d1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t lhs_size = lhs.dimension(0);
                 std::size_t rhs_size = rhs.dimension(0);
@@ -138,7 +120,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_operation1d1d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -152,8 +134,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type or_operation1d2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation1d2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t lhs_size = lhs.dimension(0);
                 auto rhs_size = rhs.dimensions();
@@ -162,7 +144,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_operation1d2d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -179,8 +161,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(rhs)});
             }
 
-            primitive_argument_type or_operation1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t rhs_dims = rhs.num_dimensions();
                 switch (rhs_dims)
@@ -197,15 +179,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_operation1d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the operands have incompatible number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-            primitive_argument_type or_operation2d0d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation2d0d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t lhs_size = lhs.dimension(0);
                 std::size_t rhs_size = rhs.dimension(0);
@@ -219,8 +201,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type or_operation2d1d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation2d1d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t rhs_size = rhs.dimension(0);
                 auto lhs_size = lhs.dimensions();
@@ -229,7 +211,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_operation2d1d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -246,8 +228,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type or_operation2d2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation2d2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 auto lhs_size = lhs.dimensions();
                 auto rhs_size = rhs.dimensions();
@@ -256,7 +238,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_operation2d2d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the dimensions of the operands do not match",
                             name_, codename_));
                 }
@@ -270,8 +252,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::node_data<bool>{std::move(lhs)});
             }
 
-            primitive_argument_type or_operation2d(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_operation2d(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t rhs_dims = rhs.num_dimensions();
                 switch (rhs_dims)
@@ -288,16 +270,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_operation2d",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "the operands have incompatible number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-        public:
-            primitive_argument_type or_all(
-                operand_type&& lhs, operand_type&& rhs) const
+    primitive_argument_type or_operation::or_all(
+        operand_type&& lhs, operand_type&& rhs) const
             {
                 std::size_t lhs_dims = lhs.num_dimensions();
                 switch (lhs_dims)
@@ -314,189 +295,184 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "or_operation::or_all",
-                        generate_error_message(
+                        execution_tree::generate_error_message(
                             "left hand side operand has unsupported number of "
                                 "dimensions",
                             name_, codename_));
                 }
             }
 
-        protected:
-            struct visit_or_operation
-            {
-                template <typename T1, typename T2>
-                primitive_argument_type operator()(T1, T2) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side are incompatible "
-                                "and can't be compared",
-                            or_.name_, or_.codename_));
-                }
+    struct or_operation::visit_or_operation
+    {
+        template <typename T1, typename T2>
+        primitive_argument_type operator()(T1, T2) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    or_.name_, or_.codename_));
+        }
 
-                primitive_argument_type operator()(
-                    ir::node_data<primitive_argument_type>&&,
-                    ir::node_data<primitive_argument_type>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be "
-                                "compared",
-                            or_.name_, or_.codename_));
-                }
+        primitive_argument_type operator()(
+            ir::node_data<primitive_argument_type>&&,
+            ir::node_data<primitive_argument_type>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be "
+                        "compared",
+                    or_.name_, or_.codename_));
+        }
 
-                primitive_argument_type operator()(
-                    std::vector<ast::expression>&&,
-                    std::vector<ast::expression>&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be "
-                                "compared",
-                            or_.name_, or_.codename_));
-                }
+        primitive_argument_type operator()(
+            std::vector<ast::expression>&&,
+            std::vector<ast::expression>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be "
+                        "compared",
+                    or_.name_, or_.codename_));
+        }
 
-                primitive_argument_type operator()(
-                    ast::expression&&, ast::expression&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be "
-                                "compared",
-                            or_.name_, or_.codename_));
-                }
+        primitive_argument_type operator()(
+            ast::expression&&, ast::expression&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be "
+                        "compared",
+                    or_.name_, or_.codename_));
+        }
 
-                primitive_argument_type operator()(
-                    primitive&&, primitive&&) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be "
-                                "compared",
-                            or_.name_, or_.codename_));
-                }
+        primitive_argument_type operator()(
+            primitive&&, primitive&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be "
+                        "compared",
+                    or_.name_, or_.codename_));
+        }
 
-                template <typename T>
-                primitive_argument_type operator()(T&& lhs, T&& rhs) const
+        template <typename T>
+        primitive_argument_type operator()(T&& lhs, T&& rhs) const
+        {
+            return primitive_argument_type(
+                ir::node_data<bool>{lhs && rhs});
+        }
+
+        primitive_argument_type operator()(
+            ast::nil lhs, ast::nil rhs) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be "
+                        "compared",
+                    or_.name_, or_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            phylanx::util::recursive_wrapper<
+                std::vector<primitive_argument_type>>
+                lhs,
+            phylanx::util::recursive_wrapper<
+                std::vector<primitive_argument_type>>
+                rhs) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be "
+                        "compared",
+                    or_.name_, or_.codename_));
+        }
+
+        primitive_argument_type operator()(
+            std::string lhs, std::string rhs) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side can't be "
+                        "compared",
+                    or_.name_, or_.codename_));
+        }
+
+        primitive_argument_type operator()(ir::node_data<double>&& lhs,
+            ir::node_data<double>&& rhs) const
+        {
+            return or_.or_all(ir::node_data<bool>{std::move(lhs)},
+                ir::node_data<bool>{std::move(rhs)});
+        }
+
+        primitive_argument_type operator()(
+            operand_type&& lhs, operand_type&& rhs) const
+        {
+            return or_.or_all(std::move(lhs), std::move(rhs));
+        }
+
+        or_operation const& or_;
+    };
+
+    hpx::future<primitive_argument_type> or_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        //TODO: support for operands.size()>2
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "the or_operation primitive requires exactly "
+                        "two operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "or_operation::eval",
+                execution_tree::generate_error_message(
+                    "the or_operation primitive requires that the "
+                        "arguments given by the operands array "
+                        "are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(
+            hpx::util::unwrapping(
+                [this_](
+                    operands_type&& ops) -> primitive_argument_type
                 {
                     return primitive_argument_type(
-                        ir::node_data<bool>{lhs && rhs});
-                }
-
-                primitive_argument_type operator()(
-                    ast::nil lhs, ast::nil rhs) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be "
-                                "compared",
-                            or_.name_, or_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    phylanx::util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>
-                        lhs,
-                    phylanx::util::recursive_wrapper<
-                        std::vector<primitive_argument_type>>
-                        rhs) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be "
-                                "compared",
-                            or_.name_, or_.codename_));
-                }
-
-                primitive_argument_type operator()(
-                    std::string lhs, std::string rhs) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "left hand side and right hand side can't be "
-                                "compared",
-                            or_.name_, or_.codename_));
-                }
-
-                primitive_argument_type operator()(ir::node_data<double>&& lhs,
-                    ir::node_data<double>&& rhs) const
-                {
-                    return or_.or_all(ir::node_data<bool>{std::move(lhs)},
-                        ir::node_data<bool>{std::move(rhs)});
-                }
-
-                primitive_argument_type operator()(
-                    operand_type&& lhs, operand_type&& rhs) const
-                {
-                    return or_.or_all(std::move(lhs), std::move(rhs));
-                }
-
-                or_operation const& or_;
-            };
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                //TODO: support for operands.size()>2
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "the or_operation primitive requires exactly "
-                                "two operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "or_operation::eval",
-                        generate_error_message(
-                            "the or_operation primitive requires that the "
-                                "arguments given by the operands array "
-                                "are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(
-                    hpx::util::unwrapping(
-                        [this_](
-                            operands_type&& ops) -> primitive_argument_type
-                        {
-                            return primitive_argument_type(
-                                util::visit(visit_or_operation{*this_},
-                                    std::move(ops[0].variant()),
-                                    std::move(ops[1].variant())));
-                        }),
-                    detail::map_operands(
-                        operands, functional::literal_operand{}, args,
-                        name_, codename_));
-            }
-        };
+                        util::visit(visit_or_operation{*this_},
+                            std::move(ops[0].variant()),
+                            std::move(ops[1].variant())));
+                }),
+            detail::map_operands(
+                operands, functional::literal_operand{}, args,
+                name_, codename_));
     }
 
-    // implement '||' for all possible combinations of lhs and rhs
+    //////////////////////////////////////////////////////////////////////////
+    // Implement '||' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> or_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::or_operation>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::or_operation>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/parallel_block_operation.cpp
+++ b/src/execution_tree/primitives/parallel_block_operation.cpp
@@ -48,54 +48,47 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
-    namespace detail
+    hpx::future<primitive_argument_type> parallel_block_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args,
+        std::string const& name, std::string const& codename) const
     {
-        struct block : std::enable_shared_from_this<block>
+        if (operands.empty())
         {
-            block() = default;
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                    "parallel_block_operation::eval",
+                execution_tree::generate_error_message(
+                    "the parallel_block_operation primitive "
+                        "requires at least one argument",
+                    name, codename));
+        }
 
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args,
-                std::string const& name, std::string const& codename) const
+        // Evaluate condition of while statement
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](std::vector<primitive_argument_type> && ops)
+            ->  primitive_argument_type
             {
-                if (operands.empty())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                            "parallel_block_operation::eval",
-                        generate_error_message(
-                            "the parallel_block_operation primitive "
-                                "requires at least one argument",
-                            name, codename));
-                }
-
-                // evaluate condition of while statement
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](std::vector<primitive_argument_type> && ops)
-                    ->  primitive_argument_type
-                    {
-                        return ops.back();
-                    }),
-                    detail::map_operands(
-                        operands, functional::value_operand{}, args,
-                        name, codename));
-            }
-        };
+                return ops.back();
+            }),
+            detail::map_operands(
+                operands, functional::value_operand{}, args,
+                name, codename));
     }
 
-    // start iteration over given parallel-block statement
+    //////////////////////////////////////////////////////////////////////////
+    // Start iteration over given parallel-block statement
     hpx::future<primitive_argument_type> parallel_block_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::block>()->eval(
+            return eval(
                 args, noargs, name_, codename_);
         }
 
-        return std::make_shared<detail::block>()->eval(
+        return eval(
             operands_, args, name_, codename_);
     }
 }}}

--- a/src/execution_tree/primitives/parallel_block_operation.cpp
+++ b/src/execution_tree/primitives/parallel_block_operation.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/parallel_block_operation.hpp>

--- a/src/execution_tree/primitives/power_operation.cpp
+++ b/src/execution_tree/primitives/power_operation.cpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2017 Parsa Amini
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Parsa Amini
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/power_operation.hpp>
@@ -48,126 +48,104 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type power_operation::power0d(operands_type && ops) const
     {
-        struct power : std::enable_shared_from_this<power>
-        {
-            power(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
-            {
-            }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<operand_type>;
-
-            primitive_argument_type power0d(operands_type && ops) const
-            {
-                ops[0] = double(std::pow(ops[0].scalar(), ops[1][0]));
-                return primitive_argument_type{std::move(ops[0])};
-            }
-
-            primitive_argument_type power1d(operands_type && ops) const
-            {
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                lhs = blaze::pow(lhs.vector(), rhs[0]);
-
-                return primitive_argument_type{std::move(lhs)};
-            }
-
-            primitive_argument_type power2d(operands_type && ops) const
-            {
-                operand_type& lhs = ops[0];
-                operand_type& rhs = ops[1];
-
-                lhs = blaze::pow(lhs.matrix(), rhs[0]);
-
-                return primitive_argument_type{std::move(lhs)};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args)
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "power_operation::eval",
-                        generate_error_message(
-                            "the power_operation primitive requires "
-                                "exactly two operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "power_operation::eval",
-                        generate_error_message(
-                            "the power_operation primitive requires "
-                                "that the arguments given by the operands "
-                                "array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type&& ops) -> primitive_argument_type
-                    {
-                        if (ops[1].num_dimensions() != 0)
-                        {
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "power_operation::eval",
-                                generate_error_message(
-                                    "right hand side operand has to be a "
-                                        "scalar value",
-                                    this_->name_, this_->codename_));
-                        }
-
-                        switch (ops[0].num_dimensions())
-                        {
-                        case 0:
-                            return this_->power0d(std::move(ops));
-
-                        case 1:
-                            return this_->power1d(std::move(ops));
-
-                        case 2:
-                            return this_->power2d(std::move(ops));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "power_operation::eval",
-                                generate_error_message(
-                                    "left hand side operand has unsupported "
-                                        "number of dimensions",
-                                    this_->name_, this_->codename_));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        ops[0] = double(std::pow(ops[0].scalar(), ops[1][0]));
+        return primitive_argument_type{std::move(ops[0])};
     }
 
+    primitive_argument_type power_operation::power1d(operands_type && ops) const
+    {
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        lhs = blaze::pow(lhs.vector(), rhs[0]);
+
+        return primitive_argument_type{std::move(lhs)};
+    }
+
+    primitive_argument_type power_operation::power2d(operands_type && ops) const
+    {
+        operand_type& lhs = ops[0];
+        operand_type& rhs = ops[1];
+
+        lhs = blaze::pow(lhs.matrix(), rhs[0]);
+
+        return primitive_argument_type{std::move(lhs)};
+    }
+
+    hpx::future<primitive_argument_type> power_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "power_operation::eval",
+                execution_tree::generate_error_message(
+                    "the power_operation primitive requires "
+                        "exactly two operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "power_operation::eval",
+                execution_tree::generate_error_message(
+                    "the power_operation primitive requires "
+                        "that the arguments given by the operands "
+                        "array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type&& ops) -> primitive_argument_type
+            {
+                if (ops[1].num_dimensions() != 0)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "power_operation::eval",
+                        execution_tree::generate_error_message(
+                            "right hand side operand has to be a "
+                                "scalar value",
+                            this_->name_, this_->codename_));
+                }
+
+                switch (ops[0].num_dimensions())
+                {
+                case 0:
+                    return this_->power0d(std::move(ops));
+
+                case 1:
+                    return this_->power1d(std::move(ops));
+
+                case 2:
+                    return this_->power2d(std::move(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "power_operation::eval",
+                        execution_tree::generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions",
+                            this_->name_, this_->codename_));
+                }
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> power_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::power>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::power>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/row_set.cpp
+++ b/src/execution_tree/primitives/row_set.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2018 Bibek Wagle
+// Copyright (c) 2018 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/row_set.hpp>
@@ -52,362 +52,335 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    bool row_set_operation::check_row_set_parameters(std::int64_t start, std::int64_t stop,
+        std::int64_t step, std::size_t array_length) const
     {
-
-        struct set_row : std::enable_shared_from_this<set_row>
+        if (start < 0)
         {
-            set_row(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            start = array_length + start;
+        }
+
+        if (stop < 0)
+        {
+            stop = array_length + stop;
+        }
+
+        if (step > 0)
+        {
+            return (stop > start);
+        }
+        else
+        {
+            return (start > stop);
+        }
+    }
+
+    std::vector<std::int64_t> row_set_operation::create_list_row_set(std::int64_t start,
+        std::int64_t stop, std::int64_t step,
+        std::int64_t array_length) const
+    {
+        HPX_ASSERT(step != 0);
+        auto actual_start = 0;
+        auto actual_stop = 0;
+
+        if (start >= 0)
+        {
+            actual_start = start;
+        }
+        else    //(start < 0)
+        {
+            actual_start = array_length + start;
+        }
+
+        if (stop >= 0)
+        {
+            actual_stop = stop;
+        }
+        else    //(stop < 0)
+        {
+            actual_stop = array_length + stop;
+        }
+
+        std::vector<std::int64_t> result;
+
+        if (step > 0)
+        {
+            HPX_ASSERT(actual_stop > actual_start);
+            result.reserve((actual_stop - actual_start + step) / step);
+            for (std::int64_t i = actual_start; i < actual_stop;
+                    i += step)
             {
+                result.push_back(i);
             }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using arg_type = ir::node_data<double>;
-            using args_type = std::vector<arg_type>;
-
-            using storage0d_type = typename arg_type::storage0d_type;
-            using storage1d_type = typename arg_type::storage1d_type;
-            using storage2d_type = typename arg_type::storage2d_type;
-
-            bool check_row_set_parameters(std::int64_t start, std::int64_t stop,
-                std::int64_t step, std::size_t array_length) const
+        }
+        else    //(step < 0)
+        {
+            HPX_ASSERT(actual_start > actual_stop);
+            result.reserve(
+                (actual_start - actual_stop - step) / (-step));
+            for (std::int64_t i = actual_start; i > actual_stop;
+                    i += step)
             {
-                if (start < 0)
-                {
-                    start = array_length + start;
-                }
-
-                if (stop < 0)
-                {
-                    stop = array_length + stop;
-                }
-
-                if (step > 0)
-                {
-                    return (stop > start);
-                }
-                else
-                {
-                    return (start > stop);
-                }
+                result.push_back(i);
             }
+        }
 
-            std::vector<std::int64_t> create_list_row_set(std::int64_t start,
-                std::int64_t stop, std::int64_t step,
-                std::int64_t array_length) const
-            {
-                HPX_ASSERT(step != 0);
-                auto actual_start = 0;
-                auto actual_stop = 0;
+        if (result.empty())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::create_list_row_set",
+                execution_tree::generate_error_message(
+                    "Set will produce empty result, please check your "
+                    "parameters",
+                    name_, codename_));
+        }
 
-                if (start >= 0)
-                {
-                    actual_start = start;
-                }
-                else    //(start < 0)
-                {
-                    actual_start = array_length + start;
-                }
+        return result;
+    }
 
-                if (stop >= 0)
-                {
-                    actual_stop = stop;
-                }
-                else    //(stop < 0)
-                {
-                    actual_stop = array_length + stop;
-                }
+    primitive_argument_type row_set_operation::row_set0d(args_type&& args) const
+    {
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::primitives::"
+            "row_set_operation::row_set_0d",
+            execution_tree::generate_error_message(
+                "use store operation for setting value to a variable",
+                name_, codename_));
+    }
 
-                std::vector<std::int64_t> result;
+    primitive_argument_type row_set_operation::row_set1d(args_type&& args) const
+    {
+        std::int64_t row_start = args[1].scalar();
+        std::int64_t row_stop = args[2].scalar();
+        std::int64_t step = args[3].scalar();
+        std::size_t value_dimnum = args[4].num_dimensions();
 
-                if (step > 0)
-                {
-                    HPX_ASSERT(actual_stop > actual_start);
-                    result.reserve((actual_stop - actual_start + step) / step);
-                    for (std::int64_t i = actual_start; i < actual_stop;
-                         i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
-                else    //(step < 0)
-                {
-                    HPX_ASSERT(actual_start > actual_stop);
-                    result.reserve(
-                        (actual_start - actual_stop - step) / (-step));
-                    for (std::int64_t i = actual_start; i > actual_stop;
-                         i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
+        if (value_dimnum == 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set1d",
+                execution_tree::generate_error_message(
+                    "can not store matrix in a vector", name_,
+                    codename_));
+        }
 
-                if (result.empty())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::create_list_row_set",
-                        generate_error_message(
-                            "Set will produce empty result, please check your "
-                            "parameters",
-                            name_, codename_));
-                }
+        if (step == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set1d",
+                execution_tree::generate_error_message(
+                    "argument 'step' can not be zero", name_,
+                    codename_));
+        }
 
-                return result;
-            }
+        if (!check_row_set_parameters(
+                row_start, row_stop, step, args[0].size()))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set1d",
+                execution_tree::generate_error_message(
+                    "argument 'start' or 'stop' are not valid", name_,
+                    codename_));
+        }
 
-            primitive_argument_type row_set0d(args_type&& args) const
+        auto init_list = create_list_row_set(
+            row_start, row_stop, step, args[0].size());
+
+        auto sv = blaze::elements(args[0].vector(), init_list);
+
+        if (value_dimnum == 0)
+        {
+            blaze::DynamicVector<double> temp(
+                sv.size(), args[4].scalar());
+            sv = temp;
+            return primitive_argument_type{ir::node_data<double>(0)};
+        }
+
+        auto temp = args[4].vector();
+
+        if (sv.size() != temp.size())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set1d",
+                execution_tree::generate_error_message("size mismatch, please check "
+                                        "your parameters or set vector",
+                    name_, codename_));
+        }
+
+        sv = temp;
+        return primitive_argument_type{ir::node_data<double>(args[0].vector())};
+    }
+
+    primitive_argument_type row_set_operation::row_set2d(args_type&& args) const
+    {
+        std::int64_t row_start = args[1].scalar();
+        std::int64_t row_stop = args[2].scalar();
+        std::int64_t step_row = args[3].scalar();
+        std::size_t  num_matrix_rows = args[0].dimensions()[0];
+        std::size_t  num_matrix_cols = args[0].dimensions()[1];
+        std::size_t  value_dimnum = args[4].num_dimensions();
+
+        if (step_row == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set2d",
+                execution_tree::generate_error_message(
+                    "argument 'step' can not be zero", name_,
+                    codename_));
+        }
+
+        if (!check_row_set_parameters(
+                row_start, row_stop, step_row, num_matrix_rows))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set2d",
+                execution_tree::generate_error_message(
+                    "argument 'row_start' or 'row_stop' are not valid",
+                    name_, codename_));
+        }
+
+        auto init_list_row = create_list_row_set(
+            row_start, row_stop, step_row, num_matrix_rows);
+
+        auto sm = blaze::rows(args[0].matrix(), init_list_row);
+
+        if (value_dimnum == 0)
+        {
+            blaze::DynamicMatrix<double> data(
+                sm.rows(), sm.columns(), args[4].scalar());
+            sm = data;
+            return primitive_argument_type{ir::node_data<double>(0)};
+        }
+
+        if (value_dimnum == 1)
+        {
+            auto data = blaze::trans(args[4].vector());
+            std::size_t data_size = data.size();
+            std::size_t num_cols = sm.columns();
+            std::size_t num_rows = sm.rows();
+            blaze::DynamicMatrix<double> temp(sm.rows(), sm.columns());
+
+            if (data_size != num_cols)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::primitives::"
-                    "row_set_operation::row_set_0d",
-                    generate_error_message(
-                        "use store operation for setting value to a variable",
+                    "row_set_operation::row_set2d",
+                    execution_tree::generate_error_message(
+                        "size of set vector does not match the number "
+                        "of columns in the input matrix",
                         name_, codename_));
             }
 
-            primitive_argument_type row_set1d(args_type&& args) const
+            for (std::size_t j = 0; j < num_rows; j++)
             {
-                std::int64_t row_start = args[1].scalar();
-                std::int64_t row_stop = args[2].scalar();
-                std::int64_t step = args[3].scalar();
-                std::size_t value_dimnum = args[4].num_dimensions();
-
-                if (value_dimnum == 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set1d",
-                        generate_error_message(
-                            "can not store matrix in a vector", name_,
-                            codename_));
-                }
-
-                if (step == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set1d",
-                        generate_error_message(
-                            "argument 'step' can not be zero", name_,
-                            codename_));
-                }
-
-                if (!check_row_set_parameters(
-                        row_start, row_stop, step, args[0].size()))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set1d",
-                        generate_error_message(
-                            "argument 'start' or 'stop' are not valid", name_,
-                            codename_));
-                }
-
-                auto init_list = create_list_row_set(
-                    row_start, row_stop, step, args[0].size());
-
-                auto sv = blaze::elements(args[0].vector(), init_list);
-
-                if (value_dimnum == 0)
-                {
-                    blaze::DynamicVector<double> temp(
-                        sv.size(), args[4].scalar());
-                    sv = temp;
-                    return primitive_argument_type{ir::node_data<double>(0)};
-                }
-
-                auto temp = args[4].vector();
-
-                if (sv.size() != temp.size())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set1d",
-                        generate_error_message("size mismatch, please check "
-                                               "your parameters or set vector",
-                            name_, codename_));
-                }
-
-                sv = temp;
-                return primitive_argument_type{ir::node_data<double>(args[0].vector())};
+                blaze::row(temp, j) = data;
             }
 
-            primitive_argument_type row_set2d(args_type&& args) const
-            {
-                std::int64_t row_start = args[1].scalar();
-                std::int64_t row_stop = args[2].scalar();
-                std::int64_t step_row = args[3].scalar();
-                std::size_t  num_matrix_rows = args[0].dimensions()[0];
-                std::size_t  num_matrix_cols = args[0].dimensions()[1];
-                std::size_t  value_dimnum = args[4].num_dimensions();
+            sm = temp;
 
-                if (step_row == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set2d",
-                        generate_error_message(
-                            "argument 'step' can not be zero", name_,
-                            codename_));
-                }
+            return primitive_argument_type{
+                ir::node_data<double>(args[0].matrix())};
+        }
 
-                if (!check_row_set_parameters(
-                        row_start, row_stop, step_row, num_matrix_rows))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set2d",
-                        generate_error_message(
-                            "argument 'row_start' or 'row_stop' are not valid",
-                            name_, codename_));
-                }
-
-                auto init_list_row = create_list_row_set(
-                    row_start, row_stop, step_row, num_matrix_rows);
-
-                auto sm = blaze::rows(args[0].matrix(), init_list_row);
-
-                if (value_dimnum == 0)
-                {
-                    blaze::DynamicMatrix<double> data(
-                        sm.rows(), sm.columns(), args[4].scalar());
-                    sm = data;
-                    return primitive_argument_type{ir::node_data<double>(0)};
-                }
-
-                if (value_dimnum == 1)
-                {
-                    auto data = blaze::trans(args[4].vector());
-                    std::size_t data_size = data.size();
-                    std::size_t num_cols = sm.columns();
-                    std::size_t num_rows = sm.rows();
-                    blaze::DynamicMatrix<double> temp(sm.rows(), sm.columns());
-
-                    if (data_size != num_cols)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                            "row_set_operation::row_set2d",
-                            generate_error_message(
-                                "size of set vector does not match the number "
-                                "of columns in the input matrix",
-                                name_, codename_));
-                    }
-
-                    for (std::size_t j = 0; j < num_rows; j++)
-                    {
-                        blaze::row(temp, j) = data;
-                    }
-
-                    sm = temp;
-
-                    return primitive_argument_type{
-                        ir::node_data<double>(args[0].matrix())};
-                }
-
-                auto data = args[4].matrix();
-                std::size_t  data_rows = data.rows();
-                std::size_t  data_cols = data.columns();
-                std::size_t  num_cols = sm.columns();
-                std::size_t  num_rows = sm.rows();
-                if (data_rows != num_rows || data_cols != num_cols)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set2d",
-                        generate_error_message(
-                            "matrix sizes dont match", name_, codename_));
-                }
-                blaze::DynamicMatrix<double> temp(data);
-                sm = temp;
-                return primitive_argument_type{ir::node_data<double>(args[0].matrix())};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 5)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "row_set_operation::row_set_operation",
-                        generate_error_message(
-                            "the row_set_operation primitive requires "
-                            "five arguments",
-                            name_, codename_));
-                }
-
-                bool arguments_valid = true;
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        arguments_valid = false;
-                    }
-                }
-
-                if (!arguments_valid)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "row_set_operation::eval",
-                        generate_error_message(
-                            "the row_set_operation primitive requires "
-                            "that the arguments given by the operands "
-                            "array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(
-                    hpx::util::unwrapping(
-                        [this_](args_type&& args) -> primitive_argument_type {
-                            std::size_t matrix_dims = args[0].num_dimensions();
-                            switch (matrix_dims)
-                            {
-                            case 0:
-                                return this_->row_set0d(std::move(args));
-
-                            case 1:
-                                return this_->row_set1d(std::move(args));
-
-                            case 2:
-                                return this_->row_set2d(std::move(args));
-
-                            default:
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "row_set_operation::eval",
-                                    generate_error_message(
-                                        "left hand side operand has "
-                                        "unsupported "
-                                        "number of dimensions",
-                                        this_->name_, this_->codename_));
-                            }
-                        }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        auto data = args[4].matrix();
+        std::size_t  data_rows = data.rows();
+        std::size_t  data_cols = data.columns();
+        std::size_t  num_cols = sm.columns();
+        std::size_t  num_rows = sm.rows();
+        if (data_rows != num_rows || data_cols != num_cols)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set2d",
+                execution_tree::generate_error_message(
+                    "matrix sizes dont match", name_, codename_));
+        }
+        blaze::DynamicMatrix<double> temp(data);
+        sm = temp;
+        return primitive_argument_type{ir::node_data<double>(args[0].matrix())};
     }
 
+    hpx::future<primitive_argument_type> row_set_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 5)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "row_set_operation::row_set_operation",
+                execution_tree::generate_error_message(
+                    "the row_set_operation primitive requires "
+                    "five arguments",
+                    name_, codename_));
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "row_set_operation::eval",
+                execution_tree::generate_error_message(
+                    "the row_set_operation primitive requires "
+                    "that the arguments given by the operands "
+                    "array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(
+            hpx::util::unwrapping(
+                [this_](args_type&& args) -> primitive_argument_type {
+                    std::size_t matrix_dims = args[0].num_dimensions();
+                    switch (matrix_dims)
+                    {
+                    case 0:
+                        return this_->row_set0d(std::move(args));
+
+                    case 1:
+                        return this_->row_set1d(std::move(args));
+
+                    case 2:
+                        return this_->row_set2d(std::move(args));
+
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "row_set_operation::eval",
+                            execution_tree::generate_error_message(
+                                "left hand side operand has "
+                                "unsupported "
+                                "number of dimensions",
+                                this_->name_, this_->codename_));
+                    }
+                }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> row_set_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::set_row>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::set_row>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/row_set.cpp
+++ b/src/execution_tree/primitives/row_set.cpp
@@ -52,8 +52,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    bool row_set_operation::check_row_set_parameters(std::int64_t start, std::int64_t stop,
-        std::int64_t step, std::size_t array_length) const
+    bool row_set_operation::check_row_set_parameters(std::int64_t start,
+        std::int64_t stop, std::int64_t step, std::size_t array_length) const
     {
         if (start < 0)
         {
@@ -75,8 +75,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    std::vector<std::int64_t> row_set_operation::create_list_row_set(std::int64_t start,
-        std::int64_t stop, std::int64_t step,
+    std::vector<std::int64_t> row_set_operation::create_list_row_set(
+        std::int64_t start, std::int64_t stop, std::int64_t step,
         std::int64_t array_length) const
     {
         HPX_ASSERT(step != 0);
@@ -207,8 +207,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::primitives::"
                 "row_set_operation::row_set1d",
-                execution_tree::generate_error_message("size mismatch, please check "
-                                        "your parameters or set vector",
+                execution_tree::generate_error_message(
+                    "size mismatch, please check your parameters or set vector",
                     name_, codename_));
         }
 

--- a/src/execution_tree/primitives/set_operation.cpp
+++ b/src/execution_tree/primitives/set_operation.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2018 Bibek Wagle
+// Copyright (c) 2018 Bibek Wagle
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/set_operation.hpp>
@@ -48,381 +48,355 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    bool set_operation::check_set_parameters(std::int64_t start, std::int64_t stop,
+        std::int64_t step, std::size_t array_length) const
     {
-
-        struct set : std::enable_shared_from_this<set>
+        if (start < 0)
         {
-            set(std::string const& name, std::string const& codename)
-              : name_(name)
-              , codename_(codename)
+            start = array_length + start;
+        }
+
+        if (stop < 0)
+        {
+            stop = array_length + stop;
+        }
+
+        if (step > 0)
+        {
+            return (stop > start);
+        }
+        else
+        {
+            return (start > stop);
+        }
+    }
+
+    std::vector<std::int64_t> set_operation::create_list_set(std::int64_t start,
+        std::int64_t stop, std::int64_t step,
+        std::size_t array_length) const
+    {
+        HPX_ASSERT(step != 0);
+        auto actual_start = 0;
+        auto actual_stop = 0;
+
+        if (start >= 0)
+        {
+            actual_start = start;
+        }
+        else    //(start < 0)
+        {
+            actual_start = array_length + start;
+        }
+
+        if (stop >= 0)
+        {
+            actual_stop = stop;
+        }
+        else    //(stop < 0)
+        {
+            actual_stop = array_length + stop;
+        }
+
+        std::vector<std::int64_t> result;
+
+        if (step > 0)
+        {
+            HPX_ASSERT(actual_stop > actual_start);
+            result.reserve((actual_stop - actual_start + step) / step);
+            for (std::int64_t i = actual_start; i < actual_stop;
+                    i += step)
             {
+                result.push_back(i);
             }
-
-        protected:
-            std::string name_;
-            std::string codename_;
-
-        protected:
-            using arg_type = ir::node_data<double>;
-            using args_type = std::vector<arg_type>;
-            using storage0d_type = typename arg_type::storage0d_type;
-            using storage1d_type = typename arg_type::storage1d_type;
-            using storage2d_type = typename arg_type::storage2d_type;
-
-            bool check_set_parameters(std::int64_t start, std::int64_t stop,
-                std::int64_t step, std::size_t array_length) const
+        }
+        else    //(step < 0)
+        {
+            HPX_ASSERT(actual_start > actual_stop);
+            result.reserve(
+                (actual_start - actual_stop - step) / (-step));
+            for (std::int64_t i = actual_start; i > actual_stop;
+                    i += step)
             {
-                if (start < 0)
-                {
-                    start = array_length + start;
-                }
-
-                if (stop < 0)
-                {
-                    stop = array_length + stop;
-                }
-
-                if (step > 0)
-                {
-                    return (stop > start);
-                }
-                else
-                {
-                    return (start > stop);
-                }
+                result.push_back(i);
             }
+        }
 
-            std::vector<std::int64_t> create_list_set(std::int64_t start,
-                std::int64_t stop, std::int64_t step,
-                std::size_t array_length) const
-            {
-                HPX_ASSERT(step != 0);
-                auto actual_start = 0;
-                auto actual_stop = 0;
+        if (result.empty())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::create_list_set",
+                execution_tree::generate_error_message(
+                    "Set will produce empty result, please check your "
+                    "parameters",
+                    name_, codename_));
+        }
+        return result;
+    }
 
-                if (start >= 0)
-                {
-                    actual_start = start;
-                }
-                else    //(start < 0)
-                {
-                    actual_start = array_length + start;
-                }
+    primitive_argument_type set_operation::set0d(args_type&& args) const
+    {
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::primitives::"
+            "set_operation::set0d",
+            execution_tree::generate_error_message(
+                "use store operation for setting value to a variable",
+                name_, codename_));
+    }
 
-                if (stop >= 0)
-                {
-                    actual_stop = stop;
-                }
-                else    //(stop < 0)
-                {
-                    actual_stop = array_length + stop;
-                }
+    primitive_argument_type set_operation::set1d(args_type&& args) const
+    {
+        std::int64_t row_start = args[1].scalar();
+        std::int64_t row_stop = args[2].scalar();
+        std::int64_t step = args[3].scalar();
+        std::size_t value_dimnum = args[7].num_dimensions();
 
-                std::vector<std::int64_t> result;
+        if (value_dimnum == 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set1d",
+                execution_tree::generate_error_message(
+                    "can not store matrix in a vetor", name_,
+                    codename_));
+        }
 
-                if (step > 0)
-                {
-                    HPX_ASSERT(actual_stop > actual_start);
-                    result.reserve((actual_stop - actual_start + step) / step);
-                    for (std::int64_t i = actual_start; i < actual_stop;
-                         i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
-                else    //(step < 0)
-                {
-                    HPX_ASSERT(actual_start > actual_stop);
-                    result.reserve(
-                        (actual_start - actual_stop - step) / (-step));
-                    for (std::int64_t i = actual_start; i > actual_stop;
-                         i += step)
-                    {
-                        result.push_back(i);
-                    }
-                }
+        if (step == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set1d",
+                execution_tree::generate_error_message(
+                    "argument 'step' can not be zero", name_,
+                    codename_));
+        }
 
-                if (result.empty())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::create_list_set",
-                        generate_error_message(
-                            "Set will produce empty result, please check your "
-                            "parameters",
-                            name_, codename_));
-                }
-                return result;
-            }
+        if (!check_set_parameters(
+                row_start, row_stop, step, args[0].size()))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set1d",
+                execution_tree::generate_error_message(
+                    "argument 'start' or 'stop' are not valid", name_,
+                    codename_));
+        }
 
-            primitive_argument_type set0d(args_type&& args) const
+        auto init_list =
+            create_list_set(row_start, row_stop, step, args[0].size());
+
+        auto sv = blaze::elements(args[0].vector(), init_list);
+
+        if (value_dimnum == 0)
+        {
+            blaze::DynamicVector<double> temp(
+                sv.size(), args[7].scalar());
+            sv = temp;
+            return primitive_argument_type{
+                ir::node_data<double>(args[0].vector())};
+        }
+
+        auto temp = args[7].vector();
+
+        if (sv.size() != temp.size())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set1d",
+                execution_tree::generate_error_message("size mismatch, please check "
+                                        "your parameters or set vector",
+                    name_, codename_));
+        }
+
+        sv = temp;
+        return primitive_argument_type{ir::node_data<double>(args[0].vector())};
+    }
+
+    primitive_argument_type set_operation::set2d(args_type&& args) const
+    {
+        std::int64_t row_start = args[1].scalar();
+        std::int64_t row_stop = args[2].scalar();
+        std::int64_t step_row = args[3].scalar();
+        std::int64_t col_start = args[4].scalar();
+        std::int64_t col_stop = args[5].scalar();
+        std::int64_t step_col = args[6].scalar();
+        std::size_t num_matrix_rows = args[0].dimensions()[0];
+        std::size_t num_matrix_cols = args[0].dimensions()[1];
+        std::size_t value_dimnum = args[7].num_dimensions();
+        auto matrix_data = args[0].matrix();
+
+        if (step_row == 0 || step_col == 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set2d",
+                execution_tree::generate_error_message(
+                    "argument 'step_row' or 'step_col' can not be zero",
+                    name_, codename_));
+        }
+
+        if (!check_set_parameters(
+                row_start, row_stop, step_row, num_matrix_rows))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set2d",
+                execution_tree::generate_error_message(
+                    "argument 'row_start' or 'row_stop' are not valid",
+                    name_, codename_));
+        }
+
+        if (!check_set_parameters(
+                col_start, col_stop, step_col, num_matrix_cols))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set2d",
+                execution_tree::generate_error_message(
+                    "argument 'col_start' or 'col_stop' are not valid",
+                    name_, codename_));
+        }
+
+        auto init_list_row = create_list_set(
+            row_start, row_stop, step_row, num_matrix_rows);
+        auto init_list_col = create_list_set(
+            col_start, col_stop, step_col, num_matrix_cols);
+
+        auto sm_row = blaze::rows(matrix_data, init_list_row);
+        auto sm = blaze::columns(sm_row, init_list_col);
+
+        if (value_dimnum == 0)
+        {
+            blaze::DynamicMatrix<double> data(
+                sm.rows(), sm.columns(), args[7].scalar());
+            sm = data;
+            return primitive_argument_type{
+                ir::node_data<double>(args[0].matrix())};
+        }
+
+        if (value_dimnum == 1)
+        {
+            auto data = blaze::trans(args[7].vector());
+            std::size_t data_size = data.size();
+            std::size_t num_cols = sm.columns();
+            std::size_t num_rows = sm.rows();
+            blaze::DynamicMatrix<double> temp(sm.rows(), sm.columns());
+
+            if (data_size != num_cols)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::primitives::"
-                    "set_operation::set0d",
-                    generate_error_message(
-                        "use store operation for setting value to a variable",
+                    "set_operation::set2d",
+                    execution_tree::generate_error_message(
+                        "size of set vector does not match the number "
+                        "of columns in the input matrix",
                         name_, codename_));
             }
 
-            primitive_argument_type set1d(args_type&& args) const
+            for (std::size_t j = 0; j < num_rows; j++)
             {
-                std::int64_t row_start = args[1].scalar();
-                std::int64_t row_stop = args[2].scalar();
-                std::int64_t step = args[3].scalar();
-                std::size_t value_dimnum = args[7].num_dimensions();
-
-                if (value_dimnum == 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set1d",
-                        generate_error_message(
-                            "can not store matrix in a vetor", name_,
-                            codename_));
-                }
-
-                if (step == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set1d",
-                        generate_error_message(
-                            "argument 'step' can not be zero", name_,
-                            codename_));
-                }
-
-                if (!check_set_parameters(
-                        row_start, row_stop, step, args[0].size()))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set1d",
-                        generate_error_message(
-                            "argument 'start' or 'stop' are not valid", name_,
-                            codename_));
-                }
-
-                auto init_list =
-                    create_list_set(row_start, row_stop, step, args[0].size());
-
-                auto sv = blaze::elements(args[0].vector(), init_list);
-
-                if (value_dimnum == 0)
-                {
-                    blaze::DynamicVector<double> temp(
-                        sv.size(), args[7].scalar());
-                    sv = temp;
-                    return primitive_argument_type{
-                        ir::node_data<double>(args[0].vector())};
-                }
-
-                auto temp = args[7].vector();
-
-                if (sv.size() != temp.size())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set1d",
-                        generate_error_message("size mismatch, please check "
-                                               "your parameters or set vector",
-                            name_, codename_));
-                }
-
-                sv = temp;
-                return primitive_argument_type{ir::node_data<double>(args[0].vector())};
+                blaze::row(temp, j) = data;
             }
 
-            primitive_argument_type set2d(args_type&& args) const
-            {
-                std::int64_t row_start = args[1].scalar();
-                std::int64_t row_stop = args[2].scalar();
-                std::int64_t step_row = args[3].scalar();
-                std::int64_t col_start = args[4].scalar();
-                std::int64_t col_stop = args[5].scalar();
-                std::int64_t step_col = args[6].scalar();
-                std::size_t num_matrix_rows = args[0].dimensions()[0];
-                std::size_t num_matrix_cols = args[0].dimensions()[1];
-                std::size_t value_dimnum = args[7].num_dimensions();
-                auto matrix_data = args[0].matrix();
+            sm = temp;
 
-                if (step_row == 0 || step_col == 0)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set2d",
-                        generate_error_message(
-                            "argument 'step_row' or 'step_col' can not be zero",
-                            name_, codename_));
-                }
+            return primitive_argument_type{
+                ir::node_data<double>(args[0].matrix())};
+        }
 
-                if (!check_set_parameters(
-                        row_start, row_stop, step_row, num_matrix_rows))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set2d",
-                        generate_error_message(
-                            "argument 'row_start' or 'row_stop' are not valid",
-                            name_, codename_));
-                }
-
-                if (!check_set_parameters(
-                        col_start, col_stop, step_col, num_matrix_cols))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set2d",
-                        generate_error_message(
-                            "argument 'col_start' or 'col_stop' are not valid",
-                            name_, codename_));
-                }
-
-                auto init_list_row = create_list_set(
-                    row_start, row_stop, step_row, num_matrix_rows);
-                auto init_list_col = create_list_set(
-                    col_start, col_stop, step_col, num_matrix_cols);
-
-                auto sm_row = blaze::rows(matrix_data, init_list_row);
-                auto sm = blaze::columns(sm_row, init_list_col);
-
-                if (value_dimnum == 0)
-                {
-                    blaze::DynamicMatrix<double> data(
-                        sm.rows(), sm.columns(), args[7].scalar());
-                    sm = data;
-                    return primitive_argument_type{
-                        ir::node_data<double>(args[0].matrix())};
-                }
-
-                if (value_dimnum == 1)
-                {
-                    auto data = blaze::trans(args[7].vector());
-                    std::size_t data_size = data.size();
-                    std::size_t num_cols = sm.columns();
-                    std::size_t num_rows = sm.rows();
-                    blaze::DynamicMatrix<double> temp(sm.rows(), sm.columns());
-
-                    if (data_size != num_cols)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "phylanx::execution_tree::primitives::"
-                            "set_operation::set2d",
-                            generate_error_message(
-                                "size of set vector does not match the number "
-                                "of columns in the input matrix",
-                                name_, codename_));
-                    }
-
-                    for (std::size_t j = 0; j < num_rows; j++)
-                    {
-                        blaze::row(temp, j) = data;
-                    }
-
-                    sm = temp;
-
-                    return primitive_argument_type{
-                        ir::node_data<double>(args[0].matrix())};
-                }
-
-                auto data = args[7].matrix();
-                std::size_t data_rows = data.rows();
-                std::size_t data_cols = data.columns();
-                std::size_t num_cols = sm.columns();
-                std::size_t num_rows = sm.rows();
-                if (data_rows != num_rows || data_cols != num_cols)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set2d",
-                        generate_error_message(
-                            "matrix sizes dont match", name_, codename_));
-                }
-                blaze::DynamicMatrix<double> temp(data);
-                sm = temp;
-                return primitive_argument_type{
-                    ir::node_data<double>(args[0].matrix())};
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 8)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::"
-                        "set_operation::set_operation",
-                        generate_error_message(
-                            "the set_operation primitive requires "
-                            "eight arguments",
-                            name_, codename_));
-                }
-
-                bool arguments_valid = true;
-                for (std::size_t i = 0; i != operands.size(); ++i)
-                {
-                    if (!valid(operands[i]))
-                    {
-                        arguments_valid = false;
-                    }
-                }
-
-                if (!arguments_valid)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "set_operation::eval",
-                        generate_error_message(
-                            "the set_operation primitive requires "
-                            "that the arguments given by the operands "
-                            "array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(
-                    hpx::util::unwrapping(
-                        [this_](args_type&& args) -> primitive_argument_type {
-                            std::size_t lhs_dims = args[0].num_dimensions();
-                            switch (lhs_dims)
-                            {
-                            case 0:
-                                return this_->set0d(std::move(args));
-
-                            case 1:
-                                return this_->set1d(std::move(args));
-
-                            case 2:
-                                return this_->set2d(std::move(args));
-
-                            default:
-                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                    "set_operation::eval",
-                                    generate_error_message(
-                                        "left hand side operand has "
-                                        "unsupported "
-                                        "number of dimensions",
-                                        this_->name_, this_->codename_));
-                            }
-                        }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name_, codename_));
-            }
-        };
+        auto data = args[7].matrix();
+        std::size_t data_rows = data.rows();
+        std::size_t data_cols = data.columns();
+        std::size_t num_cols = sm.columns();
+        std::size_t num_rows = sm.rows();
+        if (data_rows != num_rows || data_cols != num_cols)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set2d",
+                execution_tree::generate_error_message(
+                    "matrix sizes dont match", name_, codename_));
+        }
+        blaze::DynamicMatrix<double> temp(data);
+        sm = temp;
+        return primitive_argument_type{
+            ir::node_data<double>(args[0].matrix())};
     }
 
+    hpx::future<primitive_argument_type> set_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 8)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::"
+                "set_operation::set_operation",
+                execution_tree::generate_error_message(
+                    "the set_operation primitive requires "
+                    "eight arguments",
+                    name_, codename_));
+        }
+
+        bool arguments_valid = true;
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                arguments_valid = false;
+            }
+        }
+
+        if (!arguments_valid)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "set_operation::eval",
+                execution_tree::generate_error_message(
+                    "the set_operation primitive requires "
+                    "that the arguments given by the operands "
+                    "array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(
+            hpx::util::unwrapping(
+                [this_](args_type&& args) -> primitive_argument_type {
+                    std::size_t lhs_dims = args[0].num_dimensions();
+                    switch (lhs_dims)
+                    {
+                    case 0:
+                        return this_->set0d(std::move(args));
+
+                    case 1:
+                        return this_->set1d(std::move(args));
+
+                    case 2:
+                        return this_->set2d(std::move(args));
+
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "set_operation::eval",
+                            execution_tree::generate_error_message(
+                                "left hand side operand has "
+                                "unsupported "
+                                "number of dimensions",
+                                this_->name_, this_->codename_));
+                    }
+                }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> set_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::set>(name_, codename_)
-                ->eval(args, noargs);
+            return eval(args, noargs);
         }
-        return std::make_shared<detail::set>(name_, codename_)
-            ->eval(operands_, args);
+        return eval(operands_, args);
     }
 }}}

--- a/src/execution_tree/primitives/slicing_operation.cpp
+++ b/src/execution_tree/primitives/slicing_operation.cpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2017-2018 Bibek Wagle
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Bibek Wagle
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/slicing_operation.hpp>

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -47,83 +47,74 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    struct store_operation::store : std::enable_shared_from_this<store>
     {
-        struct store : std::enable_shared_from_this<store>
+        store(std::vector<primitive_argument_type> const& args,
+            std::shared_ptr<store_operation const> that)
+            : args_(args)
+            , that_(that)
         {
-            store(std::vector<primitive_argument_type> const& operands,
-                    std::vector<primitive_argument_type> const& args,
-                    std::string const& name, std::string const& codename)
-              : operands_(operands)
-              , args_(args)
-              , name_(name)
-              , codename_(codename)
+            if (that_->operands_.size() != 2)
             {
-                if (operands_.size() != 2)
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "store_operation::eval",
+                    execution_tree::generate_error_message(
+                        "the store_operation primitive requires exactly "
+                            "two operands",
+                        that_->name_, that_->codename_));
+
+                if (!valid(that_->operands_[0]) || !valid(that_->operands_[1]))
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "store_operation::eval",
-                        generate_error_message(
-                            "the store_operation primitive requires exactly "
-                                "two operands",
-                            name_, codename_));
+                        "store_operation::store_operation",
+                        execution_tree::generate_error_message(
+                            "the store_operation primitive requires that "
+                                "the arguments given by the operands array "
+                                "is valid",
+                            that_->name_, that_->codename_));
+                }
 
-                    if (!valid(operands_[0]) || !valid(operands_[1]))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "store_operation::store_operation",
-                            generate_error_message(
-                                "the store_operation primitive requires that "
-                                    "the arguments given by the operands array "
-                                    "is valid",
-                                name_, codename_));
-                    }
-
-                    if (!is_primitive_operand(operands_[0]))
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "store_operation::store_operation",
-                            generate_error_message(
-                                "the first argument of the store primitive must "
-                                    "refer to a another primitive and can't be a "
-                                    "literal value",
-                                name_, codename_));
-                    }
+                if (!is_primitive_operand(that_->operands_[0]))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "store_operation::store_operation",
+                        execution_tree::generate_error_message(
+                            "the first argument of the store primitive must "
+                                "refer to a another primitive and can't be a "
+                                "literal value",
+                            that_->name_, that_->codename_));
                 }
             }
+        }
 
-            hpx::future<primitive_argument_type> eval()
-            {
-                auto this_ = this->shared_from_this();
-                return literal_operand(operands_[1], args_, name_, codename_)
-                    .then(hpx::util::unwrapping(
-                        [this_](primitive_argument_type&& val)
-                        {
-                            primitive_operand(this_->operands_[0], this_->name_,
-                                    this_->codename_)
-                                .store(hpx::launch::sync, std::move(val));
-                            return primitive_argument_type{};
-                        }));
-            }
+        hpx::future<primitive_argument_type> eval()
+        {
+            auto this_ = this->shared_from_this();
+            return literal_operand(
+                that_->operands_[1], args_, that_->name_, that_->codename_)
+                .then(hpx::util::unwrapping(
+                    [this_](primitive_argument_type&& val) {
+                        primitive_operand(this_->that_->operands_[0],
+                            this_->that_->name_, this_->that_->codename_)
+                            .store(hpx::launch::sync, std::move(val));
+                        return primitive_argument_type{};
+                    }));
+        }
 
-            std::vector<primitive_argument_type> operands_;
-            std::vector<primitive_argument_type> args_;
-            std::string name_;
-            std::string codename_;
-        };
-    }
+        std::vector<primitive_argument_type> args_;
+        std::shared_ptr<store_operation const> that_;
+    };
 
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> store_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::store>(
-                args, noargs, name_, codename_)->eval();
+            return std::make_shared<store>(noargs, shared_from_this())->eval();
         }
 
-        return std::make_shared<detail::store>(
-            operands_, args, name_, codename_)->eval();
+        return std::make_shared<store>(args, shared_from_this())->eval();
     }
 }}}
 

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017 Alireza Kheirkhahan
+// Copyright (c) 2017 Alireza Kheirkhahan
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/detail/is_literal_value.hpp>

--- a/src/execution_tree/primitives/transpose_operation.cpp
+++ b/src/execution_tree/primitives/transpose_operation.cpp
@@ -1,7 +1,7 @@
-//   Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/detail/is_literal_value.hpp>
@@ -48,102 +48,89 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    hpx::future<primitive_argument_type> transpose_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args,
+        std::string const& name, std::string const& codename) const
     {
-        struct transpose : std::enable_shared_from_this<transpose>
+        if (operands.size() != 1)
         {
-            transpose() = default;
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "transpose_operation::transpose_operation",
+                execution_tree::generate_error_message(
+                    "the transpose_operation primitive requires"
+                        "exactly one operand",
+                    name, codename));
+        }
 
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args,
-                std::string const& name, std::string const& codename)
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "transpose_operation::transpose_operation",
+                execution_tree::generate_error_message(
+                    "the transpose_operation primitive requires "
+                        "that the arguments given by the operands "
+                        "array is valid",
+                    name, codename));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_, name, codename](operands_type&& ops)
+            -> primitive_argument_type
             {
-                if (operands.size() != 1)
+                std::size_t dims = ops[0].num_dimensions();
+                switch (dims)
                 {
+                case 0:
+                    HPX_FALLTHROUGH;
+
+                case 1:
+                    return this_->transpose0d1d(std::move(ops));
+
+                case 2:
+                    return this_->transpose2d(std::move(ops));
+
+                default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "transpose_operation::transpose_operation",
-                        generate_error_message(
-                            "the transpose_operation primitive requires"
-                                "exactly one operand",
+                        "transpose_operation::eval",
+                        execution_tree::generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions",
                             name, codename));
                 }
-
-                if (!valid(operands[0]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "transpose_operation::transpose_operation",
-                        generate_error_message(
-                            "the transpose_operation primitive requires "
-                                "that the arguments given by the operands "
-                                "array is valid",
-                            name, codename));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_, name, codename](operands_type&& ops)
-                    -> primitive_argument_type
-                    {
-                        std::size_t dims = ops[0].num_dimensions();
-                        switch (dims)
-                        {
-                        case 0:
-                            HPX_FALLTHROUGH;
-
-                        case 1:
-                            return this_->transpose0d1d(std::move(ops));
-
-                        case 2:
-                            return this_->transpose2d(std::move(ops));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "transpose_operation::eval",
-                                generate_error_message(
-                                    "left hand side operand has unsupported "
-                                        "number of dimensions",
-                                    name, codename));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name, codename));
-            }
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<operand_type>;
-
-            primitive_argument_type transpose0d1d(operands_type&& ops) const
-            {
-                return primitive_argument_type{std::move(ops[0])};       // no-op
-            }
-
-            primitive_argument_type transpose2d(operands_type && ops) const
-            {
-                if (ops[0].is_ref())
-                {
-                    ops[0] = blaze::trans(ops[0].matrix());
-                }
-                else
-                {
-                    blaze::transpose(ops[0].matrix_non_ref());
-                }
-                return primitive_argument_type{std::move(ops[0])};
-            }
-        };
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name, codename));
     }
 
+    primitive_argument_type transpose_operation::transpose0d1d(operands_type&& ops) const
+    {
+        return primitive_argument_type{std::move(ops[0])};       // no-op
+    }
+
+    primitive_argument_type transpose_operation::transpose2d(operands_type && ops) const
+    {
+        if (ops[0].is_ref())
+        {
+            ops[0] = blaze::trans(ops[0].matrix());
+        }
+        else
+        {
+            blaze::transpose(ops[0].matrix_non_ref());
+        }
+        return primitive_argument_type{std::move(ops[0])};
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> transpose_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::transpose>()->eval(
-                args, noargs, name_, codename_);
+            return eval(args, noargs, name_, codename_);
         }
-        return std::make_shared<detail::transpose>()->eval(
-            operands_, args, name_, codename_);
+        return eval(operands_, args, name_, codename_);
     }
 }}}

--- a/src/execution_tree/primitives/unary_minus_operation.cpp
+++ b/src/execution_tree/primitives/unary_minus_operation.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/unary_minus_operation.hpp>
@@ -50,104 +50,90 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
+    primitive_argument_type unary_minus_operation::neg0d(operands_type&& ops) const
     {
-        struct unary_minus : std::enable_shared_from_this<unary_minus>
-        {
-            unary_minus() = default;
-
-        protected:
-            using operand_type = ir::node_data<double>;
-            using operands_type = std::vector<operand_type>;
-
-            primitive_argument_type neg0d(operands_type&& ops) const
-            {
-                ops[0].scalar() = -ops[0].scalar();
-                return primitive_argument_type(std::move(ops[0]));
-            }
-
-            primitive_argument_type neg1d(operands_type&& ops) const
-            {
-                ops[0] = -ops[0].vector();
-                return primitive_argument_type(std::move(ops[0]));
-            }
-
-            primitive_argument_type neg2d(operands_type&& ops) const
-            {
-                ops[0] = -ops[0].matrix();
-                return primitive_argument_type(std::move(ops[0]));
-            }
-
-        public:
-            hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args,
-                std::string const& name, std::string const& codename) const
-            {
-                if (operands.size() != 1)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "unary_minus_operation::eval",
-                        generate_error_message(
-                            "the unary_minus_operation primitive requires "
-                                "exactly one operand",
-                            name, codename));
-                }
-
-                if (!valid(operands[0]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "unary_minus_operation::eval",
-                        generate_error_message(
-                            "the unary_minus_operation primitive requires "
-                                "that the argument given by the operands "
-                                "array is valid",
-                            name, codename));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_, name, codename](operands_type && ops)
-                    -> primitive_argument_type
-                    {
-                        std::size_t lhs_dims = ops[0].num_dimensions();
-                        switch (lhs_dims)
-                        {
-                        case 0:
-                            return this_->neg0d(std::move(ops));
-
-                        case 1:
-                            return this_->neg1d(std::move(ops));
-
-                        case 2:
-                            return this_->neg2d(std::move(ops));
-
-                        default:
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "unary_minus_operation::eval",
-                                generate_error_message(
-                                    "operand has unsupported number of "
-                                        "dimensions",
-                                    name, codename));
-                        }
-                    }),
-                    detail::map_operands(
-                        operands, functional::numeric_operand{}, args,
-                        name, codename));
-            }
-        };
+        ops[0].scalar() = -ops[0].scalar();
+        return primitive_argument_type(std::move(ops[0]));
     }
 
-    // implement unary '-' for all possible combinations of lhs and rhs
+    primitive_argument_type unary_minus_operation::neg1d(operands_type&& ops) const
+    {
+        ops[0] = -ops[0].vector();
+        return primitive_argument_type(std::move(ops[0]));
+    }
+
+    primitive_argument_type unary_minus_operation::neg2d(operands_type&& ops) const
+    {
+        ops[0] = -ops[0].matrix();
+        return primitive_argument_type(std::move(ops[0]));
+    }
+
+    hpx::future<primitive_argument_type> unary_minus_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args,
+        std::string const& name, std::string const& codename) const
+    {
+        if (operands.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "unary_minus_operation::eval",
+                execution_tree::generate_error_message(
+                    "the unary_minus_operation primitive requires "
+                        "exactly one operand",
+                    name, codename));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "unary_minus_operation::eval",
+                execution_tree::generate_error_message(
+                    "the unary_minus_operation primitive requires "
+                        "that the argument given by the operands "
+                        "array is valid",
+                    name, codename));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_, name, codename](operands_type && ops)
+            -> primitive_argument_type
+            {
+                std::size_t lhs_dims = ops[0].num_dimensions();
+                switch (lhs_dims)
+                {
+                case 0:
+                    return this_->neg0d(std::move(ops));
+
+                case 1:
+                    return this_->neg1d(std::move(ops));
+
+                case 2:
+                    return this_->neg2d(std::move(ops));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "unary_minus_operation::eval",
+                        execution_tree::generate_error_message(
+                            "operand has unsupported number of "
+                                "dimensions",
+                            name, codename));
+                }
+            }),
+            detail::map_operands(
+                operands, functional::numeric_operand{}, args,
+                name, codename));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // Implement unary '-' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> unary_minus_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::unary_minus>()->eval(
-                args, noargs, name_, codename_);
+            return eval(args, noargs, name_, codename_);
         }
-        return std::make_shared<detail::unary_minus>()->eval(
-            operands_, args, name_, codename_);
+        return eval(operands_, args, name_, codename_);
     }
 }}}

--- a/src/execution_tree/primitives/while_operation.cpp
+++ b/src/execution_tree/primitives/while_operation.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/while_operation.hpp>
@@ -45,95 +45,84 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
-    namespace detail
+    struct while_operation::iteration : std::enable_shared_from_this<iteration>
     {
-        struct iteration : std::enable_shared_from_this<iteration>
+        iteration(std::vector<primitive_argument_type> const& args,
+            std::shared_ptr<while_operation const> that)
+          : that_(that), args_(args)
         {
-            iteration(std::vector<primitive_argument_type> const& operands,
-                    std::vector<primitive_argument_type> const& args,
-                    std::string const& name, std::string const& codename)
-              : operands_(operands)
-              , args_(args)
-              , name_(name)
-              , codename_(codename)
+            this->args_ = args;
+            if (that_->operands_.size() != 2)
             {
-                if (operands_.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::while_operation::"
-                            "while_operation",
-                        generate_error_message(
-                            "the while_operation primitive requires exactly two "
-                                "arguments",
-                            name_, codename_));
-                }
-
-                if (!valid(operands_[0]) || !valid(operands_[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "phylanx::execution_tree::primitives::while_operation::"
-                            "while_operation",
-                        generate_error_message(
-                            "the while_operation primitive requires that the "
-                                "arguments  by the operands array are valid",
-                            name_, codename_));
-                }
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::while_operation::"
+                        "while_operation",
+                    execution_tree::generate_error_message(
+                        "the while_operation primitive requires exactly two "
+                            "arguments",
+                        that_->name_, that_->codename_));
             }
 
-            hpx::future<primitive_argument_type> body(
-                hpx::future<primitive_argument_type>&& cond)
+            if (!valid(that_->operands_[0]) || !valid(that_->operands_[1]))
             {
-                if (extract_boolean_value(cond.get(), name_, codename_))
-                {
-                    // evaluate body of while statement
-                    auto this_ = this->shared_from_this();
-                    return literal_operand(operands_[1], args_, name_, codename_)
-                        .then([this_](
-                                hpx::future<primitive_argument_type> && result
-                            ) mutable -> hpx::future<primitive_argument_type>
-                            {
-                                this_->result_ = result.get();
-                                return this_->loop();
-                            });
-                }
-
-                hpx::future<primitive_argument_type> f = p_.get_future();
-                p_.set_value(std::move(result_));
-                return f;
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::while_operation::"
+                        "while_operation",
+                    execution_tree::generate_error_message(
+                        "the while_operation primitive requires that the "
+                            "arguments  by the operands array are valid",
+                        that_->name_, that_->codename_));
             }
+        }
 
-            hpx::future<primitive_argument_type> loop()
+        hpx::future<primitive_argument_type> loop()
+        {
+            // Evaluate condition of while statement
+            auto this_ = this->shared_from_this();
+            return literal_operand(
+                that_->operands_[0], args_, that_->name_, that_->codename_)
+                .then([this_](hpx::future<primitive_argument_type>&& cond)
+                            -> hpx::future<primitive_argument_type> {
+                    return this_->body(std::move(cond));
+                });
+        }
+
+        hpx::future<primitive_argument_type> body(
+            hpx::future<primitive_argument_type>&& cond)
+        {
+            if (extract_boolean_value(
+                    cond.get(), that_->name_, that_->codename_))
             {
-                // evaluate condition of while statement
+                // Evaluate body of while statement
                 auto this_ = this->shared_from_this();
-                return literal_operand(operands_[0], args_, name_, codename_)
-                    .then([this_](hpx::future<primitive_argument_type> && cond)
-                        -> hpx::future<primitive_argument_type>
-                    {
-                        return this_->body(std::move(cond));
+                return literal_operand(
+                    that_->operands_[1], args_, that_->name_, that_->codename_)
+                    .then([this_](hpx::future<primitive_argument_type>&&
+                                    result) mutable
+                        -> hpx::future<primitive_argument_type> {
+                        this_->result_ = result.get();
+                        return this_->loop();
                     });
             }
 
-        private:
-            std::vector<primitive_argument_type> operands_;
-            std::vector<primitive_argument_type> args_;
-            hpx::promise<primitive_argument_type> p_;
-            primitive_argument_type result_;
-            std::string name_;
-            std::string codename_;
-        };
-    }
+            return hpx::make_ready_future(std::move(result_));
+        }
 
-    // start iteration over given while statement
+    private:
+        std::vector<primitive_argument_type> args_;
+        primitive_argument_type result_;
+        std::shared_ptr<while_operation const> that_;
+    };
+
+    // Start iteration over given while statement
     hpx::future<primitive_argument_type> while_operation::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return std::make_shared<detail::iteration>(
-                args, noargs, name_, codename_)->loop();
+            return std::make_shared<iteration>(noargs, shared_from_this())
+                ->loop();
         }
-        return std::make_shared<detail::iteration>(
-            operands_, args, name_, codename_)->loop();
+        return std::make_shared<iteration>(args, shared_from_this())->loop();
     }
 }}}


### PR DESCRIPTION
This PR refactors the following primitives to the new primitive structure:

- [x] `linearmatrix`
- [x] `linspace`
- [x] `mul_operation`
- [x] `not_equal`
- [x] `or_operation`
- [x] `parallel_block_operation`
- [x] `power_operation`
- [x] `row_set_operation`
- [x] `set_operation`
- [x] `square_root_operation`
- [x] `string_output`
- [x] `sub_operation`
- [x] `transpose_operation`
- [x] `unary_minus_operation`
- [x] `unary_not_operation`
- [x] `while_operation`
- [x] `store_operation`
- [x] `if_conditional`