### PR TITLE
scoped_unlock is deprecated use unlock_guard

### DIFF
--- a/src/execution_tree/primitives/variable.cpp
+++ b/src/execution_tree/primitives/variable.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/throw_exception.hpp>
+#include <hpx/util/unlock_guard.hpp>
 
 #include <mutex>
 #include <set>
@@ -70,7 +71,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 primitive_argument_type result;
                 {
-                    hpx::util::scoped_unlock<lock_type> ul(l);
+                    hpx::util::unlock_guard<lock_type> ul(l);
                     result = extract_copy_value(p->eval_direct(args));
                 }
                 operands_[0] = std::move(result);


### PR DESCRIPTION
Change: `scoped_unlock` is now deprecated in HPX use `unlock_guard` instead.

Context:
* [CircleCI build 1523 failed](https://circleci.com/gh/STEllAR-GROUP/phylanx/1523)
* From IRC:
    * \<parsa\> `error: no member named 'scoped_unlock' in namespace 'hpx::util'` :'''(
    * \<simbergm\> parsa: https://github.com/STEllAR-GROUP/hpx/pull/3185
    * \<simbergm\> use `unlock_guard` instead
    * \<zao\> # error This header exists for compatibility reasons, use `<hpx/util/unlock_guard.hpp>` instead.
    * \<zao\> You didn't explicitly include the header?
    * \<K-ballo\> unbelievable
    * \<parsa\> a deprecation warning would have been nicer
    * \<K-ballo\> parsa: that's your deprecation warning, you can turn it off via `#compatibility`
    * \<K-ballo\> we moved away from `scoped_unlock` back in 2013, we weren't as good as deprecation back then