### PR TITLE
Redirecting all std::cout output to Python's stdout

### DIFF
--- a/python/src/bindings/ast.cpp
+++ b/python/src/bindings/ast.cpp
@@ -255,7 +255,9 @@ void phylanx::bindings::bind_ast(pybind11::module m)
     ///////////////////////////////////////////////////////////////////////////
     // phylanx::ast::generate_ast()
     ast.def("generate_ast",
-        [](std::string const& code) {
+        [](std::string const& code)
+        {
+            pybind11::gil_scoped_release release;       // release GIL
             return phylanx::ast::generate_ast(code);
         },
         "generate an AST from the given expression string");

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -63,6 +63,8 @@ namespace phylanx { namespace bindings
         template <typename Ast>
         bool on_enter(Ast const& ast) const
         {
+            pybind11::gil_scoped_acquire acquire;       // acquire GIL
+
             auto d =
                 func_.attr("__class__").attr("__dict__").cast<pybind11::dict>();
             if (d.contains("on_enter"))
@@ -78,6 +80,8 @@ namespace phylanx { namespace bindings
         template <typename Ast>
         bool on_exit(Ast const& ast) const
         {
+            pybind11::gil_scoped_acquire acquire;       // acquire GIL
+
             auto d =
                 func_.attr("__class__").attr("__dict__").cast<pybind11::dict>();
             if (d.contains("on_exit"))
@@ -98,6 +102,7 @@ namespace phylanx { namespace bindings
     bool traverse(Ast const& ast, pybind11::object func, pybind11::args args,
         pybind11::kwargs kwargs)
     {
+        pybind11::gil_scoped_release release;       // release GIL
         return phylanx::ast::traverse(ast, traverse_helper{func, args, kwargs});
     }
 
@@ -105,6 +110,7 @@ namespace phylanx { namespace bindings
     template <typename Ast>
     std::vector<char> serialize(Ast const& ast)
     {
+        pybind11::gil_scoped_release release;       // release GIL
         return phylanx::util::serialize(ast);
     }
 
@@ -132,12 +138,15 @@ namespace phylanx { namespace bindings
     template <typename Ast>
     std::vector<char> pickle_helper(Ast const& ast)
     {
+        pybind11::gil_scoped_release release;       // release GIL
         return phylanx::util::serialize(ast);
     }
 
     template <typename Ast>
     Ast unpickle_helper(std::vector<char> data)
     {
+        pybind11::gil_scoped_release release;       // release GIL
+
         Ast ast;
         phylanx::util::detail::unserialize(data, ast);
         return ast;

--- a/python/src/bindings/ostream.hpp
+++ b/python/src/bindings/ostream.hpp
@@ -1,0 +1,114 @@
+//  Copyright (c) 2016-2018 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_BINDING_HELPERS_OSTREAM_HPP)
+#define PHYLANX_BINDING_HELPERS_OSTREAM_HPP
+
+#include <phylanx/config.hpp>
+
+#include <pybind11/pybind11.h>
+
+#include <cstddef>
+#include <iostream>
+#include <utility>
+
+namespace phylanx { namespace bindings
+{
+    class pythonbuf : public std::streambuf
+    {
+    private:
+        using traits_type = std::streambuf::traits_type;
+
+        char d_buffer[1024];
+        pybind11::object pywrite;
+        pybind11::object pyflush;
+
+        int overflow(int c) override
+        {
+            if (!traits_type::eq_int_type(c, traits_type::eof()))
+            {
+                *pptr() = traits_type::to_char_type(c);
+                pbump(1);
+            }
+            return sync() ? traits_type::not_eof(c) : traits_type::eof();
+        }
+
+        int sync() override
+        {
+            if (pbase() != pptr())
+            {
+                // acquire GIL to avoid multi-threading problems
+                pybind11::gil_scoped_acquire acquire;
+
+                // This subtraction cannot be negative, so dropping the sign
+                pybind11::str line(
+                    pbase(), static_cast<std::size_t>(pptr() - pbase()));
+
+                pywrite(line);
+                pyflush();
+
+                setp(pbase(), epptr());
+            }
+            return 0;
+        }
+
+    public:
+        pythonbuf(pybind11::object pyostream)
+        {
+            {
+                // acquire GIL to avoid multi-threading problems
+                pybind11::gil_scoped_acquire acquire;
+                pybind11::object tmp = std::move(pyostream);
+                pywrite = tmp.attr("write");
+                pyflush = tmp.attr("flush");
+            }
+
+            setp(d_buffer, d_buffer + sizeof(d_buffer) - 1);
+        }
+
+        /// Sync before destroy
+        ~pythonbuf()
+        {
+            sync();
+        }
+    };
+
+    class scoped_ostream_redirect
+    {
+    protected:
+        std::streambuf* old;
+        std::ostream& costream;
+        pythonbuf buffer;
+
+        static pybind11::object import_stdout()
+        {
+            pybind11::gil_scoped_acquire acquire;
+            return pybind11::module::import("sys").attr("stdout");
+        }
+
+    public:
+        scoped_ostream_redirect(std::ostream& costream = std::cout,
+                pybind11::object pyostream = import_stdout())
+          : costream(costream)
+          , buffer(std::move(pyostream))
+        {
+            old = costream.rdbuf(&buffer);
+        }
+
+        ~scoped_ostream_redirect()
+        {
+            costream.rdbuf(old);
+        }
+
+        scoped_ostream_redirect(const scoped_ostream_redirect&) = delete;
+        scoped_ostream_redirect(scoped_ostream_redirect&& other) = default;
+        scoped_ostream_redirect& operator=(
+            const scoped_ostream_redirect&) = delete;
+        scoped_ostream_redirect& operator=(scoped_ostream_redirect&&) = delete;
+    };
+}}
+
+#endif
+


### PR DESCRIPTION
This addresses part of #250