### PR TITLE
Making sure everything is built if tests are run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ if(PHYLANX_WITH_TESTS_BENCHMARKS OR PHYLANX_WITH_TESTS_REGRESSIONS OR PHYLANX_WI
   endif()
 
   add_phylanx_pseudo_target(tests)
+  add_phylanx_pseudo_dependencies(tests core phylanx_py)
 
   enable_testing()
   include(CTest)


### PR DESCRIPTION
This makes sure everything has been built before the Python tests are run. This fixes #272