### PR TITLE
Ensure mul primitive operates on elements

### DIFF
--- a/src/plugins/arithmetics/mul_operation.cpp
+++ b/src/plugins/arithmetics/mul_operation.cpp
@@ -830,14 +830,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     primitive_argument_type mul_operation::mul2d2d(operands_type && ops) const
     {
-        std::size_t dim = ops[0].dimension(1);
+        auto const operand_size = ops[0].dimensions();
         for (auto const& i : ops)
         {
-            if (i.dimension(0) == dim)
-            {
-                dim = i.dimension(1);
-            }
-            else
+            if (i.dimensions() != operand_size)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "sub_operation::mul2d2d",

--- a/tests/regressions/python/exception_swallowed_369.py
+++ b/tests/regressions/python/exception_swallowed_369.py
@@ -22,7 +22,7 @@ try:
 
 except Exception as e:
     expected = \
-        '<unknown>: __add$0/0$12$8:: the dimensions of the operands do ' + \
+        '<unknown>: __add$0/0$14$8:: the dimensions of the operands do ' + \
         'not match: HPX(bad_parameter)'
     assert(str(e) == expected)
     exception_thrown = True


### PR DESCRIPTION
This PR fixes a mistake in #415 where it multiple matrices are checked as if the matrices themselves are going to be multiplied instead of their elements.