### PR TITLE
Addressing #320: improved generated error messages

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -428,6 +428,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    PHYLANX_EXPORT bool is_literal_operand(primitive_argument_type const& val);
+
     // Extract a ir::node_data<double> type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT ir::node_data<double> extract_numeric_value(
@@ -439,6 +441,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    PHYLANX_EXPORT bool is_numeric_value(primitive_argument_type const& val);
+
     // Extract a ir::node_data<bool> type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT ir::node_data<bool> extract_boolean_data(
@@ -449,6 +453,9 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type&& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+
+    PHYLANX_EXPORT bool is_boolean_data_operand(
+        primitive_argument_type const& val);
 
     template <typename T>
     ir::node_data<T> extract_node_data(
@@ -507,6 +514,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    PHYLANX_EXPORT bool is_integer_operand(primitive_argument_type const& val);
+
     // Extract a boolean type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT std::uint8_t extract_boolean_value(
@@ -517,6 +526,8 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type && val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+
+    PHYLANX_EXPORT bool is_boolean_operand(primitive_argument_type const& val);
 
     // Extract a std::string type from a given primitive_argument_type,
     // throw if it doesn't hold one.
@@ -529,6 +540,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    PHYLANX_EXPORT bool is_string_operand(primitive_argument_type const& val);
+
     // Extract an AST type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT std::vector<ast::expression> extract_ast_value(
@@ -540,6 +553,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    PHYLANX_EXPORT bool is_ast_operand(primitive_argument_type const& val);
+
     // Extract a list type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT std::vector<primitive_argument_type> extract_list_value(
@@ -550,6 +565,8 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type && val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+
+    PHYLANX_EXPORT bool is_list_operand(primitive_argument_type const& val);
 
     ///////////////////////////////////////////////////////////////////////////
     // Extract a primitive from a given primitive_argument_type, throw

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -693,6 +693,26 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
+    bool is_literal_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 3: HPX_FALLTHROUGH;    // std::string
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6:                     // std::vector<ast::expression>
+            return true;
+
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
+        default:
+            break;
+        }
+        return false;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> extract_numeric_value(
         primitive_argument_type const& val,
@@ -785,6 +805,26 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
+    bool is_numeric_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6:     // std::vector<ast::expression>
+            return true;
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
+        default:
+            break;
+        }
+        return false;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<bool> extract_boolean_data(primitive_argument_type const& val,
         std::string const& name, std::string const& codename)
@@ -840,6 +880,26 @@ namespace phylanx { namespace execution_tree
                 "primitive_argument_type does not hold a boolean "
                     "value type (type held: '" + type + "')",
                 name, codename));
+    }
+
+    bool is_boolean_data_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 1:                     // phylanx::ir::node_data<bool>
+            return true;
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 3: HPX_FALLTHROUGH;    // string
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
+        default:
+            break;
+        }
+        return false;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -931,6 +991,26 @@ namespace phylanx { namespace execution_tree
                 "primitive_argument_type does not hold a numeric "
                     "value type (type held: '" + type + "')",
                 name, codename));
+    }
+
+    bool is_integer_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6:     // std::vector<ast::expression>
+            return false;
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
+        default:
+            break;
+        }
+        return false;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1032,6 +1112,26 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
+    bool is_boolean_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return true;
+
+        case 3: HPX_FALLTHROUGH;    // string
+        case 5: HPX_FALLTHROUGH;    // primitive
+        default:
+            break;
+        }
+        return false;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     std::string extract_string_value(primitive_argument_type const& val,
         std::string const& name, std::string const& codename)
@@ -1115,6 +1215,26 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
+    bool is_string_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 3: HPX_FALLTHROUGH;    // string
+        case 6:     // std::vector<ast::expression>
+            return true;
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
+        case 5: HPX_FALLTHROUGH;    // primitive
+        default:
+            break;
+        }
+        return false;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     std::vector<ast::expression> extract_ast_value(
         primitive_argument_type const& val,
@@ -1135,8 +1255,7 @@ namespace phylanx { namespace execution_tree
             return util::get<6>(val);
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1:
-            HPX_FALLTHROUGH;        // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
         case 5: HPX_FALLTHROUGH;    // primitive
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
         default:
@@ -1171,8 +1290,7 @@ namespace phylanx { namespace execution_tree
             return util::get<6>(std::move(val));
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1:
-            HPX_FALLTHROUGH;        // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
         case 5: HPX_FALLTHROUGH;    // primitive
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
         default:
@@ -1186,6 +1304,26 @@ namespace phylanx { namespace execution_tree
                 "primitive_argument_type does not hold a boolean "
                     "value type (type held: '" + type + "')",
                 name, codename));
+    }
+
+    bool is_ast_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 3: HPX_FALLTHROUGH;    // string
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6:     // std::vector<ast::expression>
+            return true;
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;        // phylanx::ir::node_data<bool>
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
+        default:
+            break;
+        }
+        return false;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1287,6 +1425,26 @@ namespace phylanx { namespace execution_tree
                 "primitive_argument_type does not hold a boolean "
                     "value type (type held: '" + type + "')",
                 name, codename));
+    }
+
+    bool is_list_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 2: HPX_FALLTHROUGH;    // std::uint64_t
+        case 3: HPX_FALLTHROUGH;    // string
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7:     // std::vector<primitive_argument_type>
+            return true;
+
+        default:
+            break;
+        }
+        return false;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -122,7 +122,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::primitives::primitive_component_base",
-            "store function should only be called for the store_primitive");
+            generate_error_message(
+                "store function should only be called for the primitives that "
+                    "support it (e.g. variables)"));
     }
 
     // extract_topology_action
@@ -168,8 +170,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::primitives::primitive_component_base",
-            "set_body function should only be called for the "
-                "define_function_primitive");
+            generate_error_message(
+                "set_body function should only be called for primitivces that "
+                    "support it (e.g. the define_function_primitive"));
     }
 
     std::string primitive_component_base::generate_error_message(


### PR DESCRIPTION
- flyby: add is_<foo>_operand helper functions to introspect primitive_argument_type instances