### PR TITLE
Fixing `shape(x, 0)` for x being one-dimensional

### DIFF
--- a/phylanx/execution_tree/primitives/unary_minus_operation.hpp
+++ b/phylanx/execution_tree/primitives/unary_minus_operation.hpp
@@ -29,8 +29,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hpx::future<primitive_argument_type> eval(
             std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args,
-            std::string const& name, std::string const& codename) const;
+            std::vector<primitive_argument_type> const& args) const;
 
     public:
         static match_pattern_type const match_data;
@@ -44,9 +43,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::vector<primitive_argument_type> const& params) const override;
 
     private:
-        primitive_argument_type neg0d(operands_type&& ops) const;
-        primitive_argument_type neg1d(operands_type&& ops) const;
-        primitive_argument_type neg2d(operands_type&& ops) const;
+        primitive_argument_type neg0d(operand_type&& op) const;
+        primitive_argument_type neg1d(operand_type&& op) const;
+        primitive_argument_type neg2d(operand_type&& op) const;
     };
 
     PHYLANX_EXPORT primitive create_unary_minus_operation(

--- a/src/execution_tree/primitives/extract_shape.cpp
+++ b/src/execution_tree/primitives/extract_shape.cpp
@@ -56,7 +56,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "extract_shape::eval",
-            "index out of range");
+            execution_tree::generate_error_message(
+                "index out of range", name_, codename_));
     }
 
     primitive_argument_type extract_shape::shape1d(args_type&& args) const
@@ -67,10 +68,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 primitive_argument_type{std::int64_t(args[0].size())}};
             return primitive_argument_type{std::move(result)};
         }
+        else if (args[1][0] == 0)
+        {
+            return primitive_argument_type{std::int64_t(args[0].size())};
+        }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "extract_shape::eval",
-            "index out of range");
+            execution_tree::generate_error_message(
+                "index out of range", name_, codename_));
     }
 
     primitive_argument_type extract_shape::shape2d(args_type&& args) const
@@ -99,8 +105,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "extract_shape::eval",
                 execution_tree::generate_error_message(
-                    "the extract_shape primitive requires one or two "
-                        "operands",
+                    "the extract_shape primitive requires one or two operands",
                     name_, codename_));
         }
 
@@ -125,10 +130,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                 case 0:
                     return this_->shape0d(std::move(args));
+
                 case 1:
                     return this_->shape1d(std::move(args));
+
                 case 2:
                     return this_->shape2d(std::move(args));
+
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "extract_shape::eval",

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -14,6 +14,7 @@ set(tests
     negative_integral_value_131
     no_integers_313
     out_of_scope_variable_232
+    shape1d_357
     support_nil_314
     vector_of_variables_244
    )

--- a/tests/regressions/execution_tree/shape1d_357.cpp
+++ b/tests/regressions/execution_tree/shape1d_357.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Fixing #278: Python to PhySL Translation generates empty block #278
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+void test_0d()
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile("shape(1)", snippets);
+
+    auto list = phylanx::execution_tree::extract_list_value(f());
+    HPX_TEST_EQ(list.size(), std::int64_t(0));
+}
+
+void test_1d()
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(
+        "shape([1, 2, 3, 4], 0)", snippets);
+
+    auto list = phylanx::execution_tree::extract_list_value(f());
+    HPX_TEST_EQ(list.size(), std::int64_t(1));
+    HPX_TEST_EQ(*list.begin(), std::size_t(4));
+}
+
+void test_1d_axis()
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(
+        "shape([1, 2, 3, 4], 0)", snippets);
+
+    auto result = f();
+    HPX_TEST_EQ(phylanx::execution_tree::extract_integer_value(result),
+        std::int64_t(4));
+}
+
+void test_2d()
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(
+        "shape([[1, 2, 3, 4], [1, 2, 3, 4]])", snippets);
+
+    auto list = phylanx::execution_tree::extract_list_value(f());
+    HPX_TEST_EQ(list.size(), std::int64_t(2));
+    auto it = list.begin();
+    HPX_TEST_EQ(*it++, std::size_t(2));
+    HPX_TEST_EQ(*it++, std::size_t(4));
+}
+
+void test_2d_x()
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(
+        "shape([[1, 2, 3, 4], [1, 2, 3, 4]], 0)", snippets);
+
+    auto result = f();
+    HPX_TEST_EQ(phylanx::execution_tree::extract_integer_value(result),
+        std::int64_t(2));
+}
+
+void test_2d_y()
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto f = phylanx::execution_tree::compile(
+        "shape([[1, 2, 3, 4], [1, 2, 3, 4]], 1)", snippets);
+
+    auto result = f();
+    HPX_TEST_EQ(phylanx::execution_tree::extract_integer_value(result),
+        std::int64_t(4));
+}
+
+int main(int argc, char* argv[])
+{
+    test_0d();
+
+    test_1d();
+    test_1d_axis();
+
+    test_2d();
+    test_2d_x();
+    test_2d_y();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- flyby: optimize unary_minus primitive