### PR TITLE
Making sure integer literals are recognized by the compiler

### DIFF
--- a/phylanx/ast/match_ast.hpp
+++ b/phylanx/ast/match_ast.hpp
@@ -19,6 +19,7 @@
 #include <hpx/util/tuple.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <map>
 #include <type_traits>
 #include <string>

--- a/phylanx/ast/match_ast.hpp
+++ b/phylanx/ast/match_ast.hpp
@@ -113,6 +113,12 @@ namespace phylanx { namespace ast
     bool match_ast(identifier const&, identifier const&, F&&, Ts const&...);
 
     template <typename F, typename... Ts>
+    bool match_ast(bool, identifier const&, F&&, Ts const&...);
+    template <typename F, typename... Ts>
+    bool match_ast(std::string const&, identifier const&, F&&, Ts const&...);
+    template <typename F, typename... Ts>
+    bool match_ast(std::int64_t, identifier const&, F&&, Ts const&...);
+    template <typename F, typename... Ts>
     bool match_ast(ir::node_data<double> const&, identifier const&, F&&,
         Ts const&...);
     template <typename F, typename... Ts>
@@ -216,6 +222,39 @@ namespace phylanx { namespace ast
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename F, typename... Ts>
+    bool match_ast(bool b, identifier const& id, F&& f, Ts const&... ts)
+    {
+        // handle placeholder
+        if (detail::is_placeholder(id))
+        {
+            return hpx::util::invoke(std::forward<F>(f), b, id, ts...);
+        }
+        return false;
+    }
+
+    template <typename F, typename... Ts>
+    bool match_ast(std::string const& s, identifier const& id, F&& f, Ts const&... ts)
+    {
+        // handle placeholder
+        if (detail::is_placeholder(id))
+        {
+            return hpx::util::invoke(std::forward<F>(f), s, id, ts...);
+        }
+        return false;
+    }
+
+    template <typename F, typename... Ts>
+    bool match_ast(std::int64_t i, identifier const& id, F&& f, Ts const&... ts)
+    {
+        // handle placeholder
+        if (detail::is_placeholder(id))
+        {
+            return hpx::util::invoke(std::forward<F>(f), i, id, ts...);
+        }
+        return false;
+    }
+
     template <typename F, typename... Ts>
     bool match_ast(ir::node_data<double> const& nd, identifier const& id, F&& f,
         Ts const&... ts)

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -528,8 +528,12 @@ namespace phylanx { namespace execution_tree { namespace compiler
             // remaining expression could refer to a variable
             if (ast::detail::is_identifier(expr))
             {
-                return handle_variable_reference(
-                    ast::detail::identifier_name(expr), expr);
+                std::string name = ast::detail::identifier_name(expr);
+                if (name == "nil")
+                {
+                    return literal_value(primitive_argument_type{});
+                }
+                return handle_variable_reference(name, expr);
             }
 
             // ... or a function call

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    allow_empty_blocks_278
     assign_wrong_variable_245
     cout_noargs_prints_nothing_159
     cout_prints_twice_155
@@ -11,9 +12,10 @@ set(tests
     expression_topology_213
     list_of_variables_244
     negative_integral_value_131
+    no_integers_313
     out_of_scope_variable_232
+    support_nil_314
     vector_of_variables_244
-    allow_empty_blocks_278
    )
 
 set(assign_wrong_variable_245_FLAGS COMPONENT_DEPENDENCIES iostreams)

--- a/tests/regressions/execution_tree/no_integers_313.cpp
+++ b/tests/regressions/execution_tree/no_integers_313.cpp
@@ -1,10 +1,9 @@
-// Copyright (c) 2018 Parsa Amini
 // Copyright (c) 2018 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// Fixing #278: Python to PhySL Translation generates empty block #278
+// Fixing #313: PhySL Does Not Recognize Integer Numbers
 
 #include <phylanx/phylanx.hpp>
 
@@ -14,10 +13,10 @@
 int main(int argc, char* argv[])
 {
     phylanx::execution_tree::compiler::function_list snippets;
-    auto f = phylanx::execution_tree::compile("block()", snippets);
+    auto f = phylanx::execution_tree::compile("define(x, 2 * 2)", snippets);
 
     auto result = f();
-    HPX_TEST_EQ(result, phylanx::execution_tree::primitive_argument_type{});
+    HPX_TEST_EQ(phylanx::execution_tree::extract_numeric_value(result)[0], 4.0);
 
     return hpx::util::report_errors();
 }

--- a/tests/regressions/execution_tree/support_nil_314.cpp
+++ b/tests/regressions/execution_tree/support_nil_314.cpp
@@ -1,10 +1,9 @@
-// Copyright (c) 2018 Parsa Amini
 // Copyright (c) 2018 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// Fixing #278: Python to PhySL Translation generates empty block #278
+// Fixing #314: Support 'nil' in PhySL
 
 #include <phylanx/phylanx.hpp>
 
@@ -14,7 +13,7 @@
 int main(int argc, char* argv[])
 {
     phylanx::execution_tree::compiler::function_list snippets;
-    auto f = phylanx::execution_tree::compile("block()", snippets);
+    auto f = phylanx::execution_tree::compile("nil", snippets);
 
     auto result = f();
     HPX_TEST_EQ(result, phylanx::execution_tree::primitive_argument_type{});


### PR DESCRIPTION
- flyby: adding 'nil' to compiler (fixes #314)

This fixes #313