### PR TITLE
Removing direct eval actions from primitives

### DIFF
--- a/examples/algorithms/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra_csv_instrumented.cpp
@@ -264,13 +264,7 @@ void print_performance_counter_data_csv()
     std::cout << std::endl << "Primitive Performance Counter Data in CSV:";
 
     // CSV Header
-    std::cout << "\n"
-              << "primitive_instance,"
-              << "display_name,"
-              << "count,"
-              << "time,"
-              << "direct_count,"
-              << "direct_time\n";
+    std::cout << "\nprimitive_instance,display_name,count,time,eval_direct\n";
 
     // List of existing primitive instances
     std::vector<std::string> existing_primitive_instances;
@@ -285,8 +279,7 @@ void print_performance_counter_data_csv()
     // Print performance data
     for (auto const& entry :
         phylanx::util::retrieve_counter_data(existing_primitive_instances,
-            std::vector<std::string>{"count/eval", "time/eval",
-            "count/eval_direct", "time/eval_direct"},
+            std::vector<std::string>{"count/eval", "time/eval", "eval_direct"},
             hpx::find_here()))
     {
         std::cout << "\"" << entry.first << "\",\""

--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -66,8 +66,7 @@ read_arguments(std::vector<std::string> const& args, std::size_t first_index)
 void print_performance_counter_data_csv()
 {
     // CSV Header
-    std::cout << "primitive_instance,display_name,count,time,direct_count,"
-                 "direct_time\n";
+    std::cout << "primitive_instance,display_name,count,time,eval_direct\n";
 
     // List of existing primitive instances
     std::vector<std::string> existing_primitive_instances;
@@ -81,7 +80,8 @@ void print_performance_counter_data_csv()
 
     // Print performance data
     std::vector<std::string> const counter_names{
-        "count/eval", "time/eval", "count/eval_direct", "time/eval_direct"};
+        "count/eval", "time/eval", "eval_direct"
+    };
 
     for (auto const& entry : phylanx::util::retrieve_counter_data(
              existing_primitive_instances, counter_names))

--- a/examples/profiling/primitive_instrumentation.cpp
+++ b/examples/profiling/primitive_instrumentation.cpp
@@ -61,12 +61,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     fibonacci(num_iterations);
 
     // CSV Header
-    std::cout << "primitive_instance" << ","
-        << "count" << ","
-        << "time" << ","
-        << "direct_count" << ","
-        << "direct_time"
-        << std::endl;
+    std::cout << "primitive_instance,display_name,count,time,eval_directs\n";
 
     // List of existing primitive instances
     std::vector<std::string> existing_primitive_instances;
@@ -81,10 +76,13 @@ int hpx_main(boost::program_options::variables_map& vm)
     // Print performance data
     for (auto const& entry :
         phylanx::util::retrieve_counter_data(existing_primitive_instances,
-            std::vector<std::string>{"count/eval", "time/eval",
-                "count/eval_direct", "time/eval_direct"}, hpx::find_here()))
+            std::vector<std::string>{"count/eval", "time/eval", "eval_direct"},
+            hpx::find_here()))
     {
-        std::cout << "\"" << entry.first << "\"";
+        std::cout << "\"" << entry.first << "\",\""
+                  << phylanx::execution_tree::compiler::primitive_display_name(
+                         entry.first)
+                  << "\"";
         for (auto const& counter_value : entry.second)
         {
             std::cout << "," << counter_value;

--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -119,7 +119,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 {
                     params.emplace_back(extract_ref_value(arg));
                 }
-                return extract_copy_value(p->eval_direct(std::move(params)));
+                return extract_copy_value(
+                    p->eval(hpx::launch::sync, std::move(params)));
             }
             return arg_;
         }
@@ -136,7 +137,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 {
                     params.emplace_back(extract_ref_value(std::move(arg)));
                 }
-                return extract_copy_value(p->eval_direct(std::move(params)));
+                return extract_copy_value(
+                    p->eval(hpx::launch::sync, std::move(params)));
             }
             return arg_;
         }
@@ -167,7 +169,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     params.emplace_back(extract_ref_value(arg));
                 }
 
-                return extract_copy_value(p->eval_direct(std::move(params)));
+                return extract_copy_value(
+                    p->eval(hpx::launch::sync, std::move(params)));
             }
 
             return arg_;

--- a/phylanx/execution_tree/primitives/access_argument.hpp
+++ b/phylanx/execution_tree/primitives/access_argument.hpp
@@ -26,7 +26,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         access_argument(std::vector<primitive_argument_type>&& args,
             std::string const& name, std::string const& codename);
 
-        primitive_argument_type eval_direct(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
 
     private:

--- a/phylanx/execution_tree/primitives/apply.hpp
+++ b/phylanx/execution_tree/primitives/apply.hpp
@@ -10,22 +10,25 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class apply : public primitive_component_base
+    class apply
+      : public primitive_component_base
+      , public std::enable_shared_from_this<apply>
     {
     public:
         static match_pattern_type const match_data;
 
         apply() = default;
 
-        PHYLANX_EXPORT apply(std::vector<primitive_argument_type>&& operands,
+        apply(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
-        PHYLANX_EXPORT primitive_argument_type eval_direct(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
     };
 

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -11,6 +11,7 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/ir/node_data.hpp>
 
+#include <hpx/include/runtime.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/include/serialization.hpp>
 
@@ -104,10 +105,11 @@ namespace phylanx { namespace execution_tree
         PHYLANX_EXPORT hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const;
 
-        PHYLANX_EXPORT primitive_argument_type eval_direct() const;
-        PHYLANX_EXPORT primitive_argument_type eval_direct(
+        PHYLANX_EXPORT primitive_argument_type eval(
+            hpx::launch::sync_policy) const;
+        PHYLANX_EXPORT primitive_argument_type eval(hpx::launch::sync_policy,
             std::vector<primitive_argument_type> && args) const;
-        PHYLANX_EXPORT primitive_argument_type eval_direct(
+        PHYLANX_EXPORT primitive_argument_type eval(hpx::launch::sync_policy,
             std::vector<primitive_argument_type> const& args) const;
 
         PHYLANX_EXPORT hpx::future<void> store(primitive_argument_type);

--- a/phylanx/execution_tree/primitives/define_function.hpp
+++ b/phylanx/execution_tree/primitives/define_function.hpp
@@ -39,7 +39,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         // Create a new instance of the variable and initialize it with the
         // value as returned by evaluating the given body.
-        primitive_argument_type eval_direct(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
 
         primitive_argument_type bind(

--- a/phylanx/execution_tree/primitives/define_variable.hpp
+++ b/phylanx/execution_tree/primitives/define_variable.hpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         // Create a new instance of the variable and initialize it with the
         // value as returned by evaluating the given body.
-        primitive_argument_type eval_direct(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& args) const override;
 
         void store(primitive_argument_type && val) override;

--- a/phylanx/execution_tree/primitives/enable_tracing.hpp
+++ b/phylanx/execution_tree/primitives/enable_tracing.hpp
@@ -27,7 +27,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         enable_tracing(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
-        primitive_argument_type eval_direct(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
     };
 

--- a/phylanx/execution_tree/primitives/generic_function.hpp
+++ b/phylanx/execution_tree/primitives/generic_function.hpp
@@ -20,12 +20,9 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, bool direct = Action::direct_execution::value>
-    class generic_function;
-
-    // wrapping non-direct actions
+    // wrapping generic functions as actions
     template <typename Action>
-    class generic_function<Action, false>
+    class generic_function
       : public primitive_component_base
     {
     public:
@@ -45,34 +42,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             return hpx::async(
                 Action(), hpx::find_here(), operands_, args, name_, codename_);
-        }
-
-    private:
-        std::string name_;
-    };
-
-    // wrapping direct actions
-    template <typename Action>
-    class generic_function<Action, true>
-      : public primitive_component_base
-    {
-    public:
-        static match_pattern_type const match_data;
-
-        generic_function() = default;
-
-        generic_function(std::vector<primitive_argument_type>&& operands,
-                std::string const& name, std::string const& codename)
-          : primitive_component_base(std::move(operands), name, codename)
-        {}
-
-        // Create a new instance of the variable and initialize it with the
-        // value as returned by evaluating the given body.
-        primitive_argument_type eval_direct(
-            std::vector<primitive_argument_type> const& args) const override
-        {
-            return hpx::async(hpx::launch::sync, Action(), hpx::find_here(),
-                operands_, args, name_, codename_).get();
         }
 
     private:

--- a/phylanx/execution_tree/primitives/primitive_component.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component.hpp
@@ -13,6 +13,7 @@
 #include <hpx/include/actions.hpp>
 #include <hpx/include/components.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -50,10 +51,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         PHYLANX_EXPORT hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const;
 
-        // direct_eval_action
-        PHYLANX_EXPORT primitive_argument_type eval_direct(
-            std::vector<primitive_argument_type> const& params) const;
-
         // store_action
         PHYLANX_EXPORT void store(primitive_argument_type &&);
 
@@ -68,20 +65,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // set_body_action (define_function only)
         PHYLANX_EXPORT void set_body(primitive_argument_type&& target);
 
-#if defined(PHYLANX_DEBUG)
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            primitive_component, eval, eval_action);
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(primitive_component,
-            expression_topology, expression_topology_action);
-#else
         HPX_DEFINE_COMPONENT_ACTION(
             primitive_component, eval, eval_action);
         HPX_DEFINE_COMPONENT_ACTION(
             primitive_component, expression_topology,
             expression_topology_action);
-#endif
-        HPX_DEFINE_COMPONENT_DIRECT_ACTION(
-            primitive_component, eval_direct, eval_direct_action);
         HPX_DEFINE_COMPONENT_DIRECT_ACTION(
             primitive_component, bind, bind_action);
         HPX_DEFINE_COMPONENT_ACTION(
@@ -90,10 +78,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_component, set_body, set_body_action);
 
         // access data for performance counter
-        PHYLANX_EXPORT std::int64_t get_eval_count(
-            bool reset, bool direct) const;
-        PHYLANX_EXPORT std::int64_t get_eval_duration(
-            bool reset, bool direct) const;
+        PHYLANX_EXPORT std::int64_t get_eval_count(bool reset) const;
+        PHYLANX_EXPORT std::int64_t get_eval_duration(bool reset) const;
+        PHYLANX_EXPORT std::int64_t get_direct_execution(bool reset) const;
+
+        // decide whether to execute eval directly
+        PHYLANX_EXPORT static hpx::launch select_direct_execution(eval_action,
+            hpx::launch policy, hpx::naming::address_type lva);
 
     private:
         std::shared_ptr<primitive_component_base> primitive_;
@@ -104,9 +95,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
 HPX_REGISTER_ACTION_DECLARATION(
     phylanx::execution_tree::primitives::primitive_component::eval_action,
     phylanx_primitive_eval_action);
-HPX_REGISTER_ACTION_DECLARATION(
-    phylanx::execution_tree::primitives::primitive_component::eval_direct_action,
-    phylanx_primitive_eval_direct_action);
 HPX_REGISTER_ACTION_DECLARATION(
     phylanx::execution_tree::primitives::primitive_component::store_action,
     phylanx_primitive_store_action);

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -11,6 +11,8 @@
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
 
 #include <cstdint>
 #include <memory>
@@ -36,16 +38,13 @@ namespace phylanx { namespace execution_tree
 
             primitive_component_base(
                 std::vector<primitive_argument_type>&& params,
-                std::string const& name, std::string const& codename);
+                std::string const& name, std::string const& codename,
+                bool eval_direct = false);
 
             virtual ~primitive_component_base() = default;
 
             // eval_action
             virtual hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& params) const;
-
-            // direct_eval_action
-            virtual primitive_argument_type eval_direct(
                 std::vector<primitive_argument_type> const& params) const;
 
             // store_action
@@ -68,12 +67,14 @@ namespace phylanx { namespace execution_tree
             // helper functions to invoke eval functionalities
             hpx::future<primitive_argument_type> do_eval(
                 std::vector<primitive_argument_type> const& params) const;
-            primitive_argument_type do_eval_direct(
-                std::vector<primitive_argument_type> const& params) const;
 
             // access data for performance counter
-            std::int64_t get_eval_count(bool reset, bool direct) const;
-            std::int64_t get_eval_duration(bool reset, bool direct) const;
+            std::int64_t get_eval_count(bool reset) const;
+            std::int64_t get_eval_duration(bool reset) const;
+            std::int64_t get_direct_execution(bool reset) const;
+
+            // decide whether to execute eval directly
+            hpx::launch select_direct_eval_execution(hpx::launch policy) const;
 
         protected:
             std::string generate_error_message(std::string const& msg) const;
@@ -88,12 +89,10 @@ namespace phylanx { namespace execution_tree
             // Performance counter data
             mutable std::int64_t eval_count_;
             mutable std::int64_t eval_duration_;
-            mutable std::int64_t eval_direct_count_;
-            mutable std::int64_t eval_direct_duration_;
+            mutable std::int64_t execute_directly_;
 
 #if defined(HPX_HAVE_APEX)
             std::string eval_name_;
-            std::string eval_direct_name_;
 #endif
         };
     }

--- a/phylanx/execution_tree/primitives/variable.hpp
+++ b/phylanx/execution_tree/primitives/variable.hpp
@@ -31,7 +31,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         variable(std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename);
 
-        primitive_argument_type eval_direct(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
 
         void store(primitive_argument_type && data) override;

--- a/phylanx/execution_tree/primitives/wrapped_function.hpp
+++ b/phylanx/execution_tree/primitives/wrapped_function.hpp
@@ -34,8 +34,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& params) const override;
-        primitive_argument_type eval_direct(
-            std::vector<primitive_argument_type> const& params) const override;
 
         primitive_argument_type bind(
             std::vector<primitive_argument_type> const& args) const override;

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Hartmut Kaiser
+ // Copyright (c) 2017-2018 Hartmut Kaiser
 // Copyright (c) 2017 Parsa Amini
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/phylanx/util/performance_data.hpp
+++ b/phylanx/util/performance_data.hpp
@@ -16,24 +16,28 @@
 #include <string>
 #include <vector>
 
-
 namespace phylanx { namespace util
 {
-    /// Retrieve performance counter data for selected primitives
+    /// Retrieve specified performance counter data for the selected primitives
+    ///
     /// \param primitive_instances The primitives for which performance counter
-    /// data is required
-    /// \param locality_id The locality the performance counter data is going
-    /// to be queried from
+    ///                 data is required
     /// \param counter_name_last_parts A vector containing the last part of the
-    /// performance counter names.
-    /// e.g. std::vector{ "count/eval", "count/direct_eval" }
-    /// \return a std::map containing a key/value pair of primitive
-    /// instances/performance counter values
+    ///                 performance counter names. e.g. std::vector{
+    ///                     "count/eval", "time/eval", "eval_direct" }
+    /// \param locality_id The locality the performance counter data is going
+    ///                 to be queried from
+    ///
+    /// \return a std::map containing key/value pairs of primitive
+    ///         instances (names)/performance counter values
+    ///
     /// \note primitive_instances are not verified
+    ///
     /// \exception hpx::exception
+    ///
     PHYLANX_EXPORT std::map<std::string, std::vector<std::int64_t>>
     retrieve_counter_data(std::vector<std::string> const& primitive_instances,
         std::vector<std::string> const& counter_name_last_parts,
-        hpx::naming::id_type const& locality_id = hpx::find_here());
+        hpx::id_type const& locality_id = hpx::find_here());
 }}
 #endif

--- a/src/execution_tree/compiler/primitive_name.cpp
+++ b/src/execution_tree/compiler/primitive_name.cpp
@@ -148,6 +148,12 @@ namespace phylanx { namespace execution_tree { namespace compiler
         }
 
         std::string result = parts.primitive;
+        if (result.size() > 2 && result[0] == '_' && result[1] == '_')
+        {
+            // strip leading "__"
+            result.erase(0, 2);
+        }
+
         if (!parts.instance.empty())
         {
             result += "/" + parts.instance;

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -29,7 +29,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     access_argument::access_argument(
             std::vector<primitive_argument_type>&& args,
             std::string const& name, std::string const& codename)
-      : primitive_component_base(std::move(args), name, codename)
+      : primitive_component_base(std::move(args), name, codename, true)
     {
         if (operands_.size() != 1)
         {
@@ -43,19 +43,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         argnum_ = extract_integer_value(operands_[0]);
     }
 
-    primitive_argument_type access_argument::eval_direct(
+    hpx::future<primitive_argument_type> access_argument::eval(
         std::vector<primitive_argument_type> const& params) const
     {
         if (argnum_ >= params.size())
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::primitives::"
-                    "access_argument::eval_direct",
+                    "access_argument::eval",
                 generate_error_message(hpx::util::format(
                     "argument count out of bounds, expected at least "
                         "%1% argument(s) while only %2% argument(s) "
                         "were supplied", argnum_ + 1, params.size())));
         }
-        return value_operand_ref_sync(params[argnum_], params, name_, codename_);
+        return value_operand(params[argnum_], params, name_, codename_);
     }
 }}}

--- a/src/execution_tree/primitives/apply.cpp
+++ b/src/execution_tree/primitives/apply.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 #include <hpx/throw_exception.hpp>
 
 #include <string>
@@ -41,13 +42,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
-    primitive_argument_type apply::eval_direct(
+    hpx::future<primitive_argument_type> apply::eval(
         std::vector<primitive_argument_type> const& params) const
     {
         if (operands_.size() != 2)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "apply::eval_direct",
+                "apply::eval",
                 generate_error_message(
                     "the apply primitive requires exactly two operands"));
         }
@@ -56,13 +57,29 @@ namespace phylanx { namespace execution_tree { namespace primitives
         if (p == nullptr)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "apply::eval_direct",
+                "apply::eval",
                 generate_error_message(
                     "the first argument to apply must be an invocable "
                     "object"));
         }
 
-        return p->eval_direct(
-            list_operand_sync(operands_[1], params, name_, codename_));
+        auto this_ = this->shared_from_this();
+        return list_operand(operands_[1], params, name_, codename_).then(
+            [this_](hpx::future<std::vector<primitive_argument_type>>&& f)
+            {
+                primitive const* p =
+                    util::get_if<primitive>(&this_->operands_[0]);
+
+                if (p == nullptr)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "apply::eval",
+                        this_->generate_error_message(
+                            "the first argument to apply must be an invocable "
+                            "object"));
+                }
+
+                return p->eval(hpx::launch::sync, f.get());
+            });
     }
 }}}

--- a/src/execution_tree/primitives/base_primitives.cpp
+++ b/src/execution_tree/primitives/base_primitives.cpp
@@ -14,6 +14,7 @@
 
 #include <hpx/include/actions.hpp>
 #include <hpx/include/components.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 #include <hpx/util/logging.hpp>
 
 #include <cstdint>
@@ -129,25 +130,20 @@ namespace phylanx { namespace execution_tree
         return eval(params);
     }
 
-    primitive_argument_type primitive::eval_direct(
+    primitive_argument_type primitive::eval(hpx::launch::sync_policy,
         std::vector<primitive_argument_type> const& params) const
     {
-        using action_type = primitives::primitive_component::eval_direct_action;
-        return detail::trace("eval_direct", *this,
-            action_type()(this->base_type::get_id(), params));
+        return eval(params).get();
     }
-    primitive_argument_type primitive::eval_direct(
+    primitive_argument_type primitive::eval(hpx::launch::sync_policy,
         std::vector<primitive_argument_type> && params) const
     {
-        using action_type = primitives::primitive_component::eval_direct_action;
-        return detail::trace("eval_direct", *this,
-            action_type()(this->base_type::get_id(), std::move(params)));
+        return eval(std::move(params)).get();
     }
 
-    primitive_argument_type primitive::eval_direct() const
+    primitive_argument_type primitive::eval(hpx::launch::sync_policy) const
     {
-        static std::vector<primitive_argument_type> params;
-        return eval_direct(params);
+        return eval().get();
     }
 
     hpx::future<void> primitive::store(primitive_argument_type data)
@@ -1598,8 +1594,12 @@ namespace phylanx { namespace execution_tree
                 });
         }
 
-        HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(extract_ref_value(val, name, codename));
+        if (valid(val))
+        {
+            return hpx::make_ready_future(
+                extract_ref_value(val, name, codename));
+        }
+        return hpx::make_ready_future(val);
     }
 
     hpx::future<primitive_argument_type> value_operand(
@@ -1617,8 +1617,12 @@ namespace phylanx { namespace execution_tree
                 });
         }
 
-        HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(extract_ref_value(val, name, codename));
+        if (valid(val))
+        {
+            return hpx::make_ready_future(
+                extract_ref_value(val, name, codename));
+        }
+        return hpx::make_ready_future(val);
     }
 
     hpx::future<primitive_argument_type> value_operand(
@@ -1636,9 +1640,12 @@ namespace phylanx { namespace execution_tree
                 });
         }
 
-        HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(
-            extract_ref_value(std::move(val), name, codename));
+        if (valid(val))
+        {
+            return hpx::make_ready_future(
+                extract_ref_value(std::move(val), name, codename));
+        }
+        return hpx::make_ready_future(std::move(val));
     }
 
     hpx::future<primitive_argument_type> value_operand(
@@ -1656,9 +1663,12 @@ namespace phylanx { namespace execution_tree
                 });
         }
 
-        HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(
-            extract_ref_value(std::move(val), name, codename));
+        if (valid(val))
+        {
+            return hpx::make_ready_future(
+                extract_ref_value(std::move(val), name, codename));
+        }
+        return hpx::make_ready_future(std::move(val));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1670,11 +1680,15 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_value(p->eval_direct(args), name, codename);
+            return extract_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
-        HPX_ASSERT(valid(val));
-        return extract_value(val, name, codename);
+        if (valid(val))
+        {
+            return extract_value(val, name, codename);
+        }
+        return val;
     }
 
     primitive_argument_type value_operand_sync(
@@ -1686,11 +1700,14 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
         {
             return extract_value(
-                p->eval_direct(std::move(args)), name, codename);
+                p->eval(hpx::launch::sync, std::move(args)), name, codename);
         }
 
-        HPX_ASSERT(valid(val));
-        return extract_value(val, name, codename);
+        if (valid(val))
+        {
+            return extract_value(val, name, codename);
+        }
+        return val;
     }
 
     primitive_argument_type value_operand_sync(
@@ -1701,11 +1718,15 @@ namespace phylanx { namespace execution_tree
         primitive* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_value(p->eval_direct(args), name, codename);
+            return extract_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
-        HPX_ASSERT(valid(val));
-        return extract_value(std::move(val), name, codename);
+        if (valid(val))
+        {
+            return extract_value(std::move(val), name, codename);
+        }
+        return std::move(val);
     }
 
     primitive_argument_type value_operand_sync(
@@ -1717,11 +1738,14 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
         {
             return extract_value(
-                p->eval_direct(std::move(args)), name, codename);
+                p->eval(hpx::launch::sync, std::move(args)), name, codename);
         }
 
-        HPX_ASSERT(valid(val));
-        return extract_value(std::move(val), name, codename);
+        if (valid(val))
+        {
+            return extract_value(std::move(val), name, codename);
+        }
+        return std::move(val);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1733,11 +1757,15 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_value(p->eval_direct(args), name, codename);
+            return extract_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
-        HPX_ASSERT(valid(val));
-        return extract_ref_value(val, name, codename);
+        if (valid(val))
+        {
+            return extract_ref_value(val, name, codename);
+        }
+        return val;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1830,7 +1858,8 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_literal_value(p->eval_direct(args), name, codename);
+            return extract_literal_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
         HPX_ASSERT(valid(val));
@@ -1927,7 +1956,8 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_numeric_value(p->eval_direct(args), name, codename);
+            return extract_numeric_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
         HPX_ASSERT(valid(val));
@@ -1962,7 +1992,8 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_boolean_value(p->eval_direct(args), name, codename);
+            return extract_boolean_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
         HPX_ASSERT(valid(val));
@@ -1997,7 +2028,8 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_string_value(p->eval_direct(args), name, codename);
+            return extract_string_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
         HPX_ASSERT(valid(val));
@@ -2032,7 +2064,8 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_ast_value(p->eval_direct(args), name, codename);
+            return extract_ast_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
         HPX_ASSERT(valid(val));
@@ -2126,7 +2159,8 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_list_value(p->eval_direct(args), name, codename);
+            return extract_list_value(
+                p->eval(hpx::launch::sync, args), name, codename);
         }
 
         HPX_ASSERT(valid(val));

--- a/src/execution_tree/primitives/define_function.cpp
+++ b/src/execution_tree/primitives/define_function.cpp
@@ -52,20 +52,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
         operands_.resize(1);
     }
 
-    primitive_argument_type define_function::eval_direct(
+    hpx::future<primitive_argument_type> define_function::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         // body is assumed to be operands_[0]
         if (!valid(operands_[0]))
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
-                "define_function::eval_direct",
+                "define_function::eval",
                 execution_tree::generate_error_message(
                     "the expression representing the function body "
                         "was not initialized yet",
                     name_, codename_));
         }
-        return operands_[0];
+        return hpx::make_ready_future(operands_[0]);
     }
 
     primitive_argument_type define_function::bind(

--- a/src/execution_tree/primitives/define_variable.cpp
+++ b/src/execution_tree/primitives/define_variable.cpp
@@ -64,7 +64,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return name;
     }
 
-    primitive_argument_type define_variable::eval_direct(
+    hpx::future<primitive_argument_type> define_variable::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         // this proxy was created where the variable should be created on.
@@ -85,20 +85,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive* p = util::get_if<primitive>(&operands_[1]);
             if (p != nullptr)
             {
-                p->eval_direct(args);
+                p->eval(hpx::launch::sync, args);
             }
 
-            return extract_ref_value(operands_[1]);
+            return hpx::make_ready_future(extract_ref_value(operands_[1]));
         }
 
         // just evaluate the expression bound to this name
-        primitive const* p = util::get_if<primitive>(&operands_[1]);
-        if (p != nullptr)
-        {
-            return extract_value(p->eval_direct(args));
-        }
-
-        return extract_ref_value(operands_[1]);
+        return value_operand(operands_[1], args, name_, codename_);
     }
 
     void define_variable::store(primitive_argument_type && val)

--- a/src/execution_tree/primitives/enable_tracing.cpp
+++ b/src/execution_tree/primitives/enable_tracing.cpp
@@ -45,7 +45,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     namespace detail
     {
-        primitive_argument_type eval_direct(
+        hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
             std::vector<primitive_argument_type> const& args,
             std::string const& name, std::string const& codename)
@@ -53,7 +53,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             if (operands.size() != 1)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "enable_tracing::eval_direct",
+                    "enable_tracing::eval",
                     generate_error_message(
                         "expected one (boolean) argument",
                         name, codename));
@@ -62,7 +62,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             if (!valid(operands[0]))
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "enable_tracing::eval_direct",
+                    "enable_tracing::eval",
                     generate_error_message(
                         "the enable_tracing primitive requires that the "
                             "argument given by the operand is valid",
@@ -72,17 +72,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive::enable_tracing =
                 boolean_operand_sync(operands[0], args, name, codename) != 0;
 
-            return primitive_argument_type{};
+            return hpx::make_ready_future(primitive_argument_type{});
         }
     }
 
-    primitive_argument_type enable_tracing::eval_direct(
+    hpx::future<primitive_argument_type> enable_tracing::eval(
         std::vector<primitive_argument_type> const& args) const
     {
         if (operands_.empty())
         {
-            return detail::eval_direct(args, noargs, name_, codename_);
+            return detail::eval(args, noargs, name_, codename_);
         }
-        return detail::eval_direct(operands_, args, name_, codename_);
+        return detail::eval(operands_, args, name_, codename_);
     }
 }}}

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -12,6 +12,8 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 
 #include <cstdint>
 #include <map>
@@ -32,8 +34,6 @@ typedef phylanx::execution_tree::primitives::primitive_component
 
 HPX_REGISTER_ACTION(primitive_component_type::eval_action,
     phylanx_primitive_eval_action)
-HPX_REGISTER_ACTION(primitive_component_type::eval_direct_action,
-    phylanx_primitive_eval_direct_action)
 HPX_REGISTER_ACTION(primitive_component_type::store_action,
     phylanx_primitive_store_action)
 HPX_REGISTER_ACTION(primitive_component_type::expression_topology_action,
@@ -110,13 +110,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return primitive_->do_eval(params);
     }
 
-    // direct_eval_action
-    primitive_argument_type primitive_component::eval_direct(
-        std::vector<primitive_argument_type> const& params) const
-    {
-        return primitive_->do_eval_direct(params);
-    }
-
     // store_action
     void primitive_component::store(primitive_argument_type && arg)
     {
@@ -144,16 +137,27 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     // access data for performance counter
-    std::int64_t primitive_component::get_eval_count(
-        bool reset, bool direct) const
+    std::int64_t primitive_component::get_eval_count(bool reset) const
     {
-        return primitive_->get_eval_count(reset, direct);
+        return primitive_->get_eval_count(reset);
     }
 
-    std::int64_t primitive_component::get_eval_duration(
-        bool reset, bool direct) const
+    std::int64_t primitive_component::get_eval_duration(bool reset) const
     {
-        return primitive_->get_eval_duration(reset, direct);
+        return primitive_->get_eval_duration(reset);
+    }
+
+    std::int64_t primitive_component::get_direct_execution(bool reset) const
+    {
+        return primitive_->get_direct_execution(reset);
+    }
+
+    hpx::launch primitive_component::select_direct_execution(
+        primitive_component::eval_action, hpx::launch policy,
+        hpx::naming::address_type lva)
+    {
+        auto this_ = hpx::get_lva<primitive_component>::call(lva);
+        return this_->primitive_->select_direct_eval_execution(policy);
     }
 }}}
 

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -10,9 +10,10 @@
 #include <phylanx/util/scoped_timer.hpp>
 
 #include <hpx/include/lcos.hpp>
-#include <hpx/include/traits.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/throw_exception.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 
 #include <cstdint>
 #include <set>
@@ -28,18 +29,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     primitive_component_base::primitive_component_base(
             std::vector<primitive_argument_type>&& params,
-            std::string const& name, std::string const& codename)
+            std::string const& name, std::string const& codename,
+            bool eval_direct)
       : operands_(std::move(params))
       , name_(name)
       , codename_(codename)
+      , execute_directly_(eval_direct ? 1 : -1)
       , eval_count_(0ll)
       , eval_duration_(0ll)
-      , eval_direct_count_(0ll)
-      , eval_direct_duration_(0ll)
     {
 #if defined(HPX_HAVE_APEX)
         eval_name_ = name_ + "::eval";
-        eval_direct_name_ = name_ + "::eval_direct";
 #endif
     }
 
@@ -90,38 +90,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return f;
     }
 
-    primitive_argument_type primitive_component_base::do_eval_direct(
-        std::vector<primitive_argument_type> const& params) const
-    {
-#if defined(HPX_HAVE_APEX)
-        hpx::util::annotate_function annotate(eval_direct_name_.c_str());
-#endif
-
-        util::scoped_timer<std::int64_t> timer(eval_direct_duration_);
-        ++eval_direct_count_;
-
-        return this->eval_direct(params);
-    }
-
     // eval_action
     hpx::future<primitive_argument_type> primitive_component_base::eval(
         std::vector<primitive_argument_type> const& params) const
     {
-        return hpx::make_ready_future(eval_direct(params));
-    }
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::execution_tree::primitives::primitive_component_base::eval",
+            generate_error_message(
+                "attempting to invoke an undefined evalaluation"));
 
-    // direct_eval_action
-    primitive_argument_type primitive_component_base::eval_direct(
-        std::vector<primitive_argument_type> const& params) const
-    {
-        return eval(params).get();
+        return hpx::make_ready_future(primitive_argument_type{});
     }
 
     // store_action
     void primitive_component_base::store(primitive_argument_type &&)
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
-            "phylanx::execution_tree::primitives::primitive_component_base",
+            "phylanx::execution_tree::primitives::primitive_component_base::store",
             generate_error_message(
                 "store function should only be called for the primitives that "
                     "support it (e.g. variables)"));
@@ -181,24 +166,50 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return execution_tree::generate_error_message(msg, name_, codename_);
     }
 
-    std::int64_t primitive_component_base::get_eval_count(
-        bool reset, bool direct) const
+    std::int64_t primitive_component_base::get_eval_count(bool reset) const
     {
-        if (!direct)
-        {
-            return hpx::util::get_and_reset_value(eval_count_, reset);
-        }
-        return hpx::util::get_and_reset_value(eval_direct_count_, reset);
+        return hpx::util::get_and_reset_value(eval_count_, reset);
     }
 
-    std::int64_t primitive_component_base::get_eval_duration(
-        bool reset, bool direct) const
+    std::int64_t primitive_component_base::get_eval_duration(bool reset) const
     {
-        if (!direct)
+        return hpx::util::get_and_reset_value(eval_duration_, reset);
+    }
+
+    std::int64_t primitive_component_base::get_direct_execution(bool reset) const
+    {
+        return hpx::util::get_and_reset_value(execute_directly_, reset);
+    }
+
+    // decide whether to execute eval directly
+    hpx::launch primitive_component_base::select_direct_eval_execution(
+        hpx::launch policy) const
+    {
+        if (eval_count_ != 0)
         {
-            return hpx::util::get_and_reset_value(eval_duration_, reset);
+            // check whether execution status needs to be changed (with some
+            // hysteresis)
+            std::int64_t exec_time = (eval_duration_ / eval_count_);
+            if (exec_time > 300000)
+            {
+                execute_directly_ = 0;
+            }
+            else if (exec_time < 150000)
+            {
+                execute_directly_ = 1;
+            }
         }
-        return hpx::util::get_and_reset_value(eval_direct_duration_, reset);
+
+        if (execute_directly_ == 1)
+        {
+            return hpx::launch::sync;
+        }
+        else if (execute_directly_ == 0)
+        {
+            return hpx::launch::async;
+        }
+
+        return policy;
     }
 }}}
 
@@ -216,7 +227,8 @@ namespace phylanx { namespace execution_tree
                 std::string line_col;
                 if (parts.tag1 != -1 && parts.tag2 != -1)
                 {
-                    line_col = hpx::util::format("(%1%, %2%)", parts.tag1, parts.tag2);
+                    line_col =
+                        hpx::util::format("(%1%, %2%)", parts.tag1, parts.tag2);
                 }
 
                 if (!parts.instance.empty())

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -43,7 +43,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     store_operation::store_operation(
             std::vector<primitive_argument_type> && operands,
             std::string const& name, std::string const& codename)
-      : primitive_component_base(std::move(operands), name, codename)
+      : primitive_component_base(std::move(operands), name, codename, true)
     {}
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/sum_operation.cpp
+++ b/src/execution_tree/primitives/sum_operation.cpp
@@ -196,7 +196,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::dataflow(
             hpx::util::unwrapping(
                 [this_](std::vector<primitive_argument_type>&& args)
-                    -> primitive_argument_type {
+                    -> primitive_argument_type
+                {
                     // Extract axis and keep_dims
                     // Presence of axis changes behavior for >2d cases
                     hpx::util::optional<std::int64_t> axis;

--- a/src/execution_tree/primitives/wrapped_function.cpp
+++ b/src/execution_tree/primitives/wrapped_function.cpp
@@ -63,7 +63,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive const* p = util::get_if<primitive>(&operands_[0]);
         if (p != nullptr)
         {
-            body = p->eval_direct(params);
+            body = value_operand_sync(operands_[0], params, name_, codename_);
         }
         else
         {
@@ -94,45 +94,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             fargs.push_back(value_operand_sync(*it, params, name_, codename_));
         }
         return value_operand(body, std::move(fargs), name_, codename_);
-    }
-
-    primitive_argument_type wrapped_function::eval_direct(
-        std::vector<primitive_argument_type> const& params) const
-    {
-        // evaluation of the define-function yields the function body
-        primitive_argument_type body;
-
-        primitive const* p = util::get_if<primitive>(&operands_[0]);
-        if (p != nullptr)
-        {
-            body = p->eval_direct(params);
-        }
-        else
-        {
-            body = operands_[0];
-        }
-
-        std::vector<primitive_argument_type> fargs;
-        if (operands_.size() == 1)
-        {
-            // no pre-bound arguments
-            fargs.reserve(params.size() + 1);
-            fargs.push_back(std::move(body));
-            std::copy(params.begin(), params.end(), std::back_inserter(fargs));
-
-            static std::string type("function");
-
-            return primitive_argument_type{
-                create_primitive_component(hpx::find_here(), type,
-                    std::move(fargs), extract_function_name(name_), codename_)};
-        }
-
-        fargs.reserve(operands_.size() - 1);
-        for (auto it = operands_.begin() + 1; it != operands_.end(); ++it)
-        {
-            fargs.push_back(value_operand_sync(*it, params, name_, codename_));
-        }
-        return value_operand_sync(body, std::move(fargs), name_, codename_);
     }
 
     primitive_argument_type wrapped_function::bind(

--- a/src/execution_tree/primitives/wrapped_variable.cpp
+++ b/src/execution_tree/primitives/wrapped_variable.cpp
@@ -31,7 +31,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     wrapped_variable::wrapped_variable(
             std::vector<primitive_argument_type>&& operands,
             std::string const& name, std::string const& codename)
-      : primitive_component_base(std::move(operands), name, codename)
+      : primitive_component_base(std::move(operands), name, codename, true)
     {
         if (operands_.size() != 1)
         {

--- a/src/performance_counters/register_counters.cpp
+++ b/src/performance_counters/register_counters.cpp
@@ -34,15 +34,14 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace performance_counters
 {
-    class primitive_counter
-      : public hpx::performance_counters::base_performance_counter<
-            primitive_counter>
+    namespace detail
     {
-        std::string extract_primitive_type()
+        std::string extract_primitive_type(
+            hpx::performance_counters::counter_info const& info)
         {
             hpx::performance_counters::counter_path_elements paths;
             hpx::performance_counters::get_counter_path_elements(
-                info_.fullname_, paths);
+                info.fullname_, paths);
 
             std::string result;
 
@@ -54,18 +53,22 @@ namespace phylanx { namespace performance_counters
             if (!success)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "primitive_counter::extract_primitive_type",
+                    "performance_counter::detail::extract_primitive_type",
                     "unexpected counter name");
             }
 
             return result;
         }
+    }
 
+    class primitive_counter
+      : public hpx::performance_counters::base_performance_counter<
+            primitive_counter>
+    {
     public:
         primitive_counter()
           : first_init_(false)
           , duration_counter_(false)
-          , direct_counts_(false)
         {}
 
         primitive_counter(hpx::performance_counters::counter_info const& info)
@@ -73,33 +76,30 @@ namespace phylanx { namespace performance_counters
                 primitive_counter>(info)
           , first_init_(false)
           , duration_counter_(false)
-          , direct_counts_(false)
         {
             hpx::performance_counters::counter_path_elements paths;
             hpx::performance_counters::get_counter_path_elements(
                 info.fullname_, paths);
             duration_counter_ =
                 paths.countername_.find("time") != std::string::npos;
-            direct_counts_ =
-                paths.countername_.find("direct") != std::string::npos;
         }
 
         // Produce the counter value
         hpx::performance_counters::counter_values_array
         get_counter_values_array(bool reset) override
         {
-            hpx::performance_counters::counter_values_array value;
-
-            value.time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
-            value.status_ = hpx::performance_counters::status_new_data;
-            value.count_ = ++invocation_count_;
-
             // Need to call reinit here if it has never been called before.
             bool expected = false;
             if (first_init_.compare_exchange_strong(expected, true))
             {
                 reinit(false);
             }
+
+            hpx::performance_counters::counter_values_array value;
+
+            value.time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
+            value.status_ = hpx::performance_counters::status_new_data;
+            value.count_ = ++invocation_count_;
 
             std::vector<std::int64_t> result;
             result.reserve(instances_.size());
@@ -109,13 +109,11 @@ namespace phylanx { namespace performance_counters
             {
                 if (duration_counter_)
                 {
-                    result.push_back(
-                        instance->get_eval_duration(reset, direct_counts_));
+                    result.push_back(instance->get_eval_duration(reset));
                 }
                 else
                 {
-                    result.push_back(
-                        instance->get_eval_count(reset, direct_counts_));
+                    result.push_back(instance->get_eval_count(reset));
                 }
             }
 
@@ -131,7 +129,7 @@ namespace phylanx { namespace performance_counters
             // Structure of primitives in symbolic namespace:
             //     /phylanx/<primitive>$<sequence-nr>[$<instance>]/<compile_id>$<tag>
             auto entries = hpx::agas::find_symbols(hpx::launch::sync,
-                "/phylanx/" + extract_primitive_type() + "$*");
+                "/phylanx/" + detail::extract_primitive_type(info_) + "$*");
 
             // TODO: Only keep entries that live on this locality.
             // This will be a problem when Phylanx becomes distributed.
@@ -151,9 +149,13 @@ namespace phylanx { namespace performance_counters
                 if (reset)
                 {
                     if (duration_counter_)
-                        instance->get_eval_duration(true, direct_counts_);
+                    {
+                        instance->get_eval_duration(true);
+                    }
                     else
-                        instance->get_eval_count(true, direct_counts_);
+                    {
+                        instance->get_eval_count(true);
+                    }
                 }
                 instances_sorted[instance_info.sequence_number] = instance;
             }
@@ -175,7 +177,6 @@ namespace phylanx { namespace performance_counters
         std::vector<base_primitive_ptr> instances_;
         std::atomic<bool> first_init_;
         bool duration_counter_;
-        bool direct_counts_;
     };
 
     hpx::naming::gid_type primitive_counter_creator(
@@ -215,6 +216,161 @@ namespace phylanx { namespace performance_counters
 
                 id = hpx::components::server::construct<primitive_counter_type>(
                     complemented_info);
+            }
+            catch (hpx::exception const& e)
+            {
+                if (&ec == &hpx::throws)
+                    throw;
+                ec = hpx::make_error_code(e.get_error(), e.what());
+                return hpx::naming::invalid_gid;
+            }
+
+            if (&ec != &hpx::throws)
+                ec = hpx::make_success_code();
+            return id;
+        }
+
+        HPX_THROWS_IF(ec,
+            hpx::bad_parameter,
+            "primitive_counter_creator",
+            "invalid counter instance name: " + paths.instancename_);
+        return hpx::naming::invalid_gid;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    class direct_execution_counter
+      : public hpx::performance_counters::base_performance_counter<
+            direct_execution_counter>
+    {
+    public:
+        direct_execution_counter()
+          : first_init_(false)
+        {}
+
+        direct_execution_counter(
+                hpx::performance_counters::counter_info const& info)
+          : hpx::performance_counters::base_performance_counter<
+                direct_execution_counter>(info)
+          , first_init_(false)
+        {}
+
+        // Produce the counter value
+        hpx::performance_counters::counter_values_array
+        get_counter_values_array(bool reset) override
+        {
+            // Need to call reinit here if it has never been called before.
+            bool expected = false;
+            if (first_init_.compare_exchange_strong(expected, true))
+            {
+                reinit(false);
+            }
+
+            hpx::performance_counters::counter_values_array value;
+
+            value.time_ = static_cast<std::int64_t>(hpx::get_system_uptime());
+            value.status_ = hpx::performance_counters::status_new_data;
+            value.count_ = ++invocation_count_;
+
+            std::vector<std::int64_t> result;
+            result.reserve(instances_.size());
+
+            // Extract the values from instances_
+            for (auto const& instance : instances_)
+            {
+                result.push_back(instance->get_direct_execution(reset));
+            }
+
+            value.values_ = std::move(result);
+
+            return value;
+        }
+
+        // Retrieve the list of existing primitives for the current execution
+        // tree and keep it
+        void reinit(bool reset) override
+        {
+            // Structure of primitives in symbolic namespace:
+            //     /phylanx/<primitive>$<sequence-nr>[$<instance>]/<compile_id>$<tag>
+            auto entries = hpx::agas::find_symbols(hpx::launch::sync,
+                "/phylanx/" + detail::extract_primitive_type(info_) + "$*");
+
+            // TODO: Only keep entries that live on this locality.
+            // This will be a problem when Phylanx becomes distributed.
+            std::map<std::int64_t, base_primitive_ptr> instances_sorted;
+
+            for (auto const& value : entries)
+            {
+                auto const& instance = hpx::get_ptr<
+                    phylanx::execution_tree::primitives::primitive_component>(
+                        hpx::launch::sync, value.second);
+
+                auto instance_info =
+                    phylanx::execution_tree::compiler::parse_primitive_name(
+                        value.first);
+
+                // Consider the reset flag
+                if (reset)
+                {
+                    instance->get_direct_execution(true);
+                }
+                instances_sorted[instance_info.sequence_number] = instance;
+            }
+
+            instances_.clear();
+            instances_.reserve(entries.size());
+            for (auto const& value : instances_sorted)
+            {
+                instances_.push_back(value.second);
+            }
+
+            first_init_ = true;
+        }
+
+    private:
+        using base_primitive_ptr = std::shared_ptr<
+            phylanx::execution_tree::primitives::primitive_component>;
+
+        std::vector<base_primitive_ptr> instances_;
+        std::atomic<bool> first_init_;
+    };
+
+    hpx::naming::gid_type direct_execution_counter_creator(
+        hpx::performance_counters::counter_info const& info,
+        hpx::error_code& ec)
+    {
+        namespace pc = hpx::performance_counters;
+
+        // Break down the counter name
+        pc::counter_path_elements paths;
+        pc::get_counter_path_elements(info.fullname_, paths, ec);
+        if (ec) return hpx::naming::invalid_gid;
+
+        // If another counter's name was give
+        if (paths.parentinstance_is_basename_)
+        {
+            HPX_THROWS_IF(ec,
+                hpx::bad_parameter,
+                "primitive_counter_creator",
+                "invalid counter instance parent name: " +
+                    paths.parentinstancename_);
+            return hpx::naming::invalid_gid;
+        }
+
+        if (paths.instancename_ == "total" && paths.instanceindex_ == -1)
+        {
+            pc::counter_info complemented_info = info;
+            pc::complement_counter_info(complemented_info, info, ec);
+            if (ec) return hpx::naming::invalid_gid;
+
+            hpx::naming::gid_type id;
+            try
+            {
+                // Try constructing the actual counter
+                using direct_execution_counter_type =
+                    hpx::components::component<direct_execution_counter>;
+
+                id = hpx::components::server::construct<
+                    direct_execution_counter_type>(complemented_info);
             }
             catch (hpx::exception const& e)
             {
@@ -277,7 +433,7 @@ namespace phylanx { namespace performance_counters
             std::string const& name =
                 hpx::util::get<0>(hpx::util::get<1>(pattern));
 
-            // Register a primitive time performance counters
+            // Register a primitive time performance counter
             hpx::performance_counters::install_counter_type(
                 "/phylanx/primitives/" + name + "/time/eval",
                 hpx::performance_counters::counter_raw_values,
@@ -288,17 +444,7 @@ namespace phylanx { namespace performance_counters
                 &hpx::performance_counters::locality_counter_discoverer,
                 HPX_PERFORMANCE_COUNTER_V1, "ns");
 
-            hpx::performance_counters::install_counter_type(
-                "/phylanx/primitives/" + name + "/time/eval_direct",
-                hpx::performance_counters::counter_raw_values,
-                "returns a list whose elements contain the total execution "
-                    "time of the eval_direct function for each " +
-                    name + " primitive",
-                &primitive_counter_creator,
-                &hpx::performance_counters::locality_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1, "ns");
-
-            // Register a primitive count performance counters
+            // Register a primitive count performance counter
             hpx::performance_counters::install_counter_type(
                 "/phylanx/primitives/" + name + "/count/eval",
                 hpx::performance_counters::counter_raw_values,
@@ -308,13 +454,14 @@ namespace phylanx { namespace performance_counters
                 &primitive_counter_creator,
                 &hpx::performance_counters::locality_counter_discoverer);
 
+            // Register a direct_execution performance counter
             hpx::performance_counters::install_counter_type(
-                "/phylanx/primitives/" + name + "/count/eval_direct",
+                "/phylanx/primitives/" + name + "/eval_direct",
                 hpx::performance_counters::counter_raw_values,
-                "returns a list whose elements contain the number of times "
-                    "the eval_direct function was called for each " +
-                    name + " primitive",
-                &primitive_counter_creator,
+                "returns a list whose elements contain whether "
+                    "the eval function for the " + name + " primitive "
+                    "was executed directly",
+                &direct_execution_counter_creator,
                 &hpx::performance_counters::locality_counter_discoverer);
         }
     }
@@ -344,3 +491,11 @@ using primitive_counter = phylanx::performance_counters::primitive_counter;
 
 HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
     primitive_counter_type, primitive_counter, "base_performance_counter");
+
+using direct_execution_type = hpx::components::component<
+    phylanx::performance_counters::direct_execution_counter>;
+using direct_execution_counter =
+    phylanx::performance_counters::direct_execution_counter;
+
+HPX_REGISTER_DERIVED_COMPONENT_FACTORY(
+    direct_execution_type, direct_execution_counter, "base_performance_counter");

--- a/tests/unit/execution_tree/primitives/shuffle_operation.cpp
+++ b/tests/unit/execution_tree/primitives/shuffle_operation.cpp
@@ -9,6 +9,7 @@
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/lcos.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <algorithm>
@@ -28,7 +29,8 @@ void test_shuffle_operation_1d()
             hpx::find_here(), phylanx::ir::node_data<double>(v1));
 
     phylanx::ir::node_data<double> v2_node =
-        phylanx::execution_tree::extract_numeric_value(lhs.eval_direct());
+        phylanx::execution_tree::extract_numeric_value(
+            lhs.eval(hpx::launch::sync));
     auto v2 = v2_node.vector();
 
     phylanx::execution_tree::primitive p =
@@ -71,7 +73,8 @@ void test_shuffle_operation_2d()
             hpx::find_here(), phylanx::ir::node_data<double>(m1));
 
     phylanx::ir::node_data<double> m2_node =
-        phylanx::execution_tree::extract_numeric_value(lhs.eval_direct());
+        phylanx::execution_tree::extract_numeric_value(
+            lhs.eval(hpx::launch::sync));
     auto m2 = m2_node.matrix(); // auto is CustomMatrix of with a lot of template args
 
     phylanx::execution_tree::primitive p =

--- a/tests/unit/performance_counters/primitive_counter.cpp
+++ b/tests/unit/performance_counters/primitive_counter.cpp
@@ -87,7 +87,8 @@ int main()
         {11.26, 19.83}, {13.71, 18.68}, {9.847, 15.68}, {8.571, 13.1 },
         {13.46, 18.75}, {12.34, 12.27}, {13.94, 13.17}, {12.07, 13.44}};
 
-    blaze::DynamicVector<double> const v2{1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0,
+    blaze::DynamicVector<double> const v2{
+        1, 0, 1, 0, 1, 1, 1, 1, 1, 0, 1, 1, 0, 1, 0,
         1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1};
 
     // Compile the given code
@@ -123,15 +124,9 @@ int main()
             "/phylanx{locality#0/total}/primitives/" + name + "/time/eval");
         hpx::performance_counters::performance_counter time_pc(time_pc_name);
 
-        std::string const direct_counter_pc_name(
-            "/phylanx{locality#0/total}/primitives/" + name + "/count/eval_direct");
-        hpx::performance_counters::performance_counter direct_counter_pc(
-            direct_counter_pc_name);
-
-        std::string const direct_time_pc_name(
-            "/phylanx{locality#0/total}/primitives/" + name + "/time/eval_direct");
-        hpx::performance_counters::performance_counter direct_time_pc(
-            direct_time_pc_name);
+        std::string const eval_pc_name(
+            "/phylanx{locality#0/total}/primitives/" + name + "/eval_direct");
+        hpx::performance_counters::performance_counter eval_pc(eval_pc_name);
 
         // Verify the number of primitive instances in lra
         auto entries = hpx::agas::find_symbols(
@@ -151,22 +146,10 @@ int main()
             HPX_TEST_EQ(values.count_, 1ll);
             HPX_TEST_EQ(values.values_.size(), entries.size());
 
-            auto const direct_info = direct_time_pc.get_info(hpx::launch::sync);
-            HPX_TEST_EQ(direct_info.fullname_, direct_time_pc_name);
-            HPX_TEST_EQ(direct_info.type_,
-                hpx::performance_counters::counter_raw_values);
-
-            auto const direct_values = direct_time_pc.get_counter_values_array(
-                hpx::launch::sync, false);
-
-            HPX_TEST_EQ(direct_values.count_, 1ll);
-            HPX_TEST_EQ(direct_values.values_.size(), entries.size());
-
             // At least one of the values for each primitive should be non-zero
             for (std::size_t i = 0; i != values.values_.size(); ++i)
             {
-                HPX_TEST(values.values_[i] != 0ll ||
-                    direct_values.values_[i] != 0ll);
+                HPX_TEST(values.values_[i] != 0ll);
             }
         }
 
@@ -183,22 +166,31 @@ int main()
             HPX_TEST_EQ(values.count_, 1ll);
             HPX_TEST_EQ(values.values_.size(), entries.size());
 
-            auto const direct_info = direct_counter_pc.get_info(hpx::launch::sync);
-            HPX_TEST_EQ(direct_info.fullname_, direct_counter_pc_name);
-            HPX_TEST_EQ(direct_info.type_,
-                hpx::performance_counters::counter_raw_values);
-
-            auto const direct_values = direct_counter_pc.get_counter_values_array(
-                hpx::launch::sync, false);
-
-            HPX_TEST_EQ(direct_values.count_, 1ll);
-            HPX_TEST_EQ(direct_values.values_.size(), entries.size());
-
             // At least one of the values for each primitive should be non-zero
             for (std::size_t i = 0; i != values.values_.size(); ++i)
             {
-                HPX_TEST(values.values_[i] != 0ll ||
-                    direct_values.values_[i] != 0ll);
+                HPX_TEST(values.values_[i] != 0ll);
+            }
+        }
+
+        // Eval-direct performance counters
+        {
+            auto const info = eval_pc.get_info(hpx::launch::sync);
+            HPX_TEST_EQ(info.fullname_, eval_pc_name);
+            HPX_TEST_EQ(
+                info.type_, hpx::performance_counters::counter_raw_values);
+
+            auto const values =
+                eval_pc.get_counter_values_array(hpx::launch::sync, false);
+
+            HPX_TEST_EQ(values.count_, 1ll);
+            HPX_TEST_EQ(values.values_.size(), entries.size());
+
+            // all values should be '0' or '1'
+            for (std::size_t i = 0; i != values.values_.size(); ++i)
+            {
+                HPX_TEST(values.values_[i] == -1 || values.values_[i] == 0 ||
+                    values.values_[i] == 1);
             }
         }
     }

--- a/tests/unit/util/performance_data.cpp
+++ b/tests/unit/util/performance_data.cpp
@@ -42,50 +42,51 @@ char const* const fib_code = R"(block(
     fib_test
 ))";
 
-std::map<std::string, std::vector<std::size_t>> expected_counts =
+std::map<std::string, std::size_t> expected_counts =
 {
-    { "access-variable$0", { 9, 0, } },
-    { "access-variable$1", { 0, 0, } },
-    { "access-variable$2", { 8, 0, } },
-    { "access-variable$3", { 8, 0, } },
-    { "access-variable$4", { 0, 0, } },
-    { "access-variable$5", { 8, 0, } },
-    { "access-variable$6", { 0, 0, } },
-    { "access-variable$7", { 8, 0, } },
-    { "access-variable$8", { 0, 0, } },
-    { "access-variable$9", { 8, 0, } },
-    { "access-variable$10", { 0, 0, } },
-    { "access-variable$11", { 8, 0, } },
-    { "access-variable$12", { 1, 0, } },
-    { "access-variable$13", { 1, 0, } },
-    { "__add$0", { 8, 0, } },
-    { "__add$1", { 8, 0, } },
-    { "block$0", { 0, 1, } },
-    { "block$1", { 0, 1, } },
-    { "block$2", { 8, 0, } },
-    { "define-variable$0", { 2, 0, } },
-    { "define-variable$1", { 9, 0, } },
-    { "define-variable$2", { 10, 0, } },
-    { "define-variable$3", { 17, 0, } },
-    { "define-variable$4", { 9, 0, } },
-    { "define-variable$5", { 18, 0, } },
-    { "__lt$0", { 9, 0, } },
-    { "store$0", { 8, 0, } },
-    { "store$1", { 8, 0, } },
-    { "store$2", { 8, 0, } },
-    { "store$3", { 8, 0, } },
-    { "store$4", { 8, 0, } },
-    { "while$0", { 1, 0, } },
-    { "variable$0", { 0, 2, } },
-    { "variable$1", { 0, 9, } },
-    { "variable$2", { 0, 10, } },
-    { "variable$3", { 0, 17, } },
-    { "variable$4", { 0, 9, } },
-    { "variable$5", { 0, 18, } },
+    { "access-variable$0", 9 },
+    { "access-variable$1", 0 },
+    { "access-variable$2", 8 },
+    { "access-variable$3", 8 },
+    { "access-variable$4", 0 },
+    { "access-variable$5", 8 },
+    { "access-variable$6", 0 },
+    { "access-variable$7", 8 },
+    { "access-variable$8", 0 },
+    { "access-variable$9", 8 },
+    { "access-variable$10", 0 },
+    { "access-variable$11", 8 },
+    { "access-variable$12", 1 },
+    { "access-variable$13", 1 },
+    { "__add$0", 8 },
+    { "__add$1", 8 },
+    { "block$0", 1 },
+    { "block$1", 1 },
+    { "block$2", 8 },
+    { "define-variable$0", 2 },
+    { "define-variable$1", 9 },
+    { "define-variable$2", 10 },
+    { "define-variable$3", 17 },
+    { "define-variable$4", 9 },
+    { "define-variable$5", 18 },
+    { "__lt$0", 9 },
+    { "store$0", 8 },
+    { "store$1", 8 },
+    { "store$2", 8 },
+    { "store$3", 8 },
+    { "store$4", 8 },
+    { "while$0", 1 },
+    { "variable$0", 2 },
+    { "variable$1", 9 },
+    { "variable$2", 10 },
+    { "variable$3", 17 },
+    { "variable$4", 9 },
+    { "variable$5", 18 },
 };
 
 const std::vector<std::string> performance_counter_name_last_part{
-    "count/eval", "time/eval", "count/eval_direct", "time/eval_direct"};
+    "count/eval", "time/eval", "eval_direct"
+};
 
 int main()
 {
@@ -119,14 +120,14 @@ int main()
 
         std::string const expected_key(
             tags.primitive + "$" + std::to_string(tags.sequence_number));
-        auto const& expected_values = expected_counts[expected_key];
+        auto expected_value = expected_counts[expected_key];
 
         HPX_TEST_EQ(
             entry.second.size(), performance_counter_name_last_part.size());
-        HPX_TEST_EQ(entry.second[0], expected_values[0]);
-        HPX_TEST_EQ(entry.second[1] != 0, expected_values[0] != 0);
-        HPX_TEST_EQ(entry.second[2], expected_values[1]);
-        HPX_TEST_EQ(entry.second[3] != 0, expected_values[1] != 0);
+        HPX_TEST_EQ(entry.second[0], expected_value);
+        HPX_TEST_EQ(entry.second[1] != 0, expected_value != 0);
+        HPX_TEST(entry.second[2] == -1 || entry.second[2] == 0 ||
+            entry.second[2] == 1);
     }
 
     return hpx::util::report_errors();


### PR DESCRIPTION
- This is adding runtime adaptive switching between direct or
  asynchronous execution of `primitive::eval`.
- Removing the performance counters that were reporting data from
  direct evaluation
- Adding performance counter `/phylanx/primitives/<name>/eval_direct`

To be functional, this PR also requires for
https://github.com/STEllAR-GROUP/hpx/pull/3254 to be merged first.