### PR TITLE
Change mean primitive output to blaze vector

### DIFF
--- a/phylanx/plugins/matrixops/argmax.hpp
+++ b/phylanx/plugins/matrixops/argmax.hpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2018 Parsa Amini
-//  Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(PHYLANX_PRIMITIVES_ARGMAX)
 #define PHYLANX_PRIMITIVES_ARGMAX

--- a/src/plugins/arithmetics/mul_operation.cpp
+++ b/src/plugins/arithmetics/mul_operation.cpp
@@ -492,7 +492,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "sub_operation::mul2d1d",
+            "mul_operation::mul2d1d",
             execution_tree::generate_error_message(
                 "vector size does not match either the number of matrix "
                 "columns nor rows.",
@@ -836,7 +836,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             if (i.dimensions() != operand_size)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "sub_operation::mul2d2d",
+                    "mul_operation::mul2d2d",
                     execution_tree::generate_error_message(
                         "the dimensions of the operands do not match",
                         name_, codename_));

--- a/src/plugins/matrixops/argmax.cpp
+++ b/src/plugins/matrixops/argmax.cpp
@@ -1,8 +1,8 @@
-//  Copyright (c) 2018 Parsa Amini
-//  Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>

--- a/src/plugins/matrixops/mean_operation.cpp
+++ b/src/plugins/matrixops/mean_operation.cpp
@@ -155,14 +155,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         const matrix_row_iterator<decltype(matrix)> matrix_end(
             matrix, matrix.rows());
 
-        std::vector<primitive_argument_type> result;
-        for (auto it = matrix_begin; it != matrix_end; ++it)
+        blaze::DynamicVector<double> result(matrix.rows());
+        auto result_it = result.begin();
+        for (auto it = matrix_begin; it != matrix_end; ++it, ++result_it)
         {
             const auto local_sum =
                 std::accumulate(it->begin(), it->end(), 0.0);
             const auto local_size = (*it).size();
-            result.emplace_back(
-                primitive_argument_type(local_sum / local_size));
+            *result_it = local_sum / local_size;
         }
         return primitive_argument_type{std::move(result)};
     }
@@ -178,14 +178,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         const matrix_column_iterator<decltype(matrix)> matrix_end(
             matrix, matrix.columns());
 
-        std::vector<primitive_argument_type> result;
-        for (auto it = matrix_begin; it != matrix_end; ++it)
+        blaze::DynamicVector<double> result(matrix.columns());
+        auto result_it = result.begin();
+        for (auto it = matrix_begin; it != matrix_end; ++it, ++result_it)
         {
             const auto local_sum =
                 std::accumulate(it->begin(), it->end(), 0.0);
             const auto local_size = (*it).size();
-            result.emplace_back(
-                primitive_argument_type(local_sum / local_size));
+            *result_it = local_sum / local_size;
         }
         return primitive_argument_type{std::move(result)};
     }

--- a/tests/unit/plugins/matrixops/mean_operation.cpp
+++ b/tests/unit/plugins/matrixops/mean_operation.cpp
@@ -82,7 +82,8 @@ void test_mean_operation_2d_x_axis()
 
     blaze::DynamicMatrix<double> matrix_1{{1.0, 2.0, 6.0}, {4.0, 5.0, 6.0}};
 
-    arg_type expected{std::vector<arg_type>{arg_type{3.0}, arg_type{5.0}}};
+    phylanx::ir::node_data<double> expected(
+        blaze::DynamicVector<double>{3.0, 5.0});
 
     phylanx::execution_tree::primitive first =
         phylanx::execution_tree::primitives::create_variable(
@@ -100,7 +101,7 @@ void test_mean_operation_2d_x_axis()
 
     hpx::future<arg_type> f = p.eval();
 
-    arg_type actual{phylanx::execution_tree::extract_list_value(f.get())};
+    auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
 
     HPX_TEST_EQ(expected, actual);
 }
@@ -110,8 +111,8 @@ void test_mean_operation_2d_y_axis()
     using arg_type = phylanx::execution_tree::primitive_argument_type;
     blaze::DynamicMatrix<double> matrix_1{{1.0, 2.0, 6.0}, {4.0, 5.0, 6.0}};
 
-    arg_type expected{
-        std::vector<arg_type>{arg_type{2.5}, arg_type{3.5}, arg_type{6.0}}};
+    phylanx::ir::node_data<double> expected(
+        blaze::DynamicVector<double>{2.5, 3.5, 6.0});
 
     phylanx::execution_tree::primitive first =
         phylanx::execution_tree::primitives::create_variable(
@@ -129,7 +130,7 @@ void test_mean_operation_2d_y_axis()
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
 
-    arg_type actual{phylanx::execution_tree::extract_list_value(f.get())};
+    auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
 
     HPX_TEST_EQ(expected, actual);
 }


### PR DESCRIPTION
Mean primitive was returning a `std::vector`. This PR changes the return type to a `node_data<double>` that contains a vector instead.