### PR TITLE
Fix CircleCI mistakes and wrong primitive names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,6 +98,7 @@ jobs:
                 name: Run CMake
                 command: cmake -DPHYLANX_WITH_GIT_COMMIT=${CIRCLE_SHA1} -DPHYLANX_WITH_TOOLS=On -DHPX_DIR=/usr/local/lib/cmake/HPX -Dblaze_DIR=/blaze/share/blaze/cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DPHYLANX_WITH_HIGHFIVE=On ..
                 working_directory: /phylanx/build
+                when: always
             # Inspect
             - run:
                 name: Build the Inspect tool
@@ -109,6 +110,7 @@ jobs:
             - run:
                 name: Convert inspect HTML output to XML
                 command: tools/inspect/inspect_to_junit.py /artifacts/phylanx_inspect_report.html >/code_format/phylanx_inspect.xml
+                when: always
             # Code Formatting Check Reports
             - store_artifacts:
                 path: /artifacts

--- a/phylanx/plugins/matrixops/shuffle_operation.hpp
+++ b/phylanx/plugins/matrixops/shuffle_operation.hpp
@@ -66,7 +66,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(
-            locality, "shuffle_operation", std::move(operands), name, codename);
+            locality, "shuffle", std::move(operands), name, codename);
     }
 }}}
 

--- a/phylanx/plugins/matrixops/sum_operation.hpp
+++ b/phylanx/plugins/matrixops/sum_operation.hpp
@@ -74,7 +74,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(
-            locality, "sum_operation", std::move(operands), name, codename);
+            locality, "sum", std::move(operands), name, codename);
     }
 }}}
 

--- a/src/plugins/matrixops/shuffle_operation.cpp
+++ b/src/plugins/matrixops/shuffle_operation.cpp
@@ -68,8 +68,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     match_pattern_type const shuffle_operation::match_data =
     {
-        hpx::util::make_tuple("shuffle_operation",
-            std::vector<std::string>{"shuffle_operation(_1)"},
+        hpx::util::make_tuple("shuffle",
+            std::vector<std::string>{"shuffle(_1)"},
             &create_shuffle_operation, &create_primitive<shuffle_operation>)
     };
 

--- a/src/plugins/matrixops/sum_operation.cpp
+++ b/src/plugins/matrixops/sum_operation.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     match_pattern_type const sum_operation::match_data =
     {
-        hpx::util::make_tuple("sum_operation",
+        hpx::util::make_tuple("sum",
         std::vector<std::string>{"sum(_1)", "sum(_1, _2)", "sum(_1, _2, _3)"},
         &create_sum_operation, &create_primitive<sum_operation>)
     };

--- a/tools/inspect/inspect_to_junit.py
+++ b/tools/inspect/inspect_to_junit.py
@@ -30,6 +30,7 @@ error_item = namedtuple('error_item', 'filename message')
 def parse_inspect8_log(fh):
     line_pattern = re.compile('(.+):\ (\*.+\*.+)')
     split_pattern = re.compile(',\ (?=\*)')
+    stripper_pattern = re.compile('<\/?\w+[^>]*>')
 
     errors = []
 
@@ -37,7 +38,8 @@ def parse_inspect8_log(fh):
         m = line_pattern.match(line)
         if m:
             for message in split_pattern.split(m.group(2)):
-                error = error_item(filename=m.group(1), message=message)
+                error = error_item(filename=m.group(1),
+                                   message=stripper_pattern.sub('', message))
                 errors.append(error)
 
     return errors


### PR DESCRIPTION
This PR:
* Fixes the PhySL names of `shuffle` and `sum` operations.
* Fixes a CircleCI issue that causes inspect errors not always being translated to JUnit XML.
* Fixes a CircleCI issue that causes an inspect error stopping the build.