### PR TITLE
Adding car() and cdr() primitives (and various combinations of those)

### DIFF
--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -32,9 +32,9 @@ namespace phylanx { namespace execution_tree { namespace compiler
 
     ///////////////////////////////////////////////////////////////////////////
     using expression_pattern = hpx::util::tuple<
-        std::string, std::string,
-        ast::expression, factory_function_type>;
-    using expression_pattern_list = std::vector<expression_pattern>;
+        std::string, ast::expression, factory_function_type>;
+    using expression_pattern_list =
+        std::multimap<std::string, expression_pattern>;
 
     PHYLANX_EXPORT expression_pattern_list generate_patterns(
         pattern_list const& patterns_list);

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -75,6 +75,9 @@ namespace phylanx { namespace execution_tree { namespace compiler
     PHYLANX_EXPORT primitive_name_parts parse_primitive_name(
         std::string const& name);
 
+    PHYLANX_EXPORT bool parse_primitive_name(
+        std::string const& name, primitive_name_parts& parts);
+
     // Compose a primitive name from the given parts
     PHYLANX_EXPORT std::string compose_primitive_name(
         primitive_name_parts const& parts);

--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -17,6 +17,7 @@
 #include <phylanx/execution_tree/primitives/argmax.hpp>
 #include <phylanx/execution_tree/primitives/argmin.hpp>
 #include <phylanx/execution_tree/primitives/block_operation.hpp>
+#include <phylanx/execution_tree/primitives/car_cdr_operation.hpp>
 #include <phylanx/execution_tree/primitives/column_set.hpp>
 #include <phylanx/execution_tree/primitives/column_slicing.hpp>
 #include <phylanx/execution_tree/primitives/console_output.hpp>

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -556,7 +556,7 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT bool is_ast_operand(primitive_argument_type const& val);
 
     // Extract a list type from a given primitive_argument_type,
-    // throw if it doesn't hold one.
+    // Create a list from argument if it does not hold one.
     PHYLANX_EXPORT std::vector<primitive_argument_type> extract_list_value(
         primitive_argument_type const& val,
         std::string const& name = "",
@@ -567,6 +567,17 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>");
 
     PHYLANX_EXPORT bool is_list_operand(primitive_argument_type const& val);
+
+    // Extract a list type from a given primitive_argument_type,
+    // throw if it doesn't hold one.
+    PHYLANX_EXPORT std::vector<primitive_argument_type>
+    extract_list_value_strict(primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT std::vector<primitive_argument_type>
+    extract_list_value_strict(primitive_argument_type&& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
 
     ///////////////////////////////////////////////////////////////////////////
     // Extract a primitive from a given primitive_argument_type, throw

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -579,6 +579,9 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    PHYLANX_EXPORT bool is_list_operand_strict(
+        primitive_argument_type const& val);
+
     ///////////////////////////////////////////////////////////////////////////
     // Extract a primitive from a given primitive_argument_type, throw
     // if it doesn't hold one.

--- a/phylanx/execution_tree/primitives/car_cdr_operation.hpp
+++ b/phylanx/execution_tree/primitives/car_cdr_operation.hpp
@@ -3,8 +3,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_MAP_OPERATION_MAR_08_2018_1153PM)
-#define PHYLANX_MAP_OPERATION_MAR_08_2018_1153PM
+#if !defined(PHYLANX_CAR_CDR_OPERATION_MAR_16_2018_1233PM)
+#define PHYLANX_CAR_CDR_OPERATION_MAR_16_2018_1233PM
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
@@ -18,16 +18,16 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class map_operation
+    class car_cdr_operation
       : public primitive_component_base
-      , public std::enable_shared_from_this<map_operation>
+      , public std::enable_shared_from_this<car_cdr_operation>
     {
     public:
-        static match_pattern_type const match_data;
+        static std::vector<match_pattern_type> const match_data;
 
-        map_operation() = default;
+        car_cdr_operation() = default;
 
-        map_operation(std::vector<primitive_argument_type>&& operands,
+        car_cdr_operation(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
@@ -37,9 +37,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args) const;
+
+        primitive_argument_type car(primitive_argument_type&& arg) const;
+        primitive_argument_type cdr(primitive_argument_type&& arg) const;
+
+    private:
+        std::string operation_;
     };
 
-    PHYLANX_EXPORT primitive create_map_operation(hpx::id_type const& locality,
+    PHYLANX_EXPORT primitive create_car_cdr_operation(
+        hpx::id_type const& locality,
         std::vector<primitive_argument_type>&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}

--- a/phylanx/execution_tree/primitives/filter_operation.hpp
+++ b/phylanx/execution_tree/primitives/filter_operation.hpp
@@ -37,9 +37,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args) const;
-
-    private:
-        struct iteration_for;
     };
 
     PHYLANX_EXPORT primitive create_filter_operation(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/fold_left_operation.hpp
+++ b/phylanx/execution_tree/primitives/fold_left_operation.hpp
@@ -37,9 +37,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args) const;
-
-    private:
-        struct iteration_for;
     };
 
     PHYLANX_EXPORT primitive create_fold_left_operation(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/fold_right_operation.hpp
+++ b/phylanx/execution_tree/primitives/fold_right_operation.hpp
@@ -37,9 +37,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args) const;
-
-    private:
-        struct iteration_for;
     };
 
     PHYLANX_EXPORT primitive create_fold_right_operation(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -113,7 +113,8 @@ namespace phylanx { namespace execution_tree
         std::vector<std::string>, factory_function_type,
         primitive_factory_function_type>;
 
-    using pattern_list = std::vector<match_pattern_type>;
+    using pattern_list =
+        std::vector<hpx::util::tuple<std::string, match_pattern_type>>;
 
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT primitive create_primitive_component(

--- a/src/execution_tree/compiler/primitive_name.cpp
+++ b/src/execution_tree/compiler/primitive_name.cpp
@@ -93,6 +93,15 @@ namespace phylanx { namespace execution_tree { namespace compiler
         return data;
     }
 
+    bool parse_primitive_name(std::string const& name, primitive_name_parts& parts)
+    {
+        auto begin = name.begin();
+        bool result = boost::spirit::qi::parse(begin, name.end(),
+            detail::primitive_name_parser<std::string::const_iterator>(), parts);
+
+        return result && begin != name.end();
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     // compose a new primitive name from the given parts
     std::string compose_primitive_name(primitive_name_parts const& parts)

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  Distributed under the Boost Software License}, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
@@ -13,105 +13,131 @@
 namespace phylanx { namespace execution_tree
 {
     ///////////////////////////////////////////////////////////////////////////
-    pattern_list const& get_all_known_patterns()
+    namespace detail
     {
-        static pattern_list patterns =
+#define PHYLANX_MATCH_DATA(type)                                               \
+    hpx::util::make_tuple(hpx::util::get<0>(primitives::type::match_data),     \
+        primitives::type::match_data)                                          \
+/**/
+#define PHYLANX_MATCH_DATA_VERBATIM(type)                                      \
+    hpx::util::make_tuple(                                                     \
+        hpx::util::get<0>(primitives::type), primitives::type)                 \
+/**/
+
+        pattern_list get_all_known_patterns()
         {
-            // variadic functions
-            primitives::block_operation::match_data,
-            primitives::column_set_operation::match_data,
-            primitives::column_slicing_operation::match_data,
-            primitives::console_output::match_data,
-            primitives::debug_output::match_data,
-            primitives::hstack_operation::match_data,
-            primitives::make_list::match_data,
-            primitives::map_operation::match_data,
-            primitives::parallel_block_operation::match_data,
-            primitives::row_set_operation::match_data,
-            primitives::row_slicing_operation::match_data,
-            primitives::set_operation::match_data,
-            primitives::slicing_operation::match_data,
-            primitives::string_output::match_data,
-            primitives::vstack_operation::match_data,
-            // n-nary functions
-            primitives::if_conditional::match_data,
-            primitives::fold_left_operation::match_data,
-            primitives::fold_right_operation::match_data,
-            primitives::for_operation::match_data,
-            primitives::linearmatrix::match_data,
-            primitives::linspace::match_data,
-            // binary functions
-            primitives::apply::match_data,
-            primitives::cross_operation::match_data,
-            primitives::diag_operation::match_data,
-            primitives::dot_operation::match_data,
-            primitives::file_read::match_data,
-            primitives::file_write::match_data,
-            primitives::file_read_csv::match_data,
-            primitives::file_write_csv::match_data,
-            primitives::filter_operation::match_data,
-            primitives::while_operation::match_data,
+            pattern_list patterns =
+            {
+                // variadic functions
+                PHYLANX_MATCH_DATA(block_operation),
+                PHYLANX_MATCH_DATA(column_set_operation),
+                PHYLANX_MATCH_DATA(column_slicing_operation),
+                PHYLANX_MATCH_DATA(console_output),
+                PHYLANX_MATCH_DATA(debug_output),
+                PHYLANX_MATCH_DATA(hstack_operation),
+                PHYLANX_MATCH_DATA(make_list),
+                PHYLANX_MATCH_DATA(map_operation),
+                PHYLANX_MATCH_DATA(parallel_block_operation),
+                PHYLANX_MATCH_DATA(row_set_operation),
+                PHYLANX_MATCH_DATA(row_slicing_operation),
+                PHYLANX_MATCH_DATA(set_operation),
+                PHYLANX_MATCH_DATA(slicing_operation),
+                PHYLANX_MATCH_DATA(string_output),
+                PHYLANX_MATCH_DATA(vstack_operation),
+                // n-nary functions
+                PHYLANX_MATCH_DATA(if_conditional),
+                PHYLANX_MATCH_DATA(fold_left_operation),
+                PHYLANX_MATCH_DATA(fold_right_operation),
+                PHYLANX_MATCH_DATA(for_operation),
+                PHYLANX_MATCH_DATA(linearmatrix),
+                PHYLANX_MATCH_DATA(linspace),
+                // binary functions
+                PHYLANX_MATCH_DATA(apply),
+                PHYLANX_MATCH_DATA(cross_operation),
+                PHYLANX_MATCH_DATA(diag_operation),
+                PHYLANX_MATCH_DATA(dot_operation),
+                PHYLANX_MATCH_DATA(file_read),
+                PHYLANX_MATCH_DATA(file_write),
+                PHYLANX_MATCH_DATA(file_read_csv),
+                PHYLANX_MATCH_DATA(file_write_csv),
+                PHYLANX_MATCH_DATA(filter_operation),
+                PHYLANX_MATCH_DATA(while_operation),
 #if defined(PHYLANX_HAVE_HIGHFIVE)
-            primitives::file_read_hdf5::match_data,
-            primitives::file_write_hdf5::match_data,
+                PHYLANX_MATCH_DATA(file_read_hdf5),
+                PHYLANX_MATCH_DATA(file_write_hdf5),
 #endif
 
-            // unary functions
-            primitives::all_operation::match_data,
-            primitives::any_operation::match_data,
-            primitives::argmin::match_data,
-            primitives::argmax::match_data,
-            primitives::constant::match_data,
-            primitives::determinant::match_data,
-            primitives::enable_tracing::match_data,
-            primitives::exponential_operation::match_data,
-            primitives::extract_shape::match_data,
-            primitives::identity::match_data,
-            primitives::inverse_operation::match_data,
-            primitives::mean_operation::match_data,
-            primitives::power_operation::match_data,
-            primitives::random::match_data,
-            primitives::shuffle_operation::match_data,
-            primitives::square_root_operation::match_data,
-            primitives::sum_operation::match_data,
-            primitives::transpose_operation::match_data,
-            // variadic operations
-            primitives::add_operation::match_data,
-            primitives::and_operation::match_data,
-            primitives::div_operation::match_data,
-            primitives::add_dimension::match_data,
-            primitives::mul_operation::match_data,
-            primitives::or_operation::match_data,
-            primitives::sub_operation::match_data,
-            // binary operations
-            primitives::equal::match_data,
-            primitives::greater::match_data,
-            primitives::greater_equal::match_data,
-            primitives::less::match_data,
-            primitives::less_equal::match_data,
-            primitives::not_equal::match_data,
-            primitives::store_operation::match_data,
-            // unary operations
-            primitives::unary_minus_operation::match_data,
-            primitives::unary_not_operation::match_data,
-            // generic functions
-            primitives::get_seed_match_data,
-            primitives::set_seed_match_data,
-            //
-            // compiler-specific (internal) primitives
-            //
-            primitives::access_argument::match_data,
-            primitives::function_reference::match_data,
-            primitives::wrapped_function::match_data,
-            primitives::define_function::match_data,
-            primitives::define_function::match_data_lambda,
+                // unary functions
+                PHYLANX_MATCH_DATA(all_operation),
+                PHYLANX_MATCH_DATA(any_operation),
+                PHYLANX_MATCH_DATA(argmin),
+                PHYLANX_MATCH_DATA(argmax),
+                PHYLANX_MATCH_DATA(constant),
+                PHYLANX_MATCH_DATA(determinant),
+                PHYLANX_MATCH_DATA(enable_tracing),
+                PHYLANX_MATCH_DATA(exponential_operation),
+                PHYLANX_MATCH_DATA(extract_shape),
+                PHYLANX_MATCH_DATA(identity),
+                PHYLANX_MATCH_DATA(inverse_operation),
+                PHYLANX_MATCH_DATA(mean_operation),
+                PHYLANX_MATCH_DATA(power_operation),
+                PHYLANX_MATCH_DATA(random),
+                PHYLANX_MATCH_DATA(shuffle_operation),
+                PHYLANX_MATCH_DATA(square_root_operation),
+                PHYLANX_MATCH_DATA(transpose_operation),
+                // variadic operations
+                PHYLANX_MATCH_DATA(add_operation),
+                PHYLANX_MATCH_DATA(and_operation),
+                PHYLANX_MATCH_DATA(div_operation),
+                PHYLANX_MATCH_DATA(add_dimension),
+                PHYLANX_MATCH_DATA(mul_operation),
+                PHYLANX_MATCH_DATA(or_operation),
+                PHYLANX_MATCH_DATA(sub_operation),
+                // binary operations
+                PHYLANX_MATCH_DATA(equal),
+                PHYLANX_MATCH_DATA(greater),
+                PHYLANX_MATCH_DATA(greater_equal),
+                PHYLANX_MATCH_DATA(less),
+                PHYLANX_MATCH_DATA(less_equal),
+                PHYLANX_MATCH_DATA(not_equal),
+                PHYLANX_MATCH_DATA(store_operation),
+                // unary operations
+                PHYLANX_MATCH_DATA(unary_minus_operation),
+                PHYLANX_MATCH_DATA(unary_not_operation),
+                // generic functions
+                PHYLANX_MATCH_DATA_VERBATIM(get_seed_match_data),
+                PHYLANX_MATCH_DATA_VERBATIM(set_seed_match_data),
+                //
+                // compiler-specific (internal) primitives
+                //
+                PHYLANX_MATCH_DATA(access_argument),
+                PHYLANX_MATCH_DATA(function_reference),
+                PHYLANX_MATCH_DATA(wrapped_function),
+                PHYLANX_MATCH_DATA(define_function),
+                PHYLANX_MATCH_DATA_VERBATIM(define_function::match_data_lambda),
 
-            primitives::variable::match_data,
-            primitives::wrapped_variable::match_data,
-            primitives::define_variable::match_data,
-            primitives::define_variable::match_data_define
-        };
+                PHYLANX_MATCH_DATA(variable),
+                PHYLANX_MATCH_DATA(wrapped_variable),
+                PHYLANX_MATCH_DATA(define_variable),
+                PHYLANX_MATCH_DATA_VERBATIM(define_variable::match_data_define)
+            };
 
+            std::string car_cdr_name("car_cdr");
+            for (auto const& pattern : primitives::car_cdr_operation::match_data)
+            {
+                patterns.push_back(hpx::util::make_tuple(car_cdr_name, pattern));
+            }
+
+            return patterns;
+        }
+
+#undef PHYLANX_MATCH_DATA_VERBATIM
+#undef PHYLANX_MATCH_DATA
+    }
+
+    pattern_list const& get_all_known_patterns()
+    {
+        static pattern_list patterns = detail::get_all_known_patterns();
         return patterns;
     }
 }}

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -84,6 +84,7 @@ namespace phylanx { namespace execution_tree
                 PHYLANX_MATCH_DATA(random),
                 PHYLANX_MATCH_DATA(shuffle_operation),
                 PHYLANX_MATCH_DATA(square_root_operation),
+                PHYLANX_MATCH_DATA(sum_operation),
                 PHYLANX_MATCH_DATA(transpose_operation),
                 // variadic operations
                 PHYLANX_MATCH_DATA(add_operation),

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -104,9 +104,6 @@ namespace phylanx { namespace execution_tree
                 // unary operations
                 PHYLANX_MATCH_DATA(unary_minus_operation),
                 PHYLANX_MATCH_DATA(unary_not_operation),
-                // generic functions
-                PHYLANX_MATCH_DATA_VERBATIM(get_seed_match_data),
-                PHYLANX_MATCH_DATA_VERBATIM(set_seed_match_data),
                 //
                 // compiler-specific (internal) primitives
                 //
@@ -127,6 +124,12 @@ namespace phylanx { namespace execution_tree
             {
                 patterns.push_back(hpx::util::make_tuple(car_cdr_name, pattern));
             }
+
+            // generic functions
+            patterns.push_back(hpx::util::make_tuple(
+                "get_seed_action", primitives::get_seed_match_data));
+            patterns.push_back(hpx::util::make_tuple(
+                "set_seed_action", primitives::set_seed_match_data));
 
             return patterns;
         }

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -1427,6 +1427,26 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
+    bool is_list_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 3: HPX_FALLTHROUGH;    // string
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return true;
+
+        default:
+            break;
+        }
+        return false;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     std::vector<primitive_argument_type> extract_list_value_strict(
         primitive_argument_type const& val,
@@ -1522,20 +1542,20 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
-    bool is_list_operand(primitive_argument_type const& val)
+    bool is_list_operand_strict(primitive_argument_type const& val)
     {
         switch (val.index())
         {
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return true;
+
         case 0: HPX_FALLTHROUGH;    // nil
         case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 5: HPX_FALLTHROUGH;    // primitive
-        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
-        case 7:     // std::vector<primitive_argument_type>
-            return true;
-
         default:
             break;
         }

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -1333,37 +1333,34 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 0:     // nil
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<0>(val)}};
-
-        case 1:    // phylanx::ir::node_data<bool>
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<1>(val)}};
-
-        case 2:     // std::uint64_t
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<2>(val)}};
-
-        case 3:     // string
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<3>(val)}};
-
-        case 4:     // phylanx::ir::node_data<double>
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<4>(val)}};
-
-        case 5:     // primitive
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<5>(val)}};
-
         case 6:     // std::vector<ast::expression>
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<6>(val)}};
+            {
+                std::vector<primitive_argument_type> result;
+                result.reserve(util::get<6>(val).size());
+                for (auto const& v : util::get<6>(val))
+                {
+                    if (ast::detail::is_literal_value(v))
+                    {
+                        result.push_back(to_primitive_value_type(
+                            ast::detail::literal_value(v)));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                return result;
+            }
 
         case 7:     // std::vector<primitive_argument_type>
             return util::get<7>(val).get();
 
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 3: HPX_FALLTHROUGH;    // string
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 5: HPX_FALLTHROUGH;    // primitive
         default:
             break;
         }
@@ -1372,7 +1369,7 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::extract_list_value",
             generate_error_message(
-                "primitive_argument_type does not hold a boolean "
+                "primitive_argument_type does not hold a list "
                     "value type (type held: '" + type + "')",
                 name, codename));
     }
@@ -1383,37 +1380,34 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 0:     // nil
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<0>(std::move(val))}};
-
-        case 1:    // phylanx::ir::node_data<bool>
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<1>(std::move(val))}};
-
-        case 2:     // std::uint64_t
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<2>(std::move(val))}};
-
-        case 3:     // string
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<3>(std::move(val))}};
-
-        case 4:     // phylanx::ir::node_data<double>
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<4>(std::move(val))}};
-
-        case 5:     // primitive
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<5>(std::move(val))}};
-
         case 6:     // std::vector<ast::expression>
-            return std::vector<primitive_argument_type>{
-                primitive_argument_type{util::get<6>(std::move(val))}};
+            {
+                std::vector<primitive_argument_type> result;
+                result.reserve(util::get<6>(val).size());
+                for (auto && v : util::get<6>(std::move(val)))
+                {
+                    if (ast::detail::is_literal_value(v))
+                    {
+                        result.push_back(to_primitive_value_type(
+                            ast::detail::literal_value(v)));
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+                return result;
+            }
 
         case 7:     // std::vector<primitive_argument_type>
             return util::get<7>(std::move(val)).get();
 
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 3: HPX_FALLTHROUGH;    // string
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 5: HPX_FALLTHROUGH;    // primitive
         default:
             break;
         }
@@ -1422,7 +1416,7 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::extract_list_value",
             generate_error_message(
-                "primitive_argument_type does not hold a boolean "
+                "primitive_argument_type does not hold a list "
                     "value type (type held: '" + type + "')",
                 name, codename));
     }

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -1333,6 +1333,107 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
+        case 0:     // nil
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<0>(val)}};
+
+        case 1:    // phylanx::ir::node_data<bool>
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<1>(val)}};
+
+        case 2:     // std::uint64_t
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<2>(val)}};
+
+        case 3:     // string
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<3>(val)}};
+
+        case 4:     // phylanx::ir::node_data<double>
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<4>(val)}};
+
+        case 5:     // primitive
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<5>(val)}};
+
+        case 6:     // std::vector<ast::expression>
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<6>(val)}};
+
+        case 7:     // std::vector<primitive_argument_type>
+            return util::get<7>(val).get();
+
+        default:
+            break;
+        }
+
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_list_value",
+            generate_error_message(
+                "primitive_argument_type does not hold a boolean "
+                    "value type (type held: '" + type + "')",
+                name, codename));
+    }
+
+    std::vector<primitive_argument_type> extract_list_value(
+        primitive_argument_type && val,
+        std::string const& name, std::string const& codename)
+    {
+        switch (val.index())
+        {
+        case 0:     // nil
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<0>(std::move(val))}};
+
+        case 1:    // phylanx::ir::node_data<bool>
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<1>(std::move(val))}};
+
+        case 2:     // std::uint64_t
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<2>(std::move(val))}};
+
+        case 3:     // string
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<3>(std::move(val))}};
+
+        case 4:     // phylanx::ir::node_data<double>
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<4>(std::move(val))}};
+
+        case 5:     // primitive
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<5>(std::move(val))}};
+
+        case 6:     // std::vector<ast::expression>
+            return std::vector<primitive_argument_type>{
+                primitive_argument_type{util::get<6>(std::move(val))}};
+
+        case 7:     // std::vector<primitive_argument_type>
+            return util::get<7>(std::move(val)).get();
+
+        default:
+            break;
+        }
+
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_list_value",
+            generate_error_message(
+                "primitive_argument_type does not hold a boolean "
+                    "value type (type held: '" + type + "')",
+                name, codename));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::vector<primitive_argument_type> extract_list_value_strict(
+        primitive_argument_type const& val,
+        std::string const& name, std::string const& codename)
+    {
+        switch (val.index())
+        {
         case 6:     // std::vector<ast::expression>
             {
                 std::vector<primitive_argument_type> result;
@@ -1367,14 +1468,14 @@ namespace phylanx { namespace execution_tree
 
         std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "phylanx::execution_tree::extract_list_value",
+            "phylanx::execution_tree::extract_list_value_strict",
             generate_error_message(
                 "primitive_argument_type does not hold a list "
                     "value type (type held: '" + type + "')",
                 name, codename));
     }
 
-    std::vector<primitive_argument_type> extract_list_value(
+    std::vector<primitive_argument_type> extract_list_value_strict(
         primitive_argument_type && val,
         std::string const& name, std::string const& codename)
     {
@@ -1414,7 +1515,7 @@ namespace phylanx { namespace execution_tree
 
         std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "phylanx::execution_tree::extract_list_value",
+            "phylanx::execution_tree::extract_list_value_strict",
             generate_error_message(
                 "primitive_argument_type does not hold a list "
                     "value type (type held: '" + type + "')",

--- a/src/execution_tree/primitives/car_cdr_operation.cpp
+++ b/src/execution_tree/primitives/car_cdr_operation.cpp
@@ -1,0 +1,199 @@
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/car_cdr_operation.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/assert.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_car_cdr_operation(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename)
+    {
+        static std::string type("car_cdr");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+#define PHYLANX_CAR_CDR_MATCH_DATA(name)                                       \
+    hpx::util::make_tuple(name, std::vector<std::string>{name "(_1)"},         \
+        &create_car_cdr_operation, &create_primitive<car_cdr_operation>)       \
+/**/
+
+    std::vector<match_pattern_type> const car_cdr_operation::match_data =
+    {
+        PHYLANX_CAR_CDR_MATCH_DATA("car"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cadr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cddr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caaar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caadr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cadar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caddr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdaar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdadr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cddar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdddr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caaaar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caaadr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caadar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caaddr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cadaar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cadadr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("caddar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cadddr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdaaar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdaadr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdadar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdaddr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cddaar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cddadr"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cdddar"),
+        PHYLANX_CAR_CDR_MATCH_DATA("cddddr")
+    };
+
+#undef PHYLANX_CAR_CDR_MATCH_DATA
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        std::string generate_operation_code(std::string const& name)
+        {
+            // extract actual name of the primitive and remove leading 'c' and
+            // trailing 'r'
+            std::string::size_type p = name.find_first_of("$");
+            if (p != std::string::npos)
+            {
+                return name.substr(1, p - 2);
+            }
+            return name.substr(1, name.size() - 2);
+        }
+    }
+
+    car_cdr_operation::car_cdr_operation(
+            std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+      , operation_(detail::generate_operation_code(name))
+    {
+        std::reverse(operation_.begin(), operation_.end());
+    }
+
+    primitive_argument_type car_cdr_operation::car(
+        primitive_argument_type&& arg) const
+    {
+        std::vector<primitive_argument_type> list =
+            extract_list_value(std::move(arg), name_, codename_);
+        if (list.empty())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "car_cdr_operation::car",
+                execution_tree::generate_error_message(
+                    "the car_cdr_operation primitive requires exactly "
+                        "one non-empty list-operand",
+                    name_, codename_));
+        }
+        return list[0];
+    }
+
+    primitive_argument_type car_cdr_operation::cdr(
+        primitive_argument_type&& arg) const
+    {
+        std::vector<primitive_argument_type> list =
+            extract_list_value(std::move(arg), name_, codename_);
+        if (list.empty())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "car_cdr_operation::cdr",
+                execution_tree::generate_error_message(
+                    "the car_cdr_operation primitive requires exactly "
+                        "one non-empty list-operand",
+                    name_, codename_));
+        }
+        list.erase(list.begin());
+        return primitive_argument_type{std::move(list)};
+    }
+
+    hpx::future<primitive_argument_type> car_cdr_operation::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "car_cdr_operation::eval",
+                execution_tree::generate_error_message(
+                    "the car_cdr_operation primitive requires exactly "
+                        "one (list-) operand",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "car_cdr_operation::eval",
+                execution_tree::generate_error_message(
+                    "the car_cdr_operation primitive requires that the "
+                        "arguments given by the operands array "
+                        "are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](std::vector<primitive_argument_type>&& list)
+            -> primitive_argument_type
+            {
+                primitive_argument_type result{std::move(list)};
+
+                // handle operation code for the given list
+                for (char op : this_->operation_)
+                {
+                    HPX_ASSERT(op == 'a' || op == 'd');
+                    if (op == 'a')
+                    {
+                        // replace list with first element
+                        result = this_->car(std::move(result));
+                    }
+                    else
+                    {
+                        // remove first element
+                        result = this_->cdr(std::move(result));
+                    }
+                }
+
+                return result;
+            }),
+            list_operand(operands_[0], args, name_, codename_));
+    }
+
+    // Start iteration over given for statement
+    hpx::future<primitive_argument_type> car_cdr_operation::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return eval(args, noargs);
+        }
+        return eval(operands_, args);
+    }
+}}}

--- a/src/execution_tree/primitives/car_cdr_operation.cpp
+++ b/src/execution_tree/primitives/car_cdr_operation.cpp
@@ -102,7 +102,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type&& arg) const
     {
         std::vector<primitive_argument_type> list =
-            extract_list_value(std::move(arg), name_, codename_);
+            extract_list_value_strict(std::move(arg), name_, codename_);
         if (list.empty())
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -119,7 +119,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type&& arg) const
     {
         std::vector<primitive_argument_type> list =
-            extract_list_value(std::move(arg), name_, codename_);
+            extract_list_value_strict(std::move(arg), name_, codename_);
         if (list.empty())
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -63,11 +63,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 for (auto const& pattern : get_all_known_patterns())
                 {
-                    if (hpx::util::get<3>(pattern) != nullptr)
+                    auto const& p = hpx::util::get<1>(pattern);
+                    if (hpx::util::get<3>(p) != nullptr)
                     {
                         instance_.insert(factories_map_type::value_type(
                             hpx::util::get<0>(pattern),
-                            hpx::util::get<3>(pattern)));
+                            hpx::util::get<3>(p)));
                     }
                 }
             }

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -209,24 +209,30 @@ namespace phylanx { namespace execution_tree
     {
         if (!name.empty())
         {
-            auto parts = compiler::parse_primitive_name(name);
+            compiler::primitive_name_parts parts;
 
-            std::string line_col;
-            if (parts.tag1 != -1 && parts.tag2 != -1)
+            if (compiler::parse_primitive_name(name, parts))
             {
-                line_col = hpx::util::format("(%1%, %2%)", parts.tag1, parts.tag2);
+                std::string line_col;
+                if (parts.tag1 != -1 && parts.tag2 != -1)
+                {
+                    line_col = hpx::util::format("(%1%, %2%)", parts.tag1, parts.tag2);
+                }
+
+                if (!parts.instance.empty())
+                {
+                    return hpx::util::format("%1%%2%: %3%$%4%:: %5%",
+                        codename.empty() ? "<unknown>" : codename,
+                        line_col, parts.primitive, parts.instance, msg);
+                }
+
+                return hpx::util::format("%1%%2%: %3%:: %4%",
+                    codename.empty() ? "<unknown>" : codename, line_col,
+                    parts.primitive, msg);
             }
 
-            if (!parts.instance.empty())
-            {
-                return hpx::util::format("%1%%2%: %3%$%4%:: %5%",
-                    codename.empty() ? "<unknown>" : codename,
-                    line_col, parts.primitive, parts.instance, msg);
-            }
-
-            return hpx::util::format("%1%%2%: %3%:: %4%",
-                codename.empty() ? "<unknown>" : codename, line_col,
-                parts.primitive, msg);
+            return hpx::util::format("%1%: %2%:: %3%",
+                codename.empty() ? "<unknown>" : codename, name, msg);
         }
 
         return hpx::util::format(

--- a/src/execution_tree/primitives/random.cpp
+++ b/src/execution_tree/primitives/random.cpp
@@ -651,8 +651,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     match_pattern_type const set_seed_match_data =
     {
         hpx::util::make_tuple(
-            hpx::actions::detail::get_action_name<set_seed_action>(),
-            std::vector<std::string>{"set_seed(_1)"},
+            "set_seed", std::vector<std::string>{"set_seed(_1)"},
             &create_generic_function<set_seed_action>,
             &create_primitive<generic_function<set_seed_action>>)
     };
@@ -660,8 +659,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     match_pattern_type const get_seed_match_data =
     {
         hpx::util::make_tuple(
-            hpx::actions::detail::get_action_name<get_seed_action>(),
-            std::vector<std::string>{"get_seed()"},
+            "get_seed", std::vector<std::string>{"get_seed()"},
             &create_generic_function<get_seed_action>,
             &create_primitive<generic_function<get_seed_action>>)
     };

--- a/src/performance_counters/register_counters.cpp
+++ b/src/performance_counters/register_counters.cpp
@@ -274,7 +274,8 @@ namespace phylanx { namespace performance_counters
         for (auto const& pattern : et::get_all_known_patterns())
         {
             // The name of the primitive
-            std::string const& name = hpx::util::get<0>(pattern);
+            std::string const& name =
+                hpx::util::get<0>(hpx::util::get<1>(pattern));
 
             // Register a primitive time performance counters
             hpx::performance_counters::install_counter_type(

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -72,7 +72,6 @@ if(PHYLANX_WITH_HIGHFIVE)
   set(tests ${tests}
         file_hdf5_primitives
      )
-  set(file_hdf5_primitives_FLAGS COMPILE_FLAGS -DPHYLANX_HAVE_HIGHFIVE)
 endif()
 
 foreach(test ${tests})

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tests
     argmin
     argmax
     block_operation
+    car_cdr_operation
     column_set
     column_slicing
     constant

--- a/tests/unit/execution_tree/primitives/car_cdr_operation.cpp
+++ b/tests/unit/execution_tree/primitives/car_cdr_operation.cpp
@@ -1,0 +1,60 @@
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <string>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::compiler::function compile(std::string const& code)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    return phylanx::execution_tree::compile(code, snippets, env);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_car_cdr_operation(std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile(code)(), compile(expected_str)());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_car_cdr_operation("car( '(1, 2, 3) )", "1");
+    test_car_cdr_operation("cdr( '(1, 2, 3) )", "'(2, 3)");
+
+    test_car_cdr_operation("caar( '('(1, 2), '(3, 4)) )", "1");
+    test_car_cdr_operation("cadr( '('(1, 2), '(3, 4)) )", "'(3, 4)");
+    test_car_cdr_operation("cdar( '('(1, 2), '(3, 4)) )", "'(2)");
+    test_car_cdr_operation("cddr( '('(1, 2), '(3, 4)) )", "'()");
+
+    test_car_cdr_operation(
+        "caaar( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "1");
+    test_car_cdr_operation(
+        "caadr( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "'('(3), 4)");
+    test_car_cdr_operation(
+        "cadar( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "2");
+    test_car_cdr_operation(
+        "caddr( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "7");
+    test_car_cdr_operation(
+        "cdaar( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "'()");
+    test_car_cdr_operation(
+        "cdadr( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "'('(5), 6)");
+    test_car_cdr_operation(
+        "cddar( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "'()");
+    test_car_cdr_operation(
+        "cdddr( '( '('(1), 2), '( '('(3), 4), '(5), 6), 7 ) )", "'()");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/performance_counters/primitive_counter.cpp
+++ b/tests/unit/performance_counters/primitive_counter.cpp
@@ -105,7 +105,7 @@ int main()
     for (auto const& pattern :
         phylanx::execution_tree::get_all_known_patterns())
     {
-        std::string const& name = hpx::util::get<0>(pattern);
+        std::string const& name = hpx::util::get<0>(hpx::util::get<1>(pattern));
 
         // HACK: There is an access-argument/access-variable primitive
         // registered in AGAS for each argument/variable access. This is a


### PR DESCRIPTION
- changed match_data registration to include primitive name to support primitives that
  implement more than one type
- flyby: improved performance of AST compiler, function names are now looked up in a map
- flyby: cleanup of map, filter, and fold operations
- flyby: fixed extract_list_value to only succeed for lists