### PR TITLE
Added add_dimension primitive

### DIFF
--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -40,6 +40,7 @@
 #include <phylanx/execution_tree/primitives/file_write_hdf5.hpp>
 #include <phylanx/execution_tree/primitives/for_operation.hpp>
 #include <phylanx/execution_tree/primitives/function_reference.hpp>
+#include <phylanx/execution_tree/primitives/add_dimension.hpp>
 #include <phylanx/execution_tree/primitives/greater.hpp>
 #include <phylanx/execution_tree/primitives/greater_equal.hpp>
 #include <phylanx/execution_tree/primitives/hstack_operation.hpp>

--- a/phylanx/execution_tree/primitives/add_dimension.hpp
+++ b/phylanx/execution_tree/primitives/add_dimension.hpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_ADD_DIM)
+#define PHYLANX_PRIMITIVES_ADD_DIM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    /// \brief Creates a vector from scalar values and a column matrix from
+    /// vectors
+    /// \param a may either be a scalar or a vector
+    class add_dimension
+        : public primitive_component_base
+        , public std::enable_shared_from_this<add_dimension>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using val_type = double;
+        using arg_type = ir::node_data<val_type>;
+        using args_type = std::vector<arg_type>;
+
+    public:
+        static match_pattern_type const match_data;
+
+        add_dimension() = default;
+
+        add_dimension(std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type add_dim_0d(args_type && args) const;
+        primitive_argument_type add_dim_1d(args_type && args) const;
+    };
+
+    PHYLANX_EXPORT primitive create_add_dimension(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name = "", std::string const& codename = "");
+}}}
+
+#endif

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -73,6 +73,7 @@ namespace phylanx { namespace execution_tree
             primitives::add_operation::match_data,
             primitives::and_operation::match_data,
             primitives::div_operation::match_data,
+            primitives::add_dimension::match_data,
             primitives::mul_operation::match_data,
             primitives::or_operation::match_data,
             primitives::sub_operation::match_data,

--- a/src/execution_tree/primitives/add_dimension.cpp
+++ b/src/execution_tree/primitives/add_dimension.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/add_dimension.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/iterator_facade.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx {
+    namespace execution_tree {
+        namespace primitives
+        {
+            ///////////////////////////////////////////////////////////////////////////
+            primitive create_add_dimension(hpx::id_type const& locality,
+                std::vector<primitive_argument_type>&& operands,
+                std::string const& name, std::string const& codename)
+            {
+                static std::string type("add_dimension");
+                return create_primitive_component(
+                    locality, type, std::move(operands), name, codename);
+            }
+
+            match_pattern_type const add_dimension::match_data =
+            {
+                hpx::util::make_tuple("add_dimension",
+                std::vector<std::string>{"add_dimension(_1, _2)"},
+                &create_add_dimension, &create_primitive<add_dimension>)
+            };
+
+            ///////////////////////////////////////////////////////////////////////////
+            add_dimension::add_dimension(std::vector<primitive_argument_type>&& operands,
+                std::string const& name, std::string const& codename)
+                : primitive_component_base(std::move(operands), name, codename)
+            {}
+
+            primitive_argument_type add_dimension::add_dim_0d(args_type && args) const
+            {
+                return primitive_argument_type{
+                    blaze::DynamicVector<double>{args[0].scalar()}};
+            }
+
+            primitive_argument_type add_dimension::add_dim_1d(args_type && args) const
+            {
+                auto arg = args[0].vector();
+                return primitive_argument_type{
+                    blaze::DynamicMatrix<double>{arg.size(), 1, arg.data()}};
+            }
+
+            ///////////////////////////////////////////////////////////////////////////
+            hpx::future<primitive_argument_type> add_dimension::eval(
+                std::vector<primitive_argument_type> const& operands,
+                std::vector<primitive_argument_type> const& args) const
+            {
+                if (operands.empty() || operands.size() > 2)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "add_dimension::eval",
+                        execution_tree::generate_error_message(
+                            "the add_dimension primitive requires exactly one or two "
+                            "operands",
+                            name_, codename_));
+                }
+
+                for (auto const& i : operands)
+                {
+                    if (!valid(i))
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "add_dimension::eval",
+                            execution_tree::generate_error_message(
+                                "the add_dimension primitive requires that the "
+                                "arguments given by the operands array are "
+                                "valid",
+                                name_, codename_));
+                    }
+                }
+
+                auto this_ = this->shared_from_this();
+                return hpx::dataflow(hpx::util::unwrapping(
+                    [this_](args_type&& args) -> primitive_argument_type
+                {
+                    std::size_t a_dims = args[0].num_dimensions();
+                    switch (a_dims)
+                    {
+                    case 0:
+                        return this_->add_dim_0d(std::move(args));
+                    case 1:
+                        return this_->add_dim_1d(std::move(args));
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "add_dimension::eval",
+                            execution_tree::generate_error_message(
+                                "operand a has an invalid "
+                                "number of dimensions",
+                                this_->name_, this_->codename_));
+                    }
+                }),
+                    detail::map_operands(
+                        operands, functional::numeric_operand{}, args,
+                        name_, codename_));
+            }
+
+            hpx::future<primitive_argument_type> add_dimension::eval(
+                std::vector<primitive_argument_type> const& args) const
+            {
+                if (operands_.empty())
+                {
+                    return eval(args, noargs);
+                }
+                return eval(operands_, args);
+            }
+        }
+    }
+}

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -26,6 +26,7 @@ set(tests
     file_primitives
     file_csv_primitives
     for_operation
+    add_dimension
     greater_operation
     greater_equal_operation
     hstack_operation

--- a/tests/unit/execution_tree/primitives/add_dimension.cpp
+++ b/tests/unit/execution_tree/primitives/add_dimension.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+void test_0d()
+{
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+
+    phylanx::execution_tree::primitive add_dim =
+        phylanx::execution_tree::primitives::create_add_dimension(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        add_dim.eval();
+
+    blaze::DynamicVector<double> expected{ 42. };
+
+    HPX_TEST_EQ(
+        expected, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+void test_1d()
+{
+    blaze::DynamicVector<double> subject{6., 9., 13., 42., 54.};
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+
+    phylanx::execution_tree::primitive add_dim =
+        phylanx::execution_tree::primitives::create_add_dimension(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(lhs)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        add_dim.eval();
+
+    blaze::DynamicMatrix<double> expected{{6.}, {9.}, {13.}, {42.}, {54.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+int main(int argc, char* argv[])
+{
+    test_0d();
+    test_1d();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This PR adds `add_dimension` primitive, which turns scalar values into vectors, and vectors into matrices, to provide functionality similar to `some_array[:, newaxis]` in NumPy.