### PR TITLE
Fix phylanxrun.py

### DIFF
--- a/cmake/templates/phylanxrun.py.in
+++ b/cmake/templates/phylanxrun.py.in
@@ -81,7 +81,7 @@ def run_mpi(cmd, localities, verbose):
     if mpiexec == '':
         msg = 'mpiexec not available on this platform. '
         msg += 'Please rerun CMake with HPX_PARCELPORT_MPI=True.'
-        print(msg, sys.stderr)
+        print(msg, file=sys.stderr)
         sys.exit(1)
     exec_cmd = ['@MPIEXEC@', '@MPIEXEC_NUMPROC_FLAG@', str(localities)] + cmd
     if verbose:
@@ -122,12 +122,12 @@ def build_cmd(options, args):
     if options.localities > 1:
         # Selecting the parcelport for hpx via hpx ini confifuration
         select_parcelport = (lambda pp:
-                             ['-Ihpx.parcel.verbs.enable=1'] if pp == 'verbs'
-                             else ['-Ihpx.parcel.ipc.enable=1'] if pp == 'ipc'
+                             ['--hpx:ini=hpx.parcel.verbs.enable=1'] if pp == 'verbs'
+                             else ['--hpx:ini=hpx.parcel.ipc.enable=1'] if pp == 'ipc'
                              else [
-                                 '-Ihpx.parcel.mpi.enable=1',
-                                 '-Ihpx.parcel.bootstrap=mpi'] if pp == 'mpi'
-                             else ['-Ihpx.parcel.tcp.enable=1'] if pp == 'tcp'
+                                 '--hpx:ini=hpx.parcel.mpi.enable=1',
+                                 '--hpx:ini=hpx.parcel.bootstrap=mpi'] if pp == 'mpi'
+                             else ['--hpx:ini=hpx.parcel.tcp.enable=1'] if pp == 'tcp'
                              else [])
         cmd += select_parcelport(options.parcelport)
 
@@ -150,33 +150,33 @@ def build_cmd(options, args):
 def check_options(parser, options, args):
     if 0 == len(args):
         print('Error: You need to specify at least the application to start\n',
-              sys.stderr)
+              file=sys.stderr)
         parser.print_help()
         sys.exit(1)
 
     if not os.path.exists(args[0]):
-        print('Executable ' + args[0] + ' does not exist', sys.stderr)
+        print('Executable ' + args[0] + ' does not exist', file=sys.stderr)
         sys.exit(1)
 
     if options.localities < 1:
-        print('Can not start less than one locality', sys.stderr)
+        print('Can not start less than one locality', file=sys.stderr)
         sys.exit(1)
 
     if options.threads < 1 and options.threads != -1:
-        print('Can not start less than one thread per locality', sys.stderr)
+        print('Can not start less than one thread per locality', file=sys.stderr)
         sys.exit(1)
 
     check_valid_parcelport = (
         lambda x: x == 'verbs' or x == 'ipc' or x == 'mpi' or x == 'tcp')
     if not check_valid_parcelport(options.parcelport):
-        print('Error: Parcelport option not valid\n', sys.stderr)
+        print('Error: Parcelport option not valid\n', file=sys.stderr)
         parser.print_help()
         sys.exit(1)
 
     check_valid_runwrapper = (
         lambda x: x == 'none' or x == 'mpi' or x == 'srun')
     if not check_valid_runwrapper(options.runwrapper):
-        print('Error: Runwrapper option not valid\n', sys.stderr)
+        print('Error: Runwrapper option not valid\n', file=sys.stderr)
         parser.print_help()
         sys.exit(1)
 


### PR DESCRIPTION
Updated `phylanxrun.py` to not use the short HPX options format and appropriately use the stderr in `print` statements.