### PR TITLE
Added assert primitive

### DIFF
--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -8,6 +8,7 @@
 #define PHYLANX_PRIMITIVES_PRIMITIVES_HPP
 
 #include <phylanx/execution_tree/primitives/access_argument.hpp>
+#include <phylanx/execution_tree/primitives/assert_condition.hpp>
 #include <phylanx/execution_tree/primitives/console_output.hpp>
 #include <phylanx/execution_tree/primitives/debug_output.hpp>
 #include <phylanx/execution_tree/primitives/define_function.hpp>

--- a/phylanx/execution_tree/primitives/assert_condition.hpp
+++ b/phylanx/execution_tree/primitives/assert_condition.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_ASSERT_CONDITION)
+#define PHYLANX_PRIMITIVES_ASSERT_CONDITION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    /// \brief Debug assertion
+    /// Ensures a condition is true and fails otherwise
+    /// \param cond A True or False statement
+    class assert_condition
+        : public primitive_component_base
+        , public std::enable_shared_from_this<assert_condition>
+    {
+    public:
+        static match_pattern_type const match_data;
+
+        assert_condition() = default;
+
+        assert_condition(std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& args) const override;
+
+    private:
+        using operand_type = std::vector<primitive_argument_type>;
+
+        hpx::future<primitive_argument_type> eval(
+            std::vector<primitive_argument_type> const& operands,
+            std::vector<primitive_argument_type> const& args) const;
+    };
+
+    PHYLANX_EXPORT primitive create_assert_condition(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name = "", std::string const& codename = "");
+}}}
+
+#endif
+
+

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -44,6 +44,7 @@ namespace phylanx { namespace execution_tree
                 PHYLANX_MATCH_DATA(debug_output),
                 PHYLANX_MATCH_DATA(enable_tracing),
                 PHYLANX_MATCH_DATA(string_output),
+                PHYLANX_MATCH_DATA(assert_condition),
 
                 // special purpose primitives
                 PHYLANX_MATCH_DATA(store_operation),

--- a/src/execution_tree/primitives/assert_condition.cpp
+++ b/src/execution_tree/primitives/assert_condition.cpp
@@ -1,0 +1,91 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/assert_condition.hpp>
+
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_assert_condition(hpx::id_type const& locality,
+        std::vector<primitive_argument_type>&& operands,
+        std::string const& name, std::string const& codename)
+    {
+        static std::string type("assert");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const assert_condition::match_data =
+    {
+        hpx::util::make_tuple("assert",
+            std::vector<std::string>{"assert(_1)"},
+            &create_assert_condition, &create_primitive<assert_condition>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    assert_condition::assert_condition(
+            std::vector<primitive_argument_type>&& operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    hpx::future<primitive_argument_type> assert_condition::eval(
+        std::vector<primitive_argument_type> const& operands,
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "assert_condition",
+                execution_tree::generate_error_message(
+                    "Assert requires exactly one argument", name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+            [this_](std::uint8_t cond)
+            -> primitive_argument_type
+            {
+                if (cond == 0)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "assert_condition",
+                        execution_tree::generate_error_message(
+                            "Assertion failed",
+                            this_->name_, this_->codename_));
+                }
+
+                return {};
+            }),
+            boolean_operand(operands_[0], args, name_, codename_));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> assert_condition::eval(
+        std::vector<primitive_argument_type> const& args) const
+    {
+        if (operands_.empty())
+        {
+            return eval(args, noargs);
+        }
+        return eval(operands_, args);
+    }
+}}}

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    assert_condition
     define_operation
     invoke_operation
     literal_value

--- a/tests/unit/execution_tree/primitives/assert_condition.cpp
+++ b/tests/unit/execution_tree/primitives/assert_condition.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <utility>
+#include <vector>
+
+void test_assert_true()
+{
+    phylanx::execution_tree::primitive op =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), true);
+
+    phylanx::execution_tree::primitive assert_cond =
+        phylanx::execution_tree::primitives::create_assert_condition(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{op});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        assert_cond.eval();
+
+    HPX_TEST(!phylanx::execution_tree::valid(f.get()));
+}
+
+void test_assert_false()
+{
+    phylanx::execution_tree::primitive op =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), false);
+
+    phylanx::execution_tree::primitive assert_cond =
+        phylanx::execution_tree::primitives::create_assert_condition(
+            hpx::find_here(),
+            std::vector<phylanx::execution_tree::primitive_argument_type>{op});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        assert_cond.eval();
+
+    bool exception_thrown = false;
+    try
+    {
+        // Must throw an exception
+        f.get();
+        HPX_TEST(false);
+    }
+    catch (std::exception const& e)
+    {
+        exception_thrown = true;
+    }
+
+    HPX_TEST(exception_thrown);
+}
+
+int main(int argc, char* argv[])
+{
+    test_assert_true();
+    test_assert_false();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This PR adds primitive `assert` that can be used for testing in PhySL code.