### PR TITLE
Adding support for lambda(args..., body)

### DIFF
--- a/phylanx/execution_tree/primitives/define_function.hpp
+++ b/phylanx/execution_tree/primitives/define_function.hpp
@@ -29,6 +29,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     public:
         static match_pattern_type const match_data;
+        static match_pattern_type const match_data_lambda;
 
         define_function() = default;
 

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -23,7 +23,6 @@ namespace phylanx { namespace execution_tree
             primitives::column_slicing_operation::match_data,
             primitives::console_output::match_data,
             primitives::debug_output::match_data,
-            primitives::define_variable::match_data_define,
             primitives::hstack_operation::match_data,
             primitives::make_list::match_data,
             primitives::make_vector::match_data,
@@ -96,10 +95,12 @@ namespace phylanx { namespace execution_tree
             primitives::function_reference::match_data,
             primitives::wrapped_function::match_data,
             primitives::define_function::match_data,
+            primitives::define_function::match_data_lambda,
 
             primitives::variable::match_data,
             primitives::wrapped_variable::match_data,
-            primitives::define_variable::match_data
+            primitives::define_variable::match_data,
+            primitives::define_variable::match_data_define
         };
 
         return patterns;

--- a/src/execution_tree/primitives/define_function.cpp
+++ b/src/execution_tree/primitives/define_function.cpp
@@ -27,6 +27,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
             nullptr, &create_primitive<define_function>)
     };
 
+    match_pattern_type const define_function::match_data_lambda =
+    {
+        hpx::util::make_tuple("lambda",
+            std::vector<std::string>{"lambda(__1)"},
+            nullptr, nullptr)
+    };
+
     ///////////////////////////////////////////////////////////////////////////
     define_function::define_function(
             std::vector<primitive_argument_type>&& operands,

--- a/src/execution_tree/primitives/wrapped_function.cpp
+++ b/src/execution_tree/primitives/wrapped_function.cpp
@@ -57,18 +57,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> wrapped_function::eval(
         std::vector<primitive_argument_type> const& params) const
     {
-        primitive const* p = util::get_if<primitive>(&operands_[0]);
-        if (p == nullptr)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                " wrapped_function::eval",
-                execution_tree::generate_error_message(
-                    "no target given",
-                    name_, codename_));
-        }
-
         // evaluation of the define-function yields the function body
-        auto body = p->eval_direct(params);
+        primitive_argument_type body;
+
+        primitive const* p = util::get_if<primitive>(&operands_[0]);
+        if (p != nullptr)
+        {
+            body = p->eval_direct(params);
+        }
+        else
+        {
+            body = operands_[0];
+        }
 
         std::vector<primitive_argument_type> fargs;
         if (operands_.size() == 1)


### PR DESCRIPTION
This adds a new PhySL construct: lambda functions. The syntax is `lambda([args..., ]body)` which defines a name-less function that takes zero to N `args` and uses those in its body.