### PR TITLE
Set the cout precision for float numbers to 8 by default.

### DIFF
--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -1293,7 +1293,7 @@ namespace phylanx { namespace ir
                 {
                     out << ", ";
                 }
-                out << T(r[i]);
+                out << std::setprecision(8) << T(r[i]);
             }
             out << "]";
         }
@@ -1306,7 +1306,7 @@ namespace phylanx { namespace ir
         switch (dims)
         {
         case 0:
-            out << nd[0];
+            out << std::setprecision(8) << nd[0];
             break;
 
         case 1: HPX_FALLTHROUGH;


### PR DESCRIPTION
This pull request makes sure that Phylanx `cout` prints doubles with the same precision as Phython `print`. 