### PR TITLE
Pass filename to the compiler.

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -102,6 +102,7 @@ class PhySL:
         for key, val in self.fglobals.items():
             if type(val).__name__ == 'module' and val.__name__ == 'numpy':
                 self.numpy_aliases.add(key)
+        self.file_name = self.fglobals['__file__']
 
         # Add arguments of the function to the list of discovered variables.
         if inspect.isfunction(tree.body[0]):
@@ -123,7 +124,7 @@ class PhySL:
         elif PhySL.compiler_state is None:
             PhySL.compiler_state = compiler_state()
 
-        phylanx.execution_tree.compile(self.__src__, PhySL.compiler_state)
+        phylanx.execution_tree.compile(self.file_name, self.__src__, PhySL.compiler_state)
 
     def generate_physl(self, ir):
         if len(ir) == 2 and isinstance(ir[0], str) and isinstance(

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -153,7 +153,8 @@ namespace phylanx { namespace bindings
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    inline void expression_compiler(std::string xexpr_str, compiler_state& c)
+    inline void expression_compiler(std::string const& file_name, std::string xexpr_str,
+        compiler_state& c)
     {
         pybind11::gil_scoped_release release;       // release GIL
 
@@ -161,7 +162,7 @@ namespace phylanx { namespace bindings
             [&]() -> void
             {
                 phylanx::execution_tree::compile(
-                    phylanx::ast::generate_ast(xexpr_str), c.eval_snippets,
+                    file_name, phylanx::ast::generate_ast(xexpr_str), c.eval_snippets,
                     c.eval_env);
             });
     };

--- a/tests/regressions/python/exception_swallowed_369.py
+++ b/tests/regressions/python/exception_swallowed_369.py
@@ -22,9 +22,9 @@ try:
 
 except Exception as e:
     expected = \
-        '<unknown>(14, 8): __add:: the dimensions of the ' + \
+        'exception_swallowed_369.py(14, 8): __add:: the dimensions of the ' + \
         'operands do not match: HPX(bad_parameter)'
-    assert (str(e) == expected)
+    assert (str(e).endswith(expected))
     exception_thrown = True
 
 assert (exception_thrown)

--- a/tests/regressions/python/passing_compiler_state_453.py
+++ b/tests/regressions/python/passing_compiler_state_453.py
@@ -20,7 +20,7 @@ define(mul2, n,
     )
 )
 """
-et.compile(src_mul2, cs)
+et.compile('passing_compiler_state_453.py', src_mul2, cs)
 
 
 @Phylanx(compiler_state=cs)


### PR DESCRIPTION
* To help generating better error messages.
* Fixes #539