### PR TITLE
Address Clang's '&&' within '||' warnings.

### DIFF
--- a/src/execution_tree/primitives/random.cpp
+++ b/src/execution_tree/primitives/random.cpp
@@ -539,7 +539,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         if (!valid(operands[0]) ||
-            operands.size() == 2 && !valid(operands[1]))
+            (operands.size() == 2 && !valid(operands[1])))
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "random::eval",
@@ -681,7 +681,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     name, codename));
         }
 
-        if (!valid(operands[0]) || operands.size() == 2 && !valid(operands[1]))
+        if (!valid(operands[0]) || (operands.size() == 2 && !valid(operands[1])))
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "random::set_seed",


### PR DESCRIPTION
Context: The following warnings are generated by Clang
```
[ 63%] Building CXX object src/CMakeFiles/phylanx_component.dir/execution_tree/primitives/row_set.cpp.o
/phylanx/src/execution_tree/primitives/random.cpp:542:34: warning: '&&' within '||' [-Wlogical-op-parentheses]
            operands.size() == 2 && !valid(operands[1]))
            ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/phylanx/src/execution_tree/primitives/random.cpp:542:34: note: place parentheses around the '&&' expression to silence this warning
            operands.size() == 2 && !valid(operands[1]))
                                 ^
            (                                          )
/phylanx/src/execution_tree/primitives/random.cpp:684:57: warning: '&&' within '||' [-Wlogical-op-parentheses]
        if (!valid(operands[0]) || operands.size() == 2 && !valid(operands[1]))
                                ~~ ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
/phylanx/src/execution_tree/primitives/random.cpp:684:57: note: place parentheses around the '&&' expression to silence this warning
        if (!valid(operands[0]) || operands.size() == 2 && !valid(operands[1]))
                                                        ^
                                   (                                          )
[ 65%] Building CXX object src/CMakeFiles/phylanx_component.dir/execution_tree/primitives/row_slicing.cpp.o
2 warnings generated.
```
This PR addresses these warnings.