### PR TITLE
Fixing exception handling for Python bindings

### DIFF
--- a/python/src/init_hpx.cpp
+++ b/python/src/init_hpx.cpp
@@ -267,14 +267,21 @@ manage_global_runtime* rts = nullptr;
 void init_hpx_runtime()
 {
     if (rts == nullptr)
+    {
+        pybind11::gil_scoped_release release;
         rts = new manage_global_runtime;
+    }
 }
 
 void stop_hpx_runtime()
 {
     manage_global_runtime* r = rts;
     rts = nullptr;
-    delete r;
+    if (r != nullptr)
+    {
+        pybind11::gil_scoped_release release;
+        delete r;
+    }
 }
 
 }}

--- a/tests/regressions/CMakeLists.txt
+++ b/tests/regressions/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(subdirs
     ast
     execution_tree
+    python
    )
 
 foreach(subdir ${subdirs})

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -1,10 +1,10 @@
-# Copyright (c) 2017-2018 Hartmut Kaiser
+# Copyright (c) 2017 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    version
+    exception_swallowed_369
    )
 
 foreach(test ${tests})
@@ -12,27 +12,15 @@ foreach(test ${tests})
 
   add_phylanx_python_unit_test("python" ${test}
     SCRIPT ${script}
-    FOLDER "Tests/Python/Unit"
+    FOLDER "Tests/Python/Regression"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
     ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
 
-  add_phylanx_pseudo_target(tests.unit.python.${test}_py)
+  add_phylanx_pseudo_target(tests.regressions.python_dir.${test}_py)
   add_phylanx_pseudo_dependencies(
-    tests.unit.python tests.unit.python.${test}_py)
+    tests.regressions.python_dir tests.regressions.python_dir.${test}_py)
   add_phylanx_pseudo_dependencies(
-    tests.unit.python.${test}_py ${test}_test_py)
+    tests.regressions.python_dir.${test}_py ${test}_test_py)
 
 endforeach()
-
-set(subdirs
-    ast
-    execution_tree
-   )
-
-foreach(subdir ${subdirs})
-  add_phylanx_pseudo_target(tests.unit.python_${subdir})
-  add_subdirectory(${subdir})
-  add_phylanx_pseudo_dependencies(tests.unit.python tests.unit.python_${subdir})
-endforeach()
-

--- a/tests/regressions/python/exception_swallowed_369.py
+++ b/tests/regressions/python/exception_swallowed_369.py
@@ -1,0 +1,29 @@
+#  Copyright (c) 2018 Steven R. Brandt
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx.ast import *
+
+
+@Phylanx()
+def addem(a, b):
+    c = a + b
+    print('c=', c)
+    return c
+
+
+exception_thrown = False
+try:
+    print('addem=(', addem(np.zeros((2,)), np.zeros((2, 1))), ')')
+
+except Exception as e:
+    expected = \
+        '<unknown>: __add$0/0$11$8:: vector size does not match number of ' + \
+        'matrix columns: HPX(bad_parameter)'
+    assert(str(e) == expected)
+    exception_thrown = True
+
+
+assert(exception_thrown)

--- a/tests/regressions/python/exception_swallowed_369.py
+++ b/tests/regressions/python/exception_swallowed_369.py
@@ -20,7 +20,7 @@ try:
 
 except Exception as e:
     expected = \
-        '<unknown>: __add$0/0$11$8:: vector size does not match number of ' + \
+        '<unknown>: __add$0/0$12$8:: vector size does not match number of ' + \
         'matrix columns: HPX(bad_parameter)'
     assert(str(e) == expected)
     exception_thrown = True

--- a/tests/unit/python/version.py
+++ b/tests/unit/python/version.py
@@ -3,12 +3,7 @@
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-try:
-    # first try release version
-    import phylanx
-except Exception:
-    # then try debug version
-    import phylanxd as phylanx
+import phylanx
 
 assert (phylanx.major_version() == 0)
 assert (phylanx.minor_version() == 0)


### PR DESCRIPTION
- flyby: adding version.py to tests

This requires for https://github.com/STEllAR-GROUP/hpx/pull/3305 to be merged first