### PR TITLE
Enable configuration of HPX in Python.

### DIFF
--- a/cmake/templates/__init__.py.in
+++ b/cmake/templates/__init__.py.in
@@ -56,7 +56,3 @@ except Exception:
         print("hpx_bindir: ", hpx_bindir)
 
         sys.exit(1)
-
-
-# load and initialize the HPX runtime
-init_hpx_runtime()

--- a/python/src/init_hpx.cpp
+++ b/python/src/init_hpx.cpp
@@ -145,8 +145,8 @@ get_command_line const& init_command_line()
 // This class initializes a console instance of HPX (locality 0).
 struct manage_global_runtime
 {
-    manage_global_runtime()
-      : running_(false), rts_(nullptr)
+    manage_global_runtime(std::vector<std::string> const config)
+      : running_(false), rts_(nullptr), cfg(config)
     {
 #if defined(HPX_WINDOWS)
         hpx::detail::init_winsocket();
@@ -158,21 +158,6 @@ struct manage_global_runtime
             init_command_line();
         }
 #endif
-
-        std::vector<std::string> const cfg = {
-            // make sure hpx_main is always executed
-            "hpx.run_hpx_main!=1",
-            // allow for unknown command line options
-            "hpx.commandline.allow_unknown!=1",
-            // disable HPX' short options
-            "hpx.commandline.aliasing!=0",
-            // run one thread only (for now)
-            "hpx.os_threads!=1",
-            // don't print diagnostics during forced terminate
-            "hpx.diagnostics_on_terminate!=0",
-            // disable the TCP parcelport
-            "hpx.parcel.tcp.enable!=0"
-        };
 
         using hpx::util::placeholders::_1;
         using hpx::util::placeholders::_2;
@@ -257,6 +242,7 @@ private:
     bool running_;
 
     hpx::runtime* rts_;
+    std::vector<std::string> const cfg;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -264,12 +250,12 @@ private:
 // stops running in its destructor.
 manage_global_runtime* rts = nullptr;
 
-void init_hpx_runtime()
+void init_hpx_runtime(std::vector<std::string> const cfg)
 {
     if (rts == nullptr)
     {
         pybind11::gil_scoped_release release;
-        rts = new manage_global_runtime;
+        rts = new manage_global_runtime(cfg);
     }
 }
 

--- a/python/src/init_hpx.hpp
+++ b/python/src/init_hpx.hpp
@@ -8,11 +8,12 @@
 #if !defined(PHYLANX_INIT_HPX_HPP)
 #define PHYLANX_INIT_HPX_HPP
 
+#include<vector>
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace bindings
 {
     ///////////////////////////////////////////////////////////////////////////
-    void init_hpx_runtime();
+    void init_hpx_runtime(std::vector<std::string> const cfg);
     void stop_hpx_runtime();
 }}
 

--- a/python/src/phylanx.cpp
+++ b/python/src/phylanx.cpp
@@ -11,6 +11,7 @@
 #include <bindings/binding_helpers.hpp>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <hpx/util/detail/pp/stringize.hpp>
 


### PR DESCRIPTION
Fixes #469.
Currently hpx initialized with configurations set at compile time; This commit allows dynamic initialization of HPX in Python through ::class::InitHPX.