### PR TITLE
Fixing the numbers reported as copy/move-construction/assignment counts

### DIFF
--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -113,6 +113,8 @@ namespace phylanx { namespace ir
         static std::int64_t copy_assignment_count(bool reset);
         static std::int64_t move_assignment_count(bool reset);
 
+        static bool enable_counts(bool enable);
+
     public:
         constexpr static std::size_t const max_dimensions = 2;
 
@@ -328,6 +330,21 @@ namespace phylanx { namespace ir
 
         storage_type data_;
         /// \endcond
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    struct reset_enable_counts_on_exit
+    {
+        reset_enable_counts_on_exit(bool enabled = false)
+          : enabled_(node_data<double>::enable_counts(enabled))
+        {}
+
+        ~reset_enable_counts_on_exit()
+        {
+            node_data<double>::enable_counts(enabled_);
+        }
+
+        bool enabled_;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/ast/generate_ast.cpp
+++ b/src/ast/generate_ast.cpp
@@ -211,6 +211,8 @@ namespace phylanx { namespace ast
     ///////////////////////////////////////////////////////////////////////////
     std::vector<ast::expression> generate_ast(std::string const& input)
     {
+        ir::reset_enable_counts_on_exit on_exit;
+
         using iterator = std::string::const_iterator;
 
         iterator first = input.begin();

--- a/src/ast/generate_transform_rules.cpp
+++ b/src/ast/generate_transform_rules.cpp
@@ -28,6 +28,8 @@ namespace phylanx { namespace ast
     std::vector<ast::transform_rule> generate_transform_rules(
         std::string const& input)
     {
+        ir::reset_enable_counts_on_exit on_exit;
+
         using iterator = std::string::const_iterator;
 
         iterator first = input.begin();

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -29,29 +29,40 @@ namespace phylanx { namespace ir
     static std::atomic<std::int64_t> count_move_constructions_;
     static std::atomic<std::int64_t> count_copy_assignments_;
     static std::atomic<std::int64_t> count_move_assignments_;
+    static std::atomic<bool> enable_counts_;
 
     template <typename T>
     void node_data<T>::increment_copy_construction_count()
     {
-        ++count_copy_constructions_;
+        if (enable_counts_.load(std::memory_order_relaxed))
+            ++count_copy_constructions_;
     }
 
     template <typename T>
     void node_data<T>::increment_move_construction_count()
     {
-        ++count_move_constructions_;
+        if (enable_counts_.load(std::memory_order_relaxed))
+            ++count_move_constructions_;
     }
 
     template <typename T>
     void node_data<T>::increment_copy_assignment_count()
     {
-        ++count_copy_assignments_;
+        if (enable_counts_.load(std::memory_order_relaxed))
+            ++count_copy_assignments_;
     }
 
     template <typename T>
     void node_data<T>::increment_move_assignment_count()
     {
-        ++count_move_assignments_;
+        if (enable_counts_.load(std::memory_order_relaxed))
+            ++count_move_assignments_;
+    }
+
+    template <typename T>
+    bool node_data<T>::enable_counts(bool enable)
+    {
+        return enable_counts_.exchange(enable, std::memory_order_relaxed);
     }
 
     template <typename T>


### PR DESCRIPTION
- this disables the counters during parsing of PhySL expressions