### PR TITLE
Add --docs flag to physl interpreter

### DIFF
--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -149,6 +149,7 @@ int handle_command_line(int argc, char* argv[], po::variables_map& vm)
             "Usage: physl <physl_script> [options] [arguments...]");
         cmdline_options.add_options()
             ("help,h", "print out program usage")
+            ("docs","Print out all primitives/plugins and descriptions")
             ("code,c", po::value<std::string>(),
              "Execute the PhySL code given in argument")
             ("print,p", "Print the result of evaluation of the last "
@@ -384,6 +385,11 @@ int main(int argc, char* argv[])
     if (cmdline_result != 0)
     {
         return cmdline_result > 0 ? 0 : cmdline_result;
+    }
+
+    if(vm.count("docs") != 0) {
+        phylanx::execution_tree::show_patterns();
+        return 0;
     }
 
     try

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -119,6 +119,8 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT void register_pattern(
         std::string const&, match_pattern_type const& pattern);
 
+    PHYLANX_EXPORT void show_patterns();
+
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT primitive create_primitive_component(
         hpx::id_type const& locality, std::string const& type,

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -16,6 +16,26 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     std::vector<std::pair<std::string, match_pattern_type>> registered_patterns;
 
+    void show_patterns()
+    {
+        std::set<std::string> printed;
+        for(auto p : registered_patterns)
+        {
+            std::string pattern_name = p.first; 
+            std::vector<std::string> patterns = hpx::util::get<1>(p.second);
+            auto f = printed.find(pattern_name);
+            if(f == printed.end())
+            {
+                std::cout << "pattern: " << pattern_name << std::endl;
+                for(auto pat : patterns)
+                {
+                    std::cout << "  matches: " << pat << std::endl;
+                }
+                printed.insert(pattern_name);
+            }
+        }
+    }
+
     void register_pattern(
         std::string const& name, match_pattern_type const& pattern)
     {

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -10,6 +10,8 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <set>
+#include <iostream>
 
 namespace phylanx { namespace execution_tree
 {
@@ -21,7 +23,7 @@ namespace phylanx { namespace execution_tree
         std::set<std::string> printed;
         for(auto p : registered_patterns)
         {
-            std::string pattern_name = p.first; 
+            std::string pattern_name = p.first;
             std::vector<std::string> patterns = hpx::util::get<1>(p.second);
             auto f = printed.find(pattern_name);
             if(f == printed.end())


### PR DESCRIPTION
With this pull request, launching the physl command line tool with --docs causes physl to print all primitives/plugins and and exit.