### PR TITLE
Sum primitive

### DIFF
--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -8,6 +8,7 @@
 #define PHYLANX_PRIMITIVES_PRIMITIVES_HPP
 
 #include <phylanx/execution_tree/primitives/access_argument.hpp>
+#include <phylanx/execution_tree/primitives/add_dimension.hpp>
 #include <phylanx/execution_tree/primitives/add_operation.hpp>
 #include <phylanx/execution_tree/primitives/all_operation.hpp>
 #include <phylanx/execution_tree/primitives/and_operation.hpp>
@@ -43,7 +44,6 @@
 #include <phylanx/execution_tree/primitives/fold_right_operation.hpp>
 #include <phylanx/execution_tree/primitives/for_operation.hpp>
 #include <phylanx/execution_tree/primitives/function_reference.hpp>
-#include <phylanx/execution_tree/primitives/add_dimension.hpp>
 #include <phylanx/execution_tree/primitives/greater.hpp>
 #include <phylanx/execution_tree/primitives/greater_equal.hpp>
 #include <phylanx/execution_tree/primitives/hstack_operation.hpp>
@@ -72,6 +72,7 @@
 #include <phylanx/execution_tree/primitives/store_operation.hpp>
 #include <phylanx/execution_tree/primitives/string_output.hpp>
 #include <phylanx/execution_tree/primitives/sub_operation.hpp>
+#include <phylanx/execution_tree/primitives/sum_operation.hpp>
 #include <phylanx/execution_tree/primitives/transpose_operation.hpp>
 #include <phylanx/execution_tree/primitives/unary_minus_operation.hpp>
 #include <phylanx/execution_tree/primitives/unary_not_operation.hpp>

--- a/phylanx/execution_tree/primitives/sum_operation.hpp
+++ b/phylanx/execution_tree/primitives/sum_operation.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_SUM)
+#define PHYLANX_PRIMITIVES_SUM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    /// \brief Sums the values of the elements of a vector or a matrix or
+    ///        returns the value of the scalar that was given to it
+    /// \param a the scalar, vector, or matrix to perform sum over
+    /// \param Optional. If provided, sum is calculated along the provided axis
+    ///        and a vector of results is returned. \p keep_dims is ignored if
+    ///        \p axis is present
+    /// \param Optional. keep_dims whether the sum value has to have the same
+    ///        number of dimensions as \p a
+    class sum_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<sum_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+
+        using val_type = double;
+        using arg_type = ir::node_data<val_type>;
+        using args_type = std::vector<arg_type>;
+
+    public:
+        static match_pattern_type const match_data;
+
+        sum_operation() = default;
+
+        sum_operation(std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        primitive_argument_type sum0d(arg_type&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        primitive_argument_type sum1d(arg_type&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        primitive_argument_type sum2d(arg_type&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        primitive_argument_type sum2d_flat(
+            arg_type&& arg, bool keep_dims) const;
+        primitive_argument_type sum2d_axis0(arg_type&& arg) const;
+        primitive_argument_type sum2d_axis1(arg_type&& arg) const;
+    };
+
+    PHYLANX_EXPORT primitive create_sum_operation(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name = "", std::string const& codename = "");
+}}}
+
+#endif

--- a/phylanx/execution_tree/primitives/sum_operation.hpp
+++ b/phylanx/execution_tree/primitives/sum_operation.hpp
@@ -21,13 +21,15 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     /// \brief Sums the values of the elements of a vector or a matrix or
-    ///        returns the value of the scalar that was given to it
-    /// \param a the scalar, vector, or matrix to perform sum over
-    /// \param Optional. If provided, sum is calculated along the provided axis
-    ///        and a vector of results is returned. \p keep_dims is ignored if
-    ///        \p axis is present
-    /// \param Optional. keep_dims whether the sum value has to have the same
-    ///        number of dimensions as \p a
+    ///        returns the value of the scalar that was given to it.
+    /// \param a         The scalar, vector, or matrix to perform sum over
+    /// \param axis      Optional. If provided, sum is calculated along the
+    ///                  provided axis and a vector of results is returned.
+    ///                  \p keep_dims is ignored if \p axis present. Must be
+    ///                  nil if \p keep_dims is set
+    /// \param keep_dims Optional. Whether the sum value has to have the same
+    ///                  number of dimensions as \p a. Ignored if \p axis is
+    ///                  anything except nil.
     class sum_operation
         : public primitive_component_base
         , public std::enable_shared_from_this<sum_operation>

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -73,6 +73,7 @@ namespace phylanx { namespace execution_tree
             primitives::random::match_data,
             primitives::shuffle_operation::match_data,
             primitives::square_root_operation::match_data,
+            primitives::sum_operation::match_data,
             primitives::transpose_operation::match_data,
             // variadic operations
             primitives::add_operation::match_data,

--- a/src/execution_tree/primitives/sum_operation.cpp
+++ b/src/execution_tree/primitives/sum_operation.cpp
@@ -1,0 +1,289 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/sum_operation.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/iterator_facade.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_sum_operation(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+    {
+        static std::string type("sum_operation");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const sum_operation::match_data =
+    {
+        hpx::util::make_tuple("sum_operation",
+        std::vector<std::string>{"sum(_1, _2)"},
+        &create_sum_operation, &create_primitive<sum_operation>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    sum_operation::sum_operation(
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    primitive_argument_type sum_operation::sum0d(arg_type&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "sum_operation::sum0d",
+                execution_tree::generate_error_message(
+                    "the sum_operation primitive requires operand axis to be "
+                    "either 0 or -1 for scalar values.",
+                    name_, codename_));
+        }
+
+        return primitive_argument_type{arg.scalar()};
+    }
+
+    primitive_argument_type sum_operation::sum1d(arg_type&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "sum_operation::sum1d",
+                execution_tree::generate_error_message(
+                    "the sum_operation primitive requires operand axis to be "
+                    "either 0 or -1 for vectors.",
+                    name_, codename_));
+        }
+
+        auto v = arg.vector();
+        double result = std::accumulate(v.begin(), v.end(), 0.);
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{
+                blaze::DynamicVector<val_type>{result}};
+        }
+        return primitive_argument_type{result};
+    }
+
+    primitive_argument_type sum_operation::sum2d(arg_type&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        if (axis)
+        {
+            switch (axis.value())
+            {
+            case -2: HPX_FALLTHROUGH;
+            case 0:
+                return sum2d_axis0(std::move(arg));
+            case -1: HPX_FALLTHROUGH;
+            case 1:
+                return sum2d_axis1(std::move(arg));
+            default:
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "sum_operation::sum1d",
+                    execution_tree::generate_error_message(
+                        "the sum_operation primitive requires operand axis to be "
+                        "between -2 and 1 for matrices.",
+                        name_, codename_));
+            }
+        }
+        return sum2d_flat(std::move(arg), keep_dims);
+    }
+
+    primitive_argument_type sum_operation::sum2d_flat(
+        arg_type&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+        double result = 0.;
+        for (std::size_t i = 0; i < m.columns(); ++i)
+        {
+            auto col = blaze::column(m, i);
+            result += std::accumulate(col.begin(), col.end(), 0.);
+        }
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{
+                blaze::DynamicMatrix<val_type>{{result}}};
+        }
+        return primitive_argument_type{result};
+    }
+
+    primitive_argument_type sum_operation::sum2d_axis0(arg_type&& arg) const
+    {
+        auto m = arg.matrix();
+        blaze::DynamicVector<double> result(m.columns());
+        for (std::size_t i = 0; i < m.columns(); ++i)
+        {
+            auto col = blaze::column(m, i);
+            result[i] = std::accumulate(col.begin(), col.end(), 0.);
+        }
+
+        return primitive_argument_type{result};
+    }
+
+    primitive_argument_type sum_operation::sum2d_axis1(arg_type&& arg) const
+    {
+        auto m = arg.matrix();
+        blaze::DynamicVector<double> result(m.rows());
+        for (std::size_t i = 0; i < m.rows(); ++i)
+        {
+            auto col = blaze::row(m, i);
+            result[i] = std::accumulate(col.begin(), col.end(), 0.);
+        }
+
+        return primitive_argument_type{result};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> sum_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.empty() || operands.size() > 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "sum_operation::eval",
+                execution_tree::generate_error_message(
+                    "the sum_operation primitive requires exactly one, two, or "
+                    "three operands",
+                    name_, codename_));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "sum_operation::eval",
+                    execution_tree::generate_error_message(
+                        "the sum_operation primitive requires that the "
+                        "arguments given by the operands array are "
+                        "valid",
+                        name_, codename_));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(
+            hpx::util::unwrapping(
+                [this_](std::vector<primitive_argument_type>&& args)
+                    -> primitive_argument_type {
+                    // Extract axis and keep_dims
+                    // Presence of axis changes behavior for >2d cases
+                    hpx::util::optional<std::int64_t> axis;
+                    bool keep_dims = false;
+
+                    if (args.empty() || args.size() > 3)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "sum_operation::eval",
+                            execution_tree::generate_error_message(
+                                "invalid number of arguments specified", this_->name_,
+                                this_->codename_));
+                    }
+                    else if (args.size() > 1)
+                    {
+                        switch (args[1].index())
+                        {
+                        case 0:
+                            break;
+                        case 2:
+                            axis = util::get<2>(args[1]);
+                            if (args.size() == 3)
+                            {
+                                if (args[2].index() == 1)
+                                    keep_dims = util::get<1>(args[2]).scalar();
+                                else
+                                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                        "sum_operation::eval",
+                                        execution_tree::generate_error_message(
+                                            "operand keep_dims must be a boolean",
+                                            this_->name_, this_->codename_));
+                            }
+
+                            break;
+                        case 1:
+                            keep_dims = util::get<1>(args[1]).scalar();
+                            break;
+                        default:
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "sum_operation::eval",
+                                execution_tree::generate_error_message(
+                                    "operand axis must be an integer",
+                                    this_->name_, this_->codename_));
+                        }
+                    }
+
+                    // Extract the matrix
+                    if (args[0].index() != 4)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "sum_operation::eval",
+                            execution_tree::generate_error_message(
+                                "operand a must be a scalar, vector, or a "
+                                "matrix",
+                                this_->name_, this_->codename_));
+                    }
+                    arg_type a = util::get<4>(args[0]);
+
+                    std::size_t a_dims = a.num_dimensions();
+                    switch (a_dims)
+                    {
+                    case 0:
+                        return this_->sum0d(std::move(a), axis, keep_dims);
+                    case 1:
+                        return this_->sum1d(std::move(a), axis, keep_dims);
+                    case 2:
+                        return this_->sum2d(std::move(a), axis, keep_dims);
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "sum_operation::eval",
+                            execution_tree::generate_error_message(
+                                "operand a has an invalid "
+                                "number of dimensions",
+                                this_->name_, this_->codename_));
+                    }
+                }),
+            detail::map_operands(
+                operands, functional::value_operand{}, args, name_, codename_));
+    }
+
+    hpx::future<primitive_argument_type> sum_operation::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return eval(args, noargs);
+        }
+        return eval(operands_, args);
+    }
+}}}

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -59,6 +59,7 @@ set(tests
     square_root_operation
     store_operation
     sub_operation
+    sum_operation
     transpose_operation
     unary_minus_operation
     unary_not_operation

--- a/tests/unit/execution_tree/primitives/sum_operation.cpp
+++ b/tests/unit/execution_tree/primitives/sum_operation.cpp
@@ -1,0 +1,295 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+void test_0d()
+{
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicVector<double> expected{ 42. };
+
+    HPX_TEST_EQ(
+        expected, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+void test_0d_keep_dims_true()
+{
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicVector<double> expected{ 42. };
+
+    HPX_TEST_EQ(
+        expected, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+void test_0d_keep_dims_false()
+{
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicVector<double> expected{ 42. };
+
+    HPX_TEST_EQ(
+        expected, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+void test_1d()
+{
+    blaze::DynamicVector<double> subject{6., 9., 13., 42., 54.};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    double expected = 124.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_1d_keep_dims_true()
+{
+    blaze::DynamicVector<double> subject{6., 9., 13., 42., 54.};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicVector<double> expected{124.};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_1d_keep_dims_false()
+{
+    blaze::DynamicVector<double> subject{6., 9., 13., 42., 54.};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    double expected = 124.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_2d()
+{
+    blaze::DynamicMatrix<double> subject{{6., 9.}, {13., 42.}, {54., 54.}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    double expected = 178.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_2d_axis0()
+{
+    blaze::DynamicMatrix<double> subject{{6., 9.}, {13., 42.}, {54., 54.}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), static_cast<std::int64_t>(0));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicVector<double> expected{73., 105.};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_2d_axis1()
+{
+    blaze::DynamicMatrix<double> subject{{6., 9.}, {13., 42.}, {54., 54.}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), static_cast<std::int64_t>(1));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicVector<double> expected{15., 55., 108.};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_2d_keep_dims_true()
+{
+    blaze::DynamicMatrix<double> subject{{6., 9.},{13., 42.},{54., 54.}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicMatrix<double> expected{{178.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_2d_keep_dims_false()
+{
+    blaze::DynamicMatrix<double> subject{{6., 9.},{13., 42.},{54., 54.}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{
+        std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    double expected = 178.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+int main(int argc, char* argv[])
+{
+    test_0d();
+    test_1d();
+    test_1d_keep_dims_true();
+    test_1d_keep_dims_false();
+    test_2d();
+    test_2d_axis0();
+    test_2d_axis1();
+    test_2d_keep_dims_true();
+    test_2d_keep_dims_false();
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/execution_tree/primitives/sum_operation.cpp
+++ b/tests/unit/execution_tree/primitives/sum_operation.cpp
@@ -44,13 +44,16 @@ void test_0d_keep_dims_true()
             hpx::find_here(), phylanx::ir::node_data<double>(42.0));
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<bool>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-        std::move(arg0), std::move(arg1)});
+        std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         sum.eval();
@@ -68,13 +71,16 @@ void test_0d_keep_dims_false()
             hpx::find_here(), phylanx::ir::node_data<double>(42.0));
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<bool>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-        std::move(arg0), std::move(arg1)});
+        std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         sum.eval();
@@ -115,13 +121,16 @@ void test_1d_keep_dims_true()
             hpx::find_here(), phylanx::ir::node_data<double>(subject));
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<bool>(true));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-        std::move(arg0), std::move(arg1)});
+        std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         sum.eval();
@@ -140,13 +149,16 @@ void test_1d_keep_dims_false()
             hpx::find_here(), phylanx::ir::node_data<double>(subject));
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<bool>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-        std::move(arg0), std::move(arg1)});
+        std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         sum.eval();
@@ -237,13 +249,16 @@ void test_2d_keep_dims_true()
             hpx::find_here(), phylanx::ir::node_data<double>(subject));
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<bool>(true));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-        std::move(arg0), std::move(arg1)});
+        std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         sum.eval();
@@ -262,13 +277,16 @@ void test_2d_keep_dims_false()
             hpx::find_here(), phylanx::ir::node_data<double>(subject));
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<bool>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-        std::move(arg0), std::move(arg1)});
+        std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         sum.eval();


### PR DESCRIPTION
This PR implements sum primitive, which is needed in the K-Means example. Adapted from:

* <https://docs.scipy.org/doc/numpy/reference/generated/numpy.sum.html>