### PR TITLE
Make sure, all eval-actions on primitives are run asynchronously if run on a non-HPX thread

### DIFF
--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -95,6 +95,7 @@ namespace phylanx { namespace execution_tree
 #if defined(HPX_HAVE_APEX)
             std::string eval_name_;
 #endif
+            static bool get_sync_execution();
         };
     }
 

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -11,9 +11,10 @@
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/throw_exception.hpp>
-#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/runtime/config_entry.hpp>
 #include <hpx/runtime/launch_policy.hpp>
+#include <hpx/runtime/naming_fwd.hpp>
+#include <hpx/throw_exception.hpp>
 
 #include <cstdint>
 #include <set>
@@ -181,36 +182,55 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::util::get_and_reset_value(execute_directly_, reset);
     }
 
+    ////////////////////////////////////////////////////////////////////////////
+    bool primitive_component_base::get_sync_execution()
+    {
+        static bool sync_execution =
+            hpx::get_config_entry("phylanx.sync_execution", "0") == "1";
+        return sync_execution;
+    }
+
     // decide whether to execute eval directly
     hpx::launch primitive_component_base::select_direct_eval_execution(
         hpx::launch policy) const
     {
-//         if (eval_count_ != 0)
-//         {
-//             // check whether execution status needs to be changed (with some
-//             // hysteresis)
-//             std::int64_t exec_time = (eval_duration_ / eval_count_);
-//             if (exec_time > 300000)
-//             {
-//                 execute_directly_ = 0;
-//             }
-//             else if (exec_time < 150000)
-//             {
-//                 execute_directly_ = 1;
-//             }
-//         }
-//
-//         if (execute_directly_ == 1)
-//         {
-//             return hpx::launch::sync;
-//         }
-//         else if (execute_directly_ == 0)
-//         {
-//             return hpx::launch::async;
-//         }
-//
-//         return policy;
-        return hpx::launch::sync;
+        // always run this on an HPX thread
+        if (hpx::threads::get_self_ptr() == nullptr)
+        {
+            return hpx::launch::async;
+        }
+
+        // always execute synchronously, if requested
+        if (get_sync_execution())
+        {
+            return hpx::launch::sync;
+        }
+
+        if (eval_count_ != 0)
+        {
+            // check whether execution status needs to be changed (with some
+            // hysteresis)
+            std::int64_t exec_time = (eval_duration_ / eval_count_);
+            if (exec_time > 300000)
+            {
+                execute_directly_ = 0;
+            }
+            else if (exec_time < 150000)
+            {
+                execute_directly_ = 1;
+            }
+        }
+
+        if (execute_directly_ == 1)
+        {
+            return hpx::launch::sync;
+        }
+        else if (execute_directly_ == 0)
+        {
+            return hpx::launch::async;
+        }
+
+        return policy;
     }
 }}}
 


### PR DESCRIPTION
- flyby: enable forcing sync execution for debug purposes