### PR TITLE
Various fixes to primitive evaluation, etc.

### DIFF
--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -264,12 +264,13 @@ void print_performance_counter_data_csv()
     std::cout << std::endl << "Primitive Performance Counter Data in CSV:";
 
     // CSV Header
-    std::cout << std::endl
-              << "primitive_instance" << ","
-              << "count" << ","
-              << "time" << ","
-              << "direct_count" << ","
-              << "direct_time" << std::endl;
+    std::cout << "\n"
+              << "primitive_instance,"
+              << "display_name,"
+              << "count,"
+              << "time,"
+              << "direct_count,"
+              << "direct_time\n";
 
     // List of existing primitive instances
     std::vector<std::string> existing_primitive_instances;
@@ -288,7 +289,10 @@ void print_performance_counter_data_csv()
             "count/eval_direct", "time/eval_direct"},
             hpx::find_here()))
     {
-        std::cout << "\"" << entry.first << "\"";
+        std::cout << "\"" << entry.first << "\",\""
+                  << phylanx::execution_tree::compiler::primitive_display_name(
+                         entry.first)
+                  << "\"";
         for (auto const& counter_value : entry.second)
         {
             std::cout << "," << counter_value;

--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -66,7 +66,8 @@ read_arguments(std::vector<std::string> const& args, std::size_t first_index)
 void print_performance_counter_data_csv()
 {
     // CSV Header
-    std::cout << "primitive_instance,count,time,direct_count,direct_time\n";
+    std::cout << "primitive_instance,display_name,count,time,direct_count,"
+                 "direct_time\n";
 
     // List of existing primitive instances
     std::vector<std::string> existing_primitive_instances;
@@ -85,7 +86,10 @@ void print_performance_counter_data_csv()
     for (auto const& entry : phylanx::util::retrieve_counter_data(
              existing_primitive_instances, counter_names))
     {
-        std::cout << "\"" << entry.first << "\"";
+        std::cout << "\"" << entry.first << "\",\""
+                  << phylanx::execution_tree::compiler::primitive_display_name(
+                         entry.first)
+                  << "\"";
         for (auto const& counter_value : entry.second)
         {
             std::cout << "," << counter_value;

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -75,8 +75,15 @@ namespace phylanx { namespace execution_tree { namespace compiler
     PHYLANX_EXPORT primitive_name_parts parse_primitive_name(
         std::string const& name);
 
-    // compose a new primitive name from the given parts
+    // Compose a primitive name from the given parts
     PHYLANX_EXPORT std::string compose_primitive_name(
+        primitive_name_parts const& parts);
+
+    // Return display name for a given primitive name
+    PHYLANX_EXPORT std::string primitive_display_name(std::string const& name);
+
+    // Compose a primitive display name from the given parts
+    PHYLANX_EXPORT std::string compose_primitive_display_name(
         primitive_name_parts const& parts);
 }}}
 

--- a/phylanx/execution_tree/primitives/primitive_component.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component.hpp
@@ -44,10 +44,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::string const& name, std::string const& codename)
           : primitive_(
                 create_primitive(type, std::move(operands), name, codename))
-          , eval_count_(0ll)
-          , eval_duration_(0ll)
-          , eval_direct_count_(0ll)
-          , eval_direct_duration_(0ll)
         {
         }
 
@@ -88,32 +84,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_component, set_body, set_body_action);
 
         // access data for performance counter
-        std::int64_t get_eval_count(bool reset, bool direct) const
-        {
-            if (!direct)
-            {
-                return hpx::util::get_and_reset_value(eval_count_, reset);
-            }
-            return hpx::util::get_and_reset_value(eval_direct_count_, reset);
-        }
-
-        std::int64_t get_eval_duration(bool reset, bool direct) const
-        {
-            if (!direct)
-            {
-                return hpx::util::get_and_reset_value(eval_duration_, reset);
-            }
-            return hpx::util::get_and_reset_value(eval_direct_duration_, reset);
-        }
+        PHYLANX_EXPORT std::int64_t get_eval_count(
+            bool reset, bool direct) const;
+        PHYLANX_EXPORT std::int64_t get_eval_duration(
+            bool reset, bool direct) const;
 
     private:
         std::shared_ptr<primitive_component_base> primitive_;
-
-        // Performance counter data
-        mutable std::int64_t eval_count_;
-        mutable std::int64_t eval_duration_;
-        mutable std::int64_t eval_direct_count_;
-        mutable std::int64_t eval_direct_duration_;
     };
 }}}
 

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -10,6 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 
 #include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -27,6 +28,8 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     namespace primitives
     {
+        class primitive_component;
+
         struct primitive_component_base
         {
             primitive_component_base() = default;
@@ -56,6 +59,19 @@ namespace phylanx { namespace execution_tree
             virtual void set_body(primitive_argument_type&& target);
 
         protected:
+            friend class primitive_component;
+
+            // helper functions to invoke eval functionalities
+            hpx::future<primitive_argument_type> do_eval(
+                std::vector<primitive_argument_type> const& params) const;
+            primitive_argument_type do_eval_direct(
+                std::vector<primitive_argument_type> const& params) const;
+
+            // access data for performance counter
+            std::int64_t get_eval_count(bool reset, bool direct) const;
+            std::int64_t get_eval_duration(bool reset, bool direct) const;
+
+        protected:
             std::string generate_error_message(std::string const& msg) const;
 
         protected:
@@ -64,6 +80,17 @@ namespace phylanx { namespace execution_tree
 
             std::string name_;          // the unique name of this primitive
             std::string codename_;      // the name of the original code source
+
+            // Performance counter data
+            mutable std::int64_t eval_count_;
+            mutable std::int64_t eval_duration_;
+            mutable std::int64_t eval_direct_count_;
+            mutable std::int64_t eval_direct_duration_;
+
+#if defined(HPX_HAVE_APEX)
+            std::string eval_name_;
+            std::string eval_direct_name_;
+#endif
         };
     }
 

--- a/phylanx/util/scoped_timer.hpp
+++ b/phylanx/util/scoped_timer.hpp
@@ -1,0 +1,56 @@
+////////////////////////////////////////////////////////////////////////////////
+//  Copyright (c) 2016 Thomas Heller
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+////////////////////////////////////////////////////////////////////////////////
+
+#ifndef PHYLANX_UTIL_SCOPED_TIMER_HPP
+#define PHYLANX_UTIL_SCOPED_TIMER_HPP
+
+#include <hpx/util/high_resolution_clock.hpp>
+
+#include <cstdint>
+
+namespace phylanx { namespace util
+{
+    template <typename T>
+    struct scoped_timer
+    {
+        scoped_timer(T& t)
+          : started_at_(hpx::util::high_resolution_clock::now())
+          , t_(&t)
+        {}
+
+        scoped_timer(scoped_timer const&) = default;
+        scoped_timer(scoped_timer && rhs)
+          : started_at_(rhs.started_at_)
+          , t_(rhs.t_)
+        {
+            rhs.t_ = nullptr;
+        }
+
+        ~scoped_timer()
+        {
+            if (t_ != nullptr)
+            {
+                *t_ += (hpx::util::high_resolution_clock::now() - started_at_);
+            }
+        }
+
+        scoped_timer& operator=(scoped_timer const& rhs) = default;
+        scoped_timer& operator=(scoped_timer && rhs)
+        {
+            started_at_ = rhs.started_at_;
+            t_ = rhs.t_;
+            rhs.t_ = nullptr;
+            return *this;
+        }
+
+    private:
+        std::uint64_t started_at_;
+        T* t_;
+    };
+}}
+
+#endif

--- a/src/execution_tree/compiler/primitive_name.cpp
+++ b/src/execution_tree/compiler/primitive_name.cpp
@@ -126,6 +126,45 @@ namespace phylanx { namespace execution_tree { namespace compiler
 
         return result;
     }
+
+    // Compose a primitive display name from the given parts
+    std::string compose_primitive_display_name(
+        primitive_name_parts const& parts)
+    {
+        if (parts.primitive.empty())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::compiler::compose_primitive_display_name",
+                "primitive type was not specified");
+        }
+
+        std::string result = parts.primitive;
+        if (!parts.instance.empty())
+        {
+            result += "/" + parts.instance;
+        }
+
+        if (parts.tag1 >= 0 || parts.tag2 != -1)
+        {
+            result += "(" + std::to_string(parts.tag1 < 0 ? 0 : parts.tag1);
+
+            // column is optional
+            if (parts.tag2 != -1)
+            {
+                result += ", " + std::to_string(parts.tag2);
+            }
+
+            result += ")";
+        }
+        return result;
+    }
+
+    // Return display name for a given primitive name
+    std::string primitive_display_name(std::string const& name)
+    {
+        primitive_name_parts parts = parse_primitive_name(name);
+        return compose_primitive_display_name(parts);
+    }
 }}}
 
 

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -12,7 +12,6 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/util/scoped_timer.hpp>
 
 #include <cstdint>
 #include <map>
@@ -105,18 +104,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> primitive_component::eval(
         std::vector<primitive_argument_type> const& params) const
     {
-        hpx::util::scoped_timer<std::int64_t> timer(eval_duration_);
-        ++eval_count_;
-        return primitive_->eval(params);
+        return primitive_->do_eval(params);
     }
 
     // direct_eval_action
     primitive_argument_type primitive_component::eval_direct(
         std::vector<primitive_argument_type> const& params) const
     {
-        hpx::util::scoped_timer<std::int64_t> timer(eval_direct_duration_);
-        ++eval_direct_count_;
-        return primitive_->eval_direct(params);
+        return primitive_->do_eval_direct(params);
     }
 
     // store_action
@@ -136,6 +131,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
     void primitive_component::set_body(primitive_argument_type&& target)
     {
         primitive_->set_body(std::move(target));
+    }
+
+    // access data for performance counter
+    std::int64_t primitive_component::get_eval_count(
+        bool reset, bool direct) const
+    {
+        return primitive_->get_eval_count(reset, direct);
+    }
+
+    std::int64_t primitive_component::get_eval_duration(
+        bool reset, bool direct) const
+    {
+        return primitive_->get_eval_duration(reset, direct);
     }
 }}}
 


### PR DESCRIPTION
- Times measured by asynchronous primitive evaluations is wrong (fixes #266)
- Add annotated functions for APEX (fixes #267)
- Add display name for primitives to generated CSV output (fixes #268)