### PR TITLE
Transforming Python for loops to Phylanx map.

### DIFF
--- a/python/phylanx/ast/transformation.py
+++ b/python/phylanx/ast/transformation.py
@@ -441,7 +441,6 @@ class PhySL:
             raise Exception("Lists are not supported as loop iters.")
 
         ret += ")), " + self.recompile(a.iter) + ')'
-        print(ret)
         return ret
 
     def recompile(self, a, allowreturn=False):

--- a/python/phylanx/ast/transformation.py
+++ b/python/phylanx/ast/transformation.py
@@ -255,7 +255,7 @@ class PhySL:
             s += self.recompile(a.args[-1])
             s += ')'
 
-        else: # a.func is ast.Name
+        else:  # a.func is ast.Name
             args = [arg for arg in ast.iter_child_nodes(a)]
             if args[0].id == "print":
                 args[0].id = "cout"

--- a/python/phylanx/ast/transformation.py
+++ b/python/phylanx/ast/transformation.py
@@ -425,60 +425,24 @@ class PhySL:
 
     def _For(self, a, allowreturn=False):
         symbol_info = full_node_name(a)
-        n = get_node(a, name="Name", num=0)
-        c = get_node(a, name="Call", num=1)
-        if n is not None and c is not None:
-            r = get_node(c, name="Name", num=0)
-            assert r.id == "range" or r.id == "xrange"
-            step = get_node(c, num=3)
-            if step is None:
-                step = ast.Num(1)
-            upper = get_node(c, num=2)
-            if upper is None:
-                upper = get_node(c, num=1)
-                lower = ast.Num(0)
-            else:
-                lower = get_node(c, num=1)
-            ns = self.recompile(n)
-            ls = self.recompile(lower)
-            us = self.recompile(upper)
-            ss = self.recompile(step)
-            bs = "block" + symbol_info + "("
-            blocki = 2
-            while True:
-                blockn = get_node(a, num=blocki)
-                if blockn is None:
-                    break
-                if blocki > 2:
-                    bs += ", "
-                bs += self.recompile(blockn)
-                blocki += 1
-            bs += ")"
-            # The first arg of the for loop is either
-            # a define() or a store(), depending on whether
-            # the variable has already been defined.
-            sd = "store" + symbol_info
-            if remove_line(ns) not in self.defs:
-                sd = "define" + symbol_info
-            lg = "<"
-            # Determine the direction of iteration, if possible
-            if not re.search(r'[a-zA-Z_]', ss):
-                if eval(ss) < 0:
-                    lg = ">"
-                return "for(" + sd + "(" + ns + ", " + ls + "), " + ns + " " + lg + " " \
-                       + us + ",store%s(" % symbol_info + ns + ", " + ns + \
-                    "+" + ss + "), " + bs + ")"
-            else:
-                # if we can't determine the direction of iteration, make two for loops
-                ret = "if(" + ss + " > 0, "
-                ret += "for(" + sd + "(" + ns + ", " + ls + "), " + ns + " < " + us + \
-                    ",store%s(" % symbol_info + ns + ", " + ns + "+" + ss + "), " + bs \
-                    + "), "
-                ret += "for(" + sd + "(" + ns + ", " + ls + "), " + ns + " > " + us + \
-                    ",store%s(" % symbol_info + ns + ", " + ns + "+" + ss + "), " + bs \
-                    + "))"
-                return ret
-            raise Exception("unsupported For loop structure")
+        ret = "map%s(lambda(" % symbol_info
+        ret += self.recompile(a.target) + ', block('
+
+        blocki = 2
+        while True:
+            blockn = get_node(a, num=blocki)
+            if blockn is None:
+                break
+            if blocki > 2:
+                ret += ", "
+            ret += self.recompile(blockn)
+            blocki += 1
+        if isinstance(a.iter, ast.List):
+            raise Exception("Lists are not supported as loop iters.")
+
+        ret += ")), " + self.recompile(a.iter) + ')'
+        print(ret)
+        return ret
 
     def recompile(self, a, allowreturn=False):
         nm = a.__class__.__name__

--- a/python/phylanx/ast/transformation.py
+++ b/python/phylanx/ast/transformation.py
@@ -255,10 +255,12 @@ class PhySL:
             s += self.recompile(a.args[-1])
             s += ')'
 
-        else:
+        else: # a.func is ast.Name
             args = [arg for arg in ast.iter_child_nodes(a)]
             if args[0].id == "print":
                 args[0].id = "cout"
+            if args[0].id == "xrange":
+                args[0].id = "range"
             s = args[0].id + symbol_info + '('
             for n in range(1, len(args)):
                 if n > 1:

--- a/tests/unit/python/execution_tree/for.py
+++ b/tests/unit/python/execution_tree/for.py
@@ -44,4 +44,3 @@ def sumn3():
 
 
 assert sumn3() == 9
-

--- a/tests/unit/python/execution_tree/for.py
+++ b/tests/unit/python/execution_tree/for.py
@@ -45,6 +45,7 @@ def sumn3():
 
 assert sumn3() == 9
 
+
 @Phylanx("PhySL")
 def sumn3():
     n = 0

--- a/tests/unit/python/execution_tree/for.py
+++ b/tests/unit/python/execution_tree/for.py
@@ -44,3 +44,16 @@ def sumn3():
 
 
 assert sumn3() == 9
+
+@Phylanx("PhySL")
+def sumn3():
+    n = 0
+    sum = 0
+    c = 0
+    for n in xrange(3, 0, -1):
+        sum += n
+        c += 1
+    return sum + c
+
+
+assert sumn3() == 9

--- a/tests/unit/python/execution_tree/for.py
+++ b/tests/unit/python/execution_tree/for.py
@@ -45,17 +45,3 @@ def sumn3():
 
 assert sumn3() == 9
 
-
-@Phylanx("PhySL")
-def sumn4():
-    n = 0
-    sum = 0
-    c = 0
-    ss = -1
-    for n in xrange(3, 0, ss):
-        sum += n
-        c += 1
-    return sum + c
-
-
-assert sumn4() == 9


### PR DESCRIPTION
Python `for` loops are now transformed into Phylanx `map` using lambda functions and the range primitive. Please note that the support for xrange has been dropped to follow Python3 syntax.