### PR TITLE
Fix bad tag name in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
                 command: |
                     if [ "$CIRCLE_BRANCH" == "master" ]; then
                         docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
-                        docker tag $IMAGE_NAME $IMAGE_NAME:prerequisites
+                        docker tag $IMAGE_NAME $IMAGE_NAME:devel-prerequisites
                         docker push ${IMAGE_NAME}:devel-prerequisites
                         docker push ${IMAGE_NAME}:devel
                     fi


### PR DESCRIPTION
I mismatched the Docker image tags in #286 hence CircleCI [failed while attempting to deploy the images](https://circleci.com/gh/STEllAR-GROUP/phylanx/1510). This error is fixed in this PR.