### PR TITLE
Fix bad tag name in config.yml - Attempt 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
                 name: Install to the image
                 command: |
                     docker run --name live -v $PWD:/.data ${IMAGE_NAME} /bin/sh -c "mkdir -p /phylanx && cd /.data && cp -a . /phylanx && make -C /phylanx/build install"
-                    docker commit live $IMAGE_NAME:dev
+                    docker commit live $IMAGE_NAME:devel
             # Deployment
             - deploy:
                 name: Push the Phylanx build environment Docker image


### PR DESCRIPTION
I somehow managed to miss the mismatched docker Docker image tag in #289 hence CircleCI [again failed while attempting to deploy the images](https://circleci.com/gh/STEllAR-GROUP/phylanx/1516). This error is fixed in this PR. I'm terribly sorry for the inconvenience.

I only had two tags. This time it must work.