### PR TITLE
Making sure 1d integer arrays get properly converted to node_data<int64_t>

### DIFF
--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -130,12 +130,14 @@ namespace phylanx { namespace execution_tree { namespace compiler
             primitive const* p = util::get_if<primitive>(&arg_);
             if (p != nullptr)
             {
+                arguments_type keep_alive(std::move(args));
+
                 // construct argument-pack to use for actual call
                 arguments_type params;
-                params.reserve(args.size());
-                for (auto && arg : args)
+                params.reserve(keep_alive.size());
+                for (auto const& arg : keep_alive)
                 {
-                    params.emplace_back(extract_ref_value(std::move(arg)));
+                    params.emplace_back(extract_ref_value(arg));
                 }
                 return extract_copy_value(
                     p->eval(hpx::launch::sync, std::move(params)));
@@ -186,7 +188,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 keep_alive.reserve(args.size());
                 for (auto && arg : std::move(args))
                 {
-                    keep_alive.emplace_back(extract_copy_value(std::move(arg)));
+                    keep_alive.emplace_back(extract_value(std::move(arg)));
                 }
 
                 return p->eval(std::move(keep_alive));

--- a/python/phylanx/ast/transformation.py
+++ b/python/phylanx/ast/transformation.py
@@ -623,13 +623,6 @@ class PhySL:
 
 
 def convert_to_phylanx_type(v):
-    t = type(v)
-    try:
-        import numpy
-        if t == numpy.ndarray:
-            return et.var(v)
-    except NotImplementedError:
-        pass
     return v
 
 

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    array_shape_486
     broadcasting_rules_410
     create_list_409
     exception_swallowed_369

--- a/tests/regressions/python/array_shape_486.py
+++ b/tests/regressions/python/array_shape_486.py
@@ -1,0 +1,15 @@
+#  Copyright (c) 2018 Weile Wei
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+from phylanx.ast import *
+import numpy as np
+
+
+@Phylanx()
+def phlyanx_array_shape(a):
+    return np.shape(a)
+
+
+assert([3, 1] == phlyanx_array_shape(np.array([[1], [1], [0]])))

--- a/tests/regressions/python/passing_compiler_state_453.py
+++ b/tests/regressions/python/passing_compiler_state_453.py
@@ -28,4 +28,4 @@ def foo(n):
     return mul2(n)  # noqa: F821
 
 
-print(foo(3))
+assert(6.0 == foo(3))


### PR DESCRIPTION
- flyby: don't package numpy arrays into Phylanx variables during Python -> C++ conversion


This fixes #486