### PR TITLE
Fix AGAS names generated by compiler

### DIFF
--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -5,6 +5,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
 
 #include <hpx/hpx_main.hpp>
 
@@ -309,7 +310,9 @@ phylanx::execution_tree::compiler::result_type compile_and_run(
         phylanx::execution_tree::compiler::default_environment();
 
     phylanx::execution_tree::define_variable(code_source_name,
-        "sys_argv/0$0", snippets, env,
+        phylanx::execution_tree::compiler::primitive_name_parts{
+            "sys_argv", -1, 0, 0},
+        snippets, env,
         phylanx::execution_tree::primitive_argument_type{std::move(args)});
     auto const code = phylanx::execution_tree::compile(
         code_source_name, ast, snippets, env);

--- a/phylanx/execution_tree/compile.hpp
+++ b/phylanx/execution_tree/compile.hpp
@@ -100,7 +100,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     /// Add the given variable to the compilation environment
     PHYLANX_EXPORT compiler::function define_variable(
-        std::string const& codename, std::string name,
+        std::string const& codename, compiler::primitive_name_parts const& name,
         compiler::function_list& snippets, compiler::environment& env,
         primitive_argument_type body,
         hpx::id_type const& default_locality = hpx::find_here());

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -153,11 +153,17 @@ namespace phylanx { namespace execution_tree { namespace compiler
             primitive_name_parts name_parts,
             std::string const& codename = "<unknown>") const
         {
+            if (name_parts.instance.empty())
+            {
+                name_parts.instance = name_parts.primitive;
+                name_parts.primitive = "define-variable";
+            }
+
             std::string full_name = compose_primitive_name(name_parts);
 
             return function{
                 primitive_argument_type{create_primitive_component(locality_,
-                    name_parts.primitive, std::move(arg), full_name, codename)},
+                    "define-variable", std::move(arg), full_name, codename)},
                 full_name};
         }
 
@@ -223,6 +229,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             static std::string type("access-argument");
             // The compiler does not know if it was the name of the instance or
             // a primitive.
+            HPX_ASSERT(name_parts.instance.empty());
             name_parts.instance = name_parts.primitive;
             name_parts.primitive = type;
             name_parts.sequence_number = sequence_number++;
@@ -259,6 +266,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             static std::string type("access-variable");
             // The compiler does not know if it was the name of the instance or
             // a primitive.
+            HPX_ASSERT(name_parts.instance.empty());
             name_parts.instance = name_parts.primitive;
             name_parts.primitive = type;
             name_parts.sequence_number = sequence_number++;
@@ -293,6 +301,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         {
             // The compiler does not know if it was the name of the instance or
             // a primitive.
+            HPX_ASSERT(name_parts.instance.empty());
             name_parts.instance = name_parts.primitive;
 
             arguments_type fargs;

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -47,6 +47,24 @@ namespace phylanx { namespace execution_tree { namespace compiler
           , tag2(-1)
         {}
 
+        primitive_name_parts(char const* primitive_)
+            : primitive(primitive_)
+            , sequence_number(-1)
+            , compile_id(-1)
+            , tag1(-1)
+            , tag2(-1)
+        {}
+
+        primitive_name_parts(std::string const& primitive_,
+            std::int64_t sequence_number_ = -1, std::int64_t tag1_ = -1,
+            std::int64_t tag2_ = -1, std::int64_t compile_id_ = -1)
+          : primitive(primitive_)
+          , sequence_number(sequence_number_)
+          , tag1(tag1_)
+          , tag2(tag2_)
+          , compile_id(compile_id_)
+        {}
+
         std::string primitive;
         std::int64_t sequence_number;
         std::string instance;

--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -1,7 +1,7 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2018 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
 #include <phylanx/ast/generate_ast.hpp>
@@ -134,12 +134,12 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     /// Add the given variable to the compilation environment
     compiler::function define_variable(std::string const& codename,
-        std::string name, compiler::function_list& snippets,
-        compiler::environment& env, primitive_argument_type body,
-        hpx::id_type const& default_locality)
+        compiler::primitive_name_parts const& name_parts,
+        compiler::function_list& snippets, compiler::environment& env,
+        primitive_argument_type body, hpx::id_type const& default_locality)
     {
         return compiler::define_variable(
-            codename, std::move(name), snippets, env, body, default_locality)();
+            codename, std::move(name_parts), snippets, env, body, default_locality)();
     }
 }}
 

--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -139,7 +139,7 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type body, hpx::id_type const& default_locality)
     {
         return compiler::define_variable(
-            codename, std::move(name_parts), snippets, env, body, default_locality)();
+            codename, name_parts, snippets, env, body, default_locality)();
     }
 }}
 

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -306,8 +306,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
             snippets_.snippets_.emplace_back(function{});
             function& f = snippets_.snippets_.back();
 
-            std::string lambda_name("lambda" + std::to_string(sequence_number) +
-                "/" + annotation(lambda_id));
+            std::string lambda_name("lambda$" + std::to_string(sequence_number) +
+                annotation(lambda_id));
 
             static std::string function_("call-function");
             sequence_number =
@@ -414,7 +414,11 @@ namespace phylanx { namespace execution_tree { namespace compiler
             {
                 if (id.id >= 0)
                 {
-                    name += annotation(id);
+                    std::size_t sequence_number =
+                        snippets_.sequence_numbers_[name]++;
+
+                    name +=
+                        "$" + std::to_string(sequence_number) + annotation(id);
                 }
                 return (*cf)(std::list<function>{}, name, name_);
             }

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -400,12 +400,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
             if (compiled_function* cf = env_.find(name))
             {
                 name_parts.compile_id = snippets_.compile_id_ - 1;
+                name_parts.sequence_number = snippets_.sequence_numbers_[name]++;
 
-                if (id.id >= 0)
-                {
-                    name_parts.sequence_number =
-                        snippets_.sequence_numbers_[name]++;
-                }
                 return (*cf)(std::list<function>{}, std::move(name_parts), name_);
             }
 

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -18,6 +18,7 @@
 #include <phylanx/execution_tree/compile.hpp>
 #include <phylanx/execution_tree/compiler/actors.hpp>
 #include <phylanx/execution_tree/compiler/compiler.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/ir/node_data.hpp>
 
@@ -93,21 +94,6 @@ namespace phylanx { namespace execution_tree { namespace compiler
         {}
 
     private:
-        std::string annotation(ast::tagged const& id)
-        {
-            // Note: the compile-id needs to be adjusted to be zero-based.
-            std::string result = "/" +
-                std::to_string(snippets_.compile_id_ - 1) + "$" +
-                std::to_string(id.id);
-
-            if (id.col != -1)
-            {
-                result += '$' + std::to_string(id.col);
-            }
-
-            return result;
-        }
-
         ///////////////////////////////////////////////////////////////////////
         static std::string generate_error_message(std::string const& msg,
             std::string const& name, ast::tagged const& id)
@@ -306,8 +292,10 @@ namespace phylanx { namespace execution_tree { namespace compiler
             snippets_.snippets_.emplace_back(function{});
             function& f = snippets_.snippets_.back();
 
-            std::string lambda_name("lambda$" + std::to_string(sequence_number) +
-                annotation(lambda_id));
+            primitive_name_parts name_parts("lambda", sequence_number,
+                lambda_id.id, lambda_id.col, snippets_.compile_id_ - 1);
+
+            std::string lambda_name = compose_primitive_name(name_parts);
 
             static std::string function_("call-function");
             sequence_number =
@@ -316,13 +304,13 @@ namespace phylanx { namespace execution_tree { namespace compiler
             auto extf = external_function(f, sequence_number, default_locality_);
 
             // create define_function helper object
-            f = primitive_function{default_locality_}(lambda_name, name_);
+            f = primitive_function{default_locality_}(name_parts, name_);
 
             // set the body for the compiled function
             primitive_operand(f.arg_, lambda_name, name_).set_body(
                 hpx::launch::sync, std::move(handle_lambda(args, body).arg_));
 
-            return extf({}, lambda_name, name_);
+            return extf({}, name_parts, name_);
         }
 
         function handle_define(
@@ -343,12 +331,13 @@ namespace phylanx { namespace execution_tree { namespace compiler
             std::string name = ast::detail::identifier_name(name_expr);
 
             // get global name of the component created
-            std::string full_name = name;
+            primitive_name_parts name_parts;
+            name_parts.instance = name;
+
             ast::tagged id = ast::detail::tagged_id(name_expr);
-            if (id.id >= 0)
-            {
-                full_name += annotation(id);
-            }
+            name_parts.compile_id = snippets_.compile_id_ - 1;
+            name_parts.tag1 = id.id;
+            name_parts.tag2 = id.col;
 
             auto args = extract_define_arguments(p, define_id);
             auto body = extract_define_body(p, define_id);
@@ -359,7 +348,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     std::move(name), external_variable(f, default_locality_));
 
                 static std::string define_variable("define-variable");
-                std::size_t sequence_number =
+                name_parts.primitive = define_variable;
+                name_parts.sequence_number =
                     snippets_.sequence_numbers_[define_variable]++;
 
                 // define variable
@@ -368,8 +358,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     default_locality_);
 
                 f = primitive_variable{default_locality_}(
-                        std::move(bf.arg_), define_variable + "$" +
-                            std::to_string(sequence_number) + "$" + full_name,
+                        std::move(bf.arg_), name_parts,
                             name_);
                 return f;
             }
@@ -386,41 +375,38 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 external_function(f, sequence_number, default_locality_));
 
             static std::string define_function_("define-function");
-            sequence_number =
+            name_parts.primitive = define_function_;
+            name_parts.sequence_number =
                 snippets_.sequence_numbers_[define_function_]++;
 
-            // create define_function helper object
-            std::string define_function_name =
-                std::to_string(sequence_number) + "$" + full_name;
-
-            f = primitive_function{default_locality_}(
-                    define_function_ + "$" + define_function_name,
-                    name_);
+            f = primitive_function{default_locality_}(name_parts, name_);
 
             // set the body for the compiled function
-            primitive_operand(f.arg_, define_function_name, name_).set_body(
-                hpx::launch::sync, std::move(handle_lambda(args, body).arg_));
+            primitive_operand(f.arg_, compose_primitive_name(name_parts), name_)
+                .set_body(hpx::launch::sync,
+                    std::move(handle_lambda(args, body).arg_));
 
             // define-function shouldn't return a function that evaluates
             // to itself, let it return nil{} instead
-            return always_nil{}(std::move(define_function_name));
+            return always_nil{}(std::move(name_parts));
         }
 
         function handle_variable_reference(std::string name,
             ast::expression const& expr)
         {
             ast::tagged id = ast::detail::tagged_id(expr);
+            primitive_name_parts name_parts(name, -1, id.id, id.col);
+
             if (compiled_function* cf = env_.find(name))
             {
+                name_parts.compile_id = snippets_.compile_id_ - 1;
+
                 if (id.id >= 0)
                 {
-                    std::size_t sequence_number =
+                    name_parts.sequence_number =
                         snippets_.sequence_numbers_[name]++;
-
-                    name +=
-                        "$" + std::to_string(sequence_number) + annotation(id);
                 }
-                return (*cf)(std::list<function>{}, name, name_);
+                return (*cf)(std::list<function>{}, std::move(name_parts), name_);
             }
 
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -434,6 +420,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             ast::expression const& expr)
         {
             ast::tagged id = ast::detail::tagged_id(expr);
+
             if (compiled_function* cf = env_.find(name))
             {
                 std::vector<ast::expression> argexprs =
@@ -447,11 +434,10 @@ namespace phylanx { namespace execution_tree { namespace compiler
                         patterns_, default_locality_));
                 }
 
-                if (id.id >= 0)
-                {
-                    name += annotation(id);
-                }
-                return (*cf)(std::move(args), name, name_);
+                primitive_name_parts name_parts{std::move(name), -1, id.id,
+                    id.col, static_cast<std::int64_t>(snippets_.compile_id_ - 1)};
+
+                return (*cf)(std::move(args), std::move(name_parts), name_);
             }
 
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -470,12 +456,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 snippets_.sequence_numbers_[name]++;
 
             // get global name of the component created
-            std::string global_name =
-                name + "$" + std::to_string(sequence_number);
-            if (id.id >= 0)
-            {
-                global_name += annotation(id);
-            }
+            primitive_name_parts name_parts(name, sequence_number, id.id,
+                id.col, snippets_.compile_id_ - 1);
 
             if (compiled_function* cf = env_.find(name))
             {
@@ -488,8 +470,9 @@ namespace phylanx { namespace execution_tree { namespace compiler
                         snippets_, env, patterns_, default_locality_));
                 }
 
+
                 // create primitive with given arguments
-                return (*cf)(std::move(args), global_name, name_);
+                return (*cf)(std::move(args), std::move(name_parts), name_);
             }
 
             // otherwise the match was not complete, bail out
@@ -626,30 +609,22 @@ namespace phylanx { namespace execution_tree { namespace compiler
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    function define_variable(std::string const& codename, std::string name,
-        function_list& snippets, environment& env, primitive_argument_type body,
+    function define_variable(std::string const& codename,
+        primitive_name_parts name_parts, function_list& snippets,
+        environment& env, primitive_argument_type body,
         hpx::id_type const& default_locality)
     {
-        std::string full_name = name;
-        auto p = name.find_first_of("$/");
-        if (p != std::string::npos)
-        {
-            name.erase(p);
-        }
-
         snippets.snippets_.emplace_back(function{});
         function& f = snippets.snippets_.back();
 
         // get sequence number of this component
-        env.define(std::move(name), external_variable(f, default_locality));
-
-        static std::string define_variable("define-variable");
-        std::size_t sequence_number =
-            snippets.sequence_numbers_[define_variable]++;
+        env.define(name_parts.primitive, external_variable(f, default_locality));
+        name_parts.primitive = "define-variable";
+        name_parts.sequence_number =
+            snippets.sequence_numbers_[name_parts.primitive]++;
 
         f = primitive_variable{default_locality}(
-                std::move(body), define_variable + "$" +
-                    std::to_string(sequence_number) + "$" + full_name,
+                std::move(body), std::move(name_parts),
                 codename);
         return f;
     }

--- a/src/execution_tree/compiler/primitive_name.cpp
+++ b/src/execution_tree/compiler/primitive_name.cpp
@@ -99,7 +99,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
         bool result = boost::spirit::qi::parse(begin, name.end(),
             detail::primitive_name_parser<std::string::const_iterator>(), parts);
 
-        return result && begin != name.end();
+        return result && begin == name.end();
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -106,7 +106,7 @@ namespace phylanx { namespace execution_tree
     {
         if (!name.empty())
         {
-            this->base_type::register_as("/phylanx/" + name).get();
+            this->base_type::register_as(name).get();
         }
     }
 

--- a/src/plugins/listops/car_cdr_operation.cpp
+++ b/src/plugins/listops/car_cdr_operation.cpp
@@ -77,9 +77,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             compiler::primitive_name_parts name_parts;
             if (!compiler::parse_primitive_name(name, name_parts))
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "car_cdr_operation::generate_operation_code",
-                     "Failed to extract the name of the primitive");
+                return name.substr(1, name.size() - 2);
             }
 
             return name_parts.primitive.substr(1, name_parts.primitive.size() - 2);

--- a/src/plugins/listops/car_cdr_operation.cpp
+++ b/src/plugins/listops/car_cdr_operation.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
 #include <phylanx/plugins/listops/car_cdr_operation.hpp>
 
 #include <phylanx/ir/ranges.hpp>
@@ -73,12 +74,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             // extract actual name of the primitive and remove leading 'c' and
             // trailing 'r'
-            std::string::size_type p = name.find_first_of("$");
-            if (p != std::string::npos)
+            compiler::primitive_name_parts name_parts;
+            if (!compiler::parse_primitive_name(name, name_parts))
             {
-                return name.substr(1, p - 2);
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "car_cdr_operation::generate_operation_code",
+                     "Failed to extract the name of the primitive");
             }
-            return name.substr(1, name.size() - 2);
+
+            return name_parts.primitive.substr(1, name_parts.primitive.size() - 2);
         }
     }
 

--- a/src/plugins/matrixops/generic_operation.cpp
+++ b/src/plugins/matrixops/generic_operation.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/matrixops/generic_operation.hpp>
 
@@ -943,12 +944,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
     namespace detail {
         std::string extract_function_name(std::string const& name)
         {
-            std::string::size_type p = name.find_first_of("$");
-            if (p != std::string::npos)
+            compiler::primitive_name_parts name_parts;
+            if (!compiler::parse_primitive_name(name, name_parts))
             {
-                return name.substr(0, p);
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "generic_operation::extract_function_name",
+                    "Operation extraction received an invalid name");
             }
-            return name;
+
+            return name_parts.primitive;
         }
     }
 

--- a/src/plugins/matrixops/generic_operation.cpp
+++ b/src/plugins/matrixops/generic_operation.cpp
@@ -947,9 +947,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             compiler::primitive_name_parts name_parts;
             if (!compiler::parse_primitive_name(name, name_parts))
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "generic_operation::extract_function_name",
-                    "Operation extraction received an invalid name");
+                return name;
             }
 
             return name_parts.primitive;

--- a/tests/regressions/python/exception_swallowed_369.py
+++ b/tests/regressions/python/exception_swallowed_369.py
@@ -22,8 +22,8 @@ try:
 
 except Exception as e:
     expected = \
-        '<unknown>: __add$0/0$14$8:: the dimensions of the operands do ' + \
-        'not match: HPX(bad_parameter)'
+        '<unknown>(14, 8): __add:: the dimensions of the ' + \
+        'operands do not match: HPX(bad_parameter)'
     assert(str(e) == expected)
     exception_thrown = True
 

--- a/tests/unit/execution_tree/compiler.cpp
+++ b/tests/unit/execution_tree/compiler.cpp
@@ -4,7 +4,6 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
-#include <phylanx/execution_tree/compiler/primitive_name.hpp>
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/runtime/find_here.hpp>

--- a/tests/unit/execution_tree/compiler.cpp
+++ b/tests/unit/execution_tree/compiler.cpp
@@ -1,9 +1,10 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+// Copyright (c) 2017 Hartmut Kaiser
 //
-//  Distributed under the Boost Software License, Version 1.0. (See accompanying
-//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/phylanx.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
 
 #include <hpx/hpx_main.hpp>
 #include <hpx/runtime/find_here.hpp>


### PR DESCRIPTION
* Lambdas
    * e.g `/phylanx/lambda0//2$46$9` changed to `/phylanx/lambda$0/2$46$9`
* Primitives sent as arguments
    * e.g. name of `vstack` in `apply(vstack, make_list([1], [2]))` changed from `/phylanx/vstack/0$0$7` to `/phylanx/vstack$0/0$0$7`