### PR TITLE
Support escaped strings & chars represented in hex

### DIFF
--- a/phylanx/ast/parser/expression.hpp
+++ b/phylanx/ast/parser/expression.hpp
@@ -69,6 +69,7 @@ namespace phylanx { namespace ast { namespace parser
         qi::symbols<char, ast::optoken> unary_op;
         qi::symbols<char, ast::optoken> binary_op;
         qi::symbols<char> keywords;
+        qi::symbols<char const, char const> unesc_char;
     };
 
     template <typename Iterator>

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -46,6 +46,7 @@ namespace phylanx { namespace ast { namespace parser
         qi::bool_type bool_;
         qi::int_parser<std::int64_t> long_long;
         qi::attr_type attr;
+        qi::hex_type hex;
 
         using qi::on_error;
         using qi::on_success;
@@ -84,6 +85,19 @@ namespace phylanx { namespace ast { namespace parser
         keywords.add
             ("true")
             ("false")
+            ;
+
+        unesc_char.add
+            ("\\a", '\a')   // \a is alert
+            ("\\b", '\b')   // \b is backspace
+            ("\\f", '\f')   // \f is form feed
+            ("\\n", '\n')   // \n is linefeed
+            ("\\r", '\r')   // \r is carriage return
+            ("\\t", '\t')   // \t is tab
+            ("\\v", '\v')   // \v is vertical tab
+            ("\\\\", '\\')  // \\ is backslash
+            ("\\\'", '\'')  // \' is '
+            ("\\\"", '"')   // \" is "
             ;
 
         ///////////////////////////////////////////////////////////////////////
@@ -140,7 +154,7 @@ namespace phylanx { namespace ast { namespace parser
             >>  raw[lexeme[(alpha | '_') >> *(alnum | '_')]]
             ;
 
-        string = lexeme['"' > raw[*(char_ - '"')] > '"']
+        string = lexeme['"' > *(unesc_char | "\\x" >> hex | (char_ - '"')) > '"']
             ;
 
         ///////////////////////////////////////////////////////////////////////

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -46,7 +46,7 @@ namespace phylanx { namespace ast { namespace parser
         qi::bool_type bool_;
         qi::int_parser<std::int64_t> long_long;
         qi::attr_type attr;
-        qi::hex_type hex;
+        qi::uint_parser<unsigned char, 16, 1, 2> hex;
 
         using qi::on_error;
         using qi::on_success;

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -216,8 +216,8 @@ int main(int argc, char* argv[])
     );
 
     test_expression(
-        "\"string\\x20to\\x20unescape\\x3a\\x20\\n\\r\\t\\\"\\'\\x41\"",
-        "string to unescape\x3a \n\r\t\"\'\x41\n"
+        "\"string\\x20to\\x200unescape\\x3a\\x20\\n\\r\\t\\\"\\'\\x41\"",
+        "string to 0unescape\x3a \n\r\t\"\'\x41\n"
     );
 
     test_expression(

--- a/tests/unit/ast/generate_ast.cpp
+++ b/tests/unit/ast/generate_ast.cpp
@@ -216,6 +216,11 @@ int main(int argc, char* argv[])
     );
 
     test_expression(
+        "\"string\\x20to\\x20unescape\\x3a\\x20\\n\\r\\t\\\"\\'\\x41\"",
+        "string to unescape\x3a \n\r\t\"\'\x41\n"
+    );
+
+    test_expression(
         "'(true, 1, 1.0, A, A + B)",
             "true\n"
             "1\n"


### PR DESCRIPTION
This PR adds support for escaped strings and characters written in `\x<id>` format to PhySL.
e.g.
Code:
```scheme
cout("answer\x20=\n\"\n\t42\n\"")
```
Output:
```
answer =
"
	42
"

```

### Escaped symbols
Character | Meaning
--------- | ---------------
`\a`      | Alert
`\b`      | Backspace
`\f`      | Form Feed
`\n`      | Linefeed
`\r`      | Carriage Return
`\t`      | Tab
`\v`      | Vertical Tab
`\\`      | `\`
`\'`      | `'`
`\"`      | `"`