### PR TITLE
node_data<bool> --> node_data<uint8_t>

### DIFF
--- a/phylanx/ast/generate_ast.hpp
+++ b/phylanx/ast/generate_ast.hpp
@@ -9,6 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/ast/node.hpp>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/phylanx/execution_tree/primitives/all_operation.hpp
+++ b/phylanx/execution_tree/primitives/all_operation.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -22,7 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public std::enable_shared_from_this<all_operation>
     {
     protected:
-        using arg_type = ir::node_data<bool>;
+        using arg_type = ir::node_data<std::uint8_t>;
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,

--- a/phylanx/execution_tree/primitives/and_operation.hpp
+++ b/phylanx/execution_tree/primitives/and_operation.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -39,7 +40,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
 
-        using operand_type = ir::node_data<bool>;
+        using operand_type = ir::node_data<std::uint8_t>;
         using operands_type = std::vector<primitive_argument_type>;
 
     private:

--- a/phylanx/execution_tree/primitives/any_operation.hpp
+++ b/phylanx/execution_tree/primitives/any_operation.hpp
@@ -12,6 +12,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -22,7 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public std::enable_shared_from_this<any_operation>
     {
     protected:
-        using arg_type = ir::node_data<bool>;
+        using arg_type = ir::node_data<std::uint8_t>;
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -135,7 +135,7 @@ namespace phylanx { namespace execution_tree
     using argument_value_type =
         phylanx::util::variant<
             ast::nil
-          , phylanx::ir::node_data<bool>
+          , phylanx::ir::node_data<std::uint8_t>
           , std::int64_t
           , std::string
           , phylanx::ir::node_data<double>
@@ -153,27 +153,30 @@ namespace phylanx { namespace execution_tree
         {}
 
         explicit primitive_argument_type(bool val)
-          : argument_value_type{phylanx::ir::node_data<bool>{val}}
+          : argument_value_type{phylanx::ir::node_data<std::uint8_t>{val}}
+        {}
+        explicit primitive_argument_type(std::uint8_t val)
+          : argument_value_type{phylanx::ir::node_data<std::uint8_t>{val}}
         {}
         explicit primitive_argument_type(
-                blaze::DynamicVector<bool> const& val)
-          : argument_value_type{phylanx::ir::node_data<bool>{val}}
+                blaze::DynamicVector<std::uint8_t> const& val)
+          : argument_value_type{phylanx::ir::node_data<std::uint8_t>{val}}
         {}
-        explicit primitive_argument_type(blaze::DynamicVector<bool>&& val)
-          : argument_value_type{phylanx::ir::node_data<bool>{std::move(val)}}
+        explicit primitive_argument_type(blaze::DynamicVector<std::uint8_t>&& val)
+          : argument_value_type{phylanx::ir::node_data<std::uint8_t>{std::move(val)}}
         {}
         explicit primitive_argument_type(
-                blaze::DynamicMatrix<bool> const& val)
-          : argument_value_type{phylanx::ir::node_data<bool>{val}}
+                blaze::DynamicMatrix<std::uint8_t> const& val)
+          : argument_value_type{phylanx::ir::node_data<std::uint8_t>{val}}
         {}
-        explicit primitive_argument_type(blaze::DynamicMatrix<bool>&& val)
-          : argument_value_type{phylanx::ir::node_data<bool>{std::move(val)}}
+        explicit primitive_argument_type(blaze::DynamicMatrix<std::uint8_t>&& val)
+          : argument_value_type{phylanx::ir::node_data<std::uint8_t>{std::move(val)}}
         {}
-        primitive_argument_type(phylanx::ir::node_data<bool> const& val)
+        primitive_argument_type(phylanx::ir::node_data<std::uint8_t> const& val)
           : argument_value_type{val}
         {}
 
-        primitive_argument_type(phylanx::ir::node_data<bool>&& val)
+        primitive_argument_type(phylanx::ir::node_data<std::uint8_t>&& val)
           : argument_value_type{std::move(val)}
         {}
 
@@ -443,13 +446,13 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT bool is_numeric_value(primitive_argument_type const& val);
 
-    // Extract a ir::node_data<bool> type from a given primitive_argument_type,
+    // Extract a ir::node_data<std::uint8_t> type from a given primitive_argument_type,
     // throw if it doesn't hold one.
-    PHYLANX_EXPORT ir::node_data<bool> extract_boolean_data(
+    PHYLANX_EXPORT ir::node_data<std::uint8_t> extract_boolean_data(
         primitive_argument_type const& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
-    PHYLANX_EXPORT ir::node_data<bool> extract_boolean_data(
+    PHYLANX_EXPORT ir::node_data<std::uint8_t> extract_boolean_data(
         primitive_argument_type&& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
@@ -472,7 +475,7 @@ namespace phylanx { namespace execution_tree
         return extract_numeric_value(val, name, codename);
     }
     template <>
-    inline ir::node_data<bool> extract_node_data(
+    inline ir::node_data<std::uint8_t> extract_node_data(
         primitive_argument_type const& val,
         std::string const& name,
         std::string const& codename)
@@ -495,7 +498,7 @@ namespace phylanx { namespace execution_tree
         return extract_numeric_value(std::move(val), name, codename);
     }
     template <>
-    inline ir::node_data<bool> extract_node_data(
+    inline ir::node_data<std::uint8_t> extract_node_data(
         primitive_argument_type && val,
         std::string const& name,
         std::string const& codename)

--- a/phylanx/execution_tree/primitives/equal.hpp
+++ b/phylanx/execution_tree/primitives/equal.hpp
@@ -18,8 +18,8 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     class equal
-        : public primitive_component_base
-        , public std::enable_shared_from_this<equal>
+      : public primitive_component_base
+      , public std::enable_shared_from_this<equal>
     {
     protected:
         hpx::future<primitive_argument_type> eval(
@@ -43,30 +43,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         struct visit_equal;
 
+        template <typename T>
         primitive_argument_type equal0d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal0d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal1d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal1d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal1d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal2d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal2d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal2d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type equal_all(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/greater.hpp
+++ b/phylanx/execution_tree/primitives/greater.hpp
@@ -20,8 +20,8 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     class greater
-        : public primitive_component_base
-        , public std::enable_shared_from_this<greater>
+      : public primitive_component_base
+      , public std::enable_shared_from_this<greater>
     {
     protected:
         using operand_type = ir::node_data<double>;
@@ -45,30 +45,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         struct visit_greater;
 
+        template <typename T>
         primitive_argument_type greater0d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater0d2d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater0d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater1d0d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater1d1d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater1d2d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater1d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater2d0d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater2d1d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater2d2d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater2d(
-                operand_type&& lhs, operand_type&& rhs) const;
-            primitive_argument_type greater_all(
-                operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater0d2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater0d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater1d0d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater1d1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater1d2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater2d0d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater2d1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater2d2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type greater_all(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_greater(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/greater_equal.hpp
+++ b/phylanx/execution_tree/primitives/greater_equal.hpp
@@ -20,8 +20,8 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     class greater_equal
-        : public primitive_component_base
-        , public std::enable_shared_from_this<greater_equal>
+      : public primitive_component_base
+      , public std::enable_shared_from_this<greater_equal>
     {
     protected:
         using operand_type = ir::node_data<double>;
@@ -45,30 +45,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         struct visit_greater_equal;
 
+        template <typename T>
         primitive_argument_type greater_equal0d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal0d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal1d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal1d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal1d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal2d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal2d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal2d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type greater_equal_all(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_greater_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/less.hpp
+++ b/phylanx/execution_tree/primitives/less.hpp
@@ -20,8 +20,8 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     class less
-        : public primitive_component_base
-        , public std::enable_shared_from_this<less>
+      : public primitive_component_base
+      , public std::enable_shared_from_this<less>
     {
     protected:
         using operand_type = ir::node_data<double>;
@@ -43,30 +43,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::vector<primitive_argument_type> const& args) const override;
 
     private:
+        template <typename T>
         primitive_argument_type less0d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less0d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less1d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less1d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less1d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less2d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less2d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less2d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_all(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
 
     private:
         struct visit_less;

--- a/phylanx/execution_tree/primitives/less_equal.hpp
+++ b/phylanx/execution_tree/primitives/less_equal.hpp
@@ -20,8 +20,8 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     class less_equal
-        : public primitive_component_base
-        , public std::enable_shared_from_this<less_equal>
+      : public primitive_component_base
+      , public std::enable_shared_from_this<less_equal>
     {
     protected:
         using operand_type = ir::node_data<double>;
@@ -45,30 +45,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         struct visit_less_equal;
 
+        template <typename T>
         primitive_argument_type less_equal0d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal0d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal1d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal1d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal1d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal2d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal2d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal2d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type less_equal_all(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_less_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/not_equal.hpp
+++ b/phylanx/execution_tree/primitives/not_equal.hpp
@@ -20,8 +20,8 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     class not_equal
-        : public primitive_component_base
-        , public std::enable_shared_from_this<not_equal>
+      : public primitive_component_base
+      , public std::enable_shared_from_this<not_equal>
     {
     protected:
         using operand_type = ir::node_data<double>;
@@ -45,30 +45,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         struct visit_not_equal;
 
+        template <typename T>
         primitive_argument_type not_equal0d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal0d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal1d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal1d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal1d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal2d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal2d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal2d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type not_equal_all(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
     };
 
     PHYLANX_EXPORT primitive create_not_equal(hpx::id_type const& locality,

--- a/phylanx/execution_tree/primitives/or_operation.hpp
+++ b/phylanx/execution_tree/primitives/or_operation.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,7 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public std::enable_shared_from_this<or_operation>
     {
     protected:
-        using operand_type = ir::node_data<bool>;
+        using operand_type = ir::node_data<std::uint8_t>;
         using operands_type = std::vector<primitive_argument_type>;
 
         hpx::future<primitive_argument_type> eval(

--- a/phylanx/execution_tree/primitives/unary_not_operation.hpp
+++ b/phylanx/execution_tree/primitives/unary_not_operation.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,7 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public std::enable_shared_from_this<unary_not_operation>
     {
     protected:
-        using operand_type = ir::node_data<bool>;
+        using operand_type = ir::node_data<std::uint8_t>;
         using operands_type = std::vector<primitive_argument_type>;
 
         hpx::future<primitive_argument_type> eval(
@@ -45,7 +46,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         struct visit_unary_not;
 
-        primitive_argument_type unary_not_all(operand_type&& ops) const;
+        template <typename T>
+        primitive_argument_type unary_not_all(ir::node_data<T>&& ops) const;
     };
 
     PHYLANX_EXPORT primitive create_unary_not_operation(

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Hartmut Kaiser
+ // Copyright (c) 2017-2018 Hartmut Kaiser
 // Copyright (c) 2017 Parsa Amini
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -330,7 +330,7 @@ namespace phylanx { namespace ir
     PHYLANX_EXPORT bool operator==(
         node_data<double> const& lhs, node_data<double> const& rhs);
     PHYLANX_EXPORT bool operator==(
-        node_data<bool> const& lhs, node_data<bool> const& rhs);
+        node_data<std::uint8_t> const& lhs, node_data<std::uint8_t> const& rhs);
 
     template <typename T>
     bool operator!=(node_data<T> const& lhs, node_data<T> const& rhs)
@@ -341,7 +341,7 @@ namespace phylanx { namespace ir
     PHYLANX_EXPORT std::ostream& operator<<(
         std::ostream& out, node_data<double> const& nd);
     PHYLANX_EXPORT std::ostream& operator<<(
-        std::ostream& out, node_data<bool> const& nd);
+        std::ostream& out, node_data<std::uint8_t> const& nd);
 }}
 
 #endif

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -1,4 +1,4 @@
- // Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 // Copyright (c) 2017 Parsa Amini
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -265,6 +265,7 @@ namespace phylanx { namespace ir
         custom_storage2d_type matrix() &;
         custom_storage2d_type matrix() const&;
         custom_storage2d_type matrix() &&;
+        custom_storage2d_type matrix() const&&;
 
         storage1d_type& vector_non_ref();
         storage1d_type const& vector_non_ref() const;
@@ -273,6 +274,7 @@ namespace phylanx { namespace ir
         custom_storage1d_type vector() &;
         custom_storage1d_type vector() const&;
         custom_storage1d_type vector() &&;
+        custom_storage1d_type vector() const&&;
 
         storage0d_type& scalar();
         storage0d_type const& scalar() const;
@@ -285,8 +287,10 @@ namespace phylanx { namespace ir
         std::size_t dimension(int dim) const;
 
         /// Return a new instance of node_data referring to this instance.
+        node_data<T> ref() &;
         node_data<T> ref() const&;
         node_data<T> ref() &&;
+        node_data<T> ref() const&&;
 
         /// Return a new instance of node_data holding a copy of this instance.
         node_data<T> copy() const;

--- a/phylanx/util/serialization/ast.hpp
+++ b/phylanx/util/serialization/ast.hpp
@@ -10,20 +10,21 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
 
+#include <cstdint>
 #include <vector>
 
 namespace phylanx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT std::vector<char> serialize(ir::node_data<double> const&);
-    PHYLANX_EXPORT std::vector<char> serialize(ir::node_data<bool> const&);
+    PHYLANX_EXPORT std::vector<char> serialize(ir::node_data<std::uint8_t> const&);
 
     namespace detail
     {
         PHYLANX_EXPORT void unserialize(
             std::vector<char> const&, ir::node_data<double>&);
         PHYLANX_EXPORT void unserialize(
-            std::vector<char> const&, ir::node_data<bool>&);
+            std::vector<char> const&, ir::node_data<std::uint8_t>&);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -68,7 +68,10 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
         },
         "create a new variable from a matrix floating point values");
 
-    execution_tree.def("eval", phylanx::bindings::expression_compiler,
+    execution_tree.def("compile", phylanx::bindings::expression_compiler,
+        "compile a numerical expression in PhySL");
+
+    execution_tree.def("eval", phylanx::bindings::expression_evaluator,
         "compile and evaluate a numerical expression in PhySL");
 
     pybind11::class_<phylanx::execution_tree::primitive>(execution_tree,

--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -227,26 +227,38 @@ namespace pybind11 { namespace detail
         template <typename U, typename... Us>
         bool load_alternative(handle src, bool convert, type_list<U, Us...>)
         {
+            // deliberately start from the end of the type-list, this allows
+            // to match a list before a matrix
+            if (load_alternative(src, convert, type_list<Us...>{}))
+                return true;
+
             auto caster = make_caster<U>();
             if (caster.load(src, convert))
             {
                 value = cast_op<U>(caster);
                 return true;
             }
-            return load_alternative(src, convert, type_list<Us...>{});
+
+            return false;
         }
 
         template <typename U, typename... Us>
         bool load_alternative(handle src, bool convert,
             type_list<phylanx::util::recursive_wrapper<U>, Us...>)
         {
+            // deliberately start from the end of the type-list, this allows
+            // to match a list before a matrix
+            if (load_alternative(src, convert, type_list<Us...>{}))
+                return true;
+
             auto caster = make_caster<U>();
             if (caster.load(src, convert))
             {
                 value = cast_op<U>(caster);
                 return true;
             }
-            return load_alternative(src, convert, type_list<Us...>{});
+
+            return false;
         }
 
         bool load_alternative(handle, bool, type_list<>) { return false; }

--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -10,13 +10,17 @@
 
 #include <phylanx/phylanx.hpp>
 
-#include <pybind11/pybind11.h>
+#include <hpx/util/tuple.hpp>
+
+#include <pybind11/numpy.h>
 #include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -83,15 +87,190 @@ namespace pybind11 { namespace detail
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // Takes an input array and determines whether we can make it fit into the
+    // Blaze type.
+    using array_index_type =
+        hpx::util::tuple<std::size_t, std::size_t, std::size_t, std::size_t>;
+
+    template <typename Scalar>
+    inline bool conformable(
+        array const& a, std::size_t expected_dims, array_index_type& t)
+    {
+        const auto dims = a.ndim();
+        if (dims != expected_dims)
+            return false;
+
+        if (dims == 2)
+        {
+            // Matrix type: require exact match (or dynamic)
+            std::size_t np_rows = a.shape(0);
+            std::size_t np_cols = a.shape(1);
+            std::size_t np_rstride = a.strides(0) / sizeof(Scalar);
+            std::size_t np_cstride = a.strides(1) / sizeof(Scalar);
+
+            t = array_index_type{np_rows, np_cols, np_rstride, np_cstride};
+            return true;
+        }
+
+        // Otherwise we're storing an n-vector.  Only one of the strides will
+        // be used, but whichever is used, we want the (single) numpy stride
+        // value.
+        std::size_t const n = a.shape(0);
+        std::size_t stride = a.strides(0) / sizeof(Scalar);
+
+        t = array_index_type{n, 1, stride, 0};
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Casts a Blaze type to numpy array.  If given a base, the numpy array
+    // references the src data, otherwise it'll make a copy.
+    // writeable lets you turn off the writeable flag for the array.
+    template <typename T, bool TF>
+    handle blaze_array_cast(blaze::DynamicVector<T, TF> const& src,
+        handle base = handle(), bool writeable = true)
+    {
+        array a{{src.size()}, {sizeof(T)}, src.data(), base};
+
+        if (!writeable)
+        {
+            array_proxy(a.ptr())->flags &=
+                ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
+        }
+        return a.release();
+    }
+
+    template <typename T, bool AF, bool PF, bool TF>
+    handle blaze_array_cast(blaze::CustomVector<T, AF, PF, TF> const& src,
+        handle base = handle(), bool writeable = true)
+    {
+        array a{{src.size()}, {sizeof(T)}, src.data(), base};
+
+        if (!writeable)
+        {
+            array_proxy(a.ptr())->flags &=
+                ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
+        }
+        return a.release();
+    }
+
+    template <typename T>
+    handle blaze_array_cast(blaze::DynamicMatrix<T, false> const& src,
+        handle base = handle(), bool writeable = true)
+    {
+        array a{
+            {src.rows(), src.columns()},            // sizes
+            {sizeof(T) * src.spacing(), sizeof(T)}, // strides
+            src.data(), base};
+
+        if (!writeable)
+        {
+            array_proxy(a.ptr())->flags &=
+                ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
+        }
+        return a.release();
+    }
+
+    template <typename T>
+    handle blaze_array_cast(blaze::DynamicMatrix<T, true> const& src,
+        handle base = handle(), bool writeable = true)
+    {
+        array a{
+            {src.rows(), src.columns()},            // sizes
+            {sizeof(T), sizeof(T) * src.spacing()}, // strides
+            src.data(), base};
+
+        if (!writeable)
+        {
+            array_proxy(a.ptr())->flags &=
+                ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
+        }
+        return a.release();
+    }
+
+    template <typename T, bool AF, bool PF>
+    handle blaze_array_cast(blaze::CustomMatrix<T, AF, PF, false> const& src,
+        handle base = handle(), bool writeable = true)
+    {
+        array a{
+            {src.rows(), src.columns()},            // sizes
+            {sizeof(T) * src.spacing(), sizeof(T)}, // strides
+            src.data(), base};
+
+        if (!writeable)
+        {
+            array_proxy(a.ptr())->flags &=
+                ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
+        }
+        return a.release();
+    }
+
+    template <typename T, bool AF, bool PF>
+    handle blaze_array_cast(blaze::CustomMatrix<T, AF, PF, true> const& src,
+        handle base = handle(), bool writeable = true)
+    {
+        array a{
+            {src.rows(), src.columns()},            // sizes
+            {sizeof(T), sizeof(T) * src.spacing()}, // strides
+            src.data(), base};
+
+        if (!writeable)
+        {
+            array_proxy(a.ptr())->flags &=
+                ~detail::npy_api::NPY_ARRAY_WRITEABLE_;
+        }
+        return a.release();
+    }
+
+    // Takes an lvalue ref to some Blaze type and a (python) base object,
+    // creating a numpy array that references the Blaze object's data with
+    // `base` as the python-registered base class (if omitted, the base will
+    // be set to None, and lifetime management is up to the caller). The numpy
+    // array is non-writeable if the given type is const.
+    template <typename Type>
+    handle blaze_ref_array(Type& src, handle parent = none())
+    {
+        // none here is to get past array's should-we-copy detection, which
+        // currently always copies when there is no base.  Setting the base to
+        // None should be harmless.
+        return blaze_array_cast(src, parent, !std::is_const<Type>::value);
+    }
+
+    // Takes a pointer to some dense, plain Blaze type, builds a capsule
+    // around it, then returns a numpy array that references the encapsulated
+    // data with a python-side reference to the capsule to tie its destruction
+    // to that of any dependent python objects. Const-ness is determined by
+    // whether or not the Type of the pointer given is const.
+    template <typename Type>
+    handle blaze_encapsulate(Type *src)
+    {
+        capsule base(src, [](void* o) { delete static_cast<Type*>(o); });
+        return blaze_ref_array(*src, base);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct casted_type
+    {
+        using type = T;
+    };
+
+    template <>
+    struct casted_type<std::uint8_t>
+    {
+        using type = bool;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     class type_caster<phylanx::ir::node_data<T>>
     {
         bool load0d(handle src, bool convert)
         {
-            auto caster = make_caster<T>();
+            auto caster = make_caster<typename casted_type<T>::type>();
             if (caster.load(src, convert))
             {
-                value = cast_op<T>(caster);
+                value = cast_op<typename casted_type<T>::type>(caster);
                 return true;
             }
             return false;
@@ -99,24 +278,251 @@ namespace pybind11 { namespace detail
 
         bool load1d(handle src, bool convert)
         {
-            auto caster = make_caster<std::vector<T>>();
-            if (caster.load(src, convert))
+            if (!convert &&
+                !isinstance<array_t<typename casted_type<T>::type>>(src))
             {
-                value = cast_op<std::vector<T>>(caster);
-                return true;
+                return false;
             }
-            return false;
+
+            // Coerce into an array, but don't do type conversion yet; the copy
+            // below handles it.
+            auto buf = array::ensure(src);
+            if (!buf) return false;
+
+            auto dims = buf.ndim();
+            if (dims != 1) return false;
+
+            array_index_type t;
+            bool fits = conformable<typename casted_type<T>::type>(buf, 1, t);
+            if (!fits) return false;
+
+            // Allocate the new type, then build a numpy reference into it
+            value = blaze::DynamicVector<T>(hpx::util::get<0>(t));
+
+            auto v = value.vector();
+            auto ref = reinterpret_steal<array>(blaze_ref_array(v));
+
+            if (dims == 1) ref = ref.squeeze();
+            else if (ref.ndim() == 1) buf = buf.squeeze();
+
+            int result =
+                detail::npy_api::get().PyArray_CopyInto_(ref.ptr(), buf.ptr());
+            if (result < 0)
+            {
+                // Copy failed!
+                PyErr_Clear();
+                return false;
+            }
+            return true;
         }
 
         bool load2d(handle src, bool convert)
         {
-            auto caster = make_caster<std::vector<std::vector<T>>>();
-            if (caster.load(src, convert))
+            if (!convert &&
+                !isinstance<array_t<typename casted_type<T>::type>>(src))
             {
-                value = cast_op<std::vector<std::vector<T>>>(caster);
-                return true;
+                return false;
             }
-            return false;
+
+            // Coerce into an array, but don't do type conversion yet; the copy
+            // below handles it.
+            auto buf = array::ensure(src);
+            if (!buf) return false;
+
+            auto dims = buf.ndim();
+            if (dims != 2) return false;
+
+            array_index_type t;
+            bool fits = conformable<typename casted_type<T>::type>(buf, 2, t);
+            if (!fits) return false;
+
+            // Allocate the new type, then build a numpy reference into it
+            value = blaze::DynamicMatrix<T>(hpx::util::get<0>(t),
+                hpx::util::get<1>(t), hpx::util::get<3>(t));
+
+            auto m = value.matrix();
+            auto ref = reinterpret_steal<array>(blaze_ref_array(m));
+
+            if (dims == 1) ref = ref.squeeze();
+            else if (ref.ndim() == 1) buf = buf.squeeze();
+
+            int result =
+                detail::npy_api::get().PyArray_CopyInto_(ref.ptr(), buf.ptr());
+            if (result < 0)
+            {
+                // Copy failed!
+                PyErr_Clear();
+                return false;
+            }
+            return true;
+        }
+
+        template <typename Type>
+        static handle cast_impl_automatic(Type* src)
+        {
+            switch (src->index())
+            {
+            case 1:     // blaze::DynamicVector<T>
+                return blaze_encapsulate(&(src->vector_non_ref()));
+
+            case 2:     // blaze::DynamicMatrix<T>
+                return blaze_encapsulate(&(src->matrix_non_ref()));
+
+            // custom types require a copy (done by vector_copy/matrix_copy)
+            case 3:     // blaze::CustomVector<T>
+                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                    src->vector_copy()));
+
+            case 4:     // blaze::CustomMatrix<T>
+                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                    src->matrix_copy()));
+
+            default:
+                throw cast_error("cast_impl_automatic: "
+                    "unexpected node_data type: should not happen!");
+            }
+            return handle();
+        }
+
+        template <typename Type>
+        static handle cast_impl_move(Type* src)
+        {
+            switch (src->index())
+            {
+            case 1:     // blaze::DynamicVector<T>
+                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                    std::move(src->vector_non_ref())));
+
+            case 2:     // blaze::DynamicMatrix<T>
+                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                    std::move(src->matrix_non_ref())));
+
+            // custom types require a copy (done by vector_copy/matrix_copy)
+            case 3:     // blaze::CustomVector<T>
+                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                    src->vector_copy()));
+
+            case 4:     // blaze::CustomMatrix<T>
+                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                    src->matrix_copy()));
+
+            default:
+                throw cast_error("cast_impl_move: "
+                    "unexpected node_data type: should not happen!");
+            }
+            return handle();
+        }
+
+        template <typename Type>
+        static handle cast_impl_copy(Type* src)
+        {
+            switch (src->index())
+            {
+            case 1:     // blaze::DynamicVector<T>
+                return blaze_array_cast(src->vector_non_ref());
+
+            case 2:     // blaze::DynamicMatrix<T>
+                return blaze_array_cast(src->matrix_non_ref());
+
+            case 3:     // blaze::CustomVector<T>
+                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                    src->vector_copy()));
+
+            case 4:     // blaze::CustomMatrix<T>
+                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                    src->matrix_copy()));
+
+            default:
+                throw cast_error("cast_impl_copy: "
+                    "unexpected node_data type: should not happen!");
+            }
+            return handle();
+        }
+
+        template <typename Type>
+        static handle cast_impl_automatic_reference(Type* src)
+        {
+            switch (src->index())
+            {
+            case 1:     // blaze::DynamicVector<T>
+                return blaze_ref_array(src->vector_non_ref());
+
+            case 2:     // blaze::DynamicMatrix<T>
+                return blaze_ref_array(src->matrix_non_ref());
+
+            // custom types require a copy (done by vector_copy/matrix_copy)
+            case 3:     // blaze::CustomVector<T>
+                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                    src->vector_copy()));
+
+            case 4:     // blaze::CustomMatrix<T>
+                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                    src->matrix_copy()));
+
+            default:
+                throw cast_error("cast_impl_automatic_reference: "
+                    "unexpected node_data type: should not happen!");
+            }
+            return handle();
+        }
+
+        template <typename Type>
+        static handle cast_impl_reference_internal(Type* src, handle parent)
+        {
+            switch (src->index())
+            {
+            case 1:     // blaze::DynamicVector<T>
+                return blaze_ref_array(src->vector_non_ref(), parent);
+
+            case 2:     // blaze::DynamicMatrix<T>
+                return blaze_ref_array(src->matrix_non_ref(), parent);
+
+            case 3: HPX_FALLTHROUGH;    // blaze::CustomVector<T>
+            case 4: HPX_FALLTHROUGH;    // blaze::CustomMatrix<T>
+            default:
+                throw cast_error("cast_impl_reference_internal: "
+                    "unexpected node_data type: should not happen!");
+            }
+            return handle();
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Type>
+        static handle cast_impl(
+            Type* src, return_value_policy policy, handle parent)
+        {
+            if (0 == src->index())      // T
+            {
+                return make_caster<typename casted_type<T>::type>::cast(
+                    src->scalar(), policy, parent);
+            }
+
+            switch (policy)
+            {
+            case return_value_policy::take_ownership:
+                HPX_FALLTHROUGH;
+            case return_value_policy::automatic:
+                return cast_impl_automatic(src);
+
+            case return_value_policy::move:
+                return cast_impl_move(src);
+
+            case return_value_policy::copy:
+                return cast_impl_copy(src);
+
+            case return_value_policy::reference:
+                HPX_FALLTHROUGH;
+            case return_value_policy::automatic_reference:
+                return cast_impl_automatic_reference(src);
+
+            case return_value_policy::reference_internal:
+                return cast_impl_reference_internal(src, parent);
+
+            default:
+                throw cast_error(
+                    "type_caster<phylanx::ir::node_data<T>>::cast_impl: "
+                    "unhandled return_value_policy: should not happen!");
+            };
         }
 
     public:
@@ -126,30 +532,57 @@ namespace pybind11 { namespace detail
                 load2d(src, convert);
         }
 
-        template <typename NodeData>
-        static handle cast(
-            NodeData&& src, return_value_policy policy, handle parent)
+        // Normal returned non-reference, non-const value:
+        static handle cast(phylanx::ir::node_data<T>&& src,
+            return_value_policy /* policy */, handle parent)
         {
-            switch (src.index())
+            return cast_impl(&src, return_value_policy::move, parent);
+        }
+
+        // If you return a non-reference const, we mark the numpy array as
+        // read only
+        static handle cast(phylanx::ir::node_data<T> const&& src,
+            return_value_policy /* policy */, handle parent)
+        {
+            return cast_impl(&src, return_value_policy::move, parent);
+        }
+
+        // lvalue reference return; default (automatic) becomes copy
+        static handle cast(phylanx::ir::node_data<T>& src,
+            return_value_policy policy, handle parent)
+        {
+            if (policy == return_value_policy::automatic ||
+                policy == return_value_policy::automatic_reference)
             {
-            case 0:                     // T
-                return make_caster<T>::cast(
-                    std::forward<NodeData>(src).scalar(), policy, parent);
-
-            case 1: HPX_FALLTHROUGH;    // blaze::DynamicVector<T>
-            case 3:                     // blaze::CustomVector<T>
-                return make_caster<std::vector<T>>::cast(
-                    std::forward<NodeData>(src).as_vector(), policy, parent);
-
-            case 2: HPX_FALLTHROUGH;    // blaze::DynamicMatrix<T>
-            case 4:                     // blaze::CustomMatrix<T>
-                return make_caster<std::vector<std::vector<T>>>::cast(
-                    std::forward<NodeData>(src).as_matrix(), policy, parent);
-
-            default:
-                break;
+                policy = return_value_policy::copy;
             }
-            return handle();
+            return cast_impl(&src, policy, parent);
+        }
+
+        // const lvalue reference return; default (automatic) becomes copy
+        static handle cast(phylanx::ir::node_data<T> const& src,
+            return_value_policy policy, handle parent)
+        {
+            if (policy == return_value_policy::automatic ||
+                policy == return_value_policy::automatic_reference)
+            {
+                policy = return_value_policy::copy;
+            }
+            return cast(&src, policy, parent);
+        }
+
+        // non-const pointer return
+        static handle cast(phylanx::ir::node_data<T>* src,
+            return_value_policy policy, handle parent)
+        {
+            return cast_impl(src, policy, parent);
+        }
+
+        // const pointer return
+        static handle cast(phylanx::ir::node_data<T> const* src,
+            return_value_policy policy, handle parent)
+        {
+            return cast_impl(src, policy, parent);
         }
 
         using Type = phylanx::ir::node_data<T>;
@@ -227,38 +660,26 @@ namespace pybind11 { namespace detail
         template <typename U, typename... Us>
         bool load_alternative(handle src, bool convert, type_list<U, Us...>)
         {
-            // deliberately start from the end of the type-list, this allows
-            // to match a list before a matrix
-            if (load_alternative(src, convert, type_list<Us...>{}))
-                return true;
-
             auto caster = make_caster<U>();
             if (caster.load(src, convert))
             {
                 value = cast_op<U>(caster);
                 return true;
             }
-
-            return false;
+            return load_alternative(src, convert, type_list<Us...>{});
         }
 
         template <typename U, typename... Us>
         bool load_alternative(handle src, bool convert,
             type_list<phylanx::util::recursive_wrapper<U>, Us...>)
         {
-            // deliberately start from the end of the type-list, this allows
-            // to match a list before a matrix
-            if (load_alternative(src, convert, type_list<Us...>{}))
-                return true;
-
             auto caster = make_caster<U>();
             if (caster.load(src, convert))
             {
                 value = cast_op<U>(caster);
                 return true;
             }
-
-            return false;
+            return load_alternative(src, convert, type_list<Us...>{});
         }
 
         bool load_alternative(handle, bool, type_list<>) { return false; }

--- a/python/src/bindings/util.cpp
+++ b/python/src/bindings/util.cpp
@@ -14,6 +14,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <cstdint>
+
 ///////////////////////////////////////////////////////////////////////////////
 // expose util submodule
 void phylanx::bindings::bind_util(pybind11::module m)
@@ -39,10 +41,13 @@ void phylanx::bindings::bind_util(pybind11::module m)
     util.def("serialize", &phylanx::bindings::serialize<phylanx::ast::function_call>,
         "serialize an AST expression object into a byte-stream");
 
-    util.def("serialize", &phylanx::bindings::serialize<phylanx::ir::node_data<double>>,
+    util.def("serialize",
+        &phylanx::bindings::serialize<phylanx::ir::node_data<double>>,
         "serialize a node_data<double> expression object into a byte-stream");
-    util.def("serialize", &phylanx::bindings::serialize<phylanx::ir::node_data<bool>>,
-        "serialize a node_data<bool> expression object into a byte-stream");
+    util.def("serialize",
+        &phylanx::bindings::serialize<phylanx::ir::node_data<std::uint8_t>>,
+        "serialize a node_data<std::uint8_t> expression object into a "
+        "byte-stream");
 
     util.def("unserialize", &phylanx::util::unserialize,
         "un-serialize a byte-stream into a Phylanx object");

--- a/src/execution_tree/primitives/all_operation.cpp
+++ b/src/execution_tree/primitives/all_operation.cpp
@@ -47,7 +47,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     template <typename T>
     primitive_argument_type all_operation::all0d(T&& arg) const
     {
-        return primitive_argument_type{ir::node_data<bool>{arg.scalar() != 0}};
+        return primitive_argument_type{ir::node_data<std::uint8_t>{arg.scalar() != 0}};
     }
 
     template <typename T>
@@ -55,14 +55,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         auto value = arg.vector();
         return primitive_argument_type{
-            ir::node_data<bool>{value.nonZeros() == value.size()}};
+            ir::node_data<std::uint8_t>{value.nonZeros() == value.size()}};
     }
 
     template <typename T>
     primitive_argument_type all_operation::all2d(T&& arg) const
     {
         auto value = arg.matrix();
-        return primitive_argument_type{ir::node_data<bool>{
+        return primitive_argument_type{ir::node_data<std::uint8_t>{
             value.nonZeros() == value.rows() * value.columns()}};
     }
 

--- a/src/execution_tree/primitives/and_operation.cpp
+++ b/src/execution_tree/primitives/and_operation.cpp
@@ -82,7 +82,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(
             T&& lhs, T&& rhs) const
         {
-            return primitive_argument_type(ir::node_data<bool>{lhs && rhs});
+            return primitive_argument_type(ir::node_data<std::uint8_t>{lhs && rhs});
         }
 
         primitive_argument_type operator()(
@@ -124,8 +124,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             ir::node_data<double>&& lhs,
             ir::node_data<double>&& rhs) const
         {
-            return and_.and_all(ir::node_data<bool>{std::move(lhs)},
-                ir::node_data<bool>{std::move(rhs)});
+            return and_.and_all(ir::node_data<std::uint8_t>{std::move(lhs)},
+                ir::node_data<std::uint8_t>{std::move(rhs)});
         }
 
         primitive_argument_type operator()(
@@ -170,7 +170,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             rhs.vector(), [&](bool x) { return (x && lhs.scalar()); });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
     primitive_argument_type and_operation::and0d2d(
@@ -182,7 +182,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             rhs.matrix(), [&](bool x) { return (x && lhs.scalar()); });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
     primitive_argument_type and_operation::and0d(
@@ -193,7 +193,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
         case 0:
             return primitive_argument_type(
-                ir::node_data<bool>{lhs.scalar() && rhs.scalar()});
+                ir::node_data<std::uint8_t>{lhs.scalar() && rhs.scalar()});
 
         case 1:
             return and0d1d(std::move(lhs), std::move(rhs));
@@ -219,7 +219,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             lhs.vector(), [&](bool x) { return (x && rhs.scalar()); });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
     primitive_argument_type and_operation::and1d1d(
@@ -243,7 +243,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [&](bool x, bool y) { return (x && y); });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
     primitive_argument_type and_operation::and1d2d(
@@ -270,7 +270,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     [](bool x, bool y) { return x && y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
     primitive_argument_type and_operation::and1d(
@@ -310,7 +310,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [&](double x) { return (x && rhs.scalar()); });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
     primitive_argument_type and_operation::and2d1d(
@@ -337,7 +337,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     [](bool x, bool y) { return x && y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
     primitive_argument_type and_operation::and2d2d(
@@ -361,7 +361,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [&](bool x, bool y) { return (x && y); });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
     primitive_argument_type and_operation::and2d(

--- a/src/execution_tree/primitives/any_operation.cpp
+++ b/src/execution_tree/primitives/any_operation.cpp
@@ -47,7 +47,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     template <typename T>
     primitive_argument_type any_operation::any0d(T&& arg) const
     {
-        return primitive_argument_type{ir::node_data<bool>{arg.scalar() != 0}};
+        return primitive_argument_type{ir::node_data<std::uint8_t>{arg.scalar() != 0}};
     }
 
     template <typename T>
@@ -55,7 +55,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         auto value = arg.vector();
         return primitive_argument_type{
-            ir::node_data<bool>{value.nonZeros() != 0}};
+            ir::node_data<std::uint8_t>{value.nonZeros() != 0}};
     }
 
     template <typename T>
@@ -64,7 +64,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         auto value = arg.matrix();
         return primitive_argument_type{
-            ir::node_data<bool>{value.nonZeros() != 0}};
+            ir::node_data<std::uint8_t>{value.nonZeros() != 0}};
     }
 
     template <typename T>

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree
         ///////////////////////////////////////////////////////////////////////
         char const* const primitive_argument_type_names[] = {
             "phylanx::ast::nil",
-            "phylanx::ir::node_data<bool>",
+            "phylanx::ir::node_data<std::uint8_t>",
             "std::int64_t",
             "std::string",
             "phylanx::ir::node_data<double>",
@@ -333,7 +333,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // std::string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -368,7 +368,7 @@ namespace phylanx { namespace execution_tree
         case 7:                     // std::vector<primitive_argument_type>
             return val;
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             {
                 auto const& v = util::get<1>(val);
                 if (v.is_ref())
@@ -416,7 +416,7 @@ namespace phylanx { namespace execution_tree
         case 7:                     // std::vector<primitive_argument_type>
             return val;
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             {
                 auto const& v = util::get<1>(val);
                 if (v.is_ref())
@@ -457,7 +457,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // std::string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -492,7 +492,7 @@ namespace phylanx { namespace execution_tree
         case 7:                     // std::vector<primitive_argument_type>
             return std::move(val);
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             {
                 auto && v = util::get<1>(std::move(val));
                 if (v.is_ref())
@@ -533,7 +533,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // std::string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -563,7 +563,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // std::string
         case 4:                     // phylanx::ir::node_data<double>
@@ -605,7 +605,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1:                     // phylanx::ir::node_data<bool>
+        case 1:                     // phylanx::ir::node_data<std::uint8_t>
             return primitive_argument_type{util::get<1>(val).ref()};
 
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
@@ -658,7 +658,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // std::string
         case 4:                     // phylanx::ir::node_data<double>
@@ -698,7 +698,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // std::string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -720,7 +720,7 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return ir::node_data<double>{util::get<1>(val).ref()};
 
         case 2:     // std::uint64_t
@@ -765,7 +765,7 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return ir::node_data<double>{util::get<1>(std::move(val))};
 
         case 2:     // std::uint64_t
@@ -809,7 +809,7 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 6:     // std::vector<ast::expression>
@@ -826,12 +826,12 @@ namespace phylanx { namespace execution_tree
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<bool> extract_boolean_data(primitive_argument_type const& val,
+    ir::node_data<std::uint8_t> extract_boolean_data(primitive_argument_type const& val,
         std::string const& name, std::string const& codename)
     {
         switch (val.index())
         {
-        case 1:                     // phylanx::ir::node_data<bool>
+        case 1:                     // phylanx::ir::node_data<std::uint8_t>
             return util::get<1>(val).ref();
 
         case 0: HPX_FALLTHROUGH;    // nil
@@ -854,12 +854,12 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
-    ir::node_data<bool> extract_boolean_data(primitive_argument_type&& val,
+    ir::node_data<std::uint8_t> extract_boolean_data(primitive_argument_type&& val,
         std::string const& name, std::string const& codename)
     {
         switch (val.index())
         {
-        case 1:                     // phylanx::ir::node_data<bool>
+        case 1:                     // phylanx::ir::node_data<std::uint8_t>
             return util::get<1>(std::move(val));
 
         case 0: HPX_FALLTHROUGH;    // nil
@@ -886,7 +886,7 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 1:                     // phylanx::ir::node_data<bool>
+        case 1:                     // phylanx::ir::node_data<std::uint8_t>
             return true;
 
         case 0: HPX_FALLTHROUGH;    // nil
@@ -908,7 +908,7 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return std::int64_t(util::get<1>(val)[0]);
 
         case 2:     // std::uint64_t
@@ -953,7 +953,7 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return std::int64_t(util::get<1>(std::move(val))[0]);
 
         case 2:     // std::uint64_t
@@ -997,7 +997,7 @@ namespace phylanx { namespace execution_tree
     {
         switch (val.index())
         {
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 6:     // std::vector<ast::expression>
@@ -1022,7 +1022,7 @@ namespace phylanx { namespace execution_tree
         case 0:     // nil
             return false;
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return bool(util::get<1>(val));
 
         case 2:     // std::uint64_t
@@ -1071,7 +1071,7 @@ namespace phylanx { namespace execution_tree
         case 0:     // nil
             return false;
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return bool(util::get<1>(std::move(val)));
 
         case 2:     // std::uint64_t
@@ -1117,7 +1117,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
@@ -1156,7 +1156,7 @@ namespace phylanx { namespace execution_tree
             break;
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
@@ -1197,7 +1197,7 @@ namespace phylanx { namespace execution_tree
             break;
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
@@ -1224,7 +1224,7 @@ namespace phylanx { namespace execution_tree
             return true;
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
@@ -1255,7 +1255,7 @@ namespace phylanx { namespace execution_tree
             return util::get<6>(val);
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 5: HPX_FALLTHROUGH;    // primitive
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
         default:
@@ -1290,7 +1290,7 @@ namespace phylanx { namespace execution_tree
             return util::get<6>(std::move(val));
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 5: HPX_FALLTHROUGH;    // primitive
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
         default:
@@ -1317,7 +1317,7 @@ namespace phylanx { namespace execution_tree
             return true;
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;        // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;        // phylanx::ir::node_data<std::uint8_t>
         case 5: HPX_FALLTHROUGH;    // primitive
         case 7: HPX_FALLTHROUGH;    // std::vector<primitive_argument_type>
         default:
@@ -1337,7 +1337,7 @@ namespace phylanx { namespace execution_tree
             return std::vector<primitive_argument_type>{
                 primitive_argument_type{util::get<0>(val)}};
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return std::vector<primitive_argument_type>{
                 primitive_argument_type{util::get<1>(val)}};
 
@@ -1387,7 +1387,7 @@ namespace phylanx { namespace execution_tree
             return std::vector<primitive_argument_type>{
                 primitive_argument_type{util::get<0>(std::move(val))}};
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return std::vector<primitive_argument_type>{
                 primitive_argument_type{util::get<1>(std::move(val))}};
 
@@ -1432,7 +1432,7 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -1477,7 +1477,7 @@ namespace phylanx { namespace execution_tree
             return util::get<7>(val).get();
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -1524,7 +1524,7 @@ namespace phylanx { namespace execution_tree
             return util::get<7>(std::move(val)).get();
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -1551,7 +1551,7 @@ namespace phylanx { namespace execution_tree
             return true;
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 3: HPX_FALLTHROUGH;    // string
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
@@ -2296,7 +2296,7 @@ namespace phylanx { namespace execution_tree
             os << util::get<0>(val);
             return os;
 
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             os << util::get<1>(val);
             return os;
 

--- a/src/execution_tree/primitives/equal.cpp
+++ b/src/execution_tree/primitives/equal.cpp
@@ -47,8 +47,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type equal::equal0d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -64,11 +65,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal0d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -84,18 +86,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 0:
             return primitive_argument_type(
-                ir::node_data<bool>{lhs.scalar() == rhs.scalar()});
+                ir::node_data<std::uint8_t>{lhs.scalar() == rhs.scalar()});
 
         case 1:
             return equal0d1d(std::move(lhs), std::move(rhs));
@@ -112,8 +115,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type equal::equal1d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -129,11 +133,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal1d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -161,11 +166,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal1d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = lhs.vector();
         auto cm = rhs.matrix();
@@ -190,19 +196,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x == y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
             blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
                 blaze::trans(cv),
                 [](double x, double y) { return x == y; });
+
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -226,8 +234,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type equal::equal2d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -246,11 +255,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal2d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = rhs.vector();
         auto cm = lhs.matrix();
@@ -275,7 +285,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x == y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
@@ -284,11 +294,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [](double x, double y) { return x == y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal2d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -316,11 +327,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type equal::equal2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -344,8 +356,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type equal::equal_all(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
@@ -369,103 +382,128 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-            struct equal::visit_equal
+    struct equal::visit_equal
+    {
+        template <typename T1, typename T2>
+        primitive_argument_type operator()(T1, T2) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::eval",
+                execution_tree::generate_error_message(
+                    "left hand side and right hand side are "
+                        "incompatible and can't be compared",
+                    equal_.name_, equal_.codename_));
+        }
+
+        template <typename T>
+        primitive_argument_type operator()(T && lhs, T && rhs) const
+        {
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs == rhs});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<double>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
             {
-                template <typename T1, typename T2>
-                primitive_argument_type operator()(T1, T2) const
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::eval",
-                        execution_tree::generate_error_message(
-                            "left hand side and right hand side are "
-                                "incompatible and can't be compared",
-                            equal_.name_, equal_.codename_));
-                }
-
-                template <typename T>
-                primitive_argument_type operator()(T && lhs, T && rhs) const
-                {
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs == rhs});
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<double>&& lhs, std::int64_t&& rhs) const
-                {
-                    if (lhs.num_dimensions() != 0)
-                    {
-                        return equal_.equal_all(
-                            std::move(lhs), operand_type(std::move(rhs)));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs[0] == rhs});
-                }
-
-                primitive_argument_type operator()(
-                    std::int64_t&& lhs, ir::node_data<double>&& rhs) const
-                {
-                    if (rhs.num_dimensions() != 0)
-                    {
-                        return equal_.equal_all(
-                            operand_type(std::move(lhs)), std::move(rhs));
-                    }
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs == rhs[0]});
-                }
-
-                primitive_argument_type operator()(
-                    ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
-                {
-                    return equal_.equal_all(
-                        ir::node_data<double>(std::move(lhs)),
-                        ir::node_data<double>(std::move(rhs)));
-                }
-
-                primitive_argument_type operator()(
-                    operand_type&& lhs, operand_type&& rhs) const
-                {
-                    return equal_.equal_all(std::move(lhs), std::move(rhs));
-                }
-
-                equal const& equal_;
-            };
-
-            hpx::future<primitive_argument_type> equal::eval(
-                std::vector<primitive_argument_type> const& operands,
-                std::vector<primitive_argument_type> const& args) const
-            {
-                if (operands.size() != 2)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::eval",
-                        execution_tree::generate_error_message(
-                            "the equal primitive requires exactly two operands",
-                            name_, codename_));
-                }
-
-                if (!valid(operands[0]) || !valid(operands[1]))
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "equal::eval",
-                        execution_tree::generate_error_message(
-                            "the equal primitive requires that the arguments "
-                                "given by the operands array are valid",
-                            name_, codename_));
-                }
-
-                auto this_ = this->shared_from_this();
-                return hpx::dataflow(hpx::util::unwrapping(
-                    [this_](operands_type && ops) -> primitive_argument_type
-                    {
-                        return primitive_argument_type(
-                            util::visit(visit_equal{*this_},
-                                std::move(ops[0].variant()),
-                                std::move(ops[1].variant())));
-                    }),
-                    detail::map_operands(
-                        operands, functional::literal_operand{}, args,
-                        name_, codename_));
+                return equal_.equal_all(
+                    std::move(lhs), operand_type(std::move(rhs)));
             }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs[0] == rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<double>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return equal_.equal_all(
+                    operand_type(std::move(lhs)), std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs == rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<std::uint8_t>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return equal_.equal_all(
+                    std::move(lhs), ir::node_data<std::uint8_t>{rhs != 0});
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs[0] == rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<std::uint8_t>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return equal_.equal_all(
+                    ir::node_data<std::uint8_t>{lhs != 0}, std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs == rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<std::uint8_t>&& lhs,
+            ir::node_data<std::uint8_t>&& rhs) const
+        {
+            return equal_.equal_all(
+                ir::node_data<double>(std::move(lhs)),
+                ir::node_data<double>(std::move(rhs)));
+        }
+
+        primitive_argument_type operator()(
+            operand_type&& lhs, operand_type&& rhs) const
+        {
+            return equal_.equal_all(std::move(lhs), std::move(rhs));
+        }
+
+        equal const& equal_;
+    };
+
+    hpx::future<primitive_argument_type> equal::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::eval",
+                execution_tree::generate_error_message(
+                    "the equal primitive requires exactly two operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "equal::eval",
+                execution_tree::generate_error_message(
+                    "the equal primitive requires that the arguments "
+                        "given by the operands array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::util::unwrapping(
+            [this_](operands_type && ops) -> primitive_argument_type
+            {
+                return primitive_argument_type(
+                    util::visit(visit_equal{*this_},
+                        std::move(ops[0].variant()),
+                        std::move(ops[1].variant())));
+            }),
+            detail::map_operands(
+                operands, functional::literal_operand{}, args,
+                name_, codename_));
+    }
 
     // implement '==' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> equal::eval(

--- a/src/execution_tree/primitives/greater.cpp
+++ b/src/execution_tree/primitives/greater.cpp
@@ -1,7 +1,7 @@
-// Copyright (c) 2017-2018 Hartmut Kaiser
+//  Copyright (c) 2017-2018 Hartmut Kaiser
 //
-// Distributed under the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/greater.hpp>
@@ -47,8 +47,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type greater::greater0d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -64,11 +65,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater0d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -84,18 +86,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 0:
             return primitive_argument_type(
-                ir::node_data<bool>{lhs.scalar() > rhs.scalar()});
+                ir::node_data<std::uint8_t>{lhs.scalar() > rhs.scalar()});
 
         case 1:
             return greater0d1d(std::move(lhs), std::move(rhs));
@@ -113,8 +116,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type greater::greater1d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -130,11 +134,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater1d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -162,11 +167,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater1d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = lhs.vector();
         auto cm = rhs.matrix();
@@ -191,20 +197,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x > y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
             blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
                 blaze::trans(cv),
                 [](double x, double y) { return x > y; });
-
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -228,8 +234,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type greater::greater2d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -248,11 +255,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater2d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = rhs.vector();
         auto cm = lhs.matrix();
@@ -277,7 +285,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x > y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
@@ -286,11 +294,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [](double x, double y) { return x > y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater2d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -318,11 +327,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type greater::greater2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -346,8 +356,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type greater::greater_all(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
@@ -381,7 +392,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 execution_tree::generate_error_message(
                     "left hand side and right hand side are incompatible "
                         "and can't be compared",
-                    that_.name_, that_.codename_));
+                    greater_.name_, greater_.codename_));
         }
 
         primitive_argument_type operator()(
@@ -393,7 +404,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 execution_tree::generate_error_message(
                     "left hand side and right hand side are incompatible "
                         "and can't be compared",
-                    that_.name_, that_.codename_));
+                    greater_.name_, greater_.codename_));
         }
 
         primitive_argument_type operator()(std::vector<ast::expression>&&,
@@ -404,7 +415,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 execution_tree::generate_error_message(
                     "left hand side and right hand side are incompatible "
                         "and can't be compared",
-                    that_.name_, that_.codename_));
+                    greater_.name_, greater_.codename_));
         }
 
         primitive_argument_type operator()(
@@ -415,7 +426,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 execution_tree::generate_error_message(
                     "left hand side and right hand side are incompatible "
                         "and can't be compared",
-                    that_.name_, that_.codename_));
+                    greater_.name_, greater_.codename_));
         }
 
         primitive_argument_type operator()(primitive&&, primitive&&) const
@@ -425,14 +436,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 execution_tree::generate_error_message(
                     "left hand side and right hand side are incompatible "
                         "and can't be compared",
-                    that_.name_, that_.codename_));
+                    greater_.name_, greater_.codename_));
         }
 
         template <typename T>
         primitive_argument_type operator()(T && lhs, T && rhs) const
         {
             return primitive_argument_type(
-                ir::node_data<bool>{lhs > rhs});
+                ir::node_data<std::uint8_t>{lhs > rhs});
         }
 
         primitive_argument_type operator()(
@@ -446,7 +457,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 execution_tree::generate_error_message(
                     "left hand side and right hand side are incompatible "
                         "and can't be compared",
-                    that_.name_, that_.codename_));
+                    greater_.name_, greater_.codename_));
         }
 
         primitive_argument_type operator()(
@@ -454,11 +465,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             if (lhs.num_dimensions() != 0)
             {
-                return that_.greater_all(
+                return greater_.greater_all(
                     std::move(lhs), operand_type(std::move(rhs)));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs[0] > rhs});
+                ir::node_data<std::uint8_t>{lhs[0] > rhs});
         }
 
         primitive_argument_type operator()(
@@ -466,31 +477,56 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             if (rhs.num_dimensions() != 0)
             {
-                return that_.greater_all(
+                return greater_.greater_all(
                     operand_type(std::move(lhs)), std::move(rhs));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs > rhs[0]});
+                ir::node_data<std::uint8_t>{lhs > rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<std::uint8_t>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return greater_.greater_all(std::move(lhs),
+                    ir::node_data<std::uint8_t>{rhs != 0});
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs[0] > rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<std::uint8_t>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return greater_.greater_all(
+                    ir::node_data<std::uint8_t>{lhs != 0},
+                    std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs > rhs[0]});
         }
 
         primitive_argument_type operator()(
             operand_type&& lhs, operand_type&& rhs) const
         {
-            return that_.greater_all(
+            return greater_.greater_all(
                 std::move(lhs), std::move(rhs));
         }
 
-        primitive_argument_type operator()(
-            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        primitive_argument_type operator()(ir::node_data<std::uint8_t>&& lhs,
+            ir::node_data<std::uint8_t>&& rhs) const
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "greater::eval",
                 execution_tree::generate_error_message(
                     "left hand side and right hand side can't be compared",
-                    that_.name_, that_.codename_));
+                    greater_.name_, greater_.codename_));
         }
 
-        greater const& that_;
+        greater const& greater_;
     };
 
     hpx::future<primitive_argument_type> greater::eval(

--- a/src/execution_tree/primitives/greater_equal.cpp
+++ b/src/execution_tree/primitives/greater_equal.cpp
@@ -47,329 +47,340 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal0d1d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.vector(),
-                        [&](double x) { return (x >= lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.vector() = blaze::map(rhs.vector(),
-                        [&](double x) { return (x >= lhs.scalar()); });
-                }
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            rhs = blaze::map(rhs.vector(),
+                [&](double x) { return (x >= lhs.scalar()); });
+        }
+        else
+        {
+            rhs.vector() = blaze::map(rhs.vector(),
+                [&](double x) { return (x >= lhs.scalar()); });
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(rhs)});
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal0d2d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    rhs = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x >= lhs.scalar()); });
-                }
-                else
-                {
-                    rhs.matrix() = blaze::map(rhs.matrix(),
-                        [&](double x) { return (x >= lhs.scalar()); });
-                }
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            rhs = blaze::map(rhs.matrix(),
+                [&](double x) { return (x >= lhs.scalar()); });
+        }
+        else
+        {
+            rhs.matrix() = blaze::map(rhs.matrix(),
+                [&](double x) { return (x >= lhs.scalar()); });
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(rhs)});
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal0d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return primitive_argument_type(
-                        ir::node_data<bool>{lhs.scalar() >= rhs.scalar()});
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs.scalar() >= rhs.scalar()});
 
-                case 1:
-                    return greater_equal0d1d(std::move(lhs), std::move(rhs));
+        case 1:
+            return greater_equal0d1d(std::move(lhs), std::move(rhs));
 
-                case 2:
-                    return greater_equal0d2d(std::move(lhs), std::move(rhs));
+        case 2:
+            return greater_equal0d2d(std::move(lhs), std::move(rhs));
 
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal0d",
-                        execution_tree::generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal0d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal1d0d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(),
-                        [&](double x) { return (x >= rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(),
-                        [&](double x) { return (x >= rhs.scalar()); });
-                }
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(),
+                [&](double x) { return (x >= rhs.scalar()); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(),
+                [&](double x) { return (x >= rhs.scalar()); });
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(lhs)});
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal1d1d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
 
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal1d1d",
-                        execution_tree::generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal1d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x >= y); });
-                }
-                else
-                {
-                    lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
-                        [&](double x, double y) { return (x >= y); });
-                }
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x >= y); });
+        }
+        else
+        {
+            lhs.vector() = blaze::map(lhs.vector(), rhs.vector(),
+                [&](double x, double y) { return (x >= y); });
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(lhs)});
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal1d2d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = lhs.vector();
-                auto cm = rhs.matrix();
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        auto cv = lhs.vector();
+        auto cm = rhs.matrix();
 
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal1d2d",
-                        execution_tree::generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal1d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (rhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (rhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
 
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x >= y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x >= y; });
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{std::move(m)});
+        }
 
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x >= y; });
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x >= y; });
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(rhs)});
+    }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
-            }
-
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal1d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return greater_equal1d0d(std::move(lhs), std::move(rhs));
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return greater_equal1d0d(std::move(lhs), std::move(rhs));
 
-                case 1:
-                    return greater_equal1d1d(std::move(lhs), std::move(rhs));
+        case 1:
+            return greater_equal1d1d(std::move(lhs), std::move(rhs));
 
-                case 2:
-                    return greater_equal1d2d(std::move(lhs), std::move(rhs));
+        case 2:
+            return greater_equal1d2d(std::move(lhs), std::move(rhs));
 
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal1d",
-                        execution_tree::generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal1d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal2d0d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_size = lhs.dimension(0);
-                std::size_t rhs_size = rhs.dimension(0);
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        std::size_t lhs_size = lhs.dimension(0);
+        std::size_t rhs_size = rhs.dimension(0);
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x >= rhs.scalar()); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(),
-                        [&](double x) { return (x >= rhs.scalar()); });
-                }
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(),
+                [&](double x) { return (x >= rhs.scalar()); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(),
+                [&](double x) { return (x >= rhs.scalar()); });
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(lhs)});
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal2d1d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto cv = rhs.vector();
-                auto cm = lhs.matrix();
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        auto cv = rhs.vector();
+        auto cm = lhs.matrix();
 
-                if (cv.size() != cm.columns())
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal2d1d",
-                        execution_tree::generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+        if (cv.size() != cm.columns())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal2d1d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                // is not currently available
-                if (lhs.is_ref())
-                {
-                    blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
+        // TODO: SIMD functionality should be added, blaze implementation
+        // is not currently available
+        if (lhs.is_ref())
+        {
+            blaze::DynamicMatrix<double> m{cm.rows(), cm.columns()};
 
-                    for (size_t i = 0UL; i != cm.rows(); i++)
-                        blaze::row(m, i) = blaze::map(blaze::row(cm, i),
-                            blaze::trans(cv),
-                            [](double x, double y) { return x >= y; });
-                    return primitive_argument_type(
-                        ir::node_data<bool>{std::move(m)});
-                }
+            for (size_t i = 0UL; i != cm.rows(); i++)
+                blaze::row(m, i) = blaze::map(blaze::row(cm, i),
+                    blaze::trans(cv),
+                    [](double x, double y) { return x >= y; });
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{std::move(m)});
+        }
 
-                for (size_t i = 0UL; i != cm.rows(); i++)
-                    blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
-                        blaze::trans(cv),
-                        [](double x, double y) { return x >= y; });
+        for (size_t i = 0UL; i != cm.rows(); i++)
+            blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
+                blaze::trans(cv),
+                [](double x, double y) { return x >= y; });
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(lhs)});
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal2d2d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                auto lhs_size = lhs.dimensions();
-                auto rhs_size = rhs.dimensions();
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        auto lhs_size = lhs.dimensions();
+        auto rhs_size = rhs.dimensions();
 
-                if (lhs_size != rhs_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal2d2d",
-                        execution_tree::generate_error_message(
-                            "the dimensions of the operands do not match",
-                            name_, codename_));
-                }
+        if (lhs_size != rhs_size)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal2d2d",
+                execution_tree::generate_error_message(
+                    "the dimensions of the operands do not match",
+                    name_, codename_));
+        }
 
-                // TODO: SIMD functionality should be added, blaze implementation
-                //       is not currently available
-                if (lhs.is_ref())
-                {
-                    lhs = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x >= y); });
-                }
-                else
-                {
-                    lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
-                        [&](double x, double y) { return (x >= y); });
-                }
+        // TODO: SIMD functionality should be added, blaze implementation
+        //       is not currently available
+        if (lhs.is_ref())
+        {
+            lhs = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x >= y); });
+        }
+        else
+        {
+            lhs.matrix() = blaze::map(lhs.matrix(), rhs.matrix(),
+                [&](double x, double y) { return (x >= y); });
+        }
 
-                return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
-            }
+        return primitive_argument_type(
+            ir::node_data<std::uint8_t>{std::move(lhs)});
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal2d(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t rhs_dims = rhs.num_dimensions();
-                switch(rhs_dims)
-                {
-                case 0:
-                    return greater_equal2d0d(std::move(lhs), std::move(rhs));
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        std::size_t rhs_dims = rhs.num_dimensions();
+        switch(rhs_dims)
+        {
+        case 0:
+            return greater_equal2d0d(std::move(lhs), std::move(rhs));
 
-                case 1:
-                    return greater_equal2d1d(std::move(lhs), std::move(rhs));
+        case 1:
+            return greater_equal2d1d(std::move(lhs), std::move(rhs));
 
-                case 2:
-                    return greater_equal2d2d(std::move(lhs), std::move(rhs));
+        case 2:
+            return greater_equal2d2d(std::move(lhs), std::move(rhs));
 
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal2d",
-                        execution_tree::generate_error_message(
-                            "the operands have incompatible number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal2d",
+                execution_tree::generate_error_message(
+                    "the operands have incompatible number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
 
+    template <typename T>
     primitive_argument_type greater_equal::greater_equal_all(
-        operand_type&& lhs, operand_type&& rhs) const
-            {
-                std::size_t lhs_dims = lhs.num_dimensions();
-                switch (lhs_dims)
-                {
-                case 0:
-                    return greater_equal0d(std::move(lhs), std::move(rhs));
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        std::size_t lhs_dims = lhs.num_dimensions();
+        switch (lhs_dims)
+        {
+        case 0:
+            return greater_equal0d(std::move(lhs), std::move(rhs));
 
-                case 1:
-                    return greater_equal1d(std::move(lhs), std::move(rhs));
+        case 1:
+            return greater_equal1d(std::move(lhs), std::move(rhs));
 
-                case 2:
-                    return greater_equal2d(std::move(lhs), std::move(rhs));
+        case 2:
+            return greater_equal2d(std::move(lhs), std::move(rhs));
 
-                default:
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "greater_equal::greater_equal_all",
-                        execution_tree::generate_error_message(
-                            "left hand side operand has unsupported number of "
-                                "dimensions",
-                            name_, codename_));
-                }
-            }
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "greater_equal::greater_equal_all",
+                execution_tree::generate_error_message(
+                    "left hand side operand has unsupported number of "
+                        "dimensions",
+                    name_, codename_));
+        }
+    }
 
     struct greater_equal::visit_greater_equal
     {
@@ -432,7 +443,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(T && lhs, T && rhs) const
         {
             return primitive_argument_type(
-                    ir::node_data<bool>{lhs >= rhs});
+                ir::node_data<std::uint8_t>{lhs >= rhs});
         }
 
         primitive_argument_type operator()(
@@ -458,7 +469,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     std::move(lhs), operand_type(std::move(rhs)));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs[0] >= rhs});
+                ir::node_data<std::uint8_t>{lhs[0] >= rhs});
         }
 
         primitive_argument_type operator()(
@@ -470,7 +481,32 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     operand_type(std::move(lhs)), std::move(rhs));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs >= rhs[0]});
+                ir::node_data<std::uint8_t>{lhs >= rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<std::uint8_t>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return greater_equal_.greater_equal_all(std::move(lhs),
+                    ir::node_data<std::uint8_t>{rhs != 0});
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs[0] >= rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<std::uint8_t>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return greater_equal_.greater_equal_all(
+                    ir::node_data<std::uint8_t>{lhs != 0},
+                    std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs >= rhs[0]});
         }
 
         primitive_argument_type operator()(
@@ -480,8 +516,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::move(lhs), std::move(rhs));
         }
 
-        primitive_argument_type operator()(
-            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        primitive_argument_type operator()(ir::node_data<std::uint8_t>&& lhs,
+            ir::node_data<std::uint8_t>&& rhs) const
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "greater_equal::eval",

--- a/src/execution_tree/primitives/less.cpp
+++ b/src/execution_tree/primitives/less.cpp
@@ -47,8 +47,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type less::less0d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -64,11 +65,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less0d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -84,18 +86,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 0:
             return primitive_argument_type(
-                ir::node_data<bool>{lhs.scalar() < rhs.scalar()});
+                ir::node_data<std::uint8_t>{lhs.scalar() < rhs.scalar()});
 
         case 1:
             return less0d1d(std::move(lhs), std::move(rhs));
@@ -113,8 +116,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type less::less1d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -130,11 +134,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less1d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -162,11 +167,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less1d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = lhs.vector();
         auto cm = rhs.matrix();
@@ -191,7 +197,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x < y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
@@ -199,11 +205,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 blaze::trans(cv),
                 [](double x, double y) { return x < y; });
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -227,8 +234,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type less::less2d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -247,11 +255,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less2d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = rhs.vector();
         auto cm = lhs.matrix();
@@ -276,7 +285,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x < y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
@@ -285,11 +294,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [](double x, double y) { return x < y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less2d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -317,11 +327,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less::less2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -345,8 +356,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type less::less_all(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
@@ -431,7 +443,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(T && lhs, T && rhs) const
         {
             return primitive_argument_type(
-                ir::node_data<bool>{lhs < rhs});
+                ir::node_data<std::uint8_t>{lhs < rhs});
         }
 
         primitive_argument_type operator()(
@@ -457,7 +469,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     std::move(lhs), operand_type(std::move(rhs)));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs[0] < rhs});
+                ir::node_data<std::uint8_t>{lhs[0] < rhs});
         }
 
         primitive_argument_type operator()(
@@ -469,7 +481,32 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     operand_type(std::move(lhs)), std::move(rhs));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs < rhs[0]});
+                ir::node_data<std::uint8_t>{lhs < rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<std::uint8_t>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return less_.less_all(std::move(lhs),
+                    ir::node_data<std::uint8_t>{rhs != 0});
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs[0] < rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<std::uint8_t>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return less_.less_all(
+                    ir::node_data<std::uint8_t>{lhs != 0},
+                    std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs < rhs[0]});
         }
 
         primitive_argument_type operator()(
@@ -479,8 +516,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::move(lhs), std::move(rhs));
         }
 
-        primitive_argument_type operator()(
-            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        primitive_argument_type operator()(ir::node_data<std::uint8_t>&& lhs,
+            ir::node_data<std::uint8_t>&& rhs) const
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "less::eval",

--- a/src/execution_tree/primitives/less_equal.cpp
+++ b/src/execution_tree/primitives/less_equal.cpp
@@ -47,8 +47,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type less_equal::less_equal0d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -64,11 +65,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal0d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -84,18 +86,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 0:
             return primitive_argument_type(
-                ir::node_data<bool>{lhs.scalar() <= rhs.scalar()});
+                ir::node_data<std::uint8_t>{lhs.scalar() <= rhs.scalar()});
 
         case 1:
             return less_equal0d1d(std::move(lhs), std::move(rhs));
@@ -113,8 +116,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal1d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -130,11 +134,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal1d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -162,11 +167,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal1d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = lhs.vector();
         auto cm = rhs.matrix();
@@ -191,20 +197,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x <= y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
             blaze::row(cm, i) = blaze::map(blaze::row(cm, i),
                 blaze::trans(cv),
                 [](double x, double y) { return x <= y; });
-
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -228,8 +234,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal2d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -248,11 +255,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal2d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = rhs.vector();
         auto cm = lhs.matrix();
@@ -277,7 +285,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x <= y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
@@ -286,11 +294,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [](double x, double y) { return x <= y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal2d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -318,11 +327,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -346,8 +356,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type less_equal::less_equal_all(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
@@ -432,7 +443,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(T && lhs, T && rhs) const
         {
             return primitive_argument_type(
-                    ir::node_data<bool>{lhs <= rhs});
+                ir::node_data<std::uint8_t>{lhs <= rhs});
         }
 
         primitive_argument_type operator()(
@@ -458,7 +469,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     std::move(lhs), operand_type(std::move(rhs)));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs[0] <= rhs});
+                ir::node_data<std::uint8_t>{lhs[0] <= rhs});
         }
 
         primitive_argument_type operator()(
@@ -470,7 +481,32 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     operand_type(std::move(lhs)), std::move(rhs));
             }
             return primitive_argument_type(
-                    ir::node_data<bool>{lhs <= rhs[0]});
+                ir::node_data<std::uint8_t>{lhs <= rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<std::uint8_t>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return less_equal_.less_equal_all(std::move(lhs),
+                    ir::node_data<std::uint8_t>{rhs != 0});
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs[0] <= rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<std::uint8_t>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return less_equal_.less_equal_all(
+                    ir::node_data<std::uint8_t>{lhs != 0},
+                    std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs <= rhs[0]});
         }
 
         primitive_argument_type operator()(
@@ -480,8 +516,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::move(lhs), std::move(rhs));
         }
 
-        primitive_argument_type operator()(
-            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+        primitive_argument_type operator()(ir::node_data<std::uint8_t>&& lhs,
+            ir::node_data<std::uint8_t>&& rhs) const
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "less_equal::eval",

--- a/src/execution_tree/primitives/not_equal.cpp
+++ b/src/execution_tree/primitives/not_equal.cpp
@@ -47,8 +47,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type not_equal::not_equal0d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -64,11 +65,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal0d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -84,18 +86,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
         {
         case 0:
             return primitive_argument_type(
-                ir::node_data<bool>{lhs.scalar() != rhs.scalar()});
+                ir::node_data<std::uint8_t>{lhs.scalar() != rhs.scalar()});
 
         case 1:
             return not_equal0d1d(std::move(lhs), std::move(rhs));
@@ -107,14 +110,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "not_equal::not_equal0d",
                 execution_tree::generate_error_message(
-                    "the operands have incompatible number of "
-                        "dimensions",
+                    "the operands have incompatible number of dimensions",
                     name_, codename_));
         }
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal1d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // TODO: SIMD functionality should be added, blaze implementation
         // is not currently available
@@ -130,11 +133,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal1d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -162,11 +166,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal1d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = lhs.vector();
         auto cm = rhs.matrix();
@@ -191,7 +196,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x != y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
@@ -200,11 +205,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [](double x, double y) { return x != y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(rhs)});
+            ir::node_data<std::uint8_t>{std::move(rhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -228,8 +234,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal2d0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_size = lhs.dimension(0);
         std::size_t rhs_size = rhs.dimension(0);
@@ -248,11 +255,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal2d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto cv = rhs.vector();
         auto cm = lhs.matrix();
@@ -277,7 +285,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::trans(cv),
                     [](double x, double y) { return x != y; });
             return primitive_argument_type(
-                ir::node_data<bool>{std::move(m)});
+                ir::node_data<std::uint8_t>{std::move(m)});
         }
 
         for (size_t i = 0UL; i != cm.rows(); i++)
@@ -286,11 +294,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [](double x, double y) { return x != y; });
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal2d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         auto lhs_size = lhs.dimensions();
         auto rhs_size = rhs.dimensions();
@@ -318,11 +327,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return primitive_argument_type(
-            ir::node_data<bool>{std::move(lhs)});
+            ir::node_data<std::uint8_t>{std::move(lhs)});
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t rhs_dims = rhs.num_dimensions();
         switch(rhs_dims)
@@ -346,8 +356,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    template <typename T>
     primitive_argument_type not_equal::not_equal_all(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_dims = lhs.num_dimensions();
         switch (lhs_dims)
@@ -388,7 +399,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(T && lhs, T && rhs) const
         {
             return primitive_argument_type(
-                ir::node_data<bool>{lhs != rhs});
+                ir::node_data<std::uint8_t>{lhs != rhs});
         }
 
         primitive_argument_type operator()(
@@ -400,7 +411,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     std::move(lhs), operand_type(std::move(rhs)));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs[0] != rhs});
+                ir::node_data<std::uint8_t>{lhs[0] != rhs});
         }
 
         primitive_argument_type operator()(
@@ -412,11 +423,36 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     operand_type(std::move(lhs)), std::move(rhs));
             }
             return primitive_argument_type(
-                ir::node_data<bool>{lhs != rhs[0]});
+                ir::node_data<std::uint8_t>{lhs != rhs[0]});
         }
 
         primitive_argument_type operator()(
-            ir::node_data<bool>&& lhs, ir::node_data<bool>&& rhs) const
+            ir::node_data<std::uint8_t>&& lhs, std::int64_t&& rhs) const
+        {
+            if (lhs.num_dimensions() != 0)
+            {
+                return not_equal_.not_equal_all(
+                    std::move(lhs), ir::node_data<std::uint8_t>{rhs != 0});
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs[0] != rhs});
+        }
+
+        primitive_argument_type operator()(
+            std::int64_t&& lhs, ir::node_data<std::uint8_t>&& rhs) const
+        {
+            if (rhs.num_dimensions() != 0)
+            {
+                return not_equal_.not_equal_all(
+                    ir::node_data<std::uint8_t>{lhs != 0}, std::move(rhs));
+            }
+            return primitive_argument_type(
+                ir::node_data<std::uint8_t>{lhs != rhs[0]});
+        }
+
+        primitive_argument_type operator()(
+            ir::node_data<std::uint8_t>&& lhs,
+            ir::node_data<std::uint8_t>&& rhs) const
         {
             return not_equal_.not_equal_all(
                 ir::node_data<double>(std::move(lhs)),
@@ -469,8 +505,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 name_, codename_));
     }
 
-    //////////////////////////////////////////////////////////////////////////
-    // Implement '!=' for all possible combinations of lhs and rhs
+    // implement '!=' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> not_equal::eval(
         std::vector<primitive_argument_type> const& args) const
     {

--- a/src/execution_tree/primitives/or_operation.cpp
+++ b/src/execution_tree/primitives/or_operation.cpp
@@ -57,7 +57,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     rhs.vector(), [&](bool x) { return (x || lhs.scalar()); });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
+                    ir::node_data<std::uint8_t>{std::move(rhs)});
             }
 
     primitive_argument_type or_operation::or_operation0d2d(
@@ -69,7 +69,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     rhs.matrix(), [&](bool x) { return (x || lhs.scalar()); });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
+                    ir::node_data<std::uint8_t>{std::move(rhs)});
             }
 
     primitive_argument_type or_operation::or_operation0d(
@@ -80,7 +80,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                 case 0:
                     return primitive_argument_type(
-                        ir::node_data<bool>{lhs.scalar() || rhs.scalar()});
+                        ir::node_data<std::uint8_t>{lhs.scalar() || rhs.scalar()});
 
                 case 1:
                     return or_operation0d1d(std::move(lhs), std::move(rhs));
@@ -107,7 +107,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     lhs.vector(), [&](bool x) { return (x || rhs.scalar()); });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
+                    ir::node_data<std::uint8_t>{std::move(lhs)});
             }
 
     primitive_argument_type or_operation::or_operation1d1d(
@@ -131,7 +131,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     [&](bool x, bool y) { return (x || y); });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
+                    ir::node_data<std::uint8_t>{std::move(lhs)});
             }
 
     primitive_argument_type or_operation::or_operation1d2d(
@@ -158,7 +158,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             [](bool x, bool y) { return x || y; });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(rhs)});
+                    ir::node_data<std::uint8_t>{std::move(rhs)});
             }
 
     primitive_argument_type or_operation::or_operation1d(
@@ -198,7 +198,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     [&](double x) { return (x || rhs.scalar()); });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
+                    ir::node_data<std::uint8_t>{std::move(lhs)});
             }
 
     primitive_argument_type or_operation::or_operation2d1d(
@@ -225,7 +225,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             [](bool x, bool y) { return x || y; });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
+                    ir::node_data<std::uint8_t>{std::move(lhs)});
             }
 
     primitive_argument_type or_operation::or_operation2d2d(
@@ -249,7 +249,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     [&](bool x, bool y) { return (x || y); });
 
                 return primitive_argument_type(
-                    ir::node_data<bool>{std::move(lhs)});
+                    ir::node_data<std::uint8_t>{std::move(lhs)});
             }
 
     primitive_argument_type or_operation::or_operation2d(
@@ -365,7 +365,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(T&& lhs, T&& rhs) const
         {
             return primitive_argument_type(
-                ir::node_data<bool>{lhs && rhs});
+                ir::node_data<std::uint8_t>{lhs && rhs});
         }
 
         primitive_argument_type operator()(
@@ -409,8 +409,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(ir::node_data<double>&& lhs,
             ir::node_data<double>&& rhs) const
         {
-            return or_.or_all(ir::node_data<bool>{std::move(lhs)},
-                ir::node_data<bool>{std::move(rhs)});
+            return or_.or_all(ir::node_data<std::uint8_t>{std::move(lhs)},
+                ir::node_data<std::uint8_t>{std::move(rhs)});
         }
 
         primitive_argument_type operator()(

--- a/src/execution_tree/primitives/random.cpp
+++ b/src/execution_tree/primitives/random.cpp
@@ -80,7 +80,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         switch (val.index())
         {
-        case 1:    // phylanx::ir::node_data<bool>
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
             return util::get<1>(val).dimensions();
 
         case 2:    // std::uint64_t
@@ -192,7 +192,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return distribution_parameters_type{util::get<3>(val), 0, 0.0, 1.0};
 
         case 0: HPX_FALLTHROUGH;    // nil
-        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<bool>
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
         case 2: HPX_FALLTHROUGH;    // std::uint64_t
         case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 5: HPX_FALLTHROUGH;    // primitive
@@ -403,7 +403,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         PHYLANX_RANDOM_DISTRIBUTION_2(
             uniform, std::uniform_real_distribution<double>, double, double);
         PHYLANX_RANDOM_DISTRIBUTION_1(
-            bernoulli, std::bernoulli_distribution, double, bool);
+            bernoulli, std::bernoulli_distribution, double, std::uint8_t);
         PHYLANX_RANDOM_DISTRIBUTION_2(
             binomial, std::binomial_distribution<int>, int, double);
         PHYLANX_RANDOM_DISTRIBUTION_2(negative_binomial,

--- a/src/execution_tree/primitives/unary_not_operation.cpp
+++ b/src/execution_tree/primitives/unary_not_operation.cpp
@@ -48,28 +48,30 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive_argument_type unary_not_operation::unary_not_all(operand_type&& ops) const
+    template <typename T>
+    primitive_argument_type unary_not_operation::unary_not_all(
+        ir::node_data<T> && ops) const
     {
         std::size_t dims = ops.num_dimensions();
         switch (dims)
         {
         case 0:
-            return primitive_argument_type(
-                ir::node_data<bool>{ops.scalar() == false});
+            return primitive_argument_type{
+                ir::node_data<std::uint8_t>{ops.scalar() == T(0)}};
 
         case 1:
             // TODO: SIMD functionality should be added, blaze implementation
             // is not currently available
-            return primitive_argument_type(
-                ir::node_data<bool>{blaze::map(
-                    ops.vector(), [](bool x) { return x == false; })});
+            return primitive_argument_type{
+                ir::node_data<std::uint8_t>{blaze::map(
+                    ops.vector(), [](T x) { return x == T(0); })}};
 
         case 2:
             // TODO: SIMD functionality should be added, blaze implementation
             // is not currently available
-            return primitive_argument_type(
-                ir::node_data<bool>{blaze::map(
-                    ops.matrix(), [](bool x) { return x == false; })});
+            return primitive_argument_type{
+                ir::node_data<std::uint8_t>{blaze::map(
+                    ops.matrix(), [](T x) { return x == T(0); })}};
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -95,12 +97,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type operator()(
             ir::node_data<double>&& ops) const
         {
-            return that_.unary_not_all(
-                ir::node_data<bool>{std::move(ops)});
+            return that_.unary_not_all(std::move(ops));
         }
 
         primitive_argument_type operator()(
-            ir::node_data<bool>&& ops) const
+            ir::node_data<std::uint8_t>&& ops) const
         {
             return that_.unary_not_all(std::move(ops));
         }

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -757,6 +757,21 @@ namespace phylanx { namespace ir
     }
 
     template <typename T>
+    typename node_data<T>::custom_storage2d_type node_data<T>::matrix() const&&
+    {
+        custom_storage2d_type const* cm =
+            util::get_if<custom_storage2d_type>(&data_);
+        if (cm != nullptr)
+        {
+            return *cm;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::matrix()",
+            "node_data::matrix() shouldn't be called on an rvalue");
+    }
+
+    template <typename T>
     typename node_data<T>::storage1d_type& node_data<T>::vector_non_ref()
     {
         storage1d_type* v = util::get_if<storage1d_type>(&data_);
@@ -852,6 +867,21 @@ namespace phylanx { namespace ir
     typename node_data<T>::custom_storage1d_type node_data<T>::vector() &&
     {
         custom_storage1d_type* cv =
+            util::get_if<custom_storage1d_type>(&data_);
+        if (cv != nullptr)
+        {
+            return *cv;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::vector()",
+            "node_data::vector shouldn't be called on an rvalue");
+    }
+
+    template <typename T>
+    typename node_data<T>::custom_storage1d_type node_data<T>::vector() const&&
+    {
+        custom_storage1d_type const* cv =
             util::get_if<custom_storage1d_type>(&data_);
         if (cv != nullptr)
         {
@@ -974,6 +1004,31 @@ namespace phylanx { namespace ir
 
     /// Return a new instance of node_data referring to this instance.
     template <typename T>
+    node_data<T> node_data<T>::ref() &
+    {
+        switch(data_.index())
+        {
+        case 1:
+            return node_data<T>{vector()};
+
+        case 2:
+            return node_data<T>{matrix()};
+
+        case 0: HPX_FALLTHROUGH;
+        case 3: HPX_FALLTHROUGH;
+        case 4:
+            return *this;
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::ref()",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
     node_data<T> node_data<T>::ref() const&
     {
         switch(data_.index())
@@ -1000,6 +1055,14 @@ namespace phylanx { namespace ir
 
     template <typename T>
     node_data<T> node_data<T>::ref() &&
+    {
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::ref()",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    node_data<T> node_data<T>::ref() const&&
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::ir::node_data<T>::ref()",

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -744,6 +744,13 @@ namespace phylanx { namespace ir
     template <typename T>
     typename node_data<T>::custom_storage2d_type node_data<T>::matrix() &&
     {
+        custom_storage2d_type* cm =
+            util::get_if<custom_storage2d_type>(&data_);
+        if (cm != nullptr)
+        {
+            return *cm;
+        }
+
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::ir::node_data<T>::matrix()",
             "node_data::matrix() shouldn't be called on an rvalue");
@@ -803,7 +810,9 @@ namespace phylanx { namespace ir
         custom_storage1d_type* cv =
             util::get_if<custom_storage1d_type>(&data_);
         if (cv != nullptr)
+        {
             return *cv;
+        }
 
         storage1d_type* v = util::get_if<storage1d_type>(&data_);
         if (v != nullptr)
@@ -842,6 +851,13 @@ namespace phylanx { namespace ir
     template <typename T>
     typename node_data<T>::custom_storage1d_type node_data<T>::vector() &&
     {
+        custom_storage1d_type* cv =
+            util::get_if<custom_storage1d_type>(&data_);
+        if (cv != nullptr)
+        {
+            return *cv;
+        }
+
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::ir::node_data<T>::vector()",
             "node_data::vector shouldn't be called on an rvalue");

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -1126,7 +1126,8 @@ namespace phylanx { namespace ir
             "node_data object holds unsupported data type");
     }
 
-    bool operator==(node_data<bool> const& lhs, node_data<bool> const& rhs)
+    bool operator==(
+        node_data<std::uint8_t> const& lhs, node_data<std::uint8_t> const& rhs)
     {
         if (lhs.num_dimensions() != rhs.num_dimensions() ||
             lhs.dimensions() != rhs.dimensions())
@@ -1159,7 +1160,7 @@ namespace phylanx { namespace ir
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        template <typename Range>
+        template <typename T, typename Range>
         void print_array(std::ostream& out, Range const& r, std::size_t size)
         {
             out << "[";
@@ -1169,7 +1170,7 @@ namespace phylanx { namespace ir
                 {
                     out << ", ";
                 }
-                out << r[i];
+                out << T(r[i]);
             }
             out << "]";
         }
@@ -1187,7 +1188,7 @@ namespace phylanx { namespace ir
 
         case 1: HPX_FALLTHROUGH;
         case 3:
-            detail::print_array(out, nd.vector(), nd.size());
+            detail::print_array<double>(out, nd.vector(), nd.size());
             break;
 
         case 2: HPX_FALLTHROUGH;
@@ -1199,7 +1200,7 @@ namespace phylanx { namespace ir
                 {
                     if (row != 0)
                         out << ", ";
-                    detail::print_array(
+                    detail::print_array<double>(
                         out, blaze::row(data, row), data.columns());
                 }
                 out << "]";
@@ -1320,19 +1321,19 @@ namespace phylanx { namespace ir
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::ostream& operator<<(std::ostream& out, node_data<bool> const& nd)
+    std::ostream& operator<<(std::ostream& out, node_data<std::uint8_t> const& nd)
     {
         std::size_t dims = nd.num_dimensions();
         switch (dims)
         {
         case 0:
-            out << std::boolalpha << std::to_string(nd[0]);
+            out << std::boolalpha << std::to_string(bool{nd[0] != 0});
             break;
 
         case 1: HPX_FALLTHROUGH;
         case 3:
             out << std::boolalpha;
-            detail::print_array(out, nd.vector(), nd.size());
+            detail::print_array<bool>(out, nd.vector(), nd.size());
             break;
 
         case 2: HPX_FALLTHROUGH;
@@ -1344,7 +1345,7 @@ namespace phylanx { namespace ir
                 {
                     if (row != 0)
                         out << ", ";
-                    detail::print_array(
+                    detail::print_array<bool>(
                         out, blaze::row(data, row), data.columns());
                 }
                 out << "]";
@@ -1353,7 +1354,7 @@ namespace phylanx { namespace ir
 
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,
-                "node_data<bool>::operator<<()",
+                "node_data<std::uint8_t>::operator<<()",
                 "invalid dimensionality: " + std::to_string(dims));
         }
         return out;
@@ -1361,4 +1362,4 @@ namespace phylanx { namespace ir
 }}
 
 template class PHYLANX_EXPORT phylanx::ir::node_data<double>;
-template class PHYLANX_EXPORT phylanx::ir::node_data<bool>;
+template class PHYLANX_EXPORT phylanx::ir::node_data<std::uint8_t>;

--- a/src/util/serialization/ast.cpp
+++ b/src/util/serialization/ast.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/serialization.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <sstream>
 #include <vector>
 
@@ -35,7 +36,7 @@ namespace phylanx { namespace util
         }
     }
 
-    std::vector<char> serialize(ir::node_data<bool> const& ast)
+    std::vector<char> serialize(ir::node_data<std::uint8_t> const& ast)
     {
         return detail::serialize(ast);
     }
@@ -117,7 +118,7 @@ namespace phylanx { namespace util
         }
 
         void unserialize(
-            std::vector<char> const& input, ir::node_data<bool>& ast)
+            std::vector<char> const& input, ir::node_data<std::uint8_t>& ast)
         {
             detail::unserialize_helper(input, ast);
         }

--- a/tests/unit/execution_tree/primitives/all_operation.cpp
+++ b/tests/unit/execution_tree/primitives/all_operation.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -16,7 +17,7 @@ void test_all_operation_0d_true()
 {
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
@@ -33,7 +34,7 @@ void test_all_operation_0d_false()
 {
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
@@ -104,11 +105,11 @@ void test_all_operation_1d_double()
 void test_all_operation_1d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
@@ -145,11 +146,11 @@ void test_all_operation_1d_true()
 void test_all_operation_1d_double_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 1, 2);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 1, 2);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
@@ -164,7 +165,7 @@ void test_all_operation_1d_double_true()
 
 void test_all_operation_1d_numpy_false()
 {
-    blaze::DynamicVector<bool> v{true, false, true};
+    blaze::DynamicVector<std::uint8_t> v{true, false, true};
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
@@ -241,11 +242,11 @@ void test_all_operation_1d_double_numpy_true()
 void test_all_operation_2d()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
@@ -262,11 +263,11 @@ void test_all_operation_2d()
 void test_all_operation_2d_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 1, 2);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 1, 2);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
@@ -360,11 +361,11 @@ void test_all_operation_2d_double_numpy_true()
 
 void test_all_operation_2d_numpy_true()
 {
-    blaze::DynamicMatrix<bool> m{{true, true, true}, {true, true, true}};
+    blaze::DynamicMatrix<std::uint8_t> m{{true, true, true}, {true, true, true}};
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
@@ -379,11 +380,11 @@ void test_all_operation_2d_numpy_true()
 
 void test_all_operation_2d_numpy_false()
 {
-    blaze::DynamicMatrix<bool> m{{true, true, true}, {false, true, false}};
+    blaze::DynamicMatrix<std::uint8_t> m{{true, true, true}, {false, true, false}};
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(

--- a/tests/unit/execution_tree/primitives/and_operation.cpp
+++ b/tests/unit/execution_tree/primitives/and_operation.cpp
@@ -10,7 +10,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <phylanx/execution_tree/primitives/and_operation.hpp>
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -19,11 +19,11 @@ void test_and_operation_0d_false()
 {
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
@@ -34,7 +34,7 @@ void test_and_operation_0d_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -57,7 +57,7 @@ void test_and_operation_0d_double_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -65,11 +65,11 @@ void test_and_operation_0d_true()
 {
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
@@ -80,7 +80,7 @@ void test_and_operation_0d_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -103,17 +103,17 @@ void test_and_operation_0d_double_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d_lit_false()
 {
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
@@ -124,7 +124,7 @@ void test_and_operation_0d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -145,17 +145,17 @@ void test_and_operation_0d_double_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d_lit_true()
 {
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
@@ -166,7 +166,7 @@ void test_and_operation_0d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -187,22 +187,22 @@ void test_and_operation_0d_double_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d1d_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -213,23 +213,23 @@ void test_and_operation_0d1d_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d1d_lit_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(false);
+    phylanx::ir::node_data<std::uint8_t> lhs(false);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -240,10 +240,10 @@ void test_and_operation_0d1d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -271,7 +271,7 @@ void test_and_operation_0d1d_double_false()
 
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -297,22 +297,22 @@ void test_and_operation_0d1d_double_lit_false()
 
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d1d_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -323,23 +323,23 @@ void test_and_operation_0d1d_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d1d_lit_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -350,10 +350,10 @@ void test_and_operation_0d1d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -379,10 +379,10 @@ void test_and_operation_0d1d_double_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -406,25 +406,25 @@ void test_and_operation_0d1d_double_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d2d_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -435,23 +435,23 @@ void test_and_operation_0d2d_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d2d_lit_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(false);
+    phylanx::ir::node_data<std::uint8_t> lhs(false);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -462,10 +462,10 @@ void test_and_operation_0d2d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -493,7 +493,7 @@ void test_and_operation_0d2d_double_false()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -519,22 +519,22 @@ void test_and_operation_0d2d_double_lit_false()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d2d_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -545,23 +545,23 @@ void test_and_operation_0d2d_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_0d2d_lit_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -572,10 +572,10 @@ void test_and_operation_0d2d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -601,10 +601,10 @@ void test_and_operation_0d2d_double_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](double x) { return (x != 0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -628,26 +628,26 @@ void test_and_operation_0d2d_double_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](double x) { return (x != 0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v1 = gen.generate(100UL, 0, 1);
-    blaze::DynamicVector<bool> v2 = gen.generate(100UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v1 = gen.generate(100UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v2 = gen.generate(100UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v1));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v1));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v2));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -658,24 +658,24 @@ void test_and_operation_1d()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v1 = gen.generate(1007UL, 0, 1);
-    blaze::DynamicVector<bool> v2 = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v1 = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v2 = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v1);
+    phylanx::ir::node_data<std::uint8_t> lhs(v1);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v2));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -686,10 +686,10 @@ void test_and_operation_1d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -716,10 +716,10 @@ void test_and_operation_1d_double()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -744,25 +744,25 @@ void test_and_operation_1d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d0d_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -773,23 +773,23 @@ void test_and_operation_1d0d_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d0d_lit_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -800,10 +800,10 @@ void test_and_operation_1d0d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -831,7 +831,7 @@ void test_and_operation_1d0d_double_false()
 
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -857,22 +857,22 @@ void test_and_operation_1d0d_double_lit_false()
 
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d0d_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -883,23 +883,23 @@ void test_and_operation_1d0d_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d0d_lit_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -910,10 +910,10 @@ void test_and_operation_1d0d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -939,10 +939,10 @@ void test_and_operation_1d0d_double_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -966,28 +966,28 @@ void test_and_operation_1d0d_double_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d2d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -998,30 +998,30 @@ void test_and_operation_1d2d()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_1d2d_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1032,14 +1032,14 @@ void test_and_operation_1d2d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1068,14 +1068,14 @@ void test_and_operation_1d2d_double()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1102,30 +1102,30 @@ void test_and_operation_1d2d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m1));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m1));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1136,24 +1136,24 @@ void test_and_operation_2d()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m1);
+    phylanx::ir::node_data<std::uint8_t> lhs(m1);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1164,10 +1164,10 @@ void test_and_operation_2d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1194,10 +1194,10 @@ void test_and_operation_2d_double()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1222,25 +1222,25 @@ void test_and_operation_2d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d0d_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1251,23 +1251,23 @@ void test_and_operation_2d0d_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d0d_lit_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1278,25 +1278,25 @@ void test_and_operation_2d0d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d0d_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1307,23 +1307,23 @@ void test_and_operation_2d0d_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d0d_lit_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1334,10 +1334,10 @@ void test_and_operation_2d0d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x && false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1363,10 +1363,10 @@ void test_and_operation_2d0d_double_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1390,10 +1390,10 @@ void test_and_operation_2d0d_double_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1421,7 +1421,7 @@ void test_and_operation_2d0d_double_false()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1447,25 +1447,25 @@ void test_and_operation_2d0d_double_lit_false()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d1d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1476,29 +1476,29 @@ void test_and_operation_2d1d()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_and_operation_2d1d_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
@@ -1509,13 +1509,13 @@ void test_and_operation_2d1d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1544,13 +1544,13 @@ void test_and_operation_2d1d_double()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1577,13 +1577,13 @@ void test_and_operation_2d1d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         and_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x && y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/any_operation.cpp
+++ b/tests/unit/execution_tree/primitives/any_operation.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -16,7 +17,7 @@ void test_any_operation_0d_true()
 {
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
@@ -33,7 +34,7 @@ void test_any_operation_0d_false()
 {
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
@@ -83,11 +84,11 @@ void test_any_operation_0d_double_false()
 void test_any_operation_1d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
@@ -103,11 +104,11 @@ void test_any_operation_1d()
 
 void test_any_operation_1d_false()
 {
-    blaze::DynamicVector<bool> v(1007UL, 0);
+    blaze::DynamicVector<std::uint8_t> v(1007UL, 0);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
@@ -237,11 +238,11 @@ void test_any_operation_1d_double_numpy_true()
 void test_any_operation_2d()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
@@ -257,11 +258,11 @@ void test_any_operation_2d()
 
 void test_any_operation_2d_false()
 {
-    blaze::DynamicMatrix<bool> m(101UL, 101UL, 0);
+    blaze::DynamicMatrix<std::uint8_t> m(101UL, 101UL, 0);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
@@ -321,7 +322,7 @@ void test_any_operation_2d_numpy_false()
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
@@ -340,7 +341,7 @@ void test_any_operation_2d_numpy_true()
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(

--- a/tests/unit/execution_tree/primitives/equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/equal_operation.cpp
@@ -10,7 +10,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <phylanx/execution_tree/primitives/equal.hpp>
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -35,7 +35,7 @@ void test_equal_operation_0d_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -43,11 +43,11 @@ void test_equal_operation_0d_bool_false()
 {
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive equal;
     equal =
@@ -57,7 +57,7 @@ void test_equal_operation_0d_bool_false()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -80,7 +80,7 @@ void test_equal_operation_0d_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -101,7 +101,7 @@ void test_equal_operation_0d_lit_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -122,7 +122,7 @@ void test_equal_operation_0d_lit_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(true)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(true)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -151,7 +151,7 @@ void test_equal_operation_0d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -178,22 +178,22 @@ void test_equal_operation_0d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_0d1d_bool()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -202,17 +202,17 @@ void test_equal_operation_0d1d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x == false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_0d1d_bool_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::ir::node_data<double> lhs(false);
 
@@ -227,10 +227,10 @@ void test_equal_operation_0d1d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x == false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -259,7 +259,7 @@ void test_equal_operation_0d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -286,22 +286,22 @@ void test_equal_operation_0d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_0d2d_bool()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -310,23 +310,23 @@ void test_equal_operation_0d2d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x == true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_0d2d_bool_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -335,10 +335,10 @@ void test_equal_operation_0d2d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x == true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -368,7 +368,7 @@ void test_equal_operation_1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -396,7 +396,7 @@ void test_equal_operation_1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -425,7 +425,7 @@ void test_equal_operation_1d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -452,22 +452,22 @@ void test_equal_operation_1d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_1d0d_bool()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -476,25 +476,25 @@ void test_equal_operation_1d0d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_1d0d_bool_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -503,12 +503,12 @@ void test_equal_operation_1d0d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -544,7 +544,7 @@ void test_equal_operation_1d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -578,7 +578,7 @@ void test_equal_operation_1d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -608,7 +608,7 @@ void test_equal_operation_2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -636,23 +636,23 @@ void test_equal_operation_2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_2d_bool()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m1));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m1));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -661,26 +661,26 @@ void test_equal_operation_2d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x == y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_2d_bool_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m1);
+    phylanx::ir::node_data<std::uint8_t> lhs(m1);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -689,12 +689,12 @@ void test_equal_operation_2d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x == y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -723,7 +723,7 @@ void test_equal_operation_2d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -750,22 +750,22 @@ void test_equal_operation_2d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_2d0d_bool()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -774,25 +774,25 @@ void test_equal_operation_2d0d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x == true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_2d0d_bool_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -801,10 +801,10 @@ void test_equal_operation_2d0d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x == true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -839,7 +839,7 @@ void test_equal_operation_2d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -872,25 +872,25 @@ void test_equal_operation_2d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_2d1d_bool()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -899,29 +899,29 @@ void test_equal_operation_2d1d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x == y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_equal_operation_2d1d_bool_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
@@ -930,13 +930,13 @@ void test_equal_operation_2d1d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x == y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/greater_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/greater_equal_operation.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -35,7 +36,7 @@ void test_greater_equal_operation_0d_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -60,7 +61,7 @@ void test_greater_equal_operation_0d_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -83,7 +84,7 @@ void test_greater_equal_operation_0d_lit_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -106,7 +107,7 @@ void test_greater_equal_operation_0d_lit_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(false)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -137,7 +138,7 @@ void test_greater_equal_operation_0d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -166,7 +167,7 @@ void test_greater_equal_operation_0d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -197,7 +198,7 @@ void test_greater_equal_operation_0d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -226,7 +227,7 @@ void test_greater_equal_operation_0d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -258,7 +259,7 @@ void test_greater_equal_operation_1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -288,7 +289,7 @@ void test_greater_equal_operation_1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -319,7 +320,7 @@ void test_greater_equal_operation_1d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -348,7 +349,7 @@ void test_greater_equal_operation_1d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -386,7 +387,7 @@ void test_greater_equal_operation_1d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -422,7 +423,7 @@ void test_greater_equal_operation_1d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -454,7 +455,7 @@ void test_greater_equal_operation_2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -484,7 +485,7 @@ void test_greater_equal_operation_2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -515,7 +516,7 @@ void test_greater_equal_operation_2d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -544,7 +545,7 @@ void test_greater_equal_operation_2d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -581,7 +582,7 @@ void test_greater_equal_operation_2d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -616,7 +617,7 @@ void test_greater_equal_operation_2d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/greater_operation.cpp
+++ b/tests/unit/execution_tree/primitives/greater_operation.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -33,7 +34,7 @@ void test_greater_operation_0d_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -57,7 +58,7 @@ void test_greater_operation_0d_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -79,7 +80,7 @@ void test_greater_operation_0d_lit_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -101,7 +102,7 @@ void test_greater_operation_0d_lit_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(false)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -131,7 +132,7 @@ void test_greater_operation_0d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -159,7 +160,7 @@ void test_greater_operation_0d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -189,7 +190,7 @@ void test_greater_operation_0d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -217,7 +218,7 @@ void test_greater_operation_0d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -248,7 +249,7 @@ void test_greater_operation_1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -277,7 +278,7 @@ void test_greater_operation_1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -307,7 +308,7 @@ void test_greater_operation_1d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -335,7 +336,7 @@ void test_greater_operation_1d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -372,7 +373,7 @@ void test_greater_operation_1d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -407,7 +408,7 @@ void test_greater_operation_1d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -438,7 +439,7 @@ void test_greater_operation_2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -467,7 +468,7 @@ void test_greater_operation_2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -497,7 +498,7 @@ void test_greater_operation_2d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -525,7 +526,7 @@ void test_greater_operation_2d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -561,7 +562,7 @@ void test_greater_operation_2d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -595,7 +596,7 @@ void test_greater_operation_2d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/less_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/less_equal_operation.cpp
@@ -9,21 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <iostream>
-#include <utility>
-#include <vector>
-
-//   Copyright (c) 2017 Hartmut Kaiser
-//
-//   Distributed under the Boost Software License, Version 1.0. (See accompanying
-//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
-#include <phylanx/phylanx.hpp>
-
-#include <hpx/hpx_main.hpp>
-#include <hpx/include/lcos.hpp>
-#include <hpx/util/lightweight_test.hpp>
-
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -49,7 +35,7 @@ void test_less_equal_operation_0d_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -74,7 +60,7 @@ void test_less_equal_operation_0d_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -97,7 +83,7 @@ void test_less_equal_operation_0d_lit_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -120,7 +106,7 @@ void test_less_equal_operation_0d_lit_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(false)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -151,7 +137,7 @@ void test_less_equal_operation_0d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -180,7 +166,7 @@ void test_less_equal_operation_0d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -211,7 +197,7 @@ void test_less_equal_operation_0d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -240,7 +226,7 @@ void test_less_equal_operation_0d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -272,7 +258,7 @@ void test_less_equal_operation_1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -302,7 +288,7 @@ void test_less_equal_operation_1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -333,7 +319,7 @@ void test_less_equal_operation_1d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -362,7 +348,7 @@ void test_less_equal_operation_1d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -400,7 +386,7 @@ void test_less_equal_operation_1d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -436,7 +422,7 @@ void test_less_equal_operation_1d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -468,7 +454,7 @@ void test_less_equal_operation_2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -498,7 +484,7 @@ void test_less_equal_operation_2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -529,7 +515,7 @@ void test_less_equal_operation_2d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -558,7 +544,7 @@ void test_less_equal_operation_2d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -595,7 +581,7 @@ void test_less_equal_operation_2d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -630,7 +616,7 @@ void test_less_equal_operation_2d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/less_operation.cpp
+++ b/tests/unit/execution_tree/primitives/less_operation.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -33,7 +34,7 @@ void test_less_operation_0d_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -56,7 +57,7 @@ void test_less_operation_0d_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -77,7 +78,7 @@ void test_less_operation_0d_lit_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -98,7 +99,7 @@ void test_less_operation_0d_lit_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(false)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -127,7 +128,7 @@ void test_less_operation_0d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -154,7 +155,7 @@ void test_less_operation_0d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -183,7 +184,7 @@ void test_less_operation_0d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -210,7 +211,7 @@ void test_less_operation_0d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -240,7 +241,7 @@ void test_less_operation_1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -268,7 +269,7 @@ void test_less_operation_1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -297,7 +298,7 @@ void test_less_operation_1d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -324,7 +325,7 @@ void test_less_operation_1d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -360,7 +361,7 @@ void test_less_operation_1d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -394,7 +395,7 @@ void test_less_operation_1d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -424,7 +425,7 @@ void test_less_operation_2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -452,7 +453,7 @@ void test_less_operation_2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -481,7 +482,7 @@ void test_less_operation_2d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -508,7 +509,7 @@ void test_less_operation_2d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -543,7 +544,7 @@ void test_less_operation_2d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -576,7 +577,7 @@ void test_less_operation_2d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -603,7 +604,7 @@ void test_less_operation_2d0d_int()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/not_equal_operation.cpp
+++ b/tests/unit/execution_tree/primitives/not_equal_operation.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -33,7 +34,7 @@ void test_not_equal_operation_0d_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -41,11 +42,11 @@ void test_not_equal_operation_0d_bool_true()
 {
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive not_equal;
     not_equal = phylanx::execution_tree::primitives::create_not_equal(
@@ -55,7 +56,7 @@ void test_not_equal_operation_0d_bool_true()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -79,7 +80,7 @@ void test_not_equal_operation_0d_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -101,7 +102,7 @@ void test_not_equal_operation_0d_lit_true()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -123,7 +124,7 @@ void test_not_equal_operation_0d_lit_false()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(false)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -153,7 +154,7 @@ void test_not_equal_operation_0d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -181,22 +182,22 @@ void test_not_equal_operation_0d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_0d1d_bool()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -206,17 +207,17 @@ void test_not_equal_operation_0d1d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x != false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_0d1d_bool_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::ir::node_data<double> lhs(false);
 
@@ -232,10 +233,10 @@ void test_not_equal_operation_0d1d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x != false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -265,7 +266,7 @@ void test_not_equal_operation_0d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -293,22 +294,22 @@ void test_not_equal_operation_0d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_0d2d_bool()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -318,23 +319,23 @@ void test_not_equal_operation_0d2d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x != true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_0d2d_bool_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -344,10 +345,10 @@ void test_not_equal_operation_0d2d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x != true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -378,7 +379,7 @@ void test_not_equal_operation_1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -407,7 +408,7 @@ void test_not_equal_operation_1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -437,7 +438,7 @@ void test_not_equal_operation_1d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -465,22 +466,22 @@ void test_not_equal_operation_1d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_1d0d_bool()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -490,25 +491,25 @@ void test_not_equal_operation_1d0d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x != false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_1d0d_bool_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -518,12 +519,12 @@ void test_not_equal_operation_1d0d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x != false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -560,7 +561,7 @@ void test_not_equal_operation_1d2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -595,7 +596,7 @@ void test_not_equal_operation_1d2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -626,7 +627,7 @@ void test_not_equal_operation_2d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -655,23 +656,23 @@ void test_not_equal_operation_2d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_2d_bool()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m1));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m1));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -681,26 +682,26 @@ void test_not_equal_operation_2d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x != y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_2d_bool_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m1);
+    phylanx::ir::node_data<std::uint8_t> lhs(m1);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -710,12 +711,12 @@ void test_not_equal_operation_2d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x != y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -745,7 +746,7 @@ void test_not_equal_operation_2d0d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -773,22 +774,22 @@ void test_not_equal_operation_2d0d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_2d0d_bool()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -798,25 +799,25 @@ void test_not_equal_operation_2d0d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x != true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_2d0d_bool_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -826,10 +827,10 @@ void test_not_equal_operation_2d0d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x != true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -865,7 +866,7 @@ void test_not_equal_operation_2d1d()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -899,25 +900,25 @@ void test_not_equal_operation_2d1d_lit()
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_2d1d_bool()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -927,29 +928,29 @@ void test_not_equal_operation_2d1d_bool()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x != y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_not_equal_operation_2d1d_bool_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
@@ -959,13 +960,13 @@ void test_not_equal_operation_2d1d_bool_lit()
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x != y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/or_operation.cpp
+++ b/tests/unit/execution_tree/primitives/or_operation.cpp
@@ -10,7 +10,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
-#include <phylanx/execution_tree/primitives/or_operation.hpp>
+#include <cstdint>
 #include <iostream>
 #include <utility>
 #include <vector>
@@ -19,11 +19,11 @@ void test_or_operation_0d_false()
 {
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
@@ -34,7 +34,7 @@ void test_or_operation_0d_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -57,7 +57,7 @@ void test_or_operation_0d_double_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -65,11 +65,11 @@ void test_or_operation_0d_true()
 {
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
@@ -80,7 +80,7 @@ void test_or_operation_0d_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -103,17 +103,17 @@ void test_or_operation_0d_double_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d_lit_false()
 {
-    phylanx::ir::node_data<bool> lhs(false);
+    phylanx::ir::node_data<std::uint8_t> lhs(false);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
@@ -124,7 +124,7 @@ void test_or_operation_0d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -145,17 +145,17 @@ void test_or_operation_0d_double_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d_lit_true()
 {
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
@@ -166,7 +166,7 @@ void test_or_operation_0d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -187,22 +187,22 @@ void test_or_operation_0d_double_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d1d_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -213,23 +213,23 @@ void test_or_operation_0d1d_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d1d_lit_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(false);
+    phylanx::ir::node_data<std::uint8_t> lhs(false);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -240,10 +240,10 @@ void test_or_operation_0d1d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -269,10 +269,10 @@ void test_or_operation_0d1d_double_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x || 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -296,25 +296,25 @@ void test_or_operation_0d1d_double_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x || 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d1d_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -325,23 +325,23 @@ void test_or_operation_0d1d_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d1d_lit_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -352,10 +352,10 @@ void test_or_operation_0d1d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -383,7 +383,7 @@ void test_or_operation_0d1d_double_true()
 
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -409,22 +409,22 @@ void test_or_operation_0d1d_double_lit_true()
 
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d2d_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -435,23 +435,23 @@ void test_or_operation_0d2d_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d2d_lit_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(false);
+    phylanx::ir::node_data<std::uint8_t> lhs(false);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -462,10 +462,10 @@ void test_or_operation_0d2d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -491,10 +491,10 @@ void test_or_operation_0d2d_double_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -518,25 +518,25 @@ void test_or_operation_0d2d_double_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d2d_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -547,23 +547,23 @@ void test_or_operation_0d2d_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_0d2d_lit_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(true);
+    phylanx::ir::node_data<std::uint8_t> lhs(true);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -574,10 +574,10 @@ void test_or_operation_0d2d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -605,7 +605,7 @@ void test_or_operation_0d2d_double_true()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -631,23 +631,23 @@ void test_or_operation_0d2d_double_lit_true()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v1 = gen.generate(100UL, 0, 1);
-    blaze::DynamicVector<bool> v2 = gen.generate(100UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v1 = gen.generate(100UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v2 = gen.generate(100UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v1));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v1));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v2));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -658,24 +658,24 @@ void test_or_operation_1d()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v1 = gen.generate(1007UL, 0, 1);
-    blaze::DynamicVector<bool> v2 = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v1 = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v2 = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v1);
+    phylanx::ir::node_data<std::uint8_t> lhs(v1);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v2));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -686,10 +686,10 @@ void test_or_operation_1d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -716,10 +716,10 @@ void test_or_operation_1d_double()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -744,25 +744,25 @@ void test_or_operation_1d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v1, v2, [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d0d_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -773,23 +773,23 @@ void test_or_operation_1d0d_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d0d_lit_false()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -800,10 +800,10 @@ void test_or_operation_1d0d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -829,10 +829,10 @@ void test_or_operation_1d0d_double_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -856,25 +856,25 @@ void test_or_operation_1d0d_double_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d0d_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -885,23 +885,23 @@ void test_or_operation_1d0d_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d0d_lit_true()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -912,10 +912,10 @@ void test_or_operation_1d0d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -943,7 +943,7 @@ void test_or_operation_1d0d_double_true()
 
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -969,25 +969,25 @@ void test_or_operation_1d0d_double_lit_true()
 
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d2d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -998,30 +998,30 @@ void test_or_operation_1d2d()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_1d2d_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(v);
+    phylanx::ir::node_data<std::uint8_t> lhs(v);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1032,14 +1032,14 @@ void test_or_operation_1d2d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1068,14 +1068,14 @@ void test_or_operation_1d2d_double()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1102,30 +1102,30 @@ void test_or_operation_1d2d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
 
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m1));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m1));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1136,24 +1136,24 @@ void test_or_operation_2d()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m1 = gen.generate(1007UL, 1007UL, 0, 1);
-    blaze::DynamicMatrix<bool> m2 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m1 = gen.generate(1007UL, 1007UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m2 = gen.generate(1007UL, 1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m1);
+    phylanx::ir::node_data<std::uint8_t> lhs(m1);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m2));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m2));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1164,10 +1164,10 @@ void test_or_operation_2d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1194,10 +1194,10 @@ void test_or_operation_2d_double()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1222,25 +1222,25 @@ void test_or_operation_2d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m1, m2, [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d0d_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1251,23 +1251,23 @@ void test_or_operation_2d0d_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d0d_lit_true()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1278,25 +1278,25 @@ void test_or_operation_2d0d_lit_true()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || true); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d0d_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1307,23 +1307,23 @@ void test_or_operation_2d0d_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d0d_lit_false()
 {
     blaze::Rand<blaze::DynamicMatrix<int>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(101UL, 101UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(101UL, 101UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1334,10 +1334,10 @@ void test_or_operation_2d0d_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x || false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1365,7 +1365,7 @@ void test_or_operation_2d0d_double_true()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1391,7 +1391,7 @@ void test_or_operation_2d0d_double_lit_true()
 
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1417,10 +1417,10 @@ void test_or_operation_2d0d_double_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](double x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1444,28 +1444,28 @@ void test_or_operation_2d0d_double_lit_false()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x != 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d1d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
     phylanx::execution_tree::primitive lhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1476,29 +1476,29 @@ void test_or_operation_2d1d()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
 void test_or_operation_2d1d_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(104UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(104UL, 0, 1);
 
     blaze::Rand<blaze::DynamicMatrix<int>> mat_gen{};
-    blaze::DynamicMatrix<bool> m = mat_gen.generate(101UL, 104UL, 0, 1);
+    blaze::DynamicMatrix<std::uint8_t> m = mat_gen.generate(101UL, 104UL, 0, 1);
 
-    phylanx::ir::node_data<bool> lhs(m);
+    phylanx::ir::node_data<std::uint8_t> lhs(m);
 
     phylanx::execution_tree::primitive rhs =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
@@ -1509,13 +1509,13 @@ void test_or_operation_2d1d_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](bool x, bool y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1544,13 +1544,13 @@ void test_or_operation_2d1d_double()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 
@@ -1577,13 +1577,13 @@ void test_or_operation_2d1d_double_lit()
     phylanx::execution_tree::primitive_argument_type f =
         or_operation.eval().get();
 
-    blaze::DynamicMatrix<bool> expected{m.rows(), m.columns()};
+    blaze::DynamicMatrix<std::uint8_t> expected{m.rows(), m.columns()};
     for (size_t i = 0UL; i < m.rows(); i++)
         blaze::row(expected, i) = blaze::map(blaze::row(m, i),
             blaze::trans(v),
             [](double x, double y) { return x || y; });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f));
 }
 

--- a/tests/unit/execution_tree/primitives/random_distributions.cpp
+++ b/tests/unit/execution_tree/primitives/random_distributions.cpp
@@ -65,7 +65,8 @@ void generate_0d(phylanx::execution_tree::compiler::function const& call,
 
     auto result = call(dims);
 
-    HPX_TEST_EQ(dist(gen),
+    HPX_TEST_EQ(
+        static_cast<T>(dist(gen)),
         static_cast<T>(
             phylanx::execution_tree::extract_numeric_value(result)[0]));
 }
@@ -199,15 +200,15 @@ void test_bernoulli_distribution(std::mt19937& gen)
 
     {
         std::bernoulli_distribution dist;
-        generate_0d<bool>(call, gen, dist);
+        generate_0d<std::uint8_t>(call, gen, dist);
     }
     {
         std::bernoulli_distribution dist;
-        generate_1d<bool>(call, gen, dist);
+        generate_1d<std::uint8_t>(call, gen, dist);
     }
     {
         std::bernoulli_distribution dist;
-        generate_2d<bool>(call, gen, dist);
+        generate_2d<std::uint8_t>(call, gen, dist);
     }
 }
 
@@ -222,15 +223,15 @@ void test_bernoulli_distribution_params(std::mt19937& gen)
 
     {
         std::bernoulli_distribution dist{0.8};
-        generate_0d<bool>(call, gen, dist);
+        generate_0d<std::uint8_t>(call, gen, dist);
     }
     {
         std::bernoulli_distribution dist{0.8};
-        generate_1d<bool>(call, gen, dist);
+        generate_1d<std::uint8_t>(call, gen, dist);
     }
     {
         std::bernoulli_distribution dist{0.8};
-        generate_2d<bool>(call, gen, dist);
+        generate_2d<std::uint8_t>(call, gen, dist);
     }
 }
 

--- a/tests/unit/execution_tree/primitives/sum_operation.cpp
+++ b/tests/unit/execution_tree/primitives/sum_operation.cpp
@@ -47,7 +47,7 @@ void test_0d_keep_dims_true()
             hpx::find_here(), phylanx::ast::nil{});
     phylanx::execution_tree::primitive arg2 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
@@ -74,7 +74,7 @@ void test_0d_keep_dims_false()
             hpx::find_here(), phylanx::ast::nil{});
     phylanx::execution_tree::primitive arg2 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
@@ -124,7 +124,7 @@ void test_1d_keep_dims_true()
             hpx::find_here(), phylanx::ast::nil{});
     phylanx::execution_tree::primitive arg2 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
@@ -152,7 +152,7 @@ void test_1d_keep_dims_false()
             hpx::find_here(), phylanx::ast::nil{});
     phylanx::execution_tree::primitive arg2 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
@@ -252,7 +252,7 @@ void test_2d_keep_dims_true()
             hpx::find_here(), phylanx::ast::nil{});
     phylanx::execution_tree::primitive arg2 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(true));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
@@ -280,7 +280,7 @@ void test_2d_keep_dims_false()
             hpx::find_here(), phylanx::ast::nil{});
     phylanx::execution_tree::primitive arg2 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(false));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
 
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(

--- a/tests/unit/execution_tree/primitives/unary_not_operation.cpp
+++ b/tests/unit/execution_tree/primitives/unary_not_operation.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -17,7 +18,7 @@ void test_unary_not_operation_0d_false()
 {
     phylanx::execution_tree::primitive val =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>{false});
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>{false});
 
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
@@ -28,7 +29,7 @@ void test_unary_not_operation_0d_false()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
@@ -36,7 +37,7 @@ void test_unary_not_operation_0d_true()
 {
     phylanx::execution_tree::primitive val =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>{true});
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>{true});
 
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
@@ -47,7 +48,7 @@ void test_unary_not_operation_0d_true()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
@@ -57,12 +58,12 @@ void test_unary_not_operation_0d_false_lit()
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                phylanx::ir::node_data<bool>{false}});
+                phylanx::ir::node_data<std::uint8_t>{false}});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(true),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
@@ -72,23 +73,23 @@ void test_unary_not_operation_0d_true_lit()
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
             std::vector<phylanx::execution_tree::primitive_argument_type>{
-                phylanx::ir::node_data<bool>{true}});
+                phylanx::ir::node_data<std::uint8_t>{true}});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(false),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
 void test_unary_not_operation_1d()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
     phylanx::execution_tree::primitive val =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(v));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(v));
 
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
@@ -99,19 +100,19 @@ void test_unary_not_operation_1d()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x == false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
 void test_unary_not_operation_1d_lit()
 {
     blaze::Rand<blaze::DynamicVector<int>> gen{};
-    blaze::DynamicVector<bool> v = gen.generate(1007UL, 0, 1);
+    blaze::DynamicVector<std::uint8_t> v = gen.generate(1007UL, 0, 1);
 
-    phylanx::ir::node_data<bool> val(v);
+    phylanx::ir::node_data<std::uint8_t> val(v);
 
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
@@ -122,10 +123,10 @@ void test_unary_not_operation_1d_lit()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicVector<bool> expected =
+    blaze::DynamicVector<std::uint8_t> expected =
         blaze::map(v, [](bool x) { return (x == false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
@@ -147,10 +148,10 @@ void test_unary_not_operation_1d_double()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicVector<bool> expected =
-        blaze::map(v, [](double x) { return (x == false); });
+    blaze::DynamicVector<std::uint8_t> expected =
+        blaze::map(v, [](double x) { return (x == 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
@@ -170,21 +171,21 @@ void test_unary_not_operation_1d_double_lit()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicVector<bool> expected =
-        blaze::map(v, [](double x) { return (x == false); });
+    blaze::DynamicVector<std::uint8_t> expected =
+        blaze::map(v, [](double x) { return (x == 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
 void test_unary_not_operation_2d()
 {
     blaze::Rand<blaze::DynamicMatrix<double>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(42UL, 42UL);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(42UL, 42UL);
 
     phylanx::execution_tree::primitive val =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<bool>(m));
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
 
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
@@ -195,19 +196,19 @@ void test_unary_not_operation_2d()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x == false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
 void test_unary_not_operation_2d_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<double>> gen{};
-    blaze::DynamicMatrix<bool> m = gen.generate(42UL, 42UL);
+    blaze::DynamicMatrix<std::uint8_t> m = gen.generate(42UL, 42UL);
 
-    phylanx::ir::node_data<bool> val(m);
+    phylanx::ir::node_data<std::uint8_t> val(m);
 
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
@@ -218,10 +219,10 @@ void test_unary_not_operation_2d_lit()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicMatrix<bool> expected =
+    blaze::DynamicMatrix<std::uint8_t> expected =
         blaze::map(m, [](bool x) { return (x == false); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
@@ -243,10 +244,10 @@ void test_unary_not_operation_2d_double()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicMatrix<bool> expected =
-        blaze::map(m, [](double x) { return (x == false); });
+    blaze::DynamicMatrix<std::uint8_t> expected =
+        blaze::map(m, [](double x) { return (x == 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 
@@ -266,10 +267,10 @@ void test_unary_not_operation_2d_double_lit()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         unary_not.eval();
 
-    blaze::DynamicMatrix<bool> expected =
-        blaze::map(m, [](double x) { return (x == false); });
+    blaze::DynamicMatrix<std::uint8_t> expected =
+        blaze::map(m, [](double x) { return (x == 0.0); });
 
-    HPX_TEST_EQ(phylanx::ir::node_data<bool>(std::move(expected)),
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
         phylanx::execution_tree::extract_boolean_data(f.get()));
 }
 

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 void test_serialization(phylanx::ir::node_data<double> const& array_value1)
@@ -35,11 +36,11 @@ int main(int argc, char* argv[])
     }
 
     {
-        phylanx::ir::node_data<bool> single_value(false);
+        phylanx::ir::node_data<std::uint8_t> single_value(false);
         HPX_TEST_EQ(single_value[0], false);
         HPX_TEST_EQ(single_value.num_dimensions(), std::size_t(0UL));
         HPX_TEST(single_value.dimensions() ==
-            phylanx::ir::node_data<bool>::dimensions_type({1, 1}));
+            phylanx::ir::node_data<std::uint8_t>::dimensions_type({1, 1}));
     }
 
     {
@@ -58,11 +59,11 @@ int main(int argc, char* argv[])
     {
         blaze::Rand<blaze::DynamicVector<double>> gen{};
         blaze::DynamicVector<double> v = gen.generate(1007UL);
-        phylanx::ir::node_data<bool> array_value(v);
+        phylanx::ir::node_data<std::uint8_t> array_value(v);
 
         HPX_TEST_EQ(array_value.num_dimensions(), std::size_t(1UL));
         HPX_TEST(array_value.dimensions() ==
-            phylanx::ir::node_data<bool>::dimensions_type({v.size(), 1UL}));
+            phylanx::ir::node_data<std::uint8_t>::dimensions_type({v.size(), 1UL}));
     }
 
     {
@@ -96,11 +97,11 @@ int main(int argc, char* argv[])
         blaze::Rand<blaze::DynamicMatrix<double>> gen{};
         blaze::DynamicMatrix<double> m = gen.generate(42UL, 101UL);
 
-        phylanx::ir::node_data<bool> array_value(m);
+        phylanx::ir::node_data<std::uint8_t> array_value(m);
 
         HPX_TEST_EQ(array_value.num_dimensions(), std::size_t(2UL));
         HPX_TEST(array_value.dimensions() ==
-            phylanx::ir::node_data<bool>::dimensions_type(
+            phylanx::ir::node_data<std::uint8_t>::dimensions_type(
                 {m.rows(), m.columns()}));
     }
 

--- a/tests/unit/python/execution_tree/make_array.py
+++ b/tests/unit/python/execution_tree/make_array.py
@@ -14,7 +14,7 @@ dx = 1.0
 et = phylanx.execution_tree
 var = et.var(np.linspace(x0, (nx - 1) * dx, nx))
 r = var.eval()
-assert isinstance(r, list)
+assert isinstance(r, np.ndarray)
 assert len(r) == nx
 sum2 = 0
 for i in range(11):
@@ -29,7 +29,7 @@ for i in range(len(va)):
 
 # Create a vector that's all zeros
 r = et.var(np.zeros(nx)).eval()
-assert isinstance(r, list)
+assert isinstance(r, np.ndarray)
 assert len(r) == nx
 for i in range(11):
     assert 0 == r[i]
@@ -38,7 +38,7 @@ for i in range(11):
 nx = 5
 ny = 4
 m = et.var(np.zeros((nx, ny))).eval()
-assert isinstance(m, type([[]]))
+assert isinstance(m, np.ndarray)
 assert len(m) == nx
 assert len(m[1]) == ny
 for i in range(nx):

--- a/tests/unit/python/execution_tree/primitives/make_vector.py
+++ b/tests/unit/python/execution_tree/primitives/make_vector.py
@@ -5,6 +5,7 @@
 
 import phylanx
 from phylanx.ast import *
+import numpy as np
 
 
 @Phylanx("PhySL")
@@ -33,7 +34,18 @@ def test_make_vector2():
     return hstack(a, hstack(a, b, c), c)
 
 
-assert test_make_vector_one() == [42]
-assert test_make_vector_literals() == [1, 2, 3, 4]
-assert test_make_vector() == [1, 2, 3]
-assert test_make_vector2() == [1, 1, 2, 3, 3]
+a = test_make_vector_one()
+assert (isinstance(a, np.ndarray))
+assert (a == np.array(42)).all()
+
+a = test_make_vector_literals()
+assert (isinstance(a, np.ndarray))
+assert (a == np.array([1, 2, 3, 4])).all()
+
+a = test_make_vector()
+assert (isinstance(a, np.ndarray))
+assert (a == np.array([1, 2, 3])).all()
+
+a = test_make_vector2()
+assert (isinstance(a, np.ndarray))
+assert (a == np.array([1, 1, 2, 3, 3])).all()


### PR DESCRIPTION
This is to avoid using `vector<bool>` which prevents problems in pybind11