### PR TITLE
Find MPI package before generating phylanxrun.py

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,9 @@ if(PHYLANX_WITH_TESTS_BENCHMARKS OR PHYLANX_WITH_TESTS_REGRESSIONS OR PHYLANX_WI
 endif()
 
 # Configure phylanxrun.py
-find_package(MPI QUIET)
+if(HPX_WITH_PARCELPORT_MPI)
+    find_package(MPI QUIET)
+endif(HPX_WITH_PARCELPORT_MPI)
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/phylanxrun.py.in"
                "${CMAKE_BINARY_DIR}/bin/phylanxrun.py"
                @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ if(PHYLANX_WITH_TESTS_BENCHMARKS OR PHYLANX_WITH_TESTS_REGRESSIONS OR PHYLANX_WI
 endif()
 
 # Configure phylanxrun.py
+find_package(MPI QUIET)
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/phylanxrun.py.in"
                "${CMAKE_BINARY_DIR}/bin/phylanxrun.py"
                @ONLY)


### PR DESCRIPTION
If find_package(MPI...) isn't called before phylanxrun.py is
generated, MPI CMake macros aren't defined and the generated
script is incapable of running MPI tests.