### PR TITLE
Expose AST serialization utilities to Python.

### DIFF
--- a/python/src/bindings/util.cpp
+++ b/python/src/bindings/util.cpp
@@ -39,16 +39,22 @@ void phylanx::bindings::bind_util(pybind11::module m)
     util.def("serialize", &phylanx::bindings::serialize<phylanx::ast::expression>,
         "serialize an AST expression object into a byte-stream");
     util.def("serialize", &phylanx::bindings::serialize<phylanx::ast::function_call>,
-        "serialize an AST expression object into a byte-stream");
-
+        "serialize an AST function_call object into a byte-stream");
+    util.def("serialize",
+        &phylanx::bindings::serialize<phylanx::ast::literal_value_type>,
+        "serialize an AST literal_value_type object into a byte-stream");
+    util.def("serialize",
+        &phylanx::bindings::serialize<std::vector<phylanx::ast::expression>>,
+        "serialize a vector of AST expressions into a byte-stream");
     util.def("serialize",
         &phylanx::bindings::serialize<phylanx::ir::node_data<double>>,
         "serialize a node_data<double> expression object into a byte-stream");
     util.def("serialize",
         &phylanx::bindings::serialize<phylanx::ir::node_data<std::uint8_t>>,
-        "serialize a node_data<std::uint8_t> expression object into a "
-        "byte-stream");
+        "serialize a node_data<std::uint8_t> expression object into a byte-stream");
 
+    util.def("unserialize", &phylanx::util::unserialize<std::vector<phylanx::ast::expression>>,
+        "un-serialize a byte-stream into a Phylanx object");
     util.def("unserialize", &phylanx::util::unserialize<phylanx::ast::expression>,
         "un-serialize a byte-stream into a Phylanx object");
 }

--- a/python/src/bindings/util.cpp
+++ b/python/src/bindings/util.cpp
@@ -57,6 +57,6 @@ void phylanx::bindings::bind_util(pybind11::module m)
     util.def("unserialize",
         &phylanx::util::unserialize<std::vector<phylanx::ast::expression>>,
         "un-serialize a byte-stream into a Phylanx object");
-    util.def("unserialize", &phylanx::util::unserialize<phylanx::ast::expression>,
+    util.def("unserialize_expr", &phylanx::util::unserialize<phylanx::ast::expression>,
         "un-serialize a byte-stream into a Phylanx object");
 }

--- a/python/src/bindings/util.cpp
+++ b/python/src/bindings/util.cpp
@@ -15,6 +15,7 @@
 #include <pybind11/pybind11.h>
 
 #include <cstdint>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 // expose util submodule
@@ -53,7 +54,8 @@ void phylanx::bindings::bind_util(pybind11::module m)
         &phylanx::bindings::serialize<phylanx::ir::node_data<std::uint8_t>>,
         "serialize a node_data<std::uint8_t> expression object into a byte-stream");
 
-    util.def("unserialize", &phylanx::util::unserialize<std::vector<phylanx::ast::expression>>,
+    util.def("unserialize",
+        &phylanx::util::unserialize<std::vector<phylanx::ast::expression>>,
         "un-serialize a byte-stream into a Phylanx object");
     util.def("unserialize", &phylanx::util::unserialize<phylanx::ast::expression>,
         "un-serialize a byte-stream into a Phylanx object");

--- a/tests/unit/python/CMakeLists.txt
+++ b/tests/unit/python/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(subdirs
     ast
     execution_tree
+    util
    )
 
 foreach(subdir ${subdirs})

--- a/tests/unit/python/ast/node.py
+++ b/tests/unit/python/ast/node.py
@@ -12,7 +12,7 @@ import phylanx.util as util
 
 def test_serialization(in_ast):
     data = util.serialize(in_ast)
-    out_ast = util.unserialize(data)
+    out_ast = util.unserialize_expr(data)
     assert (in_ast == out_ast)
 
     import pickle

--- a/tests/unit/python/util/CMakeLists.txt
+++ b/tests/unit/python/util/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) 2018 R. Tohid
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    serialization_ast
+   )
+
+foreach(test ${tests})
+  set(script ${test}.py)
+
+  add_phylanx_python_unit_test("util" ${test}
+    SCRIPT ${script}
+    FOLDER "Tests/Python/Unit/Util"
+    DEPENDS phylanx_py python_setup
+    WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+
+  add_phylanx_pseudo_target(tests.unit.python_util.${test}_py)
+  add_phylanx_pseudo_dependencies(tests.unit.python_util tests.unit.python_util.${test}_py)
+  add_phylanx_pseudo_dependencies(tests.unit.python_util.${test}_py ${test}_test_py)
+
+endforeach()
+

--- a/tests/unit/python/util/serialization_ast.py
+++ b/tests/unit/python/util/serialization_ast.py
@@ -6,10 +6,12 @@
 import phylanx
 from phylanx.ast import *
 
+
 @Phylanx("PhySL")
 def foo(a):
     a += 2
     return a
+
 
 foo_ast = generate_ast(foo.__src__)
 foo_serialized = phylanx.util.serialize(foo_ast)

--- a/tests/unit/python/util/serialization_ast.py
+++ b/tests/unit/python/util/serialization_ast.py
@@ -1,0 +1,17 @@
+#  Copyright (c) 2018 R. Tohid
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import phylanx
+from phylanx.ast import *
+
+@Phylanx("PhySL")
+def foo(a):
+    a += 2
+    return a
+
+foo_ast = generate_ast(foo.__src__)
+foo_serialized = phylanx.util.serialize(foo_ast)
+foo_unserialized = phylanx.util.unserialize(foo_serialized)
+assert foo_ast == foo_unserialized

--- a/tests/unit/python/util/serialization_ast.py
+++ b/tests/unit/python/util/serialization_ast.py
@@ -4,16 +4,30 @@
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 import phylanx
-from phylanx.ast import *
+
+###############################################################################
 
 
-@Phylanx("PhySL")
-def foo(a):
-    a += 2
-    return a
+def test_list():
+    expr_ast = phylanx.ast.generate_ast('A+B')
+    expr_serialized = phylanx.util.serialize(expr_ast)
+    expr_unserialized = phylanx.util.unserialize(expr_serialized)
+    assert expr_ast == expr_unserialized
 
 
-foo_ast = generate_ast(foo.__src__)
-foo_serialized = phylanx.util.serialize(foo_ast)
-foo_unserialized = phylanx.util.unserialize(foo_serialized)
-assert foo_ast == foo_unserialized
+###############################################################################
+
+
+def test_expr():
+    pe1 = phylanx.ast.primary_expr(True)
+    op1 = phylanx.ast.operand(pe1)
+    e1 = phylanx.ast.expression(op1)
+    data = phylanx.util.serialize(e1)
+    data_unserialized = phylanx.util.unserialize_expr(data)
+    assert e1 == data_unserialized
+
+
+###############################################################################
+
+test_expr()
+test_list()


### PR DESCRIPTION
This enables serialization/unserialization of Phylanx ASTs and lists of ASTs in Python.