### PR TITLE
Allow empty blocks in PhySL

### DIFF
--- a/src/execution_tree/primitives/block_operation.cpp
+++ b/src/execution_tree/primitives/block_operation.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/block_operation.hpp>
@@ -89,6 +89,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::vector<primitive_argument_type> args) const
     {
         // Empty blocks are allowed (Issue #278)
+        if (operands_.empty())
+        {
+            return hpx::make_ready_future(primitive_argument_type{ast::nil{}});
+        }
         hpx::promise<primitive_argument_type> result;
         auto f = result.get_future();
         next(0, std::move(args), std::move(result));    // trigger first step

--- a/src/execution_tree/primitives/block_operation.cpp
+++ b/src/execution_tree/primitives/block_operation.cpp
@@ -88,17 +88,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::vector<primitive_argument_type> const& operands,
         std::vector<primitive_argument_type> args) const
     {
-        if (operands_.empty())
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "phylanx::execution_tree::primitives::block_operation"
-                "block_operation::eval",
-                execution_tree::generate_error_message(
-                    "the block_operation primitive requires at least "
-                    "one argument",
-                    name_, codename_));
-        }
-
+        // Empty blocks are allowed (Issue #278)
         hpx::promise<primitive_argument_type> result;
         auto f = result.get_future();
         next(0, std::move(args), std::move(result));    // trigger first step

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
     negative_integral_value_131
     out_of_scope_variable_232
     vector_of_variables_244
+    allow_empty_blocks_278
    )
 
 set(assign_wrong_variable_245_FLAGS COMPONENT_DEPENDENCIES iostreams)

--- a/tests/regressions/execution_tree/allow_empty_blocks_278.cpp
+++ b/tests/regressions/execution_tree/allow_empty_blocks_278.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Fixing #278: Python to PhySL Translation generates empty block #278
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+
+std::string const code = "block()";
+
+int hpx_main(int argc, char* argv[])
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(code, snippets);
+
+    f();
+
+    return hpx::util::report_errors();
+}

--- a/tests/regressions/execution_tree/allow_empty_blocks_278.cpp
+++ b/tests/regressions/execution_tree/allow_empty_blocks_278.cpp
@@ -13,12 +13,10 @@
 
 #include <string>
 
-std::string const code = "block()";
-
-int hpx_main(int argc, char* argv[])
+int main(int argc, char* argv[])
 {
     phylanx::execution_tree::compiler::function_list snippets;
-    auto f = phylanx::execution_tree::compile(code, snippets);
+    auto f = phylanx::execution_tree::compile("block()", snippets);
 
     f();
 


### PR DESCRIPTION
This PR fixes #278 by allowing empty PhySL blocks.