### PR TITLE
fixed small compile issue with -lboost_regex

### DIFF
--- a/examples/algorithms/CMakeLists.txt
+++ b/examples/algorithms/CMakeLists.txt
@@ -11,7 +11,7 @@ set(example_programs
 
 foreach(example_program ${example_programs})
 
-  set(${example_program}_FLAGS DEPENDENCIES iostreams_component)
+  set(${example_program}_FLAGS DEPENDENCIES iostreams_component ${Boost_REGEX_LIBRARY})
 
   set(sources ${example_program}.cpp)
 


### PR DESCRIPTION
compile error on the lra example. ld couldn't find -lboost_regex. this patch fixes the issue on ubuntu (or ubuntu-windows).