### PR TITLE
Print Newick formatted trees in the interpreter

### DIFF
--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -237,6 +237,12 @@ int main(int argc, char* argv[])
                 << phylanx::execution_tree::dot_tree(code_source_name,
                        snippets.snippets_.back().get_expression_topology())
                 << "\n";
+
+            std::cout << "\n"
+                << phylanx::execution_tree::newick_tree(code_source_name,
+                       snippets.snippets_.back().get_expression_topology())
+                << "\n\n";
+
             print_performance_counter_data_csv();
         }
     }

--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -233,14 +233,14 @@ int main(int argc, char* argv[])
         // and the associate performance counter data
         if (vm.count("performance") != 0)
         {
+            auto topology = snippets.snippets_.back().get_expression_topology();
+
             std::cout << "\n"
-                << phylanx::execution_tree::dot_tree(code_source_name,
-                       snippets.snippets_.back().get_expression_topology())
+                << phylanx::execution_tree::dot_tree(code_source_name, topology)
                 << "\n";
 
             std::cout << "\n"
-                << phylanx::execution_tree::newick_tree(code_source_name,
-                       snippets.snippets_.back().get_expression_topology())
+                << phylanx::execution_tree::newick_tree(code_source_name, topology)
                 << "\n\n";
 
             print_performance_counter_data_csv();


### PR DESCRIPTION
This pull request allows the physl interpreter to print  Newick-formatted trees along with the currently printed dot formatted tree.   Newick-formatted  tree is required by katy's visualization tool. 