### PR TITLE
Change all vector<primitive_argument_type> to use thread local allocator

### DIFF
--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -117,12 +117,12 @@ void dump_physl_code(std::vector<phylanx::ast::expression> const& ast,
     }
 }
 
-std::vector<phylanx::execution_tree::primitive_argument_type>
+phylanx::execution_tree::primitive_arguments_type
 read_arguments(std::vector<std::string> const& args,
     phylanx::execution_tree::compiler::function_list& snippets,
     phylanx::execution_tree::compiler::environment& env)
 {
-    std::vector<phylanx::execution_tree::primitive_argument_type> result(
+    phylanx::execution_tree::primitive_arguments_type result(
         args.size());
 
     std::transform(

--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
     ///////////////////////////////////////////////////////////////////////////
     using result_type = primitive_argument_type;
     using argument_type = primitive_argument_type;
-    using arguments_type = std::vector<primitive_argument_type>;
+    using arguments_type = primitive_arguments_type;
 
     using stored_function =
         hpx::util::function_nonser<result_type(arguments_type&&)>;
@@ -114,7 +114,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             if (is_primitive_operand(arg_))
             {
                 return extract_copy_value(value_operand_sync(arg_,
-                    std::vector<primitive_argument_type>{}, name_));
+                    primitive_arguments_type{}, name_));
             }
             return extract_ref_value(arg_);
         }

--- a/phylanx/execution_tree/compiler/compiler.hpp
+++ b/phylanx/execution_tree/compiler/compiler.hpp
@@ -197,7 +197,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             return function{
                 primitive_argument_type{
                     create_primitive_component(locality_, type,
-                        std::vector<primitive_argument_type>{}, name,
+                        primitive_arguments_type{}, name,
                         codename)},
                 name};
         }
@@ -239,7 +239,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     full_name};
             }
 
-            std::vector<primitive_argument_type> fargs;
+            primitive_arguments_type fargs;
             fargs.reserve(elements.size() + 1);
 
             fargs.push_back(primitive_argument_type{argnum_});
@@ -295,7 +295,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     full_name};
             }
 
-            std::vector<primitive_argument_type> fargs;
+            primitive_arguments_type fargs;
             fargs.reserve(elements.size() + 1);
 
             fargs.push_back(f_.get().arg_);
@@ -342,7 +342,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
             name_parts.instance = std::move(name_parts.primitive);
             name_parts.primitive = "call-function";
 
-            std::vector<primitive_argument_type> fargs;
+            primitive_arguments_type fargs;
             fargs.reserve(elements.size() + 1);
 
             fargs.push_back(f_.get().arg_);

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -60,9 +60,9 @@ namespace phylanx { namespace execution_tree { namespace compiler
             std::int64_t tag2_ = -1, std::int64_t compile_id_ = -1)
           : primitive(primitive_)
           , sequence_number(sequence_number_)
+          , compile_id(compile_id_)
           , tag1(tag1_)
           , tag2(tag2_)
-          , compile_id(compile_id_)
         {}
 
         std::string primitive;

--- a/phylanx/execution_tree/primitives/access_argument.hpp
+++ b/phylanx/execution_tree/primitives/access_argument.hpp
@@ -26,11 +26,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         access_argument() = default;
 
-        access_argument(std::vector<primitive_argument_type>&& args,
+        access_argument(primitive_arguments_type&& args,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode) const override;
 
     private:

--- a/phylanx/execution_tree/primitives/access_function.hpp
+++ b/phylanx/execution_tree/primitives/access_function.hpp
@@ -25,14 +25,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         access_function() = default;
 
-        access_function(std::vector<primitive_argument_type>&& operands,
+        access_function(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
-        void store(std::vector<primitive_argument_type>&& val,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& val,
+            primitive_arguments_type&& params) override;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode mode) const override;
 
         topology expression_topology(std::set<std::string>&& functions,

--- a/phylanx/execution_tree/primitives/access_variable.hpp
+++ b/phylanx/execution_tree/primitives/access_variable.hpp
@@ -28,16 +28,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         access_variable() = default;
 
-        access_variable(std::vector<primitive_argument_type>&& operands,
+        access_variable(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
-        void store(std::vector<primitive_argument_type>&& val,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& val,
+            primitive_arguments_type&& params) override;
         void store(primitive_argument_type&& val,
-            std::vector<primitive_argument_type>&& params) override;
+            primitive_arguments_type&& params) override;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode mode) const override;
 
         topology expression_topology(std::set<std::string>&& functions,

--- a/phylanx/execution_tree/primitives/assert_condition.hpp
+++ b/phylanx/execution_tree/primitives/assert_condition.hpp
@@ -31,22 +31,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         assert_condition() = default;
 
-        assert_condition(std::vector<primitive_argument_type>&& operands,
+        assert_condition(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
-        using operand_type = std::vector<primitive_argument_type>;
+        using operand_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     PHYLANX_EXPORT primitive create_assert_condition(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}
 

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -39,25 +39,25 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT primitive_argument_type value_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT primitive_argument_type value_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args,
+        primitive_arguments_type&& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT primitive_argument_type value_operand_sync(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT primitive_argument_type value_operand_sync(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args,
+        primitive_arguments_type&& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
@@ -90,7 +90,7 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT primitive_argument_type value_operand_ref_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -304,22 +304,22 @@ namespace phylanx { namespace execution_tree
     // Extract an integer value from a primitive_argument_type
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -359,27 +359,27 @@ namespace phylanx { namespace execution_tree
     // Extract an integer value from a primitive_argument_type
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<std::int64_t> scalar_integer_operand_strict(
             primitive_argument_type const& val,
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             std::string const& name = "",
             std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -501,22 +501,22 @@ namespace phylanx { namespace execution_tree
     // could be a value type).
     PHYLANX_EXPORT hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args,
+        primitive_arguments_type&& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args,
+        primitive_arguments_type&& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
 
@@ -543,22 +543,22 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT util::future_or_value<primitive_argument_type>
     value_operand_fov(primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT util::future_or_value<primitive_argument_type>
     value_operand_fov(primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args,
+        primitive_arguments_type&& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT util::future_or_value<primitive_argument_type>
     value_operand_fov(primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
     PHYLANX_EXPORT util::future_or_value<primitive_argument_type>
     value_operand_fov(primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args,
+        primitive_arguments_type&& args,
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_mode mode = eval_default);
 
@@ -590,28 +590,28 @@ namespace phylanx { namespace execution_tree
     // was declared above
     //     PHYLANX_EXPORT primitive_argument_type value_operand_sync(
     //         primitive_argument_type const& val,
-    //         std::vector<primitive_argument_type> const& args);
+    //         primitive_arguments_type const& args);
 
     // Extract a primitive_argument_type from a primitive_argument_type (that
     // could be a primitive or a literal value).
     PHYLANX_EXPORT hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -629,7 +629,7 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT primitive_argument_type literal_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -637,22 +637,22 @@ namespace phylanx { namespace execution_tree
     // could be a primitive or a literal value).
     PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -670,7 +670,7 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT ir::node_data<double> numeric_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -678,12 +678,12 @@ namespace phylanx { namespace execution_tree
     // could be a primitive or a literal value).
     PHYLANX_EXPORT hpx::future<std::uint8_t> boolean_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT std::uint8_t boolean_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -691,12 +691,12 @@ namespace phylanx { namespace execution_tree
     // could be a primitive or a string value).
     PHYLANX_EXPORT hpx::future<std::string> string_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT std::string string_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -704,12 +704,12 @@ namespace phylanx { namespace execution_tree
     // could be a primitive or a literal value).
     PHYLANX_EXPORT hpx::future<std::vector<ast::expression>> ast_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT std::vector<ast::expression> ast_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -717,22 +717,22 @@ namespace phylanx { namespace execution_tree
     // could be a primitive or a literal value).
     PHYLANX_EXPORT hpx::future<ir::range> list_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::range> list_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::range> list_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::range> list_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -751,7 +751,7 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT ir::range list_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -759,22 +759,22 @@ namespace phylanx { namespace execution_tree
     // could be a primitive or a literal value).
     PHYLANX_EXPORT hpx::future<ir::range> list_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::range> list_operand_strict(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::range> list_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT hpx::future<ir::range> list_operand_strict(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -794,7 +794,7 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT ir::range list_operand_strict_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -803,22 +803,22 @@ namespace phylanx { namespace execution_tree
     // could be a primitive or a literal value).
     PHYLANX_EXPORT util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -842,15 +842,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         // Invoke the given function on all items in the input vector, while
         // returning another vector holding the respective results.
-        template <typename T, typename F, typename ... Ts>
-        auto map_operands(std::vector<T> const& in, F && f, Ts && ... ts)
+        template <typename T, typename Allocator, typename F, typename ... Ts>
+        auto map_operands(std::vector<T, Allocator> const& in, F && f,
+                Ts && ... ts)
         ->  std::vector<decltype(
                     hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )>
+                ),
+                typename std::allocator_traits<Allocator>::template
+                    rebind_alloc<decltype(
+                        hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
+                    )>
+            >
         {
             std::vector<decltype(
                     hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )> out;
+                ),
+                typename std::allocator_traits<Allocator>::template
+                    rebind_alloc<decltype(
+                        hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
+                    )>
+            > out;
             out.reserve(in.size());
 
             for (auto const& d : in)
@@ -860,15 +871,25 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return out;
         }
 
-        template <typename T, typename F, typename ... Ts>
-        auto map_operands(std::vector<T> && in, F && f, Ts && ... ts)
+        template <typename T, typename Allocator, typename F, typename ... Ts>
+        auto map_operands(std::vector<T, Allocator> && in, F && f, Ts && ... ts)
         ->  std::vector<decltype(
                     hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )>
+                ),
+                typename std::allocator_traits<Allocator>::template
+                    rebind_alloc<decltype(
+                        hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
+                    )>
+            >
         {
             std::vector<decltype(
                     hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )> out;
+                ),
+                typename std::allocator_traits<Allocator>::template
+                    rebind_alloc<decltype(
+                        hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
+                    )>
+            > out;
             out.reserve(in.size());
 
             for (auto && d : in)
@@ -881,8 +902,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         // Invoke the given function on all items in the input vector, while
         // returning another vector holding the respective results.
-        template <typename T, typename F, typename ... Ts>
-        auto map_operands_sv(std::vector<T> const& in, F && f, Ts && ... ts)
+        template <typename T, typename Allocator, typename F, typename ... Ts>
+        auto map_operands_sv(std::vector<T, Allocator> const& in, F && f,
+                Ts && ... ts)
         ->  util::small_vector<decltype(
                     hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
                 )>
@@ -899,8 +921,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return out;
         }
 
-        template <typename T, typename F, typename ... Ts>
-        auto map_operands_sv(std::vector<T> && in, F && f, Ts && ... ts)
+        template <typename T, typename Allocator, typename F, typename ... Ts>
+        auto map_operands_sv(std::vector<T, Allocator> && in, F && f,
+                Ts && ... ts)
         ->  util::small_vector<decltype(
                     hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
                 )>
@@ -921,7 +944,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ///////////////////////////////////////////////////////////////////////
         // check if one of the optionals in the list of operands is empty
         inline bool verify_argument_values(
-            std::vector<primitive_argument_type> const& ops)
+            primitive_arguments_type const& ops)
         {
             for (auto const& op : ops)
             {

--- a/phylanx/execution_tree/primitives/call_function.hpp
+++ b/phylanx/execution_tree/primitives/call_function.hpp
@@ -29,7 +29,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         call_function() = default;
 
-        call_function(std::vector<primitive_argument_type>&& operands,
+        call_function(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         // return the topology for this function definition
@@ -37,10 +37,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::set<std::string>&& resolve_children) const override;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
-        void store(std::vector<primitive_argument_type>&& data,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& data,
+            primitive_arguments_type&& params) override;
     };
 }}}
 

--- a/phylanx/execution_tree/primitives/console_output.hpp
+++ b/phylanx/execution_tree/primitives/console_output.hpp
@@ -27,20 +27,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         console_output() = default;
 
-        console_output(std::vector<primitive_argument_type>&& operands,
+        console_output(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     PHYLANX_EXPORT primitive create_console_output(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}
 

--- a/phylanx/execution_tree/primitives/debug_output.hpp
+++ b/phylanx/execution_tree/primitives/debug_output.hpp
@@ -24,28 +24,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
-        using args_type = std::vector<primitive_argument_type>;
+        using args_type = primitive_arguments_type;
 
     public:
         static match_pattern_type const match_data;
 
         debug_output() = default;
 
-        debug_output(std::vector<primitive_argument_type>&& operands,
+        debug_output(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type operand_;
     };
 
     PHYLANX_EXPORT primitive create_debug_output(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}
 

--- a/phylanx/execution_tree/primitives/define_variable.hpp
+++ b/phylanx/execution_tree/primitives/define_variable.hpp
@@ -33,16 +33,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         define_variable() = default;
 
-        define_variable(std::vector<primitive_argument_type>&& operands,
+        define_variable(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         // Create a new instance of the variable and initialize it with the
         // value as returned by evaluating the given body.
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
-        void store(std::vector<primitive_argument_type>&& val,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& val,
+            primitive_arguments_type&& params) override;
 
         // return the topology for this variable definition
         topology expression_topology(std::set<std::string>&& functions,

--- a/phylanx/execution_tree/primitives/enable_tracing.hpp
+++ b/phylanx/execution_tree/primitives/enable_tracing.hpp
@@ -24,15 +24,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         enable_tracing() = default;
 
-        enable_tracing(std::vector<primitive_argument_type>&& operands,
+        enable_tracing(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
     };
 
     PHYLANX_EXPORT primitive create_enable_tracing(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}
 

--- a/phylanx/execution_tree/primitives/format_string.hpp
+++ b/phylanx/execution_tree/primitives/format_string.hpp
@@ -28,20 +28,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         format_string() = default;
 
-        format_string(std::vector<primitive_argument_type>&& operands,
+        format_string(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     PHYLANX_EXPORT primitive create_format_string(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}
 

--- a/phylanx/execution_tree/primitives/function.hpp
+++ b/phylanx/execution_tree/primitives/function.hpp
@@ -27,17 +27,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         function() = default;
 
-        function(std::vector<primitive_argument_type>&& operands,
+        function(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
         bool bind(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
-        void store(std::vector<primitive_argument_type>&& data,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& data,
+            primitive_arguments_type&& params) override;
 
         topology expression_topology(std::set<std::string>&& functions,
             std::set<std::string>&& resolve_children) const override;

--- a/phylanx/execution_tree/primitives/generic_function.hpp
+++ b/phylanx/execution_tree/primitives/generic_function.hpp
@@ -30,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         generic_function() = default;
 
-        generic_function(std::vector<primitive_argument_type>&& operands,
+        generic_function(primitive_arguments_type&& operands,
                 std::string const& name, std::string const& codename)
           : primitive_component_base(std::move(operands), name, codename)
         {}
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // Create a new instance of the variable and initialize it with the
         // value as returned by evaluating the given body.
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override
+            primitive_arguments_type const& args) const override
         {
             return hpx::async(
                 Action(), hpx::find_here(), operands_, args, name_, codename_);
@@ -52,7 +52,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     template <typename Action>
     primitive create_generic_function(
         hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(locality,

--- a/phylanx/execution_tree/primitives/generic_function_impl.hpp
+++ b/phylanx/execution_tree/primitives/generic_function_impl.hpp
@@ -25,7 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action>
     primitive create_generic_function(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name)
     {
         return create_primitive_component(locality,
@@ -36,15 +36,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action>
     generic_function<Action>::generic_function(
-            std::vector<primitive_argument_type>&& operands)
+            primitive_arguments_type&& operands)
       : primitive_component_base(std::move(operands))
     {}
 
     template <typename Action>
     hpx::future<primitive_argument_type> generic_function<Action>::eval(
-        std::vector<primitive_argument_type> const& params) const
+        primitive_arguments_type const& params) const
     {
-        std::vector<primitive_argument_type> fargs;
+        primitive_arguments_type fargs;
         fargs.reserve(operands_.size());
 
         for (auto const& operand : operands_)

--- a/phylanx/execution_tree/primitives/lambda.hpp
+++ b/phylanx/execution_tree/primitives/lambda.hpp
@@ -27,7 +27,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         lambda() = default;
 
-        lambda(std::vector<primitive_argument_type>&& operands,
+        lambda(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         // return the topology for this function definition
@@ -35,11 +35,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::set<std::string>&& resolve_children) const override;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode mode) const override;
 
-        void store(std::vector<primitive_argument_type>&& data,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& data,
+            primitive_arguments_type&& params) override;
     };
 }}}
 

--- a/phylanx/execution_tree/primitives/primitive_argument_type.hpp
+++ b/phylanx/execution_tree/primitives/primitive_argument_type.hpp
@@ -120,10 +120,10 @@ namespace phylanx { namespace execution_tree
             primitive_argument_type && arg,
             eval_mode mode = eval_default) const;
         PHYLANX_EXPORT hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> && args,
+            primitive_arguments_type && args,
             eval_mode mode = eval_default) const;
         PHYLANX_EXPORT hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             eval_mode mode = eval_default) const;
 
         PHYLANX_EXPORT primitive_argument_type eval(hpx::launch::sync_policy,
@@ -132,23 +132,23 @@ namespace phylanx { namespace execution_tree
             primitive_argument_type && arg,
             eval_mode mode = eval_default) const;
         PHYLANX_EXPORT primitive_argument_type eval(hpx::launch::sync_policy,
-            std::vector<primitive_argument_type>&& args,
+            primitive_arguments_type&& args,
             eval_mode mode = eval_default) const;
         PHYLANX_EXPORT primitive_argument_type eval(hpx::launch::sync_policy,
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             eval_mode mode = eval_default) const;
 
         PHYLANX_EXPORT hpx::future<void> store(primitive_argument_type&&,
-            std::vector<primitive_argument_type>&&);
+            primitive_arguments_type&&);
         PHYLANX_EXPORT hpx::future<void> store(
-            std::vector<primitive_argument_type>&&,
-            std::vector<primitive_argument_type>&&);
+            primitive_arguments_type&&,
+            primitive_arguments_type&&);
         PHYLANX_EXPORT void store(hpx::launch::sync_policy,
             primitive_argument_type&&,
-            std::vector<primitive_argument_type>&&);
+            primitive_arguments_type&&);
         PHYLANX_EXPORT void store(hpx::launch::sync_policy,
-            std::vector<primitive_argument_type>&&,
-            std::vector<primitive_argument_type>&&);
+            primitive_arguments_type&&,
+            primitive_arguments_type&&);
 
         PHYLANX_EXPORT hpx::future<topology> expression_topology(
             std::set<std::string>&& functions) const;
@@ -163,9 +163,9 @@ namespace phylanx { namespace execution_tree
             std::set<std::string>&& resolve_children) const;
 
         PHYLANX_EXPORT bool bind(
-            std::vector<primitive_argument_type>&& args) const;
+            primitive_arguments_type&& args) const;
         PHYLANX_EXPORT bool bind(
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& args) const;
 
     public:
         static bool enable_tracing;
@@ -175,10 +175,10 @@ namespace phylanx { namespace execution_tree
     using argument_value_type =
         phylanx::util::variant<
             ast::nil
-          , phylanx::ir::node_data<std::uint8_t>
-          , phylanx::ir::node_data<std::int64_t>
+          , ir::node_data<std::uint8_t>
+          , ir::node_data<std::int64_t>
           , std::string
-          , phylanx::ir::node_data<double>
+          , ir::node_data<double>
           , primitive
           , std::vector<ast::expression>
           , ir::range
@@ -309,12 +309,12 @@ namespace phylanx { namespace execution_tree
         {}
 
         explicit primitive_argument_type(
-            std::vector<primitive_argument_type> const& val)
+            primitive_arguments_type const& val)
           : argument_value_type{ir::range{val}}
         {}
 
         explicit primitive_argument_type(
-            std::vector<primitive_argument_type>&& val)
+            primitive_arguments_type&& val)
           : argument_value_type{ir::range{std::move(val)}}
         {}
 
@@ -344,15 +344,15 @@ namespace phylanx { namespace execution_tree
         PHYLANX_EXPORT primitive_argument_type operator()() const;
 
         PHYLANX_EXPORT primitive_argument_type
-        operator()(std::vector<primitive_argument_type> const& args) const;
+        operator()(primitive_arguments_type const& args) const;
 
         PHYLANX_EXPORT primitive_argument_type
-        operator()(std::vector<primitive_argument_type> && args) const;
+        operator()(primitive_arguments_type && args) const;
 
         template <typename ... Ts>
         primitive_argument_type operator()(Ts &&... ts) const
         {
-            std::vector<primitive_argument_type> args;
+            primitive_arguments_type args;
             args.reserve(sizeof...(Ts));
 
             int const sequencer_[] = {

--- a/phylanx/execution_tree/primitives/primitive_component.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component.hpp
@@ -35,14 +35,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         PHYLANX_EXPORT static std::shared_ptr<primitive_component_base>
         create_primitive(std::string const& type,
-            std::vector<primitive_argument_type>&& params,
+            primitive_arguments_type&& params,
             std::string const& name, std::string const& codename);
 
     public:
         primitive_component() = default;
 
         primitive_component(std::string const& type,
-                std::vector<primitive_argument_type>&& operands,
+                primitive_arguments_type&& operands,
                 std::string const& name, std::string const& codename)
           : primitive_(
                 create_primitive(type, std::move(operands), name, codename))
@@ -51,18 +51,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         // eval_action
         PHYLANX_EXPORT hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode mode) const;
 
         PHYLANX_EXPORT hpx::future<primitive_argument_type> eval_single(
             primitive_argument_type && param, eval_mode mode) const;
 
         // store_action
-        PHYLANX_EXPORT void store(std::vector<primitive_argument_type>&&,
-            std::vector<primitive_argument_type>&&);
+        PHYLANX_EXPORT void store(primitive_arguments_type&&,
+            primitive_arguments_type&&);
 
         PHYLANX_EXPORT void store_single(primitive_argument_type&&,
-            std::vector<primitive_argument_type>&&);
+            primitive_arguments_type&&);
 
         // extract_topology_action
         PHYLANX_EXPORT topology expression_topology(
@@ -71,7 +71,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         // bind an invocable object
         PHYLANX_EXPORT bool bind(
-            std::vector<primitive_argument_type> const& params) const;
+            primitive_arguments_type const& params) const;
 
         HPX_DEFINE_COMPONENT_ACTION(
             primitive_component, eval, eval_action);

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -39,7 +39,7 @@ namespace phylanx { namespace execution_tree
             primitive_component_base() = default;
 
             primitive_component_base(
-                std::vector<primitive_argument_type>&& params,
+                primitive_arguments_type&& params,
                 std::string const& name, std::string const& codename,
                 bool eval_direct = false);
 
@@ -47,18 +47,18 @@ namespace phylanx { namespace execution_tree
 
             // eval_action
             virtual hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& params,
+                primitive_arguments_type const& params,
                 eval_mode mode) const;
 
             virtual hpx::future<primitive_argument_type> eval(
                 primitive_argument_type && param, eval_mode mode) const;
 
             // store_action
-            virtual void store(std::vector<primitive_argument_type>&&,
-                std::vector<primitive_argument_type>&&);
+            virtual void store(primitive_arguments_type&&,
+                primitive_arguments_type&&);
 
             virtual void store(primitive_argument_type&&,
-                std::vector<primitive_argument_type>&&);
+                primitive_arguments_type&&);
 
             // extract_topology_action
             virtual topology expression_topology(
@@ -67,21 +67,21 @@ namespace phylanx { namespace execution_tree
 
             // bind_action
             virtual bool bind(
-                std::vector<primitive_argument_type> const& params) const;
+                primitive_arguments_type const& params) const;
 
         protected:
             friend class primitive_component;
 
             // helper functions to invoke eval functionalities
             hpx::future<primitive_argument_type> do_eval(
-                std::vector<primitive_argument_type> const& params,
+                primitive_arguments_type const& params,
                 eval_mode mode) const;
 
             hpx::future<primitive_argument_type> do_eval(
                 primitive_argument_type && param, eval_mode mode) const;
 
             virtual hpx::future<primitive_argument_type> eval(
-                std::vector<primitive_argument_type> const& params) const;
+                primitive_arguments_type const& params) const;
 
             // access data for performance counter
             std::int64_t get_eval_count(bool reset) const;
@@ -100,7 +100,7 @@ namespace phylanx { namespace execution_tree
             {
                 return operands_.empty();
             }
-            std::vector<primitive_argument_type> const& operands() const
+            primitive_arguments_type const& operands() const
             {
                 return operands_.empty() ||
                         (operands_.size() == 1 && !valid(operands_[0])) ?
@@ -112,8 +112,8 @@ namespace phylanx { namespace execution_tree
             static bool get_sync_execution();
 
         protected:
-            static std::vector<primitive_argument_type> noargs;
-            mutable std::vector<primitive_argument_type> operands_;
+            static primitive_arguments_type noargs;
+            mutable primitive_arguments_type operands_;
 
             std::string const name_;        // the unique name of this primitive
             std::string const codename_;    // the name of the original code source
@@ -133,12 +133,12 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     // Factory functions
     using factory_function_type = primitive (*)(
-        hpx::id_type const&, std::vector<primitive_argument_type>&&,
+        hpx::id_type const&, primitive_arguments_type&&,
         std::string const&, std::string const&);
 
     using primitive_factory_function_type =
         std::shared_ptr<primitives::primitive_component_base> (*)(
-            std::vector<primitive_argument_type>&&, std::string const&,
+            primitive_arguments_type&&, std::string const&,
             std::string const&);
 
     using match_pattern_type = hpx::util::tuple<std::string,
@@ -157,7 +157,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT primitive create_primitive_component(
         hpx::id_type const& locality, std::string const& type,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
@@ -169,7 +169,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     template <typename Primitive>
     std::shared_ptr<primitives::primitive_component_base>
-    create_primitive(std::vector<primitive_argument_type>&& args,
+    create_primitive(primitive_arguments_type&& args,
         std::string const& name, std::string const& codename)
     {
         return std::static_pointer_cast<primitives::primitive_component_base>(

--- a/phylanx/execution_tree/primitives/store_operation.hpp
+++ b/phylanx/execution_tree/primitives/store_operation.hpp
@@ -27,11 +27,11 @@ namespace phylanx {namespace execution_tree { namespace primitives
 
         store_operation() = default;
 
-        store_operation(std::vector<primitive_argument_type>&& operands,
+        store_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             eval_mode) const override;
 
         hpx::future<primitive_argument_type> eval(
@@ -40,7 +40,7 @@ namespace phylanx {namespace execution_tree { namespace primitives
 
     PHYLANX_EXPORT primitive create_store_operation(
         hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}
 

--- a/phylanx/execution_tree/primitives/string_output.hpp
+++ b/phylanx/execution_tree/primitives/string_output.hpp
@@ -24,26 +24,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
         , public std::enable_shared_from_this<string_output>
     {
     protected:
-        using args_type = std::vector<primitive_argument_type>;
+        using args_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         string_output() = default;
 
-        string_output(std::vector<primitive_argument_type>&& operands,
+        string_output(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
     };
 
     PHYLANX_EXPORT primitive create_string_output(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "");
 }}}
 

--- a/phylanx/execution_tree/primitives/target_reference.hpp
+++ b/phylanx/execution_tree/primitives/target_reference.hpp
@@ -26,17 +26,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         target_reference() = default;
 
-        target_reference(std::vector<primitive_argument_type>&& operands,
+        target_reference(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode) const override;
         hpx::future<primitive_argument_type> eval(
             primitive_argument_type && param, eval_mode) const override;
 
-        void store(std::vector<primitive_argument_type>&& data,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& data,
+            primitive_arguments_type&& params) override;
 
         topology expression_topology(std::set<std::string>&& functions,
             std::set<std::string>&& resolve_children) const override;

--- a/phylanx/execution_tree/primitives/variable.hpp
+++ b/phylanx/execution_tree/primitives/variable.hpp
@@ -27,22 +27,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         variable() = default;
 
-        variable(std::vector<primitive_argument_type>&& operands,
+        variable(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode) const override;
         hpx::future<primitive_argument_type> eval(
             primitive_argument_type && arg, eval_mode mode) const override;
 
         bool bind(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
-        void store(std::vector<primitive_argument_type>&& data,
-            std::vector<primitive_argument_type>&& params) override;
+        void store(primitive_arguments_type&& data,
+            primitive_arguments_type&& params) override;
         void store(primitive_argument_type&& data,
-            std::vector<primitive_argument_type>&& params) override;
+            primitive_arguments_type&& params) override;
 
         topology expression_topology(std::set<std::string>&& functions,
             std::set<std::string>&& resolve_children) const override;

--- a/phylanx/ir/ranges.hpp
+++ b/phylanx/ir/ranges.hpp
@@ -16,13 +16,25 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace phylanx { namespace execution_tree
 {
+    ///////////////////////////////////////////////////////////////////////////
     struct primitive_argument_type;
+
+    using primitive_argument_allocator =
+        std::allocator<primitive_argument_type>;
+
+    template <typename T>
+    using arguments_allocator = typename std::allocator_traits<
+        primitive_argument_allocator>::template rebind_alloc<T>;
+
+    using primitive_arguments_type =
+        std::vector<primitive_argument_type, primitive_argument_allocator>;
 }}
 
 namespace phylanx { namespace ir
@@ -185,9 +197,9 @@ namespace phylanx { namespace ir
     private:
         using int_range_type = slicing_indices;
         using args_iterator_type =
-            std::vector<execution_tree::primitive_argument_type>::iterator;
+            execution_tree::primitive_arguments_type::iterator;
         using args_const_iterator_type =
-            std::vector<execution_tree::primitive_argument_type>::const_iterator;
+            execution_tree::primitive_arguments_type::const_iterator;
         using args_reverse_iterator_type = std::vector<
             execution_tree::primitive_argument_type>::reverse_iterator;
         using args_reverse_const_iterator_type = std::vector<
@@ -231,7 +243,7 @@ namespace phylanx { namespace ir
     {
     private:
         using int_range_type = slicing_indices;
-        using args_type = std::vector<execution_tree::primitive_argument_type>;
+        using args_type = execution_tree::primitive_arguments_type;
         using wrapped_args_type = phylanx::util::recursive_wrapper<args_type>;
         using arg_pair_type = std::pair<range_iterator, range_iterator>;
         using range_type =

--- a/phylanx/plugins/algorithms/als.hpp
+++ b/phylanx/plugins/algorithms/als.hpp
@@ -25,8 +25,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
@@ -40,19 +40,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         /// \param args Is a (possibly empty) list of any values to be
         ///             concatenated into a PhySL list in order.
         ///
-        als(std::vector<primitive_argument_type>&& operands,
+        als(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     protected:
         primitive_argument_type calculate_als(
-            std::vector<primitive_argument_type>&& args) const;
+            primitive_arguments_type&& args) const;
     };
 
     inline primitive create_als(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/algorithms/lra.hpp
+++ b/phylanx/plugins/algorithms/lra.hpp
@@ -25,8 +25,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
@@ -40,19 +40,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         /// \param args Is a (possibly empty) list of any values to be
         ///             concatenated into a PhySL list in order.
         ///
-        lra(std::vector<primitive_argument_type>&& operands,
+        lra(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     protected:
         primitive_argument_type calculate_lra(
-            std::vector<primitive_argument_type>&& args) const;
+            primitive_arguments_type&& args) const;
     };
 
     inline primitive create_lra(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/arithmetics/add_operation.hpp
+++ b/phylanx/plugins/arithmetics/add_operation.hpp
@@ -29,22 +29,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         add_operation() = default;
 
-        add_operation(std::vector<primitive_argument_type>&& operands,
+        add_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             eval_mode) const override;
 
     private:
@@ -97,16 +97,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
 
         primitive_argument_type handle_list_operands(
-            std::vector<primitive_argument_type>&& ops) const;
+            primitive_arguments_type&& ops) const;
         primitive_argument_type handle_numeric_operands(
-            std::vector<primitive_argument_type>&& ops) const;
+            primitive_arguments_type&& ops) const;
 
-        void append_element(std::vector<primitive_argument_type>& result,
+        void append_element(primitive_arguments_type& result,
             primitive_argument_type&& rhs) const;
     };
 
     inline primitive create_add_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/arithmetics/div_operation.hpp
+++ b/phylanx/plugins/arithmetics/div_operation.hpp
@@ -27,22 +27,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type =
+            std::vector<operand_type, arguments_allocator<operand_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         div_operation() = default;
 
-        div_operation(std::vector<primitive_argument_type>&& operands,
+        div_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         enum struct stretch_operand { neither, lhs, rhs };
@@ -102,7 +103,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_div_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/arithmetics/mul_operation.hpp
+++ b/phylanx/plugins/arithmetics/mul_operation.hpp
@@ -28,22 +28,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type =
+            std::vector<operand_type, arguments_allocator<operand_type>>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         mul_operation() = default;
 
-        mul_operation(std::vector<primitive_argument_type>&& operands,
+        mul_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         enum struct stretch_operand { neither, lhs, rhs };
@@ -103,7 +104,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_mul_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/arithmetics/sub_operation.hpp
+++ b/phylanx/plugins/arithmetics/sub_operation.hpp
@@ -29,22 +29,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         sub_operation() = default;
 
-        sub_operation(std::vector<primitive_argument_type>&& operands,
+        sub_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         enum struct stretch_operand { neither, lhs, rhs };
@@ -103,7 +103,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_sub_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/arithmetics/unary_minus_operation.hpp
+++ b/phylanx/plugins/arithmetics/unary_minus_operation.hpp
@@ -29,19 +29,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         unary_minus_operation() = default;
 
-        unary_minus_operation(std::vector<primitive_argument_type>&& operands,
+        unary_minus_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         primitive_argument_type neg0d(operand_type&& op) const;
@@ -51,7 +51,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     inline primitive create_unary_minus_operation(
         hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/all_operation.hpp
+++ b/phylanx/plugins/booleans/all_operation.hpp
@@ -28,19 +28,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using arg_type = ir::node_data<std::uint8_t>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         all_operation() = default;
 
-        all_operation(std::vector<primitive_argument_type>&& params,
+        all_operation(primitive_arguments_type&& params,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         template <typename T>
@@ -57,7 +57,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_all_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/and_operation.hpp
+++ b/phylanx/plugins/booleans/and_operation.hpp
@@ -27,22 +27,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         and_operation() = default;
 
-        and_operation(std::vector<primitive_argument_type>&& operands,
+        and_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
         using operand_type = ir::node_data<std::uint8_t>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
     private:
         struct visit_and;
@@ -97,7 +97,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_and_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/any_operation.hpp
+++ b/phylanx/plugins/booleans/any_operation.hpp
@@ -28,19 +28,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using arg_type = ir::node_data<std::uint8_t>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         any_operation() = default;
 
-        any_operation(std::vector<primitive_argument_type>&& params,
+        any_operation(primitive_arguments_type&& params,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         template <typename T>
@@ -57,7 +57,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_any_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/equal.hpp
+++ b/phylanx/plugins/booleans/equal.hpp
@@ -25,22 +25,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
     public:
         static match_pattern_type const match_data;
 
         equal() = default;
 
-        equal(std::vector<primitive_argument_type>&& operands,
+        equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         struct visit_equal;
@@ -87,7 +87,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_equal(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/greater.hpp
+++ b/phylanx/plugins/booleans/greater.hpp
@@ -26,22 +26,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         greater() = default;
 
-        greater(std::vector<primitive_argument_type>&& operands,
+        greater(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         struct visit_greater;
@@ -88,7 +88,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_greater(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/greater_equal.hpp
+++ b/phylanx/plugins/booleans/greater_equal.hpp
@@ -26,22 +26,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         greater_equal() = default;
 
-        greater_equal(std::vector<primitive_argument_type>&& operands,
+        greater_equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         struct visit_greater_equal;
@@ -88,7 +88,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_greater_equal(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/less.hpp
+++ b/phylanx/plugins/booleans/less.hpp
@@ -26,22 +26,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         less() = default;
 
-        less(std::vector<primitive_argument_type>&& operands,
+        less(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         template <typename T>
@@ -89,7 +89,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_less(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/less_equal.hpp
+++ b/phylanx/plugins/booleans/less_equal.hpp
@@ -26,22 +26,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         less_equal() = default;
 
-        less_equal(std::vector<primitive_argument_type>&& operands,
+        less_equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         struct visit_less_equal;
@@ -88,7 +88,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_less_equal(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/not_equal.hpp
+++ b/phylanx/plugins/booleans/not_equal.hpp
@@ -27,22 +27,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         not_equal() = default;
 
-        not_equal(std::vector<primitive_argument_type>&& operands,
+        not_equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         struct visit_not_equal;
@@ -89,7 +89,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_not_equal(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/or_operation.hpp
+++ b/phylanx/plugins/booleans/or_operation.hpp
@@ -27,22 +27,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<std::uint8_t>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         or_operation() = default;
 
-        or_operation(std::vector<primitive_argument_type>&& operands,
+        or_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         struct visit_or_operation;
@@ -85,7 +85,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_or_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/booleans/unary_not_operation.hpp
+++ b/phylanx/plugins/booleans/unary_not_operation.hpp
@@ -27,22 +27,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<std::uint8_t>;
-        using operands_type = std::vector<primitive_argument_type>;
+        using operands_type = primitive_arguments_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         unary_not_operation() = default;
 
-        unary_not_operation(std::vector<primitive_argument_type>&& operands,
+        unary_not_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         struct visit_unary_not;
@@ -53,7 +53,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     inline primitive create_unary_not_operation(
         hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/apply.hpp
+++ b/phylanx/plugins/controls/apply.hpp
@@ -26,15 +26,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         apply() = default;
 
-        apply(std::vector<primitive_argument_type>&& operands,
+        apply(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
     };
 
     inline primitive create_apply(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/block_operation.hpp
+++ b/phylanx/plugins/controls/block_operation.hpp
@@ -27,24 +27,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> args, eval_mode mode) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type args, eval_mode mode) const;
 
     public:
         static match_pattern_type const match_data;
 
         block_operation() = default;
 
-        block_operation(std::vector<primitive_argument_type>&& operands,
+        block_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             eval_mode) const override;
     };
 
     inline primitive create_block_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/filter_operation.hpp
+++ b/phylanx/plugins/controls/filter_operation.hpp
@@ -28,20 +28,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         filter_operation() = default;
 
-        filter_operation(std::vector<primitive_argument_type>&& operands,
+        filter_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     inline primitive create_filter_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/fold_left_operation.hpp
+++ b/phylanx/plugins/controls/fold_left_operation.hpp
@@ -28,20 +28,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         fold_left_operation() = default;
 
-        fold_left_operation(std::vector<primitive_argument_type>&& operands,
+        fold_left_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     inline primitive create_fold_left_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/fold_right_operation.hpp
+++ b/phylanx/plugins/controls/fold_right_operation.hpp
@@ -28,20 +28,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         fold_right_operation() = default;
 
-        fold_right_operation(std::vector<primitive_argument_type>&& operands,
+        fold_right_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     inline primitive create_fold_right_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/for_each.hpp
+++ b/phylanx/plugins/controls/for_each.hpp
@@ -28,17 +28,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         for_each() = default;
 
-        for_each(std::vector<primitive_argument_type>&& operands,
+        for_each(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             eval_mode mode) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
             eval_mode mode) const;
 
     private:
@@ -46,7 +46,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_for_each(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/for_operation.hpp
+++ b/phylanx/plugins/controls/for_operation.hpp
@@ -28,18 +28,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         for_operation() = default;
 
-        for_operation(std::vector<primitive_argument_type>&& operands,
+        for_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         struct iteration_for;
     };
 
     inline primitive create_for_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/if_conditional.hpp
+++ b/phylanx/plugins/controls/if_conditional.hpp
@@ -26,23 +26,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         if_conditional() = default;
 
-        if_conditional(std::vector<primitive_argument_type>&& operand,
+        if_conditional(primitive_arguments_type&& operand,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
     };
 
     inline primitive create_if_conditional(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/map_operation.hpp
+++ b/phylanx/plugins/controls/map_operation.hpp
@@ -28,23 +28,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         map_operation() = default;
 
-        map_operation(std::vector<primitive_argument_type>&& operands,
+        map_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         hpx::future<primitive_argument_type> map_1(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
         hpx::future<primitive_argument_type> map_n(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         primitive_argument_type map_1_scalar(
             primitive const* p, primitive_argument_type&& arg) const;
@@ -54,18 +54,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive const* p, primitive_argument_type&& arg) const;
 
         primitive_argument_type map_n_lists(primitive const* p,
-            std::vector<primitive_argument_type>&& args) const;
+            primitive_arguments_type&& args) const;
 
         primitive_argument_type map_n_scalar(primitive const* p,
-            std::vector<primitive_argument_type>&& args) const;
+            primitive_arguments_type&& args) const;
         primitive_argument_type map_n_vector(primitive const* p,
-            std::vector<primitive_argument_type>&& args) const;
+            primitive_arguments_type&& args) const;
         primitive_argument_type map_n_matrix(primitive const* p,
-            std::vector<primitive_argument_type>&& args) const;
+            primitive_arguments_type&& args) const;
     };
 
     inline primitive create_map_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/parallel_block_operation.hpp
+++ b/phylanx/plugins/controls/parallel_block_operation.hpp
@@ -26,8 +26,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
@@ -35,16 +35,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
         parallel_block_operation() = default;
 
         parallel_block_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
     };
 
     inline primitive create_parallel_block_operation(
         hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/parallel_map_operation.hpp
+++ b/phylanx/plugins/controls/parallel_map_operation.hpp
@@ -28,27 +28,27 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         parallel_map_operation() = default;
 
-        parallel_map_operation(std::vector<primitive_argument_type>&& operands,
+        parallel_map_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         hpx::future<primitive_argument_type> map_1(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
         hpx::future<primitive_argument_type> map_n(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     inline primitive create_parallel_map_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/range_operation.hpp
+++ b/phylanx/plugins/controls/range_operation.hpp
@@ -29,22 +29,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<std::int64_t>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         range_operation() = default;
 
-        range_operation(std::vector<primitive_argument_type>&& operands,
+        range_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type generate_range(args_type && args) const;
@@ -52,7 +52,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     inline primitive create_range_operation(
         hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/controls/while_operation.hpp
+++ b/phylanx/plugins/controls/while_operation.hpp
@@ -28,18 +28,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         while_operation() = default;
 
-        while_operation(std::vector<primitive_argument_type>&& operands,
+        while_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         struct iteration;
     };
 
     inline primitive create_while_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/fileio/file_read.hpp
+++ b/phylanx/plugins/fileio/file_read.hpp
@@ -25,15 +25,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         file_read() = default;
 
-        file_read(std::vector<primitive_argument_type>&& operands,
+        file_read(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
     };
 
     inline primitive create_file_read(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/fileio/file_read_csv.hpp
+++ b/phylanx/plugins/fileio/file_read_csv.hpp
@@ -25,15 +25,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         file_read_csv() = default;
 
-        file_read_csv(std::vector<primitive_argument_type>&& operands,
+        file_read_csv(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
     };
 
     inline primitive create_file_read_csv(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/fileio/file_read_hdf5.hpp
+++ b/phylanx/plugins/fileio/file_read_hdf5.hpp
@@ -27,15 +27,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         file_read_hdf5() = default;
 
-        file_read_hdf5(std::vector<primitive_argument_type>&& operands,
+        file_read_hdf5(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
     };
 
     inline primitive create_file_read_hdf5(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/fileio/file_write.hpp
+++ b/phylanx/plugins/fileio/file_write.hpp
@@ -25,19 +25,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         file_write() = default;
 
-        file_write(std::vector<primitive_argument_type>&& operands,
+        file_write(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         void write_to_file(primitive_argument_type const& val,
@@ -48,7 +48,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_file_write(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/fileio/file_write_csv.hpp
+++ b/phylanx/plugins/fileio/file_write_csv.hpp
@@ -25,25 +25,25 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     public:
         static match_pattern_type const match_data;
 
         file_write_csv() = default;
 
-        file_write_csv(std::vector<primitive_argument_type>&& operands,
+        file_write_csv(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
     private:
         void write_to_file_csv(ir::node_data<double> const& val,
             std::string const& filename) const;
     };
 
     inline primitive create_file_write_csv(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/fileio/file_write_hdf5.hpp
+++ b/phylanx/plugins/fileio/file_write_hdf5.hpp
@@ -27,19 +27,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         file_write_hdf5() = default;
 
-        file_write_hdf5(std::vector<primitive_argument_type>&& operands,
+        file_write_hdf5(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         void write_to_file_hdf5(ir::node_data<double> const& val,
@@ -47,7 +47,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_file_write_hdf5(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/listops/append_operation.hpp
+++ b/phylanx/plugins/listops/append_operation.hpp
@@ -26,8 +26,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     private:
         primitive_argument_type handle_list_operands(
@@ -38,16 +38,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         append_operation() = default;
 
-        append_operation(std::vector<primitive_argument_type>&& operands,
+        append_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode) const override;
     };
 
     inline primitive create_append_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/listops/car_cdr_operation.hpp
+++ b/phylanx/plugins/listops/car_cdr_operation.hpp
@@ -28,16 +28,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         car_cdr_operation() = default;
 
-        car_cdr_operation(std::vector<primitive_argument_type>&& operands,
+        car_cdr_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         primitive_argument_type car(primitive_argument_type&& arg) const;
         primitive_argument_type cdr(primitive_argument_type&& arg) const;
@@ -47,7 +47,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_car_cdr_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/listops/len_operation.hpp
+++ b/phylanx/plugins/listops/len_operation.hpp
@@ -29,8 +29,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
@@ -43,15 +43,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         /// \param args Is a (possibly empty) list of any values to be
         ///             concatenated into a PhySL list in order.
         ///
-        len_operation(std::vector<primitive_argument_type>&& operands,
+        len_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
     };
 
     inline primitive create_len_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/listops/make_list.hpp
+++ b/phylanx/plugins/listops/make_list.hpp
@@ -25,8 +25,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static std::vector<match_pattern_type> const match_data;
@@ -39,15 +39,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         /// \param args Is a (possibly empty) list of any values to be
         ///             concatenated into a PhySL list in order.
         ///
-        make_list(std::vector<primitive_argument_type>&& operands,
+        make_list(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
     };
 
     inline primitive create_make_list(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/add_dimension.hpp
+++ b/phylanx/plugins/matrixops/add_dimension.hpp
@@ -29,23 +29,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using val_type = double;
         using arg_type = ir::node_data<val_type>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         add_dimension() = default;
 
-        add_dimension(std::vector<primitive_argument_type>&& operands,
+        add_dimension(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type add_dim_0d(args_type && args) const;
@@ -53,7 +53,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_add_dimension(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/argmax.hpp
+++ b/phylanx/plugins/matrixops/argmax.hpp
@@ -32,23 +32,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using val_type = double;
         using arg_type = ir::node_data<val_type>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         argmax() = default;
 
-        argmax(std::vector<primitive_argument_type>&& operands,
+        argmax(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type argmax0d(args_type && args) const;
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_argmax(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/argmin.hpp
+++ b/phylanx/plugins/matrixops/argmin.hpp
@@ -32,23 +32,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using val_type = double;
         using arg_type = ir::node_data<val_type>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         argmin() = default;
 
-        argmin(std::vector<primitive_argument_type>&& operands,
+        argmin(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type argmin0d(args_type && args) const;
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_argmin(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/column_set.hpp
+++ b/phylanx/plugins/matrixops/column_set.hpp
@@ -28,11 +28,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
         using storage0d_type = typename arg_type::storage0d_type;
         using storage1d_type = typename arg_type::storage1d_type;
@@ -65,11 +65,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
          */
 
         column_set_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         bool check_col_set_parameters(std::int64_t start, std::int64_t stop,
@@ -84,7 +84,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_column_set_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/constant.hpp
+++ b/phylanx/plugins/matrixops/constant.hpp
@@ -27,8 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using operand_type = ir::node_data<double>;
         using operands_type = std::vector<operand_type>;
@@ -38,11 +38,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         constant() = default;
 
-        constant(std::vector<primitive_argument_type>&& operands,
+        constant(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type constant0d(operand_type && op) const;
@@ -53,7 +53,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_constant(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/cross_operation.hpp
+++ b/phylanx/plugins/matrixops/cross_operation.hpp
@@ -27,8 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using operand_type = ir::node_data<double>;
         using operands_type = std::vector<operand_type>;
@@ -38,11 +38,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         cross_operation() = default;
 
-        cross_operation(std::vector<primitive_argument_type>&& operands,
+        cross_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type cross1d(
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_cross_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/determinant.hpp
+++ b/phylanx/plugins/matrixops/determinant.hpp
@@ -27,8 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using operand_type = ir::node_data<double>;
         using operands_type = std::vector<operand_type>;
@@ -38,11 +38,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         determinant() = default;
 
-        determinant(std::vector<primitive_argument_type>&& operands,
+        determinant(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type determinant0d(operand_type&& op) const;
@@ -50,7 +50,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_determinant(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/diag_operation.hpp
+++ b/phylanx/plugins/matrixops/diag_operation.hpp
@@ -26,11 +26,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
 
@@ -62,11 +62,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
          * >numpy.diag</a>
          */
 
-        diag_operation(std::vector<primitive_argument_type>&& operands,
+        diag_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         primitive_argument_type diag0d(args_type&& args) const;
@@ -75,7 +75,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_diag_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/dot_operation.hpp
+++ b/phylanx/plugins/matrixops/dot_operation.hpp
@@ -27,8 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using operand_type = ir::node_data<double>;
         using operands_type = std::vector<operand_type>;
@@ -38,11 +38,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         dot_operation() = default;
 
-        dot_operation(std::vector<primitive_argument_type>&& operands,
+        dot_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             eval_mode) const override;
 
     private:
@@ -73,7 +73,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_dot_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/extract_shape.hpp
+++ b/phylanx/plugins/matrixops/extract_shape.hpp
@@ -27,8 +27,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
 
@@ -37,11 +37,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         extract_shape() = default;
 
-        extract_shape(std::vector<primitive_argument_type>&& params,
+        extract_shape(primitive_arguments_type&& params,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         primitive_argument_type shape0d(arg_type&& arg) const;
@@ -54,7 +54,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_extract_shape(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/generic_operation.hpp
+++ b/phylanx/plugins/matrixops/generic_operation.hpp
@@ -26,11 +26,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
         using dynamic_vector_type = ir::node_data<double>::storage1d_type;
 
@@ -41,11 +41,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         generic_operation() = default;
 
-        generic_operation(std::vector<primitive_argument_type>&& operands,
+        generic_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     public:
         using scalar_function = double(double);
@@ -69,7 +69,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_generic_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/gradient_operation.hpp
+++ b/phylanx/plugins/matrixops/gradient_operation.hpp
@@ -26,11 +26,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type =
+            std::vector<operand_type, arguments_allocator<operand_type>>;
 
     public:
         static match_pattern_type const match_data;
@@ -52,11 +53,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
          *          axis  : Axis to perform gradient along (optional)
          */
 
-        gradient_operation(std::vector<primitive_argument_type>&& operands,
+        gradient_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         primitive_argument_type gradient0d(operands_type&& ops) const;
@@ -65,7 +66,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_gradient_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/hstack_operation.hpp
+++ b/phylanx/plugins/matrixops/hstack_operation.hpp
@@ -27,11 +27,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
 
@@ -40,11 +40,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         hstack_operation() = default;
 
-        hstack_operation(std::vector<primitive_argument_type>&& operands,
+        hstack_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         std::size_t get_vecsize(args_type& args) const;
@@ -53,7 +53,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_hstack_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/identity.hpp
+++ b/phylanx/plugins/matrixops/identity.hpp
@@ -30,26 +30,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         identity() = default;
 
-        identity(std::vector<primitive_argument_type>&& operands,
+        identity(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type identity_nd(operand_type&& op) const;
     };
 
     inline primitive create_identity(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/inverse_operation.hpp
+++ b/phylanx/plugins/matrixops/inverse_operation.hpp
@@ -29,19 +29,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         inverse_operation() = default;
 
-        inverse_operation(std::vector<primitive_argument_type>&& operands,
+        inverse_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type inverse0d(operand_type&& ops) const;
@@ -49,7 +49,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_inverse_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/linearmatrix.hpp
+++ b/phylanx/plugins/matrixops/linearmatrix.hpp
@@ -26,30 +26,30 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using matrix_type = blaze::DynamicMatrix<double>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         linearmatrix() = default;
 
-        linearmatrix(std::vector<primitive_argument_type>&& args,
+        linearmatrix(primitive_arguments_type&& args,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type linmatrix(args_type&& args) const;
     };
 
     inline primitive create_linearmatrix(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         static std::string type("linearmatrix");

--- a/phylanx/plugins/matrixops/linspace.hpp
+++ b/phylanx/plugins/matrixops/linspace.hpp
@@ -35,12 +35,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using vector_type = blaze::DynamicVector<double>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
@@ -60,18 +60,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
         /// samples is less than 2.\n
         /// num_samples: number of samples in the sequence.
         ///
-        linspace(std::vector<primitive_argument_type>&& args,
+        linspace(primitive_arguments_type&& args,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type linspace1d(args_type&& args) const;
     };
 
     inline primitive create_linspace(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/mean_operation.hpp
+++ b/phylanx/plugins/matrixops/mean_operation.hpp
@@ -40,22 +40,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     protected:
         using val_type = double;
         using arg_type = ir::node_data<val_type>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         mean_operation() = default;
 
-        mean_operation(std::vector<primitive_argument_type>&& operands,
+        mean_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params)
+            primitive_arguments_type const& params)
             const override;
 
     private:
@@ -68,7 +68,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_mean_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/power_operation.hpp
+++ b/phylanx/plugins/matrixops/power_operation.hpp
@@ -33,11 +33,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         power_operation() = default;
 
-        power_operation(std::vector<primitive_argument_type>&& operands,
+        power_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type power0d(
@@ -48,12 +48,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             operand_type&& lhs, operand_type&& rhs) const;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     inline primitive create_power_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/random.hpp
+++ b/phylanx/plugins/matrixops/random.hpp
@@ -127,16 +127,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ///             values, distributed according to the student probability
         ///             density function (n: degrees of freedom)\n
         ///
-        random(std::vector<primitive_argument_type>&& operands,
+        random(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         primitive_argument_type random0d(
             distribution_parameters_type&& params) const;
@@ -147,7 +147,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_random(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/row_set.hpp
+++ b/phylanx/plugins/matrixops/row_set.hpp
@@ -49,15 +49,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
         using storage0d_type = typename arg_type::storage0d_type;
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
@@ -65,11 +65,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         row_set_operation() = default;
 
         row_set_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         bool check_row_set_parameters(std::int64_t start, std::int64_t stop,
@@ -83,7 +83,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_row_set_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/set_operation.hpp
+++ b/phylanx/plugins/matrixops/set_operation.hpp
@@ -52,7 +52,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using storage0d_type = typename arg_type::storage0d_type;
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
@@ -62,11 +62,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         set_operation() = default;
 
-        set_operation(std::vector<primitive_argument_type>&& operands,
+        set_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         bool check_set_parameters(std::int64_t start, std::int64_t stop,
@@ -78,12 +78,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type set1d(args_type&& args) const;
         primitive_argument_type set2d(args_type&& args) const;
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
     };
 
     inline primitive create_set_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/shuffle_operation.hpp
+++ b/phylanx/plugins/matrixops/shuffle_operation.hpp
@@ -37,22 +37,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         shuffle_operation() = default;
 
-        shuffle_operation(std::vector<primitive_argument_type>&& operands,
+        shuffle_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         static std::mt19937 rand_machine;
@@ -62,7 +62,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_shuffle_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/slicing_operation.hpp
+++ b/phylanx/plugins/matrixops/slicing_operation.hpp
@@ -30,8 +30,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static std::vector<match_pattern_type> const match_data;
@@ -65,11 +65,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         *        indicate direction, similar to python.
         */
 
-        slicing_operation(std::vector<primitive_argument_type>&& operands,
+        slicing_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params,
+            primitive_arguments_type const& params,
             eval_mode) const override;
 
     private:
@@ -80,7 +80,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_slicing_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/square_root_operation.hpp
+++ b/phylanx/plugins/matrixops/square_root_operation.hpp
@@ -29,19 +29,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         square_root_operation() = default;
 
-        square_root_operation(std::vector<primitive_argument_type>&& operands,
+        square_root_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type square_root_0d(operand_type&& op) const;
@@ -50,7 +50,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_square_root_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/sum_operation.hpp
+++ b/phylanx/plugins/matrixops/sum_operation.hpp
@@ -38,23 +38,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using val_type = double;
         using arg_type = ir::node_data<val_type>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
 
     public:
         static match_pattern_type const match_data;
 
         sum_operation() = default;
 
-        sum_operation(std::vector<primitive_argument_type>&& operands,
+        sum_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type sum0d(arg_type&& arg,
@@ -70,7 +70,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_sum_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/transpose_operation.hpp
+++ b/phylanx/plugins/matrixops/transpose_operation.hpp
@@ -25,11 +25,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
+        using operands_type =
+            std::vector<operand_type, arguments_allocator<operand_type>>;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
             std::string const& name, std::string const& codename) const;
 
     public:
@@ -37,11 +38,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         transpose_operation() = default;
 
-        transpose_operation(std::vector<primitive_argument_type>&& operands,
+        transpose_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& args) const override;
+            primitive_arguments_type const& args) const override;
 
     private:
         primitive_argument_type transpose0d1d(operands_type&& ops) const;
@@ -49,7 +50,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_transpose_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/matrixops/vstack_operation.hpp
+++ b/phylanx/plugins/matrixops/vstack_operation.hpp
@@ -26,24 +26,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
     public:
         static match_pattern_type const match_data;
 
         vstack_operation() = default;
 
-        vstack_operation(std::vector<primitive_argument_type>&& operands,
+        vstack_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
 
     private:
         primitive_argument_type vstack0d(args_type&& args) const;
@@ -51,7 +51,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_vstack_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/solvers/decomposition.hpp
+++ b/phylanx/plugins/solvers/decomposition.hpp
@@ -27,11 +27,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using storage0d_type = typename arg_type::storage0d_type;
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
@@ -40,11 +40,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         static std::vector<match_pattern_type> const match_data;
         decomposition() = default;
 
-        decomposition(std::vector<primitive_argument_type>&& operands,
+        decomposition(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
         using vector_function = primitive_argument_type(args_type&&);
 
         using vector_function_ptr = vector_function*;
@@ -58,7 +58,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_decomposition(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/phylanx/plugins/solvers/linear_solver.hpp
+++ b/phylanx/plugins/solvers/linear_solver.hpp
@@ -26,11 +26,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
     protected:
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args) const;
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
 
         using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type>;
+        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
         using storage1d_type = typename arg_type::storage1d_type;
         using storage2d_type = typename arg_type::storage2d_type;
 
@@ -38,11 +38,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         static std::vector<match_pattern_type> const match_data;
         linear_solver() = default;
 
-        linear_solver(std::vector<primitive_argument_type>&& operands,
+        linear_solver(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& params) const override;
+            primitive_arguments_type const& params) const override;
         using vector_function = arg_type(args_type&&);
         using vector_function_ul = arg_type(
             arg_type&&, arg_type&&, std::string);
@@ -64,7 +64,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     inline primitive create_linear_solver(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -182,11 +182,9 @@ namespace phylanx { namespace bindings
                     xexpr, c.eval_snippets, c.eval_env);
                 auto x = code_x.run();
 
-                std::vector<phylanx::execution_tree::primitive_argument_type>
-                    keep_alive;
+                phylanx::execution_tree::primitive_arguments_type keep_alive;
                 keep_alive.reserve(args.size());
-                std::vector<phylanx::execution_tree::primitive_argument_type>
-                    fargs;
+                phylanx::execution_tree::primitive_arguments_type fargs;
                 fargs.reserve(args.size());
 
                 for (auto const& item : args)

--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -67,7 +67,7 @@ namespace pybind11 { namespace detail
     // specialize get_name for vector<primitive_argument_type> to avoid infinite recursion
     template <>
     inline PHYLANX_PYBIND_DESCR
-    get_name<std::vector<phylanx::execution_tree::primitive_argument_type>>()
+    get_name<phylanx::execution_tree::primitive_arguments_type>()
     {
 #if defined(_DEBUG)
         return _("List[_phylanxd.execution_tree.primitive_argument_type]");
@@ -821,8 +821,7 @@ namespace pybind11 { namespace detail
     class type_caster<phylanx::ir::range>
     {
     private:
-        using list_type =
-            std::vector<phylanx::execution_tree::primitive_argument_type>;
+        using list_type = phylanx::execution_tree::primitive_arguments_type;
 
         using list_caster_type = make_caster<list_type>;
         list_caster_type subcaster;

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -557,7 +557,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     id.id, id.col, snippets_.compile_id_ - 1);
                 name_parts.instance = std::move(name);
 
-                std::vector<primitive_argument_type> fargs;
+                primitive_arguments_type fargs;
                 fargs.reserve(argexprs.size() + 1);
 
                 fargs.push_back(

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -29,7 +29,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     access_argument::access_argument(
-            std::vector<primitive_argument_type>&& args,
+            primitive_arguments_type&& args,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename, true)
     {
@@ -46,7 +46,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> access_argument::eval(
-        std::vector<primitive_argument_type> const& params, eval_mode) const
+        primitive_arguments_type const& params, eval_mode) const
     {
         if (argnum_ >= params.size())
         {

--- a/src/execution_tree/primitives/access_function.cpp
+++ b/src/execution_tree/primitives/access_function.cpp
@@ -30,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     access_function::access_function(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename, true)
     {
@@ -51,14 +51,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> access_function::eval(
-        std::vector<primitive_argument_type> const& params,
+        primitive_arguments_type const& params,
         eval_mode mode) const
     {
         if (!(mode & eval_dont_wrap_functions) && !params.empty())
         {
             if (!params.empty())
             {
-                std::vector<primitive_argument_type> fargs;
+                primitive_arguments_type fargs;
                 fargs.reserve(params.size() + 1);
 
                 fargs.push_back(extract_ref_value(operands_[0]));
@@ -83,8 +83,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::make_ready_future(extract_ref_value(operands_[0]));
     }
 
-    void access_function::store(std::vector<primitive_argument_type>&& vals,
-        std::vector<primitive_argument_type>&& params)
+    void access_function::store(primitive_arguments_type&& vals,
+        primitive_arguments_type&& params)
     {
         primitive* p = util::get_if<primitive>(&operands_[0]);
         if (p != nullptr)

--- a/src/execution_tree/primitives/access_variable.cpp
+++ b/src/execution_tree/primitives/access_variable.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     access_variable::access_variable(
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
         : primitive_component_base(std::move(operands), name, codename, true)
     {
@@ -65,7 +65,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> access_variable::eval(
-        std::vector<primitive_argument_type> const& params,
+        primitive_arguments_type const& params,
         eval_mode mode) const
     {
         // handle slicing, we can replace the params with our slicing
@@ -104,7 +104,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         util::future_or_value<primitive_argument_type>&& cols)
                     -> hpx::future<primitive_argument_type>
                     {
-                        std::vector<primitive_argument_type> args;
+                        primitive_arguments_type args;
                         args.reserve(2);
                         args.emplace_back(rows.get());
                         args.emplace_back(cols.get());
@@ -131,8 +131,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return value_operand(operands_[0], noargs, name_, codename_, mode);
     }
 
-    void access_variable::store(std::vector<primitive_argument_type>&& vals,
-            std::vector<primitive_argument_type>&& params)
+    void access_variable::store(primitive_arguments_type&& vals,
+            primitive_arguments_type&& params)
     {
         if (vals.size() != 1)
         {
@@ -164,13 +164,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     void access_variable::store(primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& params)
     {
         if (operands_.size() > 1)
         {
             // handle slicing, simply append the slicing parameters to the end of
             // the argument list
-            std::vector<primitive_argument_type> vals;
+            primitive_arguments_type vals;
             vals.reserve(operands_.size());
             vals.emplace_back(std::move(val));
 

--- a/src/execution_tree/primitives/assert_condition.cpp
+++ b/src/execution_tree/primitives/assert_condition.cpp
@@ -25,7 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     primitive create_assert_condition(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
     {
         static std::string type("assert");
@@ -42,14 +42,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     assert_condition::assert_condition(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> assert_condition::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -77,7 +77,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> assert_condition::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -137,7 +137,7 @@ namespace phylanx { namespace execution_tree
     }
 
     hpx::future<primitive_argument_type> primitive::eval(
-        std::vector<primitive_argument_type> const& params,
+        primitive_arguments_type const& params,
         eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
@@ -146,7 +146,7 @@ namespace phylanx { namespace execution_tree
         return detail::lazy_trace("eval", *this, std::move(f));
     }
     hpx::future<primitive_argument_type> primitive::eval(
-        std::vector<primitive_argument_type>&& params,
+        primitive_arguments_type&& params,
         eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
@@ -169,12 +169,12 @@ namespace phylanx { namespace execution_tree
     hpx::future<primitive_argument_type> primitive::eval(
         eval_mode mode) const
     {
-        static std::vector<primitive_argument_type> params;
+        static primitive_arguments_type params;
         return eval(params, mode);
     }
 
     primitive_argument_type primitive::eval(hpx::launch::sync_policy,
-        std::vector<primitive_argument_type> const& params,
+        primitive_arguments_type const& params,
         eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
@@ -184,7 +184,7 @@ namespace phylanx { namespace execution_tree
         return detail::trace("eval", *this, f.get());
     }
     primitive_argument_type primitive::eval(hpx::launch::sync_policy,
-        std::vector<primitive_argument_type>&& params,
+        primitive_arguments_type&& params,
         eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
@@ -208,15 +208,15 @@ namespace phylanx { namespace execution_tree
         eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
-        static std::vector<primitive_argument_type> params;
+        static primitive_arguments_type params;
         hpx::future<primitive_argument_type> f = hpx::sync<action_type>(
             this->base_type::get_id(), std::move(params), mode);
         return detail::trace("eval", *this, f.get());
     }
 
     hpx::future<void> primitive::store(
-        std::vector<primitive_argument_type>&& data,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
     {
         using action_type = primitives::primitive_component::store_action;
         return hpx::async<action_type>(
@@ -224,7 +224,7 @@ namespace phylanx { namespace execution_tree
     }
 
     hpx::future<void> primitive::store(primitive_argument_type&& data,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& params)
     {
         using action_type = primitives::primitive_component::store_single_action;
         return hpx::async<action_type>(
@@ -232,8 +232,8 @@ namespace phylanx { namespace execution_tree
     }
 
     void primitive::store(hpx::launch::sync_policy,
-        std::vector<primitive_argument_type>&& data,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
     {
         using action_type = primitives::primitive_component::store_action;
         hpx::sync<action_type>(
@@ -242,7 +242,7 @@ namespace phylanx { namespace execution_tree
 
     void primitive::store(hpx::launch::sync_policy,
         primitive_argument_type&& data,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& params)
     {
         using action_type = primitives::primitive_component::store_single_action;
         hpx::sync<action_type>(
@@ -304,13 +304,13 @@ namespace phylanx { namespace execution_tree
     }
 
     bool primitive::bind(
-        std::vector<primitive_argument_type> const& params) const
+        primitive_arguments_type const& params) const
     {
         using action_type = primitives::primitive_component::bind_action;
         return detail::trace("bind", *this,
             action_type()(this->base_type::get_id(), params));
     }
-    bool primitive::bind(std::vector<primitive_argument_type>&& params) const
+    bool primitive::bind(primitive_arguments_type&& params) const
     {
         using action_type = primitives::primitive_component::bind_action;
         return detail::trace("bind", *this,
@@ -2123,31 +2123,31 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0:     // nil
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<0>(val)}};
 
         case 1:    // phylanx::ir::node_data<std::uint8_t>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<1>(val)}};
 
         case 2:     // ir::node_data<std::int64_t>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<2>(val)}};
 
         case 3:     // string
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<3>(val)}};
 
         case 4:     // phylanx::ir::node_data<double>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<4>(val)}};
 
         case 5:     // primitive
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<5>(val)}};
 
         case 6:     // std::vector<ast::expression>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<6>(val)}};
 
         case 7:     // phylanx::ir::range
@@ -2173,31 +2173,31 @@ namespace phylanx { namespace execution_tree
         switch (val.index())
         {
         case 0:     // nil
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<0>(std::move(val))}};
 
         case 1:    // phylanx::ir::node_data<std::uint8_t>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<1>(std::move(val))}};
 
         case 2:     // ir::node_data<std::int64_t>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<2>(std::move(val))}};
 
         case 3:     // string
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<3>(std::move(val))}};
 
         case 4:     // phylanx::ir::node_data<double>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<4>(std::move(val))}};
 
         case 5:     // primitive
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<5>(std::move(val))}};
 
         case 6:     // std::vector<ast::expression>
-            return std::vector<primitive_argument_type>{
+            return primitive_arguments_type{
                 primitive_argument_type{util::get<6>(std::move(val))}};
 
         case 7:     // phylanx::ir::range
@@ -2245,7 +2245,7 @@ namespace phylanx { namespace execution_tree
         {
         case 6:     // std::vector<ast::expression>
             {
-                std::vector<primitive_argument_type> result;
+                primitive_arguments_type result;
                 result.reserve(util::get<6>(val).size());
                 for (auto const& v : util::get<6>(val))
                 {
@@ -2292,7 +2292,7 @@ namespace phylanx { namespace execution_tree
         {
         case 6:     // std::vector<ast::expression>
             {
-                std::vector<primitive_argument_type> result;
+                primitive_arguments_type result;
                 result.reserve(util::get<6>(val).size());
                 for (auto && v : util::get<6>(std::move(val)))
                 {
@@ -2397,11 +2397,11 @@ namespace phylanx { namespace execution_tree
     }
 
     primitive_argument_type primitive_argument_type::operator()(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (is_primitive_operand(*this))
         {
-            std::vector<primitive_argument_type> params;
+            primitive_arguments_type params;
             params.reserve(args.size());
             for (auto const& arg : args)
             {
@@ -2415,15 +2415,15 @@ namespace phylanx { namespace execution_tree
     }
 
     primitive_argument_type primitive_argument_type::operator()(
-        std::vector<primitive_argument_type> && args) const
+        primitive_arguments_type && args) const
     {
         if (is_primitive_operand(*this))
         {
             // evaluate the function itself
-            std::vector<primitive_argument_type> keep_alive(std::move(args));
+            primitive_arguments_type keep_alive(std::move(args));
 
             // construct argument-pack to use for actual call
-            std::vector<primitive_argument_type> params;
+            primitive_arguments_type params;
             params.reserve(keep_alive.size());
             for (auto const& arg : keep_alive)
             {
@@ -2439,7 +2439,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename, eval_mode mode)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2468,7 +2468,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename, eval_mode mode)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2498,7 +2498,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename,
         eval_mode mode)
     {
@@ -2528,7 +2528,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<primitive_argument_type> value_operand(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename, eval_mode mode)
     {
         primitive* p = util::get_if<primitive>(&val);
@@ -2619,7 +2619,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     util::future_or_value<primitive_argument_type> value_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename, eval_mode mode)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2647,7 +2647,7 @@ namespace phylanx { namespace execution_tree
 
     util::future_or_value<primitive_argument_type> value_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename, eval_mode mode)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2676,7 +2676,7 @@ namespace phylanx { namespace execution_tree
 
     util::future_or_value<primitive_argument_type> value_operand_fov(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename,
         eval_mode mode)
     {
@@ -2705,7 +2705,7 @@ namespace phylanx { namespace execution_tree
 
     util::future_or_value<primitive_argument_type> value_operand_fov(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename, eval_mode mode)
     {
         primitive* p = util::get_if<primitive>(&val);
@@ -2793,7 +2793,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type value_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename,
         eval_mode mode)
     {
@@ -2813,7 +2813,7 @@ namespace phylanx { namespace execution_tree
 
     primitive_argument_type value_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename, eval_mode mode)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2832,7 +2832,7 @@ namespace phylanx { namespace execution_tree
     }
 
     primitive_argument_type value_operand_sync(primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename,
         eval_mode mode)
     {
@@ -2851,7 +2851,7 @@ namespace phylanx { namespace execution_tree
     }
 
     primitive_argument_type value_operand_sync(primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename, eval_mode mode)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2910,7 +2910,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type value_operand_ref_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2930,7 +2930,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2957,7 +2957,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -2984,7 +2984,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive* p = util::get_if<primitive>(&val);
@@ -3011,7 +3011,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<primitive_argument_type> literal_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3039,7 +3039,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type literal_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3056,7 +3056,7 @@ namespace phylanx { namespace execution_tree
     // Extract an integer value from a primitive_argument_type
     hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3083,7 +3083,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3110,7 +3110,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3137,7 +3137,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3165,7 +3165,7 @@ namespace phylanx { namespace execution_tree
     // Extract an integer value from a primitive_argument_type
     hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3194,7 +3194,7 @@ namespace phylanx { namespace execution_tree
     //make extract_shape.cpp error happy
     hpx::future<std::int64_t> scalar_integer_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3222,7 +3222,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3250,7 +3250,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3277,7 +3277,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type&& val,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3305,7 +3305,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3332,7 +3332,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3359,7 +3359,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive* p = util::get_if<primitive>(&val);
@@ -3386,7 +3386,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::node_data<double>> numeric_operand(
         primitive_argument_type && val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
     {
         primitive* p = util::get_if<primitive>(&val);
@@ -3414,7 +3414,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     ir::node_data<double> numeric_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3431,7 +3431,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<std::uint8_t> boolean_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3457,7 +3457,7 @@ namespace phylanx { namespace execution_tree
     }
 
     std::uint8_t boolean_operand_sync(primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3474,7 +3474,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<std::string> string_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3500,7 +3500,7 @@ namespace phylanx { namespace execution_tree
     }
 
     std::string string_operand_sync(primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3517,7 +3517,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<std::vector<ast::expression>> ast_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3543,7 +3543,7 @@ namespace phylanx { namespace execution_tree
 
     std::vector<ast::expression> ast_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3560,7 +3560,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<ir::range> list_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3586,7 +3586,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::range> list_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3612,7 +3612,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::range> list_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string && codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3639,7 +3639,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::range> list_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string && codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3666,7 +3666,7 @@ namespace phylanx { namespace execution_tree
 
     ir::range list_operand_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3683,7 +3683,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<ir::range> list_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3710,7 +3710,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::range> list_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3737,7 +3737,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::range> list_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string && codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3764,7 +3764,7 @@ namespace phylanx { namespace execution_tree
 
     hpx::future<ir::range> list_operand_strict(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string && codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3792,7 +3792,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     ir::range list_operand_strict_sync(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3809,7 +3809,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3834,7 +3834,7 @@ namespace phylanx { namespace execution_tree
 
     util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3859,7 +3859,7 @@ namespace phylanx { namespace execution_tree
 
     util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string && codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3884,7 +3884,7 @@ namespace phylanx { namespace execution_tree
 
     util::future_or_value<ir::range> list_operand_fov(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> && args,
+        primitive_arguments_type && args,
         std::string const& name, std::string && codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -3932,7 +3932,7 @@ namespace phylanx { namespace execution_tree
         case 5:
             {
                 auto && v = util::get<5>(std::move(val)).get();
-                std::vector<primitive_argument_type> data;
+                primitive_arguments_type data;
                 data.reserve(v.size());
                 for (auto && value : std::move(v))
                 {

--- a/src/execution_tree/primitives/call_function.cpp
+++ b/src/execution_tree/primitives/call_function.cpp
@@ -31,7 +31,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     call_function::call_function(
-            std::vector<primitive_argument_type>&& args,
+            primitive_arguments_type&& args,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
     {
@@ -51,7 +51,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> call_function::eval(
-        std::vector<primitive_argument_type> const& params) const
+        primitive_arguments_type const& params) const
     {
         if (!valid(operands_[0]))
         {
@@ -62,7 +62,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "has not been initialized"));
         }
 
-        std::vector<primitive_argument_type> fargs;
+        primitive_arguments_type fargs;
         fargs.reserve(operands_.size() - 1);
 
         // pass along pre-bound arguments
@@ -74,7 +74,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
                 [this_](primitive_argument_type&& func,
-                    std::vector<primitive_argument_type>&& args)
+                    primitive_arguments_type&& args)
                 {
                     return value_operand_sync(std::move(func),
                         std::move(args), this_->name_, this_->codename_);
@@ -87,8 +87,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 params, name_, codename_, eval_dont_evaluate_partials));
     }
 
-    void call_function::store(std::vector<primitive_argument_type>&& data,
-        std::vector<primitive_argument_type>&& params)
+    void call_function::store(primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
     {
         if (valid(operands_[0]))
         {

--- a/src/execution_tree/primitives/console_output.cpp
+++ b/src/execution_tree/primitives/console_output.cpp
@@ -23,7 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     primitive create_console_output(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
     {
         static std::string type("cout");
@@ -40,18 +40,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     console_output::console_output(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> console_output::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_](std::vector<primitive_argument_type>&& args)
+            [this_](primitive_arguments_type&& args)
                 -> primitive_argument_type
             {
                 bool init = true;
@@ -79,7 +79,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // write data to given file and return content
     hpx::future<primitive_argument_type> console_output::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/execution_tree/primitives/debug_output.cpp
+++ b/src/execution_tree/primitives/debug_output.cpp
@@ -23,7 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     primitive create_debug_output(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
     {
         static std::string type("debug");
@@ -40,14 +40,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     debug_output::debug_output(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> debug_output::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
@@ -67,7 +67,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // write data to given file and return content
     hpx::future<primitive_argument_type> debug_output::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/execution_tree/primitives/define_variable.cpp
+++ b/src/execution_tree/primitives/define_variable.cpp
@@ -45,7 +45,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     define_variable::define_variable(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> define_variable::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         // evaluate the expression bound to this name and store the value in
         // the associated variable
@@ -72,8 +72,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::make_ready_future(extract_ref_value(operands_[0]));
     }
 
-    void define_variable::store(std::vector<primitive_argument_type>&& vals,
-        std::vector<primitive_argument_type>&& params)
+    void define_variable::store(primitive_arguments_type&& vals,
+        primitive_arguments_type&& params)
     {
         if (!valid(operands_[1]))
         {

--- a/src/execution_tree/primitives/enable_tracing.cpp
+++ b/src/execution_tree/primitives/enable_tracing.cpp
@@ -21,7 +21,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     primitive create_enable_tracing(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
     {
         static std::string type("enable_tracing");
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     enable_tracing::enable_tracing(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -46,8 +46,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     namespace detail
     {
         hpx::future<primitive_argument_type> eval(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
             std::string const& name, std::string const& codename)
         {
             if (operands.size() != 1)
@@ -77,7 +77,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> enable_tracing::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/execution_tree/primitives/format_string.cpp
+++ b/src/execution_tree/primitives/format_string.cpp
@@ -241,7 +241,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     primitive create_format_string(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
     {
         static std::string type("format");
@@ -258,14 +258,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     format_string::format_string(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> format_string::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands_.empty())
         {
@@ -278,7 +278,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_](std::vector<primitive_argument_type>&& args)
+            [this_](primitive_arguments_type&& args)
             ->  primitive_argument_type
             {
                 if (!is_string_operand(args[0]))
@@ -310,7 +310,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // write data to given file and return content
     hpx::future<primitive_argument_type> format_string::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (operands_.empty())
         {

--- a/src/execution_tree/primitives/function.cpp
+++ b/src/execution_tree/primitives/function.cpp
@@ -40,7 +40,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    function::function(std::vector<primitive_argument_type>&& operands,
+    function::function(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename, true)
       , value_set_(false)
@@ -61,7 +61,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> function::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (!value_set_)
         {
@@ -80,7 +80,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return hpx::make_ready_future(extract_ref_value(operands_[0]));
     }
 
-    bool function::bind(std::vector<primitive_argument_type> const& args) const
+    bool function::bind(primitive_arguments_type const& args) const
     {
         if (!value_set_)
         {
@@ -93,8 +93,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return true;
     }
 
-    void function::store(std::vector<primitive_argument_type>&& data,
-        std::vector<primitive_argument_type>&& params)
+    void function::store(primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
     {
         if (data.empty())
         {

--- a/src/execution_tree/primitives/lambda.cpp
+++ b/src/execution_tree/primitives/lambda.cpp
@@ -31,7 +31,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    lambda::lambda(std::vector<primitive_argument_type>&& args,
+    lambda::lambda(primitive_arguments_type&& args,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
     {
@@ -52,7 +52,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> lambda::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode mode) const
+        primitive_arguments_type const& args, eval_mode mode) const
     {
         if (!valid(operands_[0]))
         {
@@ -67,7 +67,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             if (!args.empty())
             {
-                std::vector<primitive_argument_type> fargs;
+                primitive_arguments_type fargs;
                 fargs.reserve(args.size() + 1);
 
                 fargs.push_back(extract_ref_value(operands_[0]));
@@ -95,8 +95,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             eval_mode(eval_dont_evaluate_lambdas | eval_dont_wrap_functions));
     }
 
-    void lambda::store(std::vector<primitive_argument_type>&& data,
-        std::vector<primitive_argument_type>&& params)
+    void lambda::store(primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
     {
         if (valid(operands_[0]))
         {

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -89,7 +89,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     /////////////////////////////////////////////////////////////////////////
     std::shared_ptr<primitive_component_base>
     primitive_component::create_primitive(std::string const& type,
-        std::vector<primitive_argument_type>&& args, std::string const& name,
+        primitive_arguments_type&& args, std::string const& name,
         std::string const& codename)
     {
         auto const& factories = detail::get_factories();
@@ -108,7 +108,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // eval_action
     hpx::future<primitive_argument_type> primitive_component::eval(
-        std::vector<primitive_argument_type> const& params,
+        primitive_arguments_type const& params,
         eval_mode mode) const
     {
         if ((mode & eval_dont_evaluate_partials) &&
@@ -139,14 +139,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     // store_action
-    void primitive_component::store(std::vector<primitive_argument_type>&& args,
-        std::vector<primitive_argument_type>&& params)
+    void primitive_component::store(primitive_arguments_type&& args,
+        primitive_arguments_type&& params)
     {
         primitive_->store(std::move(args), std::move(params));
     }
 
     void primitive_component::store_single(primitive_argument_type&& arg,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& params)
     {
         primitive_->store(std::move(arg), std::move(params));
     }
@@ -162,7 +162,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // bind_action
     bool primitive_component::bind(
-        std::vector<primitive_argument_type> const& params) const
+        primitive_arguments_type const& params) const
     {
         return primitive_->bind(params);
     }
@@ -209,7 +209,7 @@ namespace phylanx { namespace execution_tree
 {
     primitive create_primitive_component(
         hpx::id_type const& locality, std::string const& type,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
     {
         return primitive{
@@ -223,7 +223,7 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type operand, std::string const& name,
         std::string const& codename)
     {
-        std::vector<primitive_argument_type> operands;
+        primitive_arguments_type operands;
         operands.emplace_back(std::move(operand));
 
         return primitive{

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -27,10 +27,10 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-    std::vector<primitive_argument_type> primitive_component_base::noargs{};
+    primitive_arguments_type primitive_component_base::noargs{};
 
     primitive_component_base::primitive_component_base(
-            std::vector<primitive_argument_type>&& params,
+            primitive_arguments_type&& params,
             std::string const& name, std::string const& codename,
             bool eval_direct)
       : operands_(std::move(params))
@@ -70,7 +70,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> primitive_component_base::do_eval(
-        std::vector<primitive_argument_type> const& params,
+        primitive_arguments_type const& params,
         eval_mode mode) const
     {
 #if defined(HPX_HAVE_APEX)
@@ -136,13 +136,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // eval_action
     hpx::future<primitive_argument_type> primitive_component_base::eval(
-        std::vector<primitive_argument_type> const& params) const
+        primitive_arguments_type const& params) const
     {
         return this->eval(params, eval_default);
     }
 
     hpx::future<primitive_argument_type> primitive_component_base::eval(
-        std::vector<primitive_argument_type> const& params,
+        primitive_arguments_type const& params,
         eval_mode mode) const
     {
         return this->eval(params);
@@ -151,14 +151,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> primitive_component_base::eval(
         primitive_argument_type && param, eval_mode mode) const
     {
-        std::vector<primitive_argument_type> params;
+        primitive_arguments_type params;
         params.emplace_back(std::move(param));
         return this->eval(params, mode);
     }
 
     // store_action
-    void primitive_component_base::store(std::vector<primitive_argument_type>&&,
-        std::vector<primitive_argument_type>&&)
+    void primitive_component_base::store(primitive_arguments_type&&,
+        primitive_arguments_type&&)
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::primitives::primitive_component_base::"
@@ -169,9 +169,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     void primitive_component_base::store(primitive_argument_type&& param,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& params)
     {
-        std::vector<primitive_argument_type> args;
+        primitive_arguments_type args;
         args.emplace_back(std::move(param));
         return this->store(std::move(args), std::move(params));
     }
@@ -212,7 +212,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // bind_action
     bool primitive_component_base::bind(
-        std::vector<primitive_argument_type> const& params) const
+        primitive_arguments_type const& params) const
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::primitives::"

--- a/src/execution_tree/primitives/slice_range.cpp
+++ b/src/execution_tree/primitives/slice_range.cpp
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree
         // handle case of consecutive elements to return
         if (indices.step() == 1)
         {
-            std::vector<primitive_argument_type> result;
+            primitive_arguments_type result;
             result.reserve(stop - start);
 
             if (list.is_ref())
@@ -83,7 +83,7 @@ namespace phylanx { namespace execution_tree
         std::vector<std::int64_t> index_list =
             util::slicing_helpers::create_list_slice(start, stop, step);
 
-        std::vector<primitive_argument_type> result;
+        primitive_arguments_type result;
         result.reserve(index_list.size());
 
         auto idx_it = index_list.begin();

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -30,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     primitive create_store_operation(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
     {
         static std::string type("store");
@@ -47,14 +47,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     store_operation::store_operation(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename, true)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> store_operation::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode) const
+        primitive_arguments_type const& args, eval_mode) const
     {
         if (operands_.size() != 2)
         {
@@ -86,7 +86,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
 
-        std::vector<primitive_argument_type> params;
+        primitive_arguments_type params;
         if (!args.empty())
         {
             params.reserve(args.size());
@@ -144,7 +144,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
 
-        std::vector<primitive_argument_type> params;
+        primitive_arguments_type params;
         params.emplace_back(extract_ref_value(arg));
 
         return value_operand_fov(operands_[1], std::move(arg), name_, codename_)

--- a/src/execution_tree/primitives/string_output.cpp
+++ b/src/execution_tree/primitives/string_output.cpp
@@ -23,7 +23,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
     primitive create_string_output(hpx::id_type const& locality,
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
     {
         static std::string type("string");
@@ -40,14 +40,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     string_output::string_output(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> string_output::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
@@ -73,7 +73,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // Write data to given file and return content
     hpx::future<primitive_argument_type> string_output::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/execution_tree/primitives/target_reference.cpp
+++ b/src/execution_tree/primitives/target_reference.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     target_reference::target_reference(
-            std::vector<primitive_argument_type>&& args, std::string const& name,
+            primitive_arguments_type&& args, std::string const& name,
             std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
     {
@@ -56,12 +56,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> target_reference::eval(
-        std::vector<primitive_argument_type> const& params, eval_mode) const
+        primitive_arguments_type const& params, eval_mode) const
     {
         if (operands_.size() > 1)
         {
             // the function has pre-bound arguments
-            std::vector<primitive_argument_type> fargs;
+            primitive_arguments_type fargs;
             fargs.reserve(operands_.size() - 1 + params.size());
 
             for (auto it = operands_.begin() + 1; it != operands_.end(); ++it)
@@ -98,7 +98,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         if (operands_.size() > 1)
         {
             // the function has pre-bound arguments
-            std::vector<primitive_argument_type> fargs;
+            primitive_arguments_type fargs;
             fargs.reserve(operands_.size());
 
             for (auto it = operands_.begin() + 1; it != operands_.end(); ++it)
@@ -126,8 +126,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             eval_dont_wrap_functions);
     }
 
-    void target_reference::store(std::vector<primitive_argument_type>&& data,
-        std::vector<primitive_argument_type>&& params)
+    void target_reference::store(primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
     {
         if (target_)
         {

--- a/src/execution_tree/primitives/variable.cpp
+++ b/src/execution_tree/primitives/variable.cpp
@@ -43,7 +43,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    variable::variable(std::vector<primitive_argument_type>&& operands,
+    variable::variable(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename, true)
       , value_set_(false)
@@ -69,7 +69,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> variable::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode mode) const
+        primitive_arguments_type const& args, eval_mode mode) const
     {
         if (!value_set_ && !valid(bound_value_))
         {
@@ -125,7 +125,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     //////////////////////////////////////////////////////////////////////////
-    bool variable::bind(std::vector<primitive_argument_type> const& args) const
+    bool variable::bind(primitive_arguments_type const& args) const
     {
         if (!value_set_)
         {
@@ -149,8 +149,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return true;
     }
 
-    void variable::store(std::vector<primitive_argument_type>&& data,
-        std::vector<primitive_argument_type>&& params)
+    void variable::store(primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
     {
         // data[0] is the new value to store in this variable
         // data[1] and data[2] (optional) are interpreted as slicing arguments
@@ -218,7 +218,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     void variable::store(primitive_argument_type&& data,
-        std::vector<primitive_argument_type>&& params)
+        primitive_arguments_type&& params)
     {
         // data is the new value to store in this variable
         if (!value_set_ || !valid(operands_[0]))

--- a/src/plugins/algorithms/als.cpp
+++ b/src/plugins/algorithms/als.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         &create_als, &create_primitive<als>)};
 
     ///////////////////////////////////////////////////////////////////////////
-    als::als(std::vector<primitive_argument_type> && operands,
+    als::als(primitive_arguments_type && operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -40,7 +40,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type als::calculate_als(
-        std::vector<primitive_argument_type> && args) const
+        primitive_arguments_type && args) const
     {
         // extract arguments
         auto arg1 = extract_numeric_value(args[0], name_, codename_);
@@ -165,7 +165,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         return primitive_argument_type
         {
-            std::vector<primitive_argument_type>{
+            primitive_arguments_type{
                 ir::node_data<double>{std::move(X)},
                 ir::node_data<double>{std::move(Y)}}
         };
@@ -173,8 +173,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> als::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 5 && operands.size() != 6)
         {
@@ -206,7 +206,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync,
             hpx::util::unwrapping(
-                [this_](std::vector<primitive_argument_type>&& args)
+                [this_](primitive_arguments_type&& args)
                     -> primitive_argument_type {
                     return this_->calculate_als(std::move(args));
                 }),
@@ -215,7 +215,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> als::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/algorithms/lra.cpp
+++ b/src/plugins/algorithms/lra.cpp
@@ -38,14 +38,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    lra::lra(std::vector<primitive_argument_type>&& operands,
+    lra::lra(primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type lra::calculate_lra(
-        std::vector<primitive_argument_type> && args) const
+        primitive_arguments_type && args) const
     {
         // extract arguments
         auto arg1 = extract_numeric_value(args[0], name_, codename_);
@@ -125,8 +125,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> lra::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 4 && operands.size() != 5)
         {
@@ -157,7 +157,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_](std::vector<primitive_argument_type> && args)
+            [this_](primitive_arguments_type && args)
             ->  primitive_argument_type
             {
                 return this_->calculate_lra(std::move(args));
@@ -168,7 +168,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> lra::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/arithmetics/add_operation.cpp
+++ b/src/plugins/arithmetics/add_operation.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     add_operation::add_operation(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -866,7 +866,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     void add_operation::append_element(
-        std::vector<primitive_argument_type>& result,
+        primitive_arguments_type& result,
         primitive_argument_type&& rhs) const
     {
         if (is_list_operand_strict(rhs))
@@ -903,7 +903,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     primitive_argument_type add_operation::handle_list_operands(
-        std::vector<primitive_argument_type>&& ops) const
+        primitive_arguments_type&& ops) const
     {
         auto it = ops.begin();
         auto end = ops.end();
@@ -958,7 +958,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     primitive_argument_type add_operation::handle_numeric_operands(
-        std::vector<primitive_argument_type>&& ops) const
+        primitive_arguments_type&& ops) const
     {
         args_type args;
         args.reserve(ops.size());
@@ -992,8 +992,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> add_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2)
         {
@@ -1042,7 +1042,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_](std::vector<primitive_argument_type>&& ops)
+            [this_](primitive_arguments_type&& ops)
             ->  primitive_argument_type
             {
                 if (is_list_operand_strict(ops[0]))
@@ -1059,7 +1059,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '+' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> add_operation::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode) const
+        primitive_arguments_type const& args, eval_mode) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/arithmetics/div_operation.cpp
+++ b/src/plugins/arithmetics/div_operation.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    div_operation::div_operation(std::vector<primitive_argument_type>&& operands,
+    div_operation::div_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -880,8 +880,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> div_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2)
         {
@@ -976,7 +976,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // implement '/' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> div_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/arithmetics/mul_operation.cpp
+++ b/src/plugins/arithmetics/mul_operation.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    mul_operation::mul_operation(std::vector<primitive_argument_type>&& operands,
+    mul_operation::mul_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -896,8 +896,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> mul_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2)
         {
@@ -993,7 +993,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '*' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> mul_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/arithmetics/sub_operation.cpp
+++ b/src/plugins/arithmetics/sub_operation.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     sub_operation::sub_operation(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -868,8 +868,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> sub_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2)
         {
@@ -963,7 +963,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '-' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> sub_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/arithmetics/unary_minus_operation.cpp
+++ b/src/plugins/arithmetics/unary_minus_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     unary_minus_operation::unary_minus_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -77,8 +77,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> unary_minus_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -132,7 +132,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement unary '-' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> unary_minus_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/all_operation.cpp
+++ b/src/plugins/booleans/all_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             &create_all_operation, &create_primitive<all_operation>)};
 
     ///////////////////////////////////////////////////////////////////////////
-    all_operation::all_operation(std::vector<primitive_argument_type> && args,
+    all_operation::all_operation(primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
     {
@@ -80,8 +80,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> all_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 1)
         {
@@ -132,7 +132,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> all_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/and_operation.cpp
+++ b/src/plugins/booleans/and_operation.cpp
@@ -183,7 +183,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    and_operation::and_operation(std::vector<primitive_argument_type>&& operands,
+    and_operation::and_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -505,8 +505,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> and_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         // TODO: support for operands.size() > 2
         if (operands.size() != 2)
@@ -548,7 +548,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // implement '&&' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> and_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/any_operation.cpp
+++ b/src/plugins/booleans/any_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             &create_any_operation, &create_primitive<any_operation>)};
 
     ///////////////////////////////////////////////////////////////////////////
-    any_operation::any_operation(std::vector<primitive_argument_type> && args,
+    any_operation::any_operation(primitive_arguments_type && args,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
     {
@@ -82,8 +82,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> any_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 1)
         {
@@ -132,7 +132,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> any_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/equal.cpp
+++ b/src/plugins/booleans/equal.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    equal::equal(std::vector<primitive_argument_type>&& operands,
+    equal::equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -565,8 +565,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> equal::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2 || operands.size() > 3)
         {
@@ -620,7 +620,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // implement '==' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> equal::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/greater.cpp
+++ b/src/plugins/booleans/greater.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    greater::greater(std::vector<primitive_argument_type>&& operands,
+    greater::greater(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -630,8 +630,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> greater::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2 || operands.size() > 3)
         {
@@ -687,7 +687,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '>' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> greater::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/greater_equal.cpp
+++ b/src/plugins/booleans/greater_equal.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    greater_equal::greater_equal(std::vector<primitive_argument_type>&& operands,
+    greater_equal::greater_equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -637,8 +637,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> greater_equal::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2 || operands.size() > 3)
         {
@@ -694,7 +694,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '>=' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> greater_equal::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/less.cpp
+++ b/src/plugins/booleans/less.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    less::less(std::vector<primitive_argument_type>&& operands,
+    less::less(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -626,8 +626,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> less::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2 || operands.size() > 3)
         {
@@ -683,7 +683,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '<' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> less::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/less_equal.cpp
+++ b/src/plugins/booleans/less_equal.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    less_equal::less_equal(std::vector<primitive_argument_type>&& operands,
+    less_equal::less_equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -630,8 +630,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> less_equal::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2 || operands.size() > 3)
         {
@@ -687,7 +687,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '<=' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> less_equal::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/not_equal.cpp
+++ b/src/plugins/booleans/not_equal.cpp
@@ -34,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    not_equal::not_equal(std::vector<primitive_argument_type>&& operands,
+    not_equal::not_equal(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -562,8 +562,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> not_equal::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2 || operands.size() > 3)
         {
@@ -617,7 +617,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // implement '!=' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> not_equal::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/or_operation.cpp
+++ b/src/plugins/booleans/or_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    or_operation::or_operation(std::vector<primitive_argument_type>&& operands,
+    or_operation::or_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -512,8 +512,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> or_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         //TODO: support for operands.size()>2
         if (operands.size() != 2)
@@ -556,7 +556,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement '||' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> or_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/booleans/unary_not_operation.cpp
+++ b/src/plugins/booleans/unary_not_operation.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     unary_not_operation::unary_not_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -101,8 +101,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> unary_not_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         //TODO: support for operands.size()>1
         if (operands.size() != 1)
@@ -144,7 +144,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Implement unary '!' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> unary_not_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/apply.cpp
+++ b/src/plugins/controls/apply.cpp
@@ -30,13 +30,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    apply::apply(std::vector<primitive_argument_type>&& operands,
+    apply::apply(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> apply::eval(
-        std::vector<primitive_argument_type> const& params) const
+        primitive_arguments_type const& params) const
     {
         if (operands_.size() != 2)
         {

--- a/src/plugins/controls/block_operation.cpp
+++ b/src/plugins/controls/block_operation.cpp
@@ -31,14 +31,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
 
     block_operation::block_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> block_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> args, eval_mode mode) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type args, eval_mode mode) const
     {
         // Empty blocks are allowed (Issue #278)
         if (this->no_operands())
@@ -69,7 +69,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // start iteration over given block statement
     hpx::future<primitive_argument_type> block_operation::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode mode) const
+        primitive_arguments_type const& args, eval_mode mode) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/filter_operation.cpp
+++ b/src/plugins/controls/filter_operation.cpp
@@ -31,14 +31,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     filter_operation::filter_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> filter_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2)
         {
@@ -89,12 +89,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // sequentially evaluate all operations
                 std::size_t size = list.size();
 
-                std::vector<primitive_argument_type> result;
+                primitive_arguments_type result;
                 result.reserve(size);
 
                 for (auto && curr : list)
                 {
-                    std::vector<primitive_argument_type> arg(1, curr);
+                    primitive_arguments_type arg(1, curr);
                     if (boolean_operand_sync(bound_func, std::move(arg),
                             this_->name_, this_->codename_))
                     {
@@ -111,7 +111,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // Start iteration over given for statement
     hpx::future<primitive_argument_type> filter_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/fold_left_operation.cpp
+++ b/src/plugins/controls/fold_left_operation.cpp
@@ -32,14 +32,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     fold_left_operation::fold_left_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> fold_left_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 3)
         {
@@ -91,7 +91,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // sequentially evaluate all operations
                 for (auto&& elem : list)
                 {
-                    std::vector<primitive_argument_type> args(2);
+                    primitive_arguments_type args(2);
                     args[0] = std::move(initial);
                     args[1] = std::move(elem);
 
@@ -109,7 +109,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // Start iteration over given for statement
     hpx::future<primitive_argument_type> fold_left_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/fold_right_operation.cpp
+++ b/src/plugins/controls/fold_right_operation.cpp
@@ -32,14 +32,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     fold_right_operation::fold_right_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> fold_right_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 3)
         {
@@ -91,7 +91,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 // sequentially evaluate all operations
                 for (auto i = list.rbegin(); i != list.rend() ; ++i)
                 {
-                    std::vector<primitive_argument_type> args(2);
+                    primitive_arguments_type args(2);
 
                     args[0] = std::move(*i);
                     args[1] = std::move(initial);
@@ -110,7 +110,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // Start iteration over given for statement
     hpx::future<primitive_argument_type> fold_right_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/for_each.cpp
+++ b/src/plugins/controls/for_each.cpp
@@ -33,14 +33,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     for_each::for_each(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> for_each::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args, eval_mode mode) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_mode mode) const
     {
         if (operands.size() != 2)
         {
@@ -116,7 +116,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // Start iteration over given for_each statement
     hpx::future<primitive_argument_type> for_each::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode mode) const
+        primitive_arguments_type const& args, eval_mode mode) const
     {
         if (operands_.empty())
         {

--- a/src/plugins/controls/for_operation.cpp
+++ b/src/plugins/controls/for_operation.cpp
@@ -30,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     for_operation::for_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -67,8 +67,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         hpx::future<primitive_argument_type> init(
-            std::vector<primitive_argument_type> const& operands,
-            std::vector<primitive_argument_type> const& args)
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args)
         {
             this->args_ = args;
             auto this_ = this->shared_from_this();
@@ -135,14 +135,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
     private:
-        std::vector<primitive_argument_type> args_;
+        primitive_arguments_type args_;
         primitive_argument_type result_;
         std::shared_ptr<for_operation const> that_;
     };
 
     // Start iteration over given for statement
     hpx::future<primitive_argument_type> for_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/if_conditional.cpp
+++ b/src/plugins/controls/if_conditional.cpp
@@ -33,15 +33,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     if_conditional::if_conditional(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> if_conditional::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands_.size() != 3 && operands_.size() != 2)
         {
@@ -98,7 +98,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // Evaluate 'true_case' or 'false_case' based on 'cond'
     hpx::future<primitive_argument_type> if_conditional::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/map_operation.cpp
+++ b/src/plugins/controls/map_operation.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     map_operation::map_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -215,8 +215,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> map_operation::map_1(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync,
@@ -243,7 +243,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     ir::range&& list = extract_list_value_strict(
                         std::move(arg), this_->name_, this_->codename_);
 
-                    std::vector<primitive_argument_type> result;
+                    primitive_arguments_type result;
                     result.reserve(list.size());
 
                     for (auto && elem : list)
@@ -291,19 +291,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        bool all_list_operands(std::vector<primitive_argument_type> const& args)
+        bool all_list_operands(primitive_arguments_type const& args)
         {
             return std::all_of(args.begin(), args.end(), &is_list_operand_strict);
         }
 
         bool all_numeric_operands(
-            std::vector<primitive_argument_type> const& args)
+            primitive_arguments_type const& args)
         {
             return std::all_of(args.begin(), args.end(), &is_numeric_operand);
         }
 
         std::size_t extract_numeric_value_dimension(
-            std::vector<primitive_argument_type> const& args,
+            primitive_arguments_type const& args,
             std::string const& name, std::string const& codename)
         {
             std::size_t dimension = 0;
@@ -337,7 +337,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     primitive_argument_type map_operation::map_n_lists(
-        primitive const* p, std::vector<primitive_argument_type>&& args) const
+        primitive const* p, primitive_arguments_type&& args) const
     {
         std::vector<ir::range> lists;
         lists.reserve(args.size());
@@ -372,12 +372,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             iters.push_back(j.begin());
         }
 
-        std::vector<primitive_argument_type> result;
+        primitive_arguments_type result;
         result.reserve(size);
 
         for (std::size_t i = 0; i != size; ++i)
         {
-            std::vector<primitive_argument_type> args;
+            primitive_arguments_type args;
             args.reserve(numlists);
 
             // Each invocation has its own argument set
@@ -394,13 +394,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     primitive_argument_type map_operation::map_n_scalar(primitive const* p,
-        std::vector<primitive_argument_type>&& args) const
+        primitive_arguments_type&& args) const
     {
         return p->eval(hpx::launch::sync, std::move(args));
     }
 
     primitive_argument_type map_operation::map_n_vector(primitive const* p,
-        std::vector<primitive_argument_type>&& args) const
+        primitive_arguments_type&& args) const
     {
         std::vector<ir::node_data<double>> values;
         values.reserve(args.size());
@@ -415,7 +415,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         for (std::size_t i = 0; i != size; ++i)
         {
-            std::vector<primitive_argument_type> params;
+            primitive_arguments_type params;
             params.reserve(args.size());
             for (std::size_t j = 0; j != args.size(); ++j)
             {
@@ -445,7 +445,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     primitive_argument_type map_operation::map_n_matrix(primitive const* p,
-        std::vector<primitive_argument_type>&& args) const
+        primitive_arguments_type&& args) const
     {
         std::vector<ir::node_data<double>> values;
         values.reserve(args.size());
@@ -461,7 +461,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         for (std::size_t i = 0; i != m0.rows(); ++i)
         {
-            std::vector<primitive_argument_type> params;
+            primitive_arguments_type params;
             params.reserve(args.size());
             for (std::size_t j = 0; j != args.size(); ++j)
             {
@@ -496,18 +496,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> map_operation::map_n(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         // all remaining operands have to be lists
-        std::vector<primitive_argument_type> lists;
+        primitive_arguments_type lists;
         std::copy(operands.begin() + 1, operands.end(),
             std::back_inserter(lists));
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
             [this_](primitive_argument_type&& bound_func,
-                std::vector<primitive_argument_type>&& args)
+                primitive_arguments_type&& args)
             ->  primitive_argument_type
             {
                 primitive const* p = util::get_if<primitive>(&bound_func);
@@ -560,8 +560,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> map_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() < 2)
         {
@@ -610,7 +610,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // Start iteration over given for statement
     hpx::future<primitive_argument_type> map_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/parallel_block_operation.cpp
+++ b/src/plugins/controls/parallel_block_operation.cpp
@@ -32,14 +32,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     parallel_block_operation::parallel_block_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     hpx::future<primitive_argument_type> parallel_block_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty())
         {
@@ -55,7 +55,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // Evaluate condition of while statement
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_](std::vector<primitive_argument_type> && ops)
+            [this_](primitive_arguments_type && ops)
             ->  primitive_argument_type
             {
                 return ops.back();
@@ -68,7 +68,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     //////////////////////////////////////////////////////////////////////////
     // Start iteration over given parallel-block statement
     hpx::future<primitive_argument_type> parallel_block_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/range_operation.cpp
+++ b/src/plugins/controls/range_operation.cpp
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     range_operation::range_operation(
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -71,8 +71,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> range_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 3)
         {
@@ -99,7 +99,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_](args_type&& args) -> primitive_argument_type
+            [this_](auto&& args) -> primitive_argument_type
             {
                 return this_->generate_range(std::move(args));
             }),
@@ -109,7 +109,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> range_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/controls/while_operation.cpp
+++ b/src/plugins/controls/while_operation.cpp
@@ -31,14 +31,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     while_operation::while_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     struct while_operation::iteration : std::enable_shared_from_this<iteration>
     {
-        iteration(std::vector<primitive_argument_type> const& args,
+        iteration(primitive_arguments_type const& args,
             std::shared_ptr<while_operation const> that)
           : that_(that), args_(args)
         {
@@ -102,14 +102,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
     private:
-        std::vector<primitive_argument_type> args_;
+        primitive_arguments_type args_;
         primitive_argument_type result_;
         std::shared_ptr<while_operation const> that_;
     };
 
     // Start iteration over given while statement
     hpx::future<primitive_argument_type> while_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/fileio/file_read.cpp
+++ b/src/plugins/fileio/file_read.cpp
@@ -32,14 +32,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    file_read::file_read(std::vector<primitive_argument_type>&& operands,
+    file_read::file_read(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     // read data from given file and return content
     hpx::future<primitive_argument_type> file_read::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (operands_.size() != 1)
         {

--- a/src/plugins/fileio/file_read_csv.cpp
+++ b/src/plugins/fileio/file_read_csv.cpp
@@ -37,14 +37,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     file_read_csv::file_read_csv(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     // read data from given file and return content
     hpx::future<primitive_argument_type> file_read_csv::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (operands_.size() != 1)
         {

--- a/src/plugins/fileio/file_read_hdf5.cpp
+++ b/src/plugins/fileio/file_read_hdf5.cpp
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     file_read_hdf5::file_read_hdf5(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -46,7 +46,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // read data from given file and return content
     hpx::future<primitive_argument_type> file_read_hdf5::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (operands_.size() != 2)
         {

--- a/src/plugins/fileio/file_write.cpp
+++ b/src/plugins/fileio/file_write.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    file_write::file_write(std::vector<primitive_argument_type>&& operands,
+    file_write::file_write(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -65,8 +65,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> file_write::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2)
         {
@@ -115,7 +115,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // Write data to given file and return content
     hpx::future<primitive_argument_type> file_write::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/fileio/file_write_csv.cpp
+++ b/src/plugins/fileio/file_write_csv.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     file_write_csv::file_write_csv(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -96,8 +96,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> file_write_csv::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2)
         {
@@ -137,7 +137,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // write data to given file in CSV format and return content
     hpx::future<primitive_argument_type> file_write_csv::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/fileio/file_write_hdf5.cpp
+++ b/src/plugins/fileio/file_write_hdf5.cpp
@@ -40,7 +40,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     file_write_hdf5::file_write_hdf5(
-        std::vector<primitive_argument_type> && operands,
+        primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -93,8 +93,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> file_write_hdf5::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 3)
         {
@@ -148,7 +148,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     // write data to given file in hdf5 format and return content
     hpx::future<primitive_argument_type> file_write_hdf5::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/listops/append_operation.cpp
+++ b/src/plugins/listops/append_operation.cpp
@@ -37,7 +37,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     append_operation::append_operation(
-        std::vector<primitive_argument_type> && operands,
+        primitive_arguments_type && operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -62,8 +62,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> append_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2)
         {
@@ -105,7 +105,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> append_operation::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode) const
+        primitive_arguments_type const& args, eval_mode) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/listops/car_cdr_operation.cpp
+++ b/src/plugins/listops/car_cdr_operation.cpp
@@ -85,7 +85,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     car_cdr_operation::car_cdr_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
       , operation_(detail::generate_operation_code(name))
@@ -133,7 +133,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         // create a copy of the vector excluding index 0
-        std::vector<primitive_argument_type> list_copy;
+        primitive_arguments_type list_copy;
         list_copy.reserve(list.size() - 1);
         auto it = list.begin();
         std::move(++it, list.end(), std::back_inserter(list_copy));
@@ -142,8 +142,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> car_cdr_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -196,7 +196,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // Start iteration over given for statement
     hpx::future<primitive_argument_type> car_cdr_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/listops/len_operation.cpp
+++ b/src/plugins/listops/len_operation.cpp
@@ -37,15 +37,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     len_operation::len_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> len_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -93,7 +93,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> len_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/listops/make_list.cpp
+++ b/src/plugins/listops/make_list.cpp
@@ -37,19 +37,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     make_list::make_list(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> make_list::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_](std::vector<primitive_argument_type> && args)
+            [this_](primitive_arguments_type && args)
             ->  primitive_argument_type
             {
                 return primitive_argument_type{std::move(args)};
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> make_list::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/add_dimension.cpp
+++ b/src/plugins/matrixops/add_dimension.cpp
@@ -37,7 +37,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    add_dimension::add_dimension(std::vector<primitive_argument_type>&& operands,
+    add_dimension::add_dimension(primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
         : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -57,8 +57,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> add_dimension::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -106,7 +106,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> add_dimension::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/argmax.cpp
+++ b/src/plugins/matrixops/argmax.cpp
@@ -37,7 +37,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    argmax::argmax(std::vector<primitive_argument_type>&& operands,
+    argmax::argmax(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -250,8 +250,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> argmax::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 2)
         {
@@ -311,7 +311,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> argmax::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/argmin.cpp
+++ b/src/plugins/matrixops/argmin.cpp
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    argmin::argmin(std::vector<primitive_argument_type>&& operands,
+    argmin::argmin(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -251,8 +251,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> argmin::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 2)
         {
@@ -310,7 +310,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> argmin::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/column_set.cpp
+++ b/src/plugins/matrixops/column_set.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     column_set_operation::column_set_operation(
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -310,8 +310,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> column_set_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 5)
         {
@@ -376,7 +376,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> column_set_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/constant.cpp
+++ b/src/plugins/matrixops/constant.cpp
@@ -58,7 +58,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    constant::constant(std::vector<primitive_argument_type>&& operands,
+    constant::constant(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -85,8 +85,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> constant::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1 && operands.size() != 2)
         {
@@ -177,7 +177,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> constant::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/cross_operation.cpp
+++ b/src/plugins/matrixops/cross_operation.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     cross_operation::cross_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -358,8 +358,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> cross_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2)
         {
@@ -408,7 +408,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> cross_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/determinant.cpp
+++ b/src/plugins/matrixops/determinant.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    determinant::determinant(std::vector<primitive_argument_type>&& operands,
+    determinant::determinant(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -41,8 +41,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
 
     hpx::future<primitive_argument_type> determinant::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -103,7 +103,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> determinant::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/diag_operation.cpp
+++ b/src/plugins/matrixops/diag_operation.cpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     diag_operation::diag_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -91,8 +91,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> diag_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() > 2)
         {
@@ -157,7 +157,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> diag_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/dot_operation.cpp
+++ b/src/plugins/matrixops/dot_operation.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     dot_operation::dot_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -259,8 +259,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> dot_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2)
         {
@@ -315,7 +315,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // implement 'dot' for all possible combinations of lhs and rhs
     hpx::future<primitive_argument_type> dot_operation::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode) const
+        primitive_arguments_type const& args, eval_mode) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/extract_shape.cpp
+++ b/src/plugins/matrixops/extract_shape.cpp
@@ -32,14 +32,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     extract_shape::extract_shape(
-            std::vector<primitive_argument_type> && operands,
+            primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     primitive_argument_type extract_shape::shape0d(arg_type&& arg) const
     {
-        std::vector<primitive_argument_type> result{};
+        primitive_arguments_type result{};
         return primitive_argument_type{std::move(result)};
     }
 
@@ -54,7 +54,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     primitive_argument_type extract_shape::shape1d(arg_type&& arg) const
     {
-        std::vector<primitive_argument_type> result{
+        primitive_arguments_type result{
             primitive_argument_type{std::int64_t(arg.size())}};
         return primitive_argument_type{std::move(result)};
     }
@@ -78,7 +78,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // return a list of numbers representing the
         // dimensions of the first argument
         auto dims = arg.dimensions();
-        std::vector<primitive_argument_type> result{
+        primitive_arguments_type result{
             primitive_argument_type{std::int64_t(dims[0])},
             primitive_argument_type{std::int64_t(dims[1])}};
         return primitive_argument_type{std::move(result)};
@@ -100,8 +100,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> extract_shape::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 2)
         {
@@ -186,7 +186,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> extract_shape::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/generic_operation.cpp
+++ b/src/plugins/matrixops/generic_operation.cpp
@@ -955,7 +955,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     generic_operation::generic_operation(
-        std::vector<primitive_argument_type> && operands,
+        primitive_arguments_type && operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -988,8 +988,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> generic_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -1039,7 +1039,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> generic_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/gradient_operation.cpp
+++ b/src/plugins/matrixops/gradient_operation.cpp
@@ -37,14 +37,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     gradient_operation::gradient_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     using arg_type = ir::node_data<double>;
-    using args_type = std::vector<arg_type>;
+    using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
     using storage1d_type = typename arg_type::storage1d_type;
     using storage2d_type = typename arg_type::storage2d_type;
 
@@ -172,7 +172,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     }
                 }
             }
-            return primitive_argument_type{std::vector<primitive_argument_type>{
+            return primitive_argument_type{primitive_arguments_type{
                 primitive_argument_type{
                     ir::node_data<double>{storage2d_type{std::move(gradient)}}},
                 primitive_argument_type{ir::node_data<double>{
@@ -181,8 +181,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> gradient_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 2)
         {
@@ -246,7 +246,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> gradient_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/hstack_operation.cpp
+++ b/src/plugins/matrixops/hstack_operation.cpp
@@ -34,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hstack_operation::hstack_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -154,8 +154,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> hstack_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty())
         {
@@ -216,7 +216,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> hstack_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/identity.cpp
+++ b/src/plugins/matrixops/identity.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    identity::identity(std::vector<primitive_argument_type> && operands,
+    identity::identity(primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename    )
     {
@@ -57,8 +57,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> identity::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -92,7 +92,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> identity::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/inverse_operation.cpp
+++ b/src/plugins/matrixops/inverse_operation.cpp
@@ -32,15 +32,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     inverse_operation::inverse_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> inverse_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -121,7 +121,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> inverse_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/linearmatrix.cpp
+++ b/src/plugins/matrixops/linearmatrix.cpp
@@ -32,7 +32,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    linearmatrix::linearmatrix(std::vector<primitive_argument_type>&& args,
+    linearmatrix::linearmatrix(primitive_arguments_type&& args,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
     {}
@@ -93,8 +93,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> linearmatrix::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 5)
         {
@@ -133,7 +133,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> linearmatrix::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/linspace.cpp
+++ b/src/plugins/matrixops/linspace.cpp
@@ -30,7 +30,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    linspace::linspace(std::vector<primitive_argument_type>&& args,
+    linspace::linspace(primitive_arguments_type&& args,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
     {}
@@ -71,8 +71,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> linspace::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 3)
         {
@@ -110,7 +110,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> linspace::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/mean_operation.cpp
+++ b/src/plugins/matrixops/mean_operation.cpp
@@ -39,7 +39,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     mean_operation::mean_operation(
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -253,8 +253,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> mean_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1 && operands.size() != 2)
         {
@@ -319,7 +319,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> mean_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/power_operation.cpp
+++ b/src/plugins/matrixops/power_operation.cpp
@@ -33,7 +33,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     power_operation::power_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -75,8 +75,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> power_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2)
         {
@@ -140,7 +140,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> power_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/random.cpp
+++ b/src/plugins/matrixops/random.cpp
@@ -124,7 +124,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     hpx::future<std::array<std::size_t, 2>> dimensions_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -206,7 +206,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     hpx::future<distribution_parameters_type> distribution_parameters_operand(
         primitive_argument_type const& val,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         primitive const* p = util::get_if<primitive>(&val);
@@ -226,7 +226,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    random::random(std::vector<primitive_argument_type>&& operands,
+    random::random(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -520,8 +520,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> random::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 2)
         {
@@ -610,7 +610,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> random::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {
@@ -624,13 +624,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     hpx::future<primitive_argument_type> set_seed(
-        std::vector<primitive_argument_type> const&,
-        std::vector<primitive_argument_type> const&,
+        primitive_arguments_type const&,
+        primitive_arguments_type const&,
         std::string const&, std::string const&);
 
     primitive_argument_type get_seed(
-        std::vector<primitive_argument_type> const&,
-        std::vector<primitive_argument_type> const&,
+        primitive_arguments_type const&,
+        primitive_arguments_type const&,
         std::string const&, std::string const&);
 }}}
 
@@ -660,8 +660,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> set_seed(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename)
     {
         if (operands.empty() || operands.size() > 2)
@@ -693,8 +693,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     primitive_argument_type get_seed(
-        std::vector<primitive_argument_type> const&,
-        std::vector<primitive_argument_type> const&,
+        primitive_arguments_type const&,
+        primitive_arguments_type const&,
         std::string const&, std::string const&)
     {
         return primitive_argument_type{

--- a/src/plugins/matrixops/row_set.cpp
+++ b/src/plugins/matrixops/row_set.cpp
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     row_set_operation::row_set_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -303,8 +303,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> row_set_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 5)
         {
@@ -370,7 +370,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> row_set_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/set_operation.cpp
+++ b/src/plugins/matrixops/set_operation.cpp
@@ -38,7 +38,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     set_operation::set_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -355,8 +355,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> set_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 8)
         {
@@ -422,7 +422,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> set_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/shuffle_operation.cpp
+++ b/src/plugins/matrixops/shuffle_operation.cpp
@@ -77,7 +77,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     std::mt19937 shuffle_operation::rand_machine{std::random_device{}()};
 
     shuffle_operation::shuffle_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -103,8 +103,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> shuffle_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -154,7 +154,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> shuffle_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/slicing_operation.cpp
+++ b/src/plugins/matrixops/slicing_operation.cpp
@@ -53,7 +53,7 @@ namespace phylanx {namespace execution_tree {    namespace primitives {
 
     ///////////////////////////////////////////////////////////////////////////
     slicing_operation::slicing_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
       , slice_rows_(false)
@@ -88,8 +88,8 @@ namespace phylanx {namespace execution_tree {    namespace primitives {
     }
 
     hpx::future<primitive_argument_type> slicing_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 3)
         {
@@ -170,7 +170,7 @@ namespace phylanx {namespace execution_tree {    namespace primitives {
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> slicing_operation::eval(
-        std::vector<primitive_argument_type> const& args, eval_mode) const
+        primitive_arguments_type const& args, eval_mode) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/square_root_operation.cpp
+++ b/src/plugins/matrixops/square_root_operation.cpp
@@ -34,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     square_root_operation::square_root_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -76,8 +76,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> square_root_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -130,7 +130,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> square_root_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/sum_operation.cpp
+++ b/src/plugins/matrixops/sum_operation.cpp
@@ -39,7 +39,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     sum_operation::sum_operation(
-        std::vector<primitive_argument_type>&& operands,
+        primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -156,8 +156,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> sum_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty() || operands.size() > 3)
         {
@@ -186,7 +186,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync,
             hpx::util::unwrapping(
-                [this_](std::vector<primitive_argument_type>&& args)
+                [this_](primitive_arguments_type&& args)
                     -> primitive_argument_type
                 {
                     // Extract axis and keep_dims
@@ -237,7 +237,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> sum_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/transpose_operation.cpp
+++ b/src/plugins/matrixops/transpose_operation.cpp
@@ -32,15 +32,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     transpose_operation::transpose_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> transpose_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args,
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args,
         std::string const& name, std::string const& codename) const
     {
         if (operands.size() != 1)
@@ -115,7 +115,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> transpose_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/matrixops/vstack_operation.cpp
+++ b/src/plugins/matrixops/vstack_operation.cpp
@@ -34,7 +34,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     vstack_operation::vstack_operation(
-            std::vector<primitive_argument_type>&& operands,
+            primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
@@ -157,8 +157,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> vstack_operation::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.empty())
         {
@@ -219,7 +219,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     //////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> vstack_operation::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/src/plugins/solvers/decomposition.cpp
+++ b/src/plugins/solvers/decomposition.cpp
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::lu(A, L, U, P);
                 }
                 return primitive_argument_type{
-                    std::vector<primitive_argument_type>{
+                    primitive_arguments_type{
                         primitive_argument_type{L}, primitive_argument_type{U},
                         primitive_argument_type{P}}};
             }}};
@@ -82,7 +82,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
     ///////////////////////////////////////////////////////////////////////////
     decomposition::decomposition(
-        std::vector<primitive_argument_type> && operands,
+        primitive_arguments_type && operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -101,8 +101,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> decomposition::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 1)
         {
@@ -148,7 +148,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> decomposition::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (operands_.empty())
         {

--- a/src/plugins/solvers/linear_solver.cpp
+++ b/src/plugins/solvers/linear_solver.cpp
@@ -119,7 +119,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
     ///////////////////////////////////////////////////////////////////////////
     linear_solver::linear_solver(
-        std::vector<primitive_argument_type> && operands,
+        primitive_arguments_type && operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {
@@ -164,8 +164,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     hpx::future<primitive_argument_type> linear_solver::eval(
-        std::vector<primitive_argument_type> const& operands,
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
     {
         if (operands.size() != 2 && operands.size() != 3)
         {
@@ -254,7 +254,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> linear_solver::eval(
-        std::vector<primitive_argument_type> const& args) const
+        primitive_arguments_type const& args) const
     {
         if (this->no_operands())
         {

--- a/tests/unit/distributed/remote_run.cpp
+++ b/tests/unit/distributed/remote_run.cpp
@@ -21,8 +21,8 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     hpx::future<primitive_argument_type> locality_id(
-        std::vector<primitive_argument_type> const&,
-        std::vector<primitive_argument_type> const&,
+        phylanx::execution_tree::primitive_arguments_type const&,
+        phylanx::execution_tree::primitive_arguments_type const&,
         std::string const&, std::string const&);
 }}}
 
@@ -40,8 +40,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     hpx::future<primitive_argument_type> locality_id(
-        std::vector<primitive_argument_type> const&,
-        std::vector<primitive_argument_type> const&,
+        phylanx::execution_tree::primitive_arguments_type const&,
+        phylanx::execution_tree::primitive_arguments_type const&,
         std::string const&, std::string const&)
     {
         std::int64_t locality_ =

--- a/tests/unit/execution_tree/primitives/assert_condition.cpp
+++ b/tests/unit/execution_tree/primitives/assert_condition.cpp
@@ -14,7 +14,7 @@
 #include <vector>
 
 using arg_type = phylanx::execution_tree::primitive_argument_type;
-using args_type = std::vector<phylanx::execution_tree::primitive_argument_type>;
+using args_type = phylanx::execution_tree::primitive_arguments_type;
 
 void test_assert_true()
 {

--- a/tests/unit/execution_tree/primitives/define_operation.cpp
+++ b/tests/unit/execution_tree/primitives/define_operation.cpp
@@ -64,7 +64,7 @@ void test_define_operation(char const* expr, char const* name, double expected,
     auto f = def_f.run();     // bind the function
 
     // evaluate expression
-    std::vector<phylanx::execution_tree::primitive_argument_type> values;
+    phylanx::execution_tree::primitive_arguments_type values;
     for (double d : argvalues)
     {
         values.push_back(phylanx::ir::node_data<double>{d});

--- a/tests/unit/plugins/arithmetics/add_operation.cpp
+++ b/tests/unit/plugins/arithmetics/add_operation.cpp
@@ -26,7 +26,7 @@ void test_add_operation_0d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -46,7 +46,7 @@ void test_add_operation_0d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -71,7 +71,7 @@ void test_add_operation_0d1d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -96,7 +96,7 @@ void test_add_operation_0d1d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -123,7 +123,7 @@ void test_add_operation_0d2d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -148,7 +148,7 @@ void test_add_operation_0d2d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -176,7 +176,7 @@ void test_add_operation_1d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -201,7 +201,7 @@ void test_add_operation_1d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -227,7 +227,7 @@ void test_add_operation_1d0d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -252,7 +252,7 @@ void test_add_operation_1d0d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -282,7 +282,7 @@ void test_add_operation_1d2d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -313,7 +313,7 @@ void test_add_operation_1d2d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -344,7 +344,7 @@ void test_add_operation_2d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -369,7 +369,7 @@ void test_add_operation_2d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -395,7 +395,7 @@ void test_add_operation_2d0d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -420,7 +420,7 @@ void test_add_operation_2d0d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -450,7 +450,7 @@ void test_add_operation_2d1d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -481,7 +481,7 @@ void test_add_operation_2d1d_lit()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();

--- a/tests/unit/plugins/arithmetics/div_operation.cpp
+++ b/tests/unit/plugins/arithmetics/div_operation.cpp
@@ -29,7 +29,7 @@ void test_div_operation_0d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -48,7 +48,7 @@ void test_div_operation_0d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -72,7 +72,7 @@ void test_div_operation_0d1d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -98,7 +98,7 @@ void test_div_operation_0d1d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -126,7 +126,7 @@ void test_div_operation_0d2d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -151,7 +151,7 @@ void test_div_operation_0d2d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -178,7 +178,7 @@ void test_div_operation_1d0d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -203,7 +203,7 @@ void test_div_operation_1d0d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -231,7 +231,7 @@ void test_div_operation_1d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -257,7 +257,7 @@ void test_div_operation_1d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -287,7 +287,7 @@ void test_div_operation_1d2d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -318,7 +318,7 @@ void test_div_operation_1d2d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -348,7 +348,7 @@ void test_div_operation_2d0d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -373,7 +373,7 @@ void test_div_operation_2d0d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -401,7 +401,7 @@ void test_div_operation_2d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -427,7 +427,7 @@ void test_div_operation_2d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -457,7 +457,7 @@ void test_div_operation_2d1d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();
@@ -488,7 +488,7 @@ void test_div_operation_2d1d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_div_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = div.eval();

--- a/tests/unit/plugins/arithmetics/mul_operation.cpp
+++ b/tests/unit/plugins/arithmetics/mul_operation.cpp
@@ -30,7 +30,7 @@ void test_mul_operation_0d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -51,7 +51,7 @@ void test_mul_operation_0d_lit()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -77,7 +77,7 @@ void test_mul_operation_0d1d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -104,7 +104,7 @@ void test_mul_operation_0d1d_lit()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -132,7 +132,7 @@ void test_mul_operation_0d1d_numpy()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -159,7 +159,7 @@ void test_mul_operation_0d2d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -186,7 +186,7 @@ void test_mul_operation_0d2d_lit()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -214,7 +214,7 @@ void test_mul_operation_0d2d_numpy()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -242,7 +242,7 @@ void test_mul_operation_1d0d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -269,7 +269,7 @@ void test_mul_operation_1d0d_lit()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -297,7 +297,7 @@ void test_mul_operation_1d0d_numpy()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -327,7 +327,7 @@ void test_mul_operation_1d1d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -355,7 +355,7 @@ void test_mul_operation_1d1d_lit()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -380,7 +380,7 @@ void test_mul_operation_1d1d_numpy()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -413,7 +413,7 @@ void test_mul_operation_1d1d_numpy_1()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(ops1), std::move(ops2), std::move(ops3)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -444,7 +444,7 @@ void test_mul_operation_1d2d()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -477,7 +477,7 @@ void test_mul_operation_1d2d_lit()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -509,7 +509,7 @@ void test_mul_operation_1d2d_numpy()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -537,7 +537,7 @@ void test_mul_operation_2d0d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -564,7 +564,7 @@ void test_mul_operation_2d0d_lit()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -592,7 +592,7 @@ void test_mul_operation_2d0d_numpy()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -622,7 +622,7 @@ void test_mul_operation_2d1d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -656,7 +656,7 @@ void test_mul_operation_2d1d_numpy()
     phylanx::execution_tree::primitive div =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -683,7 +683,7 @@ void test_mul_operation_2d1d_lit()
     phylanx::execution_tree::primitive mul =
             phylanx::execution_tree::primitives::create_mul_operation(
                     hpx::find_here(),
-                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                    phylanx::execution_tree::primitive_arguments_type{
                             std::move(lhs), std::move(rhs)
                     });
 
@@ -718,7 +718,7 @@ void test_mul_operation_2d()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -745,7 +745,7 @@ void test_mul_operation_2d_lit()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -774,7 +774,7 @@ void test_mul_operation_2d_numpy()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -806,7 +806,7 @@ void test_mul_operation_2d_numpy_1()
     phylanx::execution_tree::primitive mul =
         phylanx::execution_tree::primitives::create_mul_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(ops1), std::move(ops2), std::move(ops3)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/arithmetics/sub_operation.cpp
+++ b/tests/unit/plugins/arithmetics/sub_operation.cpp
@@ -28,7 +28,7 @@ void test_sub_operation_0d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -47,7 +47,7 @@ void test_sub_operation_0d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -71,7 +71,7 @@ void test_sub_operation_0d1d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -96,7 +96,7 @@ void test_sub_operation_0d1d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -123,7 +123,7 @@ void test_sub_operation_0d2d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -148,7 +148,7 @@ void test_sub_operation_0d2d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -176,7 +176,7 @@ void test_sub_operation_1d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -201,7 +201,7 @@ void test_sub_operation_1d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -227,7 +227,7 @@ void test_sub_operation_1d0d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -252,7 +252,7 @@ void test_sub_operation_1d0d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -282,7 +282,7 @@ void test_sub_operation_1d2d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -313,7 +313,7 @@ void test_sub_operation_1d2d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -344,7 +344,7 @@ void test_sub_operation_2d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -369,7 +369,7 @@ void test_sub_operation_2d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -395,7 +395,7 @@ void test_sub_operation_2d0d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     blaze::DynamicMatrix<double> expected =
@@ -420,7 +420,7 @@ void test_sub_operation_2d0d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     blaze::DynamicMatrix<double> expected =
@@ -450,7 +450,7 @@ void test_sub_operation_2d1d()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();
@@ -481,7 +481,7 @@ void test_sub_operation_2d1d_lit()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = sub.eval();

--- a/tests/unit/plugins/arithmetics/unary_minus_operation.cpp
+++ b/tests/unit/plugins/arithmetics/unary_minus_operation.cpp
@@ -22,7 +22,7 @@ void test_unary_minus_operation_0d()
     phylanx::execution_tree::primitive unary_minus =
         phylanx::execution_tree::primitives::create_unary_minus_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 
@@ -40,7 +40,7 @@ void test_unary_minus_operation_0d_lit()
     phylanx::execution_tree::primitive unary_minus =
         phylanx::execution_tree::primitives::create_unary_minus_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 
@@ -63,7 +63,7 @@ void test_unary_minus_operation_2d()
     phylanx::execution_tree::primitive unary_minus =
         phylanx::execution_tree::primitives::create_unary_minus_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 

--- a/tests/unit/plugins/booleans/all_operation.cpp
+++ b/tests/unit/plugins/booleans/all_operation.cpp
@@ -22,7 +22,7 @@ void test_all_operation_0d_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -39,7 +39,7 @@ void test_all_operation_0d_false()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -56,7 +56,7 @@ void test_all_operation_0d_double_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -73,7 +73,7 @@ void test_all_operation_0d_double_false()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -93,7 +93,7 @@ void test_all_operation_1d_double()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -114,7 +114,7 @@ void test_all_operation_1d()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -135,7 +135,7 @@ void test_all_operation_1d_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -155,7 +155,7 @@ void test_all_operation_1d_double_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -174,7 +174,7 @@ void test_all_operation_1d_numpy_false()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -193,7 +193,7 @@ void test_all_operation_1d_numpy_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -212,7 +212,7 @@ void test_all_operation_1d_double_numpy_false()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -231,7 +231,7 @@ void test_all_operation_1d_double_numpy_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -251,7 +251,7 @@ void test_all_operation_2d()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -272,7 +272,7 @@ void test_all_operation_2d_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -292,7 +292,7 @@ void test_all_operation_2d_double()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -313,7 +313,7 @@ void test_all_operation_2d_double_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -332,7 +332,7 @@ void test_all_operation_2d_double_numpy_false()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -351,7 +351,7 @@ void test_all_operation_2d_double_numpy_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -370,7 +370,7 @@ void test_all_operation_2d_numpy_true()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
@@ -389,7 +389,7 @@ void test_all_operation_2d_numpy_false()
     phylanx::execution_tree::primitive all =
         phylanx::execution_tree::primitives::create_all_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();

--- a/tests/unit/plugins/booleans/and_operation.cpp
+++ b/tests/unit/plugins/booleans/and_operation.cpp
@@ -28,7 +28,7 @@ void test_and_operation_0d_false()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -51,7 +51,7 @@ void test_and_operation_0d_double_false()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -74,7 +74,7 @@ void test_and_operation_0d_true()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -97,7 +97,7 @@ void test_and_operation_0d_double_true()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -118,7 +118,7 @@ void test_and_operation_0d_lit_false()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -139,7 +139,7 @@ void test_and_operation_0d_double_lit_false()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -160,7 +160,7 @@ void test_and_operation_0d_lit_true()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -181,7 +181,7 @@ void test_and_operation_0d_double_lit_true()
     phylanx::execution_tree::primitive and_operation;
     and_operation = phylanx::execution_tree::primitives::create_and_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -207,7 +207,7 @@ void test_and_operation_0d1d_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -234,7 +234,7 @@ void test_and_operation_0d1d_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -263,7 +263,7 @@ void test_and_operation_0d1d_double_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -289,7 +289,7 @@ void test_and_operation_0d1d_double_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -317,7 +317,7 @@ void test_and_operation_0d1d_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -344,7 +344,7 @@ void test_and_operation_0d1d_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -373,7 +373,7 @@ void test_and_operation_0d1d_double_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -400,7 +400,7 @@ void test_and_operation_0d1d_double_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -429,7 +429,7 @@ void test_and_operation_0d2d_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -456,7 +456,7 @@ void test_and_operation_0d2d_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -485,7 +485,7 @@ void test_and_operation_0d2d_double_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -511,7 +511,7 @@ void test_and_operation_0d2d_double_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -539,7 +539,7 @@ void test_and_operation_0d2d_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -566,7 +566,7 @@ void test_and_operation_0d2d_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -595,7 +595,7 @@ void test_and_operation_0d2d_double_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -622,7 +622,7 @@ void test_and_operation_0d2d_double_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -652,7 +652,7 @@ void test_and_operation_1d()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -680,7 +680,7 @@ void test_and_operation_1d_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -710,7 +710,7 @@ void test_and_operation_1d_double()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -738,7 +738,7 @@ void test_and_operation_1d_double_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -767,7 +767,7 @@ void test_and_operation_1d0d_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -794,7 +794,7 @@ void test_and_operation_1d0d_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -823,7 +823,7 @@ void test_and_operation_1d0d_double_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -849,7 +849,7 @@ void test_and_operation_1d0d_double_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -877,7 +877,7 @@ void test_and_operation_1d0d_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -904,7 +904,7 @@ void test_and_operation_1d0d_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -933,7 +933,7 @@ void test_and_operation_1d0d_double_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -960,7 +960,7 @@ void test_and_operation_1d0d_double_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -992,7 +992,7 @@ void test_and_operation_1d2d()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1026,7 +1026,7 @@ void test_and_operation_1d2d_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1062,7 +1062,7 @@ void test_and_operation_1d2d_double()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1096,7 +1096,7 @@ void test_and_operation_1d2d_double_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1130,7 +1130,7 @@ void test_and_operation_2d()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1158,7 +1158,7 @@ void test_and_operation_2d_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1188,7 +1188,7 @@ void test_and_operation_2d_double()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1216,7 +1216,7 @@ void test_and_operation_2d_double_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1245,7 +1245,7 @@ void test_and_operation_2d0d_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1272,7 +1272,7 @@ void test_and_operation_2d0d_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1301,7 +1301,7 @@ void test_and_operation_2d0d_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1328,7 +1328,7 @@ void test_and_operation_2d0d_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1357,7 +1357,7 @@ void test_and_operation_2d0d_double_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1384,7 +1384,7 @@ void test_and_operation_2d0d_double_lit_true()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1413,7 +1413,7 @@ void test_and_operation_2d0d_double_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1439,7 +1439,7 @@ void test_and_operation_2d0d_double_lit_false()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1470,7 +1470,7 @@ void test_and_operation_2d1d()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1503,7 +1503,7 @@ void test_and_operation_2d1d_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1538,7 +1538,7 @@ void test_and_operation_2d1d_double()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1571,7 +1571,7 @@ void test_and_operation_2d1d_double_lit()
     phylanx::execution_tree::primitive and_operation =
         phylanx::execution_tree::primitives::create_and_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =

--- a/tests/unit/plugins/booleans/any_operation.cpp
+++ b/tests/unit/plugins/booleans/any_operation.cpp
@@ -22,7 +22,7 @@ void test_any_operation_0d_true()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -39,7 +39,7 @@ void test_any_operation_0d_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -56,7 +56,7 @@ void test_any_operation_0d_double_true()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -73,7 +73,7 @@ void test_any_operation_0d_double_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -93,7 +93,7 @@ void test_any_operation_1d()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -113,7 +113,7 @@ void test_any_operation_1d_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -132,7 +132,7 @@ void test_any_operation_1d_double()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -152,7 +152,7 @@ void test_any_operation_1d_double_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -170,7 +170,7 @@ void test_any_operation_1d_numpy_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -189,7 +189,7 @@ void test_any_operation_1d_numpy_true()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -208,7 +208,7 @@ void test_any_operation_1d_double_numpy_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -227,7 +227,7 @@ void test_any_operation_1d_double_numpy_true()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -247,7 +247,7 @@ void test_any_operation_2d()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -267,7 +267,7 @@ void test_any_operation_2d_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -287,7 +287,7 @@ void test_any_operation_2d_double()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -307,7 +307,7 @@ void test_any_operation_2d_double_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -327,7 +327,7 @@ void test_any_operation_2d_numpy_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -346,7 +346,7 @@ void test_any_operation_2d_numpy_true()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -365,7 +365,7 @@ void test_any_operation_2d_double_numpy_false()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
@@ -384,7 +384,7 @@ void test_any_operation_2d_double_numpy_true()
     phylanx::execution_tree::primitive any =
         phylanx::execution_tree::primitives::create_any_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();

--- a/tests/unit/plugins/booleans/equal_operation.cpp
+++ b/tests/unit/plugins/booleans/equal_operation.cpp
@@ -28,7 +28,7 @@ void test_equal_operation_0d_false()
     phylanx::execution_tree::primitive equal;
     equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -52,7 +52,7 @@ void test_equal_operation_0d_bool_false()
     phylanx::execution_tree::primitive equal;
     equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -73,7 +73,7 @@ void test_equal_operation_0d_bool_false_return_bool()
 
     phylanx::execution_tree::primitive equal;
     equal = phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs),
             phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -96,7 +96,7 @@ void test_equal_operation_0d_true()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -119,7 +119,7 @@ void test_equal_operation_0d_true_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -140,7 +140,7 @@ void test_equal_operation_0d_lit_false()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -161,7 +161,7 @@ void test_equal_operation_0d_lit_true()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -187,7 +187,7 @@ void test_equal_operation_0d1d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -214,7 +214,7 @@ void test_equal_operation_0d1d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -243,7 +243,7 @@ void test_equal_operation_0d1d_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -268,7 +268,7 @@ void test_equal_operation_0d1d_bool_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -295,7 +295,7 @@ void test_equal_operation_0d1d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -324,7 +324,7 @@ void test_equal_operation_0d1d_return_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -353,7 +353,7 @@ void test_equal_operation_0d2d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -380,7 +380,7 @@ void test_equal_operation_0d2d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -409,7 +409,7 @@ void test_equal_operation_0d2d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -438,7 +438,7 @@ void test_equal_operation_0d2d_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -463,7 +463,7 @@ void test_equal_operation_0d2d_bool_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -491,7 +491,7 @@ void test_equal_operation_1d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -521,7 +521,7 @@ void test_equal_operation_1d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -549,7 +549,7 @@ void test_equal_operation_1d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -578,7 +578,7 @@ void test_equal_operation_1d0d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -607,7 +607,7 @@ void test_equal_operation_1d0d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -634,7 +634,7 @@ void test_equal_operation_1d0d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -663,7 +663,7 @@ void test_equal_operation_1d0d_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -690,7 +690,7 @@ void test_equal_operation_1d0d_bool_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -722,7 +722,7 @@ void test_equal_operation_1d2d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -756,7 +756,7 @@ void test_equal_operation_1d2d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -792,7 +792,7 @@ void test_equal_operation_1d2d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -828,7 +828,7 @@ void test_equal_operation_1d2d_return_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -862,7 +862,7 @@ void test_equal_operation_2d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -892,7 +892,7 @@ void test_equal_operation_2d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -920,7 +920,7 @@ void test_equal_operation_2d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -950,7 +950,7 @@ void test_equal_operation_2d_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -978,7 +978,7 @@ void test_equal_operation_2d_bool_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1007,7 +1007,7 @@ void test_equal_operation_2d0d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1036,7 +1036,7 @@ void test_equal_operation_2d0d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -1063,7 +1063,7 @@ void test_equal_operation_2d0d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1092,7 +1092,7 @@ void test_equal_operation_2d0d_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1119,7 +1119,7 @@ void test_equal_operation_2d0d_bool_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1149,7 +1149,7 @@ void test_equal_operation_2d1d()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1184,7 +1184,7 @@ void test_equal_operation_2d1d_return_double()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -1217,7 +1217,7 @@ void test_equal_operation_2d1d_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1252,7 +1252,7 @@ void test_equal_operation_2d1d_bool()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
@@ -1283,7 +1283,7 @@ void test_equal_operation_2d1d_bool_lit()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();

--- a/tests/unit/plugins/booleans/greater_equal_operation.cpp
+++ b/tests/unit/plugins/booleans/greater_equal_operation.cpp
@@ -28,7 +28,7 @@ void test_greater_equal_operation_0d_true()
     greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -53,7 +53,7 @@ void test_greater_equal_operation_0d_false()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -76,7 +76,7 @@ void test_greater_equal_operation_0d_lit_true()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -99,7 +99,7 @@ void test_greater_equal_operation_0d_lit_false()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -127,7 +127,7 @@ void test_greater_equal_operation_0d1d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -156,7 +156,7 @@ void test_greater_equal_operation_0d1d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -187,7 +187,7 @@ void test_greater_equal_operation_0d2d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -216,7 +216,7 @@ void test_greater_equal_operation_0d2d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -248,7 +248,7 @@ void test_greater_equal_operation_1d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -278,7 +278,7 @@ void test_greater_equal_operation_1d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -309,7 +309,7 @@ void test_greater_equal_operation_1d0d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -338,7 +338,7 @@ void test_greater_equal_operation_1d0d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -372,7 +372,7 @@ void test_greater_equal_operation_1d2d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -408,7 +408,7 @@ void test_greater_equal_operation_1d2d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -444,7 +444,7 @@ void test_greater_equal_operation_2d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -474,7 +474,7 @@ void test_greater_equal_operation_2d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -505,7 +505,7 @@ void test_greater_equal_operation_2d0d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -534,7 +534,7 @@ void test_greater_equal_operation_2d0d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -568,7 +568,7 @@ void test_greater_equal_operation_2d1d()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -603,7 +603,7 @@ void test_greater_equal_operation_2d1d_lit()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -634,7 +634,7 @@ void test_greater_equal_operation_0d_true_return_double()
     phylanx::execution_tree::primitive greater_equal;
     greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -660,7 +660,7 @@ void test_greater_equal_operation_0d1d_return_double()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -689,7 +689,7 @@ void test_greater_equal_operation_0d1d_return_bool()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -718,7 +718,7 @@ void test_greater_equal_operation_0d2d_return_double()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -748,7 +748,7 @@ void test_greater_equal_operation_1d_return_double()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -778,7 +778,7 @@ void test_greater_equal_operation_1d0d_return_double()
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -810,7 +810,7 @@ void test_greater_equal_operation_1d2d_return_double()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -844,7 +844,7 @@ void test_greater_equal_operation_2d_return_double()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -873,7 +873,7 @@ void test_greater_equal_operation_2d0d_return_double()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -905,7 +905,7 @@ void test_greater_equal_operation_2d1d_return_double()
 
     phylanx::execution_tree::primitive greater_equal =
         phylanx::execution_tree::primitives::create_greater_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 

--- a/tests/unit/plugins/booleans/greater_operation.cpp
+++ b/tests/unit/plugins/booleans/greater_operation.cpp
@@ -27,7 +27,7 @@ void test_greater_operation_0d_true()
     phylanx::execution_tree::primitive greater;
     greater = phylanx::execution_tree::primitives::create_greater(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -51,7 +51,7 @@ void test_greater_operation_0d_true_return_double()
     phylanx::execution_tree::primitive greater;
     greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -75,7 +75,7 @@ void test_greater_operation_0d_false()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -97,7 +97,7 @@ void test_greater_operation_0d_lit_true()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -119,7 +119,7 @@ void test_greater_operation_0d_lit_false()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -146,7 +146,7 @@ void test_greater_operation_0d1d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -174,7 +174,7 @@ void test_greater_operation_0d1d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -203,7 +203,7 @@ void test_greater_operation_0d1d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -232,7 +232,7 @@ void test_greater_operation_0d1d_return_bool()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -262,7 +262,7 @@ void test_greater_operation_0d2d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -290,7 +290,7 @@ void test_greater_operation_0d2d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -319,7 +319,7 @@ void test_greater_operation_0d2d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -350,7 +350,7 @@ void test_greater_operation_1d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -379,7 +379,7 @@ void test_greater_operation_1d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -409,7 +409,7 @@ void test_greater_operation_1d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -439,7 +439,7 @@ void test_greater_operation_1d0d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -467,7 +467,7 @@ void test_greater_operation_1d0d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -496,7 +496,7 @@ void test_greater_operation_1d0d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -529,7 +529,7 @@ void test_greater_operation_1d2d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -564,7 +564,7 @@ void test_greater_operation_1d2d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -600,7 +600,7 @@ void test_greater_operation_1d2d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -635,7 +635,7 @@ void test_greater_operation_2d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -664,7 +664,7 @@ void test_greater_operation_2d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -694,7 +694,7 @@ void test_greater_operation_2d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -724,7 +724,7 @@ void test_greater_operation_2d0d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -752,7 +752,7 @@ void test_greater_operation_2d0d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -781,7 +781,7 @@ void test_greater_operation_2d0d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -814,7 +814,7 @@ void test_greater_operation_2d1d()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -848,7 +848,7 @@ void test_greater_operation_2d1d_lit()
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = greater.eval().get();
@@ -883,7 +883,7 @@ void test_greater_operation_2d1d_return_double()
 
     phylanx::execution_tree::primitive greater =
         phylanx::execution_tree::primitives::create_greater(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 

--- a/tests/unit/plugins/booleans/less_equal_operation.cpp
+++ b/tests/unit/plugins/booleans/less_equal_operation.cpp
@@ -27,7 +27,7 @@ void test_less_equal_operation_0d_true()
     phylanx::execution_tree::primitive less_equal;
     less_equal = phylanx::execution_tree::primitives::create_less_equal(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -52,7 +52,7 @@ void test_less_equal_operation_0d_false()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -75,7 +75,7 @@ void test_less_equal_operation_0d_lit_true()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -98,7 +98,7 @@ void test_less_equal_operation_0d_lit_false()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -126,7 +126,7 @@ void test_less_equal_operation_0d1d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -155,7 +155,7 @@ void test_less_equal_operation_0d1d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -186,7 +186,7 @@ void test_less_equal_operation_0d2d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -215,7 +215,7 @@ void test_less_equal_operation_0d2d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -247,7 +247,7 @@ void test_less_equal_operation_1d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -277,7 +277,7 @@ void test_less_equal_operation_1d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -308,7 +308,7 @@ void test_less_equal_operation_1d0d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -337,7 +337,7 @@ void test_less_equal_operation_1d0d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -371,7 +371,7 @@ void test_less_equal_operation_1d2d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -407,7 +407,7 @@ void test_less_equal_operation_1d2d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -443,7 +443,7 @@ void test_less_equal_operation_2d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -473,7 +473,7 @@ void test_less_equal_operation_2d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -504,7 +504,7 @@ void test_less_equal_operation_2d0d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -533,7 +533,7 @@ void test_less_equal_operation_2d0d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -567,7 +567,7 @@ void test_less_equal_operation_2d1d()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -602,7 +602,7 @@ void test_less_equal_operation_2d1d_lit()
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -632,7 +632,7 @@ void test_less_equal_operation_0d_true_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -659,7 +659,7 @@ void test_less_equal_operation_0d1d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -689,7 +689,7 @@ void test_less_equal_operation_0d1d_return_bool()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -719,7 +719,7 @@ void test_less_equal_operation_0d2d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -750,7 +750,7 @@ void test_less_equal_operation_1d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -780,7 +780,7 @@ void test_less_equal_operation_1d0d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -813,7 +813,7 @@ void test_less_equal_operation_1d2d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -848,7 +848,7 @@ void test_less_equal_operation_2d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -878,7 +878,7 @@ void test_less_equal_operation_2d0d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -911,7 +911,7 @@ void test_less_equal_operation_2d1d_return_double()
 
     phylanx::execution_tree::primitive less_equal =
         phylanx::execution_tree::primitives::create_less_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 

--- a/tests/unit/plugins/booleans/less_operation.cpp
+++ b/tests/unit/plugins/booleans/less_operation.cpp
@@ -27,7 +27,7 @@ void test_less_operation_0d_true()
     phylanx::execution_tree::primitive less;
     less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -50,7 +50,7 @@ void test_less_operation_0d_false()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -71,7 +71,7 @@ void test_less_operation_0d_lit_true()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -92,7 +92,7 @@ void test_less_operation_0d_lit_false()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -118,7 +118,7 @@ void test_less_operation_0d1d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -145,7 +145,7 @@ void test_less_operation_0d1d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -174,7 +174,7 @@ void test_less_operation_0d2d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -201,7 +201,7 @@ void test_less_operation_0d2d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -231,7 +231,7 @@ void test_less_operation_1d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -259,7 +259,7 @@ void test_less_operation_1d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -288,7 +288,7 @@ void test_less_operation_1d0d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -315,7 +315,7 @@ void test_less_operation_1d0d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -347,7 +347,7 @@ void test_less_operation_1d2d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -381,7 +381,7 @@ void test_less_operation_1d2d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -415,7 +415,7 @@ void test_less_operation_2d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -443,7 +443,7 @@ void test_less_operation_2d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -472,7 +472,7 @@ void test_less_operation_2d0d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -499,7 +499,7 @@ void test_less_operation_2d0d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -531,7 +531,7 @@ void test_less_operation_2d1d()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -564,7 +564,7 @@ void test_less_operation_2d1d_lit()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -594,7 +594,7 @@ void test_less_operation_2d0d_int()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = less.eval().get();
@@ -620,7 +620,7 @@ void test_less_operation_0d_true_return_double()
 
     phylanx::execution_tree::primitive less;
     less = phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs),
             phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -646,7 +646,7 @@ void test_less_operation_0d1d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -675,7 +675,7 @@ void test_less_operation_0d1d_return_bool()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -704,7 +704,7 @@ void test_less_operation_0d2d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -734,7 +734,7 @@ void test_less_operation_1d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -763,7 +763,7 @@ void test_less_operation_1d0d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -795,7 +795,7 @@ void test_less_operation_1d2d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -829,7 +829,7 @@ void test_less_operation_2d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -858,7 +858,7 @@ void test_less_operation_2d0d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -890,7 +890,7 @@ void test_less_operation_2d1d_return_double()
 
     phylanx::execution_tree::primitive less =
         phylanx::execution_tree::primitives::create_less(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 

--- a/tests/unit/plugins/booleans/not_equal_operation.cpp
+++ b/tests/unit/plugins/booleans/not_equal_operation.cpp
@@ -28,7 +28,7 @@ void test_not_equal_operation_0d_true()
     phylanx::execution_tree::primitive not_equal;
     not_equal = phylanx::execution_tree::primitives::create_not_equal(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -52,7 +52,7 @@ void test_not_equal_operation_0d_true_return_double()
     phylanx::execution_tree::primitive not_equal;
     not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -76,7 +76,7 @@ void test_not_equal_operation_0d_bool_true()
     phylanx::execution_tree::primitive not_equal;
     not_equal = phylanx::execution_tree::primitives::create_not_equal(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -98,7 +98,7 @@ void test_not_equal_operation_0d_bool_true_return_bool()
     phylanx::execution_tree::primitive not_equal;
     not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -122,7 +122,7 @@ void test_not_equal_operation_0d_false()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -144,7 +144,7 @@ void test_not_equal_operation_0d_lit_true()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -166,7 +166,7 @@ void test_not_equal_operation_0d_lit_false()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -193,7 +193,7 @@ void test_not_equal_operation_0d1d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -221,7 +221,7 @@ void test_not_equal_operation_0d1d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -251,7 +251,7 @@ void test_not_equal_operation_0d1d_bool()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -277,7 +277,7 @@ void test_not_equal_operation_0d1d_bool_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -304,7 +304,7 @@ void test_not_equal_operation_0d1d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -333,7 +333,7 @@ void test_not_equal_operation_0d1d_return_bool()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -363,7 +363,7 @@ void test_not_equal_operation_0d2d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -392,7 +392,7 @@ void test_not_equal_operation_0d2d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -420,7 +420,7 @@ void test_not_equal_operation_0d2d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -450,7 +450,7 @@ void test_not_equal_operation_0d2d_bool()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -476,7 +476,7 @@ void test_not_equal_operation_0d2d_bool_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -505,7 +505,7 @@ void test_not_equal_operation_1d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -535,7 +535,7 @@ void test_not_equal_operation_1d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -564,7 +564,7 @@ void test_not_equal_operation_1d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -594,7 +594,7 @@ void test_not_equal_operation_1d0d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -623,7 +623,7 @@ void test_not_equal_operation_1d0d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -651,7 +651,7 @@ void test_not_equal_operation_1d0d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -681,7 +681,7 @@ void test_not_equal_operation_1d0d_bool()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -709,7 +709,7 @@ void test_not_equal_operation_1d0d_bool_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -742,7 +742,7 @@ void test_not_equal_operation_1d2d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -777,7 +777,7 @@ void test_not_equal_operation_1d2d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -813,7 +813,7 @@ void test_not_equal_operation_1d2d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -849,7 +849,7 @@ void test_not_equal_operation_1d2d_return_bool()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(false)});
 
@@ -884,7 +884,7 @@ void test_not_equal_operation_2d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -914,7 +914,7 @@ void test_not_equal_operation_2d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -943,7 +943,7 @@ void test_not_equal_operation_2d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -974,7 +974,7 @@ void test_not_equal_operation_2d_bool()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1003,7 +1003,7 @@ void test_not_equal_operation_2d_bool_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1033,7 +1033,7 @@ void test_not_equal_operation_2d0d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1062,7 +1062,7 @@ void test_not_equal_operation_2d0d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -1090,7 +1090,7 @@ void test_not_equal_operation_2d0d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1120,7 +1120,7 @@ void test_not_equal_operation_2d0d_bool()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1148,7 +1148,7 @@ void test_not_equal_operation_2d0d_bool_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1179,7 +1179,7 @@ void test_not_equal_operation_2d1d()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1214,7 +1214,7 @@ void test_not_equal_operation_2d1d_return_double()
 
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs),
                 phylanx::ir::node_data<std::uint8_t>(true)});
 
@@ -1248,7 +1248,7 @@ void test_not_equal_operation_2d1d_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1284,7 +1284,7 @@ void test_not_equal_operation_2d1d_bool()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
@@ -1316,7 +1316,7 @@ void test_not_equal_operation_2d1d_bool_lit()
     phylanx::execution_tree::primitive not_equal =
         phylanx::execution_tree::primitives::create_not_equal(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();

--- a/tests/unit/plugins/booleans/or_operation.cpp
+++ b/tests/unit/plugins/booleans/or_operation.cpp
@@ -28,7 +28,7 @@ void test_or_operation_0d_false()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -51,7 +51,7 @@ void test_or_operation_0d_double_false()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -74,7 +74,7 @@ void test_or_operation_0d_true()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -97,7 +97,7 @@ void test_or_operation_0d_double_true()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -118,7 +118,7 @@ void test_or_operation_0d_lit_false()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -139,7 +139,7 @@ void test_or_operation_0d_double_lit_false()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -160,7 +160,7 @@ void test_or_operation_0d_lit_true()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -181,7 +181,7 @@ void test_or_operation_0d_double_lit_true()
     phylanx::execution_tree::primitive or_operation;
     or_operation = phylanx::execution_tree::primitives::create_or_operation(
         hpx::find_here(),
-        std::vector<phylanx::execution_tree::primitive_argument_type>{
+        phylanx::execution_tree::primitive_arguments_type{
             std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -207,7 +207,7 @@ void test_or_operation_0d1d_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -234,7 +234,7 @@ void test_or_operation_0d1d_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -263,7 +263,7 @@ void test_or_operation_0d1d_double_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -290,7 +290,7 @@ void test_or_operation_0d1d_double_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -319,7 +319,7 @@ void test_or_operation_0d1d_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -346,7 +346,7 @@ void test_or_operation_0d1d_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -375,7 +375,7 @@ void test_or_operation_0d1d_double_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -401,7 +401,7 @@ void test_or_operation_0d1d_double_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -429,7 +429,7 @@ void test_or_operation_0d2d_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -456,7 +456,7 @@ void test_or_operation_0d2d_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -485,7 +485,7 @@ void test_or_operation_0d2d_double_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -512,7 +512,7 @@ void test_or_operation_0d2d_double_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -541,7 +541,7 @@ void test_or_operation_0d2d_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -568,7 +568,7 @@ void test_or_operation_0d2d_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -597,7 +597,7 @@ void test_or_operation_0d2d_double_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -623,7 +623,7 @@ void test_or_operation_0d2d_double_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -652,7 +652,7 @@ void test_or_operation_1d()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -680,7 +680,7 @@ void test_or_operation_1d_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -710,7 +710,7 @@ void test_or_operation_1d_double()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -738,7 +738,7 @@ void test_or_operation_1d_double_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -767,7 +767,7 @@ void test_or_operation_1d0d_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -794,7 +794,7 @@ void test_or_operation_1d0d_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -823,7 +823,7 @@ void test_or_operation_1d0d_double_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -850,7 +850,7 @@ void test_or_operation_1d0d_double_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -879,7 +879,7 @@ void test_or_operation_1d0d_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -906,7 +906,7 @@ void test_or_operation_1d0d_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -935,7 +935,7 @@ void test_or_operation_1d0d_double_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -961,7 +961,7 @@ void test_or_operation_1d0d_double_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -992,7 +992,7 @@ void test_or_operation_1d2d()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1026,7 +1026,7 @@ void test_or_operation_1d2d_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1062,7 +1062,7 @@ void test_or_operation_1d2d_double()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1096,7 +1096,7 @@ void test_or_operation_1d2d_double_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1130,7 +1130,7 @@ void test_or_operation_2d()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1158,7 +1158,7 @@ void test_or_operation_2d_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1188,7 +1188,7 @@ void test_or_operation_2d_double()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1216,7 +1216,7 @@ void test_or_operation_2d_double_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1245,7 +1245,7 @@ void test_or_operation_2d0d_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1272,7 +1272,7 @@ void test_or_operation_2d0d_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1301,7 +1301,7 @@ void test_or_operation_2d0d_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1328,7 +1328,7 @@ void test_or_operation_2d0d_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1357,7 +1357,7 @@ void test_or_operation_2d0d_double_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1383,7 +1383,7 @@ void test_or_operation_2d0d_double_lit_true()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1411,7 +1411,7 @@ void test_or_operation_2d0d_double_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1438,7 +1438,7 @@ void test_or_operation_2d0d_double_lit_false()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1470,7 +1470,7 @@ void test_or_operation_2d1d()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1503,7 +1503,7 @@ void test_or_operation_2d1d_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1538,7 +1538,7 @@ void test_or_operation_2d1d_double()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =
@@ -1571,7 +1571,7 @@ void test_or_operation_2d1d_double_lit()
     phylanx::execution_tree::primitive or_operation =
         phylanx::execution_tree::primitives::create_or_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive_argument_type f =

--- a/tests/unit/plugins/booleans/unary_not_operation.cpp
+++ b/tests/unit/plugins/booleans/unary_not_operation.cpp
@@ -23,7 +23,7 @@ void test_unary_not_operation_0d_false()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -42,7 +42,7 @@ void test_unary_not_operation_0d_true()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -57,7 +57,7 @@ void test_unary_not_operation_0d_false_lit()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::ir::node_data<std::uint8_t>{false}});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -72,7 +72,7 @@ void test_unary_not_operation_0d_true_lit()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::ir::node_data<std::uint8_t>{true}});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -94,7 +94,7 @@ void test_unary_not_operation_1d()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -117,7 +117,7 @@ void test_unary_not_operation_1d_lit()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -142,7 +142,7 @@ void test_unary_not_operation_1d_double()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -165,7 +165,7 @@ void test_unary_not_operation_1d_double_lit()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -190,7 +190,7 @@ void test_unary_not_operation_2d()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -213,7 +213,7 @@ void test_unary_not_operation_2d_lit()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -238,7 +238,7 @@ void test_unary_not_operation_2d_double()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -261,7 +261,7 @@ void test_unary_not_operation_2d_double_lit()
     phylanx::execution_tree::primitive unary_not =
         phylanx::execution_tree::primitives::create_unary_not_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/controls/block_operation.cpp
+++ b/tests/unit/plugins/controls/block_operation.cpp
@@ -30,7 +30,7 @@ void test_block_operation()
     phylanx::execution_tree::primitive block =
         phylanx::execution_tree::primitives::create_block_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(arg1)},
                 phylanx::execution_tree::primitive_argument_type{std::move(arg2)},
                 phylanx::execution_tree::primitive_argument_type{std::move(arg3)}

--- a/tests/unit/plugins/controls/if_conditional.cpp
+++ b/tests/unit/plugins/controls/if_conditional.cpp
@@ -37,7 +37,7 @@ void test_if_conditional_t1()
     phylanx::execution_tree::primitive if_prim =
         phylanx::execution_tree::primitives::create_if_conditional(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(cond), std::move(true_case), std::move(false_case)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -62,7 +62,7 @@ void test_if_conditional_t2()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(add_lhs), std::move(add_rhs)});
 
     // Create subtration expression
@@ -78,7 +78,7 @@ void test_if_conditional_t2()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(sub_lhs), std::move(sub_rhs)});
 
     // Create conditional
@@ -89,7 +89,7 @@ void test_if_conditional_t2()
     phylanx::execution_tree::primitive if_prim =
         phylanx::execution_tree::primitives::create_if_conditional(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(cond), std::move(add), std::move(sub)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -115,7 +115,7 @@ void test_if_conditional_t3()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(add_lhs), std::move(add_rhs)});
 
     // Create subtration expression
@@ -130,7 +130,7 @@ void test_if_conditional_t3()
     phylanx::execution_tree::primitive sub =
         phylanx::execution_tree::primitives::create_sub_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(sub_lhs), std::move(sub_rhs)});
 
     // Create conditional expression
@@ -144,13 +144,13 @@ void test_if_conditional_t3()
 
     phylanx::execution_tree::primitive equal =
         phylanx::execution_tree::primitives::create_equal(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     phylanx::execution_tree::primitive if_prim =
         phylanx::execution_tree::primitives::create_if_conditional(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(equal), std::move(add), std::move(sub)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -175,7 +175,7 @@ void test_if_conditional_t4()
     phylanx::execution_tree::primitive if_prim =
         phylanx::execution_tree::primitives::create_if_conditional(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(cond), std::move(true_case)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -204,13 +204,13 @@ void test_if_conditional_t5()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(add_lhs), std::move(add_rhs)});
 
     phylanx::execution_tree::primitive if_prim =
         phylanx::execution_tree::primitives::create_if_conditional(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(cond), std::move(add)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -239,13 +239,13 @@ void test_if_conditional_t6()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_add_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(add_lhs), std::move(add_rhs)});
 
     phylanx::execution_tree::primitive if_prim =
         phylanx::execution_tree::primitives::create_if_conditional(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(cond), std::move(add)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/controls/parallel_block_operation.cpp
+++ b/tests/unit/plugins/controls/parallel_block_operation.cpp
@@ -28,7 +28,7 @@ void test_parallel_block_operation()
     phylanx::execution_tree::primitive block =
         phylanx::execution_tree::primitives::create_parallel_block_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(arg1)},
                 phylanx::execution_tree::primitive_argument_type{std::move(arg2)},
                 phylanx::execution_tree::primitive_argument_type{std::move(arg3)}

--- a/tests/unit/plugins/controls/while_operation.cpp
+++ b/tests/unit/plugins/controls/while_operation.cpp
@@ -27,7 +27,7 @@ void test_while_operation_false()
     phylanx::execution_tree::primitive while_ =
         phylanx::execution_tree::primitives::create_while_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(cond)},
                 phylanx::execution_tree::primitive_argument_type{std::move(body)}
             });
@@ -47,7 +47,7 @@ void test_while_operation_true()
     phylanx::execution_tree::primitive body =
         phylanx::execution_tree::primitives::create_store_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{cond},
                 phylanx::execution_tree::primitive_argument_type{false}
             });
@@ -55,7 +55,7 @@ void test_while_operation_true()
     phylanx::execution_tree::primitive while_ =
         phylanx::execution_tree::primitives::create_while_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(cond)},
                 phylanx::execution_tree::primitive_argument_type{std::move(body)}
             });
@@ -75,14 +75,14 @@ void test_while_operation_true_return()
     phylanx::execution_tree::primitive store =
         phylanx::execution_tree::primitives::create_store_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{cond},
                 phylanx::execution_tree::primitive_argument_type{false}
             });
     phylanx::execution_tree::primitive body =
         phylanx::execution_tree::primitives::create_block_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(store)},
                 phylanx::execution_tree::primitive_argument_type{true}
             });
@@ -90,7 +90,7 @@ void test_while_operation_true_return()
     phylanx::execution_tree::primitive while_ =
         phylanx::execution_tree::primitives::create_while_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(cond)},
                 phylanx::execution_tree::primitive_argument_type{std::move(body)}
             });

--- a/tests/unit/plugins/fileio/file_csv_primitives.cpp
+++ b/tests/unit/plugins/fileio/file_csv_primitives.cpp
@@ -28,7 +28,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive outfile =
             phylanx::execution_tree::primitives::create_file_write_csv(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}, litval});
 
         auto f = outfile.eval();
@@ -41,7 +41,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive infile =
             phylanx::execution_tree::primitives::create_file_read_csv(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}});
 
         f = infile.eval();
@@ -61,7 +61,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive outfile =
             phylanx::execution_tree::primitives::create_file_write_csv(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}, in});
 
         auto f = outfile.eval();
@@ -74,7 +74,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive infile =
             phylanx::execution_tree::primitives::create_file_read_csv(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}});
 
         f = infile.eval();

--- a/tests/unit/plugins/fileio/file_hdf5_primitives.cpp
+++ b/tests/unit/plugins/fileio/file_hdf5_primitives.cpp
@@ -29,7 +29,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive outfile =
             phylanx::execution_tree::primitives::create_file_write_hdf5(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     filename, dataset_name, litval});
 
         auto f = outfile.eval();
@@ -42,7 +42,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive infile =
             phylanx::execution_tree::primitives::create_file_read_hdf5(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     filename, dataset_name});
 
         f = infile.eval();
@@ -63,7 +63,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive outfile =
             phylanx::execution_tree::primitives::create_file_write_hdf5(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     filename, dataset_name, in});
 
         auto f = outfile.eval();
@@ -76,7 +76,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive infile =
             phylanx::execution_tree::primitives::create_file_read_hdf5(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     filename, dataset_name});
 
         f = infile.eval();

--- a/tests/unit/plugins/fileio/file_primitives.cpp
+++ b/tests/unit/plugins/fileio/file_primitives.cpp
@@ -29,7 +29,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive outfile =
             phylanx::execution_tree::primitives::create_file_write(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}, litval
                 });
 
@@ -43,7 +43,7 @@ void test_file_io_lit(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive infile =
             phylanx::execution_tree::primitives::create_file_read(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}
                 });
 
@@ -65,7 +65,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive outfile =
             phylanx::execution_tree::primitives::create_file_write(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}, in
                 });
 
@@ -79,7 +79,7 @@ void test_file_io_primitive(phylanx::ir::node_data<double> const& in)
         phylanx::execution_tree::primitive infile =
             phylanx::execution_tree::primitives::create_file_read(
                 hpx::find_here(),
-                std::vector<phylanx::execution_tree::primitive_argument_type>{
+                phylanx::execution_tree::primitive_arguments_type{
                     {filename}
                 });
 

--- a/tests/unit/plugins/matrixops/add_dimension.cpp
+++ b/tests/unit/plugins/matrixops/add_dimension.cpp
@@ -25,7 +25,7 @@ void test_0d()
     phylanx::execution_tree::primitive add_dim =
         phylanx::execution_tree::primitives::create_add_dimension(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -47,7 +47,7 @@ void test_1d()
     phylanx::execution_tree::primitive add_dim =
         phylanx::execution_tree::primitives::create_add_dimension(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/argmax.cpp
+++ b/tests/unit/plugins/matrixops/argmax.cpp
@@ -30,7 +30,7 @@ void test_argmax_0d()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmax(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)
     });
 
@@ -55,7 +55,7 @@ void test_argmax_1d()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmax(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)
     });
 
@@ -80,7 +80,7 @@ void test_argmax_2d_flat()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmax(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)
     });
 
@@ -111,7 +111,8 @@ void test_argmax_2d_x_axis()
 
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmax(hpx::find_here(),
-            std::vector<arg_type>{std::move(lhs), std::move(rhs)});
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(lhs), std::move(rhs)});
 
     hpx::future<arg_type> f = p.eval();
 
@@ -139,7 +140,8 @@ void test_argmax_2d_y_axis()
 
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmax(hpx::find_here(),
-            std::vector<arg_type>{std::move(lhs), std::move(rhs)});
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(lhs), std::move(rhs)});
 
     hpx::future<arg_type> f = p.eval();
 

--- a/tests/unit/plugins/matrixops/argmin.cpp
+++ b/tests/unit/plugins/matrixops/argmin.cpp
@@ -30,7 +30,7 @@ void test_argmin_0d()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmin(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)
     });
 
@@ -55,7 +55,7 @@ void test_argmin_1d()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmin(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)
     });
 
@@ -80,7 +80,7 @@ void test_argmin_2d_flat()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmin(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)
     });
 
@@ -111,7 +111,8 @@ void test_argmin_2d_x_axis()
 
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmin(hpx::find_here(),
-            std::vector<arg_type>{std::move(lhs), std::move(rhs)});
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(lhs), std::move(rhs)});
 
     hpx::future<arg_type> f = p.eval();
 
@@ -139,7 +140,8 @@ void test_argmin_2d_y_axis()
 
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_argmin(hpx::find_here(),
-            std::vector<arg_type>{std::move(lhs), std::move(rhs)});
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(lhs), std::move(rhs)});
 
     hpx::future<arg_type> f = p.eval();
 

--- a/tests/unit/plugins/matrixops/column_set.cpp
+++ b/tests/unit/plugins/matrixops/column_set.cpp
@@ -41,7 +41,7 @@ void test_column_set_operation_1d()
     phylanx::execution_tree::primitive column_set =
         phylanx::execution_tree::primitives::create_column_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_vector, std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(column_set_vector)});
 
@@ -86,7 +86,7 @@ void test_column_set_operation_1d_negative_step()
     phylanx::execution_tree::primitive column_set =
         phylanx::execution_tree::primitives::create_column_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_vector, std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(column_set_vector)});
 
@@ -138,7 +138,7 @@ void test_column_set_operation_2d()
     phylanx::execution_tree::primitive column_set =
         phylanx::execution_tree::primitives::create_column_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(column_set_matrix)});
 
@@ -194,7 +194,7 @@ void test_column_set_operation_2d_vector_input()
     phylanx::execution_tree::primitive column_set =
         phylanx::execution_tree::primitives::create_column_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(column_set_vector)});
 
@@ -251,7 +251,7 @@ void test_column_set_operation_2d_negetive_step()
     phylanx::execution_tree::primitive column_set =
         phylanx::execution_tree::primitives::create_column_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(column_set_matrix)});
 

--- a/tests/unit/plugins/matrixops/constant.cpp
+++ b/tests/unit/plugins/matrixops/constant.cpp
@@ -23,7 +23,7 @@ void test_constant_0d()
     phylanx::execution_tree::primitive const_ =
         phylanx::execution_tree::primitives::create_constant(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)
             });
 
@@ -45,7 +45,7 @@ void test_constant_1d()
     phylanx::execution_tree::primitive const_ =
         phylanx::execution_tree::primitives::create_constant(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val), phylanx::ir::node_data<std::int64_t>(1007)
             });
 
@@ -69,7 +69,7 @@ void test_constant_2d()
 
     phylanx::execution_tree::primitive const_ =
         phylanx::execution_tree::primitives::create_constant(hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val),
                 phylanx::execution_tree::primitive_argument_type{std::vector<
                     phylanx::execution_tree::primitive_argument_type>{

--- a/tests/unit/plugins/matrixops/cross_operation.cpp
+++ b/tests/unit/plugins/matrixops/cross_operation.cpp
@@ -33,7 +33,7 @@ void test_vector_cross_product()
     phylanx::execution_tree::primitive cross =
         phylanx::execution_tree::primitives::create_cross_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -63,7 +63,7 @@ void test_one_vector_with_dimension_2()
     phylanx::execution_tree::primitive cross =
         phylanx::execution_tree::primitives::create_cross_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -93,7 +93,7 @@ void test_both_vectors_with_dimension_2()
     phylanx::execution_tree::primitive cross =
         phylanx::execution_tree::primitives::create_cross_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -123,7 +123,7 @@ void test_multiple_vector_cross_products()
     phylanx::execution_tree::primitive cross =
         phylanx::execution_tree::primitives::create_cross_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -154,7 +154,7 @@ void test_cross_product_1d2d()
     phylanx::execution_tree::primitive cross =
         phylanx::execution_tree::primitives::create_cross_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -184,7 +184,7 @@ void test_cross_product_2d1d()
     phylanx::execution_tree::primitive cross =
         phylanx::execution_tree::primitives::create_cross_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -215,7 +215,7 @@ void test_cross_product_vector_by_2col_matrix()
     phylanx::execution_tree::primitive cross =
         phylanx::execution_tree::primitives::create_cross_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 

--- a/tests/unit/plugins/matrixops/determinant.cpp
+++ b/tests/unit/plugins/matrixops/determinant.cpp
@@ -22,7 +22,7 @@ void test_determinant_0d()
     phylanx::execution_tree::primitive inverse =
         phylanx::execution_tree::primitives::create_determinant(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -39,7 +39,7 @@ void test_determinant_0d_lit()
     phylanx::execution_tree::primitive inverse =
         phylanx::execution_tree::primitives::create_determinant(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 
@@ -62,7 +62,7 @@ void test_determinant_2d()
     phylanx::execution_tree::primitive determinant =
         phylanx::execution_tree::primitives::create_determinant(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 

--- a/tests/unit/plugins/matrixops/diag_operation.cpp
+++ b/tests/unit/plugins/matrixops/diag_operation.cpp
@@ -26,7 +26,7 @@ void test_diag_operation_0d()
     phylanx::execution_tree::primitive diag =
         phylanx::execution_tree::primitives::create_diag_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(data), std::move(k)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -51,7 +51,7 @@ void test_diag_operation_1d()
     phylanx::execution_tree::primitive diag =
         phylanx::execution_tree::primitives::create_diag_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(vec), std::move(k)
             });
 
@@ -84,7 +84,7 @@ void test_diag_operation_1d_plus_one()
     phylanx::execution_tree::primitive diag =
         phylanx::execution_tree::primitives::create_diag_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(vec), std::move(k)
             });
 
@@ -118,7 +118,7 @@ void test_diag_operation_1d_minus_one()
     phylanx::execution_tree::primitive diag =
         phylanx::execution_tree::primitives::create_diag_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(vec), std::move(k)
             });
 
@@ -156,7 +156,7 @@ void test_diag_operation_2d()
     phylanx::execution_tree::primitive diag =
         phylanx::execution_tree::primitives::create_diag_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(mat), std::move(k)
             });
 
@@ -189,7 +189,7 @@ void test_diag_operation_2d_plus_one()
     phylanx::execution_tree::primitive diag =
         phylanx::execution_tree::primitives::create_diag_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(mat), std::move(k)
             });
 
@@ -222,7 +222,7 @@ void test_diag_operation_2d_minus_one()
     phylanx::execution_tree::primitive diag =
         phylanx::execution_tree::primitives::create_diag_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(mat), std::move(k)
             });
 

--- a/tests/unit/plugins/matrixops/dot_operation.cpp
+++ b/tests/unit/plugins/matrixops/dot_operation.cpp
@@ -29,7 +29,7 @@ void test_dot_operation_0d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -49,7 +49,7 @@ void test_dot_operation_0d_lit()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -74,7 +74,7 @@ void test_dot_operation_0d1d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -100,7 +100,7 @@ void test_dot_operation_0d1d_lit()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -127,7 +127,7 @@ void test_dot_operation_0d1d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -153,7 +153,7 @@ void test_dot_operation_0d2d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -179,7 +179,7 @@ void test_dot_operation_0d2d_lit()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -206,7 +206,7 @@ void test_dot_operation_0d2d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -234,7 +234,7 @@ void test_dot_operation_1d0d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -260,7 +260,7 @@ void test_dot_operation_1d0d_lit()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -287,7 +287,7 @@ void test_dot_operation_1d0d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -314,7 +314,7 @@ void test_dot_operation_1d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -341,7 +341,7 @@ void test_dot_operation_1d_lit()
     phylanx::execution_tree::primitive dot =
             phylanx::execution_tree::primitives::create_dot_operation(
                     hpx::find_here(),
-                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                    phylanx::execution_tree::primitive_arguments_type{
                             std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -369,7 +369,7 @@ void test_dot_operation_1d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -400,7 +400,7 @@ void test_dot_operation_1d2d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -429,7 +429,7 @@ void test_dot_operation_1d2d_lit()
     phylanx::execution_tree::primitive dot =
             phylanx::execution_tree::primitives::create_dot_operation(
                     hpx::find_here(),
-                    std::vector<phylanx::execution_tree::primitive_argument_type>{
+                    phylanx::execution_tree::primitive_arguments_type{
                             std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -458,7 +458,7 @@ void test_dot_operation_1d2d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -485,7 +485,7 @@ void test_dot_operation_2d0d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -511,7 +511,7 @@ void test_dot_operation_2d0d_lit()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -538,7 +538,7 @@ void test_dot_operation_2d0d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -571,7 +571,7 @@ void test_dot_operation_2d1d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs), std::move(rhs)
     });
 
@@ -601,7 +601,7 @@ void test_dot_operation_2d1d_lit()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -628,7 +628,7 @@ void test_dot_operation_2d1d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -658,7 +658,7 @@ void test_dot_operation_2d2d()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)
             });
 
@@ -686,7 +686,7 @@ void test_dot_operation_2d2d_lit()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -712,7 +712,7 @@ void test_dot_operation_2d2d_numpy()
     phylanx::execution_tree::primitive dot =
         phylanx::execution_tree::primitives::create_dot_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/extract_shape.cpp
+++ b/tests/unit/plugins/matrixops/extract_shape.cpp
@@ -23,7 +23,7 @@ void test_extract_shape_0d()
     phylanx::execution_tree::primitive shape =
         phylanx::execution_tree::primitives::create_extract_shape(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = shape.eval().get();
@@ -43,7 +43,7 @@ void test_extract_shape_1d()
     phylanx::execution_tree::primitive shape =
         phylanx::execution_tree::primitives::create_extract_shape(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = shape.eval().get();
@@ -64,7 +64,7 @@ void test_extract_shape_2d_1()
     phylanx::execution_tree::primitive shape =
         phylanx::execution_tree::primitives::create_extract_shape(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = shape.eval().get();
@@ -91,7 +91,7 @@ void test_extract_shape_2d_2()
     phylanx::execution_tree::primitive shape =
         phylanx::execution_tree::primitives::create_extract_shape(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(arg1), std::move(arg2)});
 
     phylanx::execution_tree::primitive_argument_type f = shape.eval().get();

--- a/tests/unit/plugins/matrixops/generic_operation.cpp
+++ b/tests/unit/plugins/matrixops/generic_operation.cpp
@@ -25,7 +25,7 @@ void test_generic_operation_0d(std::string const& func_name,
     phylanx::execution_tree::primitive generic =
         phylanx::execution_tree::primitives::create_generic_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)},
             func_name);
 
@@ -45,7 +45,7 @@ void test_generic_operation_0d_greater1(std::string const& func_name,
     phylanx::execution_tree::primitive generic =
         phylanx::execution_tree::primitives::create_generic_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)},
             func_name);
 
@@ -70,7 +70,7 @@ void test_generic_operation_1d(std::string const& func_name,
     phylanx::execution_tree::primitive generic =
         phylanx::execution_tree::primitives::create_generic_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)},
             func_name);
 
@@ -96,7 +96,7 @@ void test_generic_operation_1d_greater1(std::string const& func_name,
     phylanx::execution_tree::primitive generic =
         phylanx::execution_tree::primitives::create_generic_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)},
             func_name);
 
@@ -123,7 +123,7 @@ void test_generic_operation_2d(std::string const& func_name,
     phylanx::execution_tree::primitive generic =
         phylanx::execution_tree::primitives::create_generic_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)},
             func_name);
 
@@ -150,7 +150,7 @@ void test_generic_operation_2d_greater1(std::string const& func_name,
     phylanx::execution_tree::primitive generic =
         phylanx::execution_tree::primitives::create_generic_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)},
             func_name);
 

--- a/tests/unit/plugins/matrixops/gradient_operation.cpp
+++ b/tests/unit/plugins/matrixops/gradient_operation.cpp
@@ -23,7 +23,7 @@ void test_gradient_operation_1d()
     phylanx::execution_tree::primitive gradient =
         phylanx::execution_tree::primitives::create_gradient_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(vec)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -51,7 +51,7 @@ void test_gradient_operation_2d_axis_zero()
     phylanx::execution_tree::primitive gradient =
         phylanx::execution_tree::primitives::create_gradient_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(mat), std::move(k)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -81,7 +81,7 @@ void test_gradient_operation_2d_axis_one()
     phylanx::execution_tree::primitive gradient =
         phylanx::execution_tree::primitives::create_gradient_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(mat), std::move(k)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -107,7 +107,7 @@ void test_gradient_operation_2d_no_axis_given()
     phylanx::execution_tree::primitive gradient =
         phylanx::execution_tree::primitives::create_gradient_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(mat)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/hstack_operation.cpp
+++ b/tests/unit/plugins/matrixops/hstack_operation.cpp
@@ -26,7 +26,7 @@ void hstack_operation_0d()
     phylanx::execution_tree::primitive hstack =
         phylanx::execution_tree::primitives::create_hstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first), std::move(second)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -54,7 +54,7 @@ void hstack_operation_1d()
     phylanx::execution_tree::primitive hstack =
         phylanx::execution_tree::primitives::create_hstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first), std::move(second)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -85,7 +85,7 @@ void hstack_operation_2d()
     phylanx::execution_tree::primitive hstack =
         phylanx::execution_tree::primitives::create_hstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first), std::move(second)});
 
     blaze::DynamicMatrix<double> expected{{1, 2, 3, 11, 22},
@@ -122,7 +122,7 @@ void hstack_operation_0d_1d_1d_0d()
     phylanx::execution_tree::primitive hstack =
         phylanx::execution_tree::primitives::create_hstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first), std::move(firstvec), std::move(secondvec),
                 std::move(second)});
 
@@ -160,7 +160,7 @@ void hstack_operation_1d_0d_0d_1d()
     phylanx::execution_tree::primitive hstack =
         phylanx::execution_tree::primitives::create_hstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(firstvec), std::move(first), std::move(second),
                 std::move(secondvec)});
 

--- a/tests/unit/plugins/matrixops/identity.cpp
+++ b/tests/unit/plugins/matrixops/identity.cpp
@@ -21,7 +21,7 @@ void test_identity()
     phylanx::execution_tree::primitive identity =
         phylanx::execution_tree::primitives::create_identity(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(val)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/inverse_operation.cpp
+++ b/tests/unit/plugins/matrixops/inverse_operation.cpp
@@ -22,7 +22,7 @@ void test_inversion_0d()
     phylanx::execution_tree::primitive inversion =
         phylanx::execution_tree::primitives::create_inverse_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -39,7 +39,7 @@ void test_inversion_0d_lit()
     phylanx::execution_tree::primitive inversion =
         phylanx::execution_tree::primitives::create_inverse_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 
@@ -62,7 +62,7 @@ void test_inversion_2d()
     phylanx::execution_tree::primitive inversion =
         phylanx::execution_tree::primitives::create_inverse_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 

--- a/tests/unit/plugins/matrixops/linearmatrix.cpp
+++ b/tests/unit/plugins/matrixops/linearmatrix.cpp
@@ -39,7 +39,7 @@ void test_linmatrix()
     phylanx::execution_tree::primitive linearmatrix =
         phylanx::execution_tree::primitives::create_linearmatrix(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 move(nx), move(ny), move(base_value), move(dx), move(dy)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/linspace.cpp
+++ b/tests/unit/plugins/matrixops/linspace.cpp
@@ -30,7 +30,7 @@ void test_linspace0d()
     phylanx::execution_tree::primitive linspace =
         phylanx::execution_tree::primitives::create_linspace(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(start), std::move(stop), std::move(num_samples)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -60,7 +60,7 @@ void test_linspace1d()
     phylanx::execution_tree::primitive linspace =
         phylanx::execution_tree::primitives::create_linspace(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(start), std::move(stop), std::move(num_samples)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/mean_operation.cpp
+++ b/tests/unit/plugins/matrixops/mean_operation.cpp
@@ -22,7 +22,7 @@ void test_mean_operation_0d()
     phylanx::execution_tree::primitive mean =
         phylanx::execution_tree::primitives::create_mean_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -45,7 +45,7 @@ void test_mean_operation_1d()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_mean_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
@@ -67,7 +67,7 @@ void test_mean_operation_2d_flat()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_mean_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
@@ -96,7 +96,7 @@ void test_mean_operation_2d_x_axis()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_mean_operation(
             hpx::find_here(),
-            std::vector<arg_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first), std::move(second)});
 
     hpx::future<arg_type> f = p.eval();
@@ -125,7 +125,7 @@ void test_mean_operation_2d_y_axis()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_mean_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(first), std::move(second)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();

--- a/tests/unit/plugins/matrixops/power_operation.cpp
+++ b/tests/unit/plugins/matrixops/power_operation.cpp
@@ -27,7 +27,7 @@ void test_power_operation_0d()
     phylanx::execution_tree::primitive power =
         phylanx::execution_tree::primitives::create_power_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(lhs)},
                 phylanx::execution_tree::primitive_argument_type{std::move(rhs)}
             });
@@ -56,7 +56,7 @@ void test_power_operation_1d()
     phylanx::execution_tree::primitive power =
         phylanx::execution_tree::primitives::create_power_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(lhs)},
                 phylanx::execution_tree::primitive_argument_type{std::move(rhs)}
             });
@@ -87,7 +87,7 @@ void test_power_operation_2d()
     phylanx::execution_tree::primitive power =
         phylanx::execution_tree::primitives::create_power_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(lhs)},
                 phylanx::execution_tree::primitive_argument_type{std::move(rhs)}
             });

--- a/tests/unit/plugins/matrixops/random.cpp
+++ b/tests/unit/plugins/matrixops/random.cpp
@@ -22,7 +22,7 @@ void test_random_0d()
     phylanx::execution_tree::primitive const_ =
         phylanx::execution_tree::primitives::create_random(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(dim)
             });
 
@@ -46,7 +46,7 @@ void test_random_1d()
     phylanx::execution_tree::primitive const_ =
         phylanx::execution_tree::primitives::create_random(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(dim)
             });
 
@@ -71,7 +71,7 @@ void test_random_2d()
     phylanx::execution_tree::primitive const_ =
         phylanx::execution_tree::primitives::create_random(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(dim)
             });
 

--- a/tests/unit/plugins/matrixops/random_distributions.cpp
+++ b/tests/unit/plugins/matrixops/random_distributions.cpp
@@ -59,7 +59,7 @@ template <typename T, typename Gen, typename Dist>
 void generate_0d(phylanx::execution_tree::compiler::function const& call,
     Gen& gen, Dist& dist)
 {
-    std::vector<phylanx::execution_tree::primitive_argument_type> dims = {
+    phylanx::execution_tree::primitive_arguments_type dims = {
         phylanx::execution_tree::primitive_argument_type{std::int64_t{1}},
         phylanx::execution_tree::primitive_argument_type{std::int64_t{1}}
     };
@@ -77,7 +77,7 @@ template <typename T, typename Gen, typename Dist>
 void generate_1d(phylanx::execution_tree::compiler::function const& call,
     Gen& gen, Dist& dist)
 {
-    std::vector<phylanx::execution_tree::primitive_argument_type> dims = {
+    phylanx::execution_tree::primitive_arguments_type dims = {
         phylanx::execution_tree::primitive_argument_type{std::int64_t{32}},
         phylanx::execution_tree::primitive_argument_type{std::int64_t{1}}
     };
@@ -99,7 +99,7 @@ template <typename T, typename Gen, typename Dist>
 void generate_2d(phylanx::execution_tree::compiler::function const& call,
     Gen& gen, Dist& dist)
 {
-    std::vector<phylanx::execution_tree::primitive_argument_type> dims = {
+    phylanx::execution_tree::primitive_arguments_type dims = {
         phylanx::execution_tree::primitive_argument_type{std::int64_t{32}},
         phylanx::execution_tree::primitive_argument_type{std::int64_t{16}}
     };

--- a/tests/unit/plugins/matrixops/row_set.cpp
+++ b/tests/unit/plugins/matrixops/row_set.cpp
@@ -41,7 +41,7 @@ void test_row_set_operation_1d()
     phylanx::execution_tree::primitive row_set =
         phylanx::execution_tree::primitives::create_row_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_vector, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(row_set_vector)});
 
@@ -86,7 +86,7 @@ void test_row_set_operation_1d_negative_step()
     phylanx::execution_tree::primitive row_set =
         phylanx::execution_tree::primitives::create_row_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_vector, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(row_set_vector)});
 
@@ -138,7 +138,7 @@ void test_row_set_operation_2d()
     phylanx::execution_tree::primitive row_set =
         phylanx::execution_tree::primitives::create_row_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(row_set_matrix)});
 
@@ -194,7 +194,7 @@ void test_row_set_operation_2d_vector_input()
     phylanx::execution_tree::primitive row_set =
         phylanx::execution_tree::primitives::create_row_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(row_set_vector)});
 
@@ -251,7 +251,7 @@ void test_row_set_operation_2d_negetive_step()
     phylanx::execution_tree::primitive row_set =
         phylanx::execution_tree::primitives::create_row_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(row_set_matrix)});
 

--- a/tests/unit/plugins/matrixops/set_operation.cpp
+++ b/tests/unit/plugins/matrixops/set_operation.cpp
@@ -53,7 +53,7 @@ void test_set_operation_1d()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_vector, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_vector)});
@@ -111,7 +111,7 @@ void test_set_operation_1d_single_step()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_vector, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_vector)});
@@ -169,7 +169,7 @@ void test_set_operation_1d_single_negative_step()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_vector, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_vector)});
@@ -233,7 +233,7 @@ void test_set_operation_2d()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_matrix)});
@@ -302,7 +302,7 @@ void test_set_operation_2d_vector_input()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_matrix)});
@@ -371,7 +371,7 @@ void test_set_operation_2d_vector_input_single_step()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_matrix)});
@@ -440,7 +440,7 @@ void test_set_operation_2d_vector_input_negative_single_step()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_matrix)});
@@ -506,7 +506,7 @@ void test_set_operation_2d_negetive_step()
     phylanx::execution_tree::primitive set =
         phylanx::execution_tree::primitives::create_set_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 input_matrix, std::move(row_start), std::move(row_stop),
                 std::move(step_row), std::move(col_start), std::move(col_stop),
                 std::move(step_col), std::move(set_matrix)});
@@ -570,7 +570,7 @@ void test_set_operation_2d_single_element_input()
     phylanx::execution_tree::primitive set =
       phylanx::execution_tree::primitives::create_set_operation(
           hpx::find_here(),
-          std::vector<phylanx::execution_tree::primitive_argument_type>{
+          phylanx::execution_tree::primitive_arguments_type{
               input_matrix, std::move(row_start), std::move(row_stop),
               std::move(step_row), std::move(col_start), std::move(col_stop),
               std::move(step_col), std::move(set_element)});

--- a/tests/unit/plugins/matrixops/shuffle_operation.cpp
+++ b/tests/unit/plugins/matrixops/shuffle_operation.cpp
@@ -36,7 +36,7 @@ void test_shuffle_operation_1d()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_shuffle_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
@@ -80,7 +80,7 @@ void test_shuffle_operation_2d()
     phylanx::execution_tree::primitive p =
         phylanx::execution_tree::primitives::create_shuffle_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();

--- a/tests/unit/plugins/matrixops/square_root_operation.cpp
+++ b/tests/unit/plugins/matrixops/square_root_operation.cpp
@@ -24,7 +24,7 @@ void test_square_root_operation_0d()
     phylanx::execution_tree::primitive add =
         phylanx::execution_tree::primitives::create_square_root_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f = add.eval();
@@ -45,7 +45,7 @@ void test_square_root_operation_1d()
     phylanx::execution_tree::primitive square_root =
         phylanx::execution_tree::primitives::create_square_root_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 
@@ -69,7 +69,7 @@ void test_square_root_operation_2d()
     phylanx::execution_tree::primitive square_root =
         phylanx::execution_tree::primitives::create_square_root_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)
             });
 

--- a/tests/unit/plugins/matrixops/sum_operation.cpp
+++ b/tests/unit/plugins/matrixops/sum_operation.cpp
@@ -25,7 +25,7 @@ void test_0d()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -52,7 +52,7 @@ void test_0d_keep_dims_true()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -79,7 +79,7 @@ void test_0d_keep_dims_false()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -101,7 +101,7 @@ void test_1d()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -129,7 +129,7 @@ void test_1d_keep_dims_true()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -157,7 +157,7 @@ void test_1d_keep_dims_false()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -179,7 +179,7 @@ void test_2d()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -204,7 +204,7 @@ void test_2d_axis0()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -229,7 +229,7 @@ void test_2d_axis1()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -257,7 +257,7 @@ void test_2d_keep_dims_true()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -285,7 +285,7 @@ void test_2d_keep_dims_false()
     phylanx::execution_tree::primitive sum =
         phylanx::execution_tree::primitives::create_sum_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
         std::move(arg0), std::move(arg1), std::move(arg2)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/transpose_operation.cpp
+++ b/tests/unit/plugins/matrixops/transpose_operation.cpp
@@ -21,7 +21,7 @@ void test_transpose_operation_0d()
     phylanx::execution_tree::primitive transpose =
         phylanx::execution_tree::primitives::create_transpose_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -38,7 +38,7 @@ void test_transpose_operation_0d_lit()
     phylanx::execution_tree::primitive transpose =
         phylanx::execution_tree::primitives::create_transpose_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -60,7 +60,7 @@ void test_transpose_operation_1d()
     phylanx::execution_tree::primitive transpose =
         phylanx::execution_tree::primitives::create_transpose_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -82,7 +82,7 @@ void test_transpose_operation_1d_lit()
     phylanx::execution_tree::primitive transpose =
         phylanx::execution_tree::primitives::create_transpose_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -106,7 +106,7 @@ void test_transpose_operation_2d()
     phylanx::execution_tree::primitive transpose =
         phylanx::execution_tree::primitives::create_transpose_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
@@ -128,7 +128,7 @@ void test_transpose_operation_2d_lit()
     phylanx::execution_tree::primitive transpose =
         phylanx::execution_tree::primitives::create_transpose_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =

--- a/tests/unit/plugins/matrixops/vstack_operation.cpp
+++ b/tests/unit/plugins/matrixops/vstack_operation.cpp
@@ -28,7 +28,7 @@ void vstack_operation_0d()
     phylanx::execution_tree::primitive vstack =
         phylanx::execution_tree::primitives::create_vstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(first)},
                 phylanx::execution_tree::primitive_argument_type{std::move(second)}
             });
@@ -62,7 +62,7 @@ void vstack_operation_1d()
     phylanx::execution_tree::primitive vstack =
         phylanx::execution_tree::primitives::create_vstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(first)},
                 phylanx::execution_tree::primitive_argument_type{std::move(second)}
             });
@@ -108,7 +108,7 @@ void vstack_operation_1d_2d_mix()
     phylanx::execution_tree::primitive vstack =
         phylanx::execution_tree::primitives::create_vstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{
                     std::move(first)},
                 phylanx::execution_tree::primitive_argument_type{
@@ -148,7 +148,7 @@ void vstack_operation_2d()
     phylanx::execution_tree::primitive vstack =
         phylanx::execution_tree::primitives::create_vstack_operation(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{std::move(first)},
                 phylanx::execution_tree::primitive_argument_type{std::move(second)}
             });

--- a/tests/unit/plugins/solvers/decomposition.cpp
+++ b/tests/unit/plugins/solvers/decomposition.cpp
@@ -49,7 +49,7 @@ void test_decomposition(std::string const& func_name)
     phylanx::execution_tree::primitive decomposition =
         phylanx::execution_tree::primitives::create_decomposition(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(m)},
             func_name);
 

--- a/tests/unit/plugins/solvers/linear_solver.cpp
+++ b/tests/unit/plugins/solvers/linear_solver.cpp
@@ -147,7 +147,7 @@ void test_linear_solver_lu(std::string const& func_name)
     phylanx::execution_tree::primitive linear_solver =
         phylanx::execution_tree::primitives::create_linear_solver(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)},
             func_name);
 
@@ -172,7 +172,7 @@ void test_linear_solver(std::string const& func_name)
     phylanx::execution_tree::primitive linear_solver =
         phylanx::execution_tree::primitives::create_linear_solver(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs)},
             func_name);
 
@@ -201,7 +201,7 @@ void test_linear_solver_l(std::string const& func_name)
     phylanx::execution_tree::primitive linear_solver =
         phylanx::execution_tree::primitives::create_linear_solver(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs), std::move(ul)},
             func_name);
 
@@ -230,7 +230,7 @@ void test_linear_solver_u(std::string const& func_name)
     phylanx::execution_tree::primitive linear_solver =
         phylanx::execution_tree::primitives::create_linear_solver(
             hpx::find_here(),
-            std::vector<phylanx::execution_tree::primitive_argument_type>{
+            phylanx::execution_tree::primitive_arguments_type{
                 std::move(lhs), std::move(rhs), std::move(ul)},
             func_name);
 


### PR DESCRIPTION
- This allows to reduce overheads caused by std::vector allocations
