### PR TITLE
Adding arange primitive

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -207,6 +207,14 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type && val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT double extract_scalar_numeric_value(
+        primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT double extract_scalar_numeric_value(
+        primitive_argument_type && val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
 
     PHYLANX_EXPORT ir::node_data<double> extract_numeric_value_strict(
         primitive_argument_type const& val,
@@ -385,11 +393,11 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
-    PHYLANX_EXPORT std::uint8_t extract_boolean_value_scalar(
+    PHYLANX_EXPORT std::uint8_t extract_scalar_boolean_value(
         primitive_argument_type const& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
-    PHYLANX_EXPORT std::uint8_t extract_boolean_value_scalar(
+    PHYLANX_EXPORT std::uint8_t extract_scalar_boolean_value(
         primitive_argument_type && val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
@@ -458,6 +466,69 @@ namespace phylanx { namespace execution_tree
         std::string const& codename)
     {
         return extract_boolean_value(std::move(val), name, codename);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    T extract_scalar_data(
+        primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <>
+    inline double extract_scalar_data(
+        primitive_argument_type const& val,
+        std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_numeric_value(val, name, codename);
+    }
+    template <>
+    inline std::int64_t extract_scalar_data(
+        primitive_argument_type const& val,
+        std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_integer_value(val, name, codename);
+    }
+    template <>
+    inline std::uint8_t extract_scalar_data(
+        primitive_argument_type const& val,
+        std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_boolean_value(val, name, codename);
+    }
+
+    template <typename T>
+    T extract_scalar_data(
+        primitive_argument_type && val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <>
+    inline double extract_scalar_data(
+        primitive_argument_type && val,
+        std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_numeric_value(std::move(val), name, codename);
+    }
+    template <>
+    inline std::int64_t extract_scalar_data(
+        primitive_argument_type && val,
+        std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_integer_value(std::move(val), name, codename);
+    }
+    template <>
+    inline std::uint8_t extract_scalar_data(
+        primitive_argument_type && val,
+        std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_boolean_value(std::move(val), name, codename);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/phylanx/plugins/booleans/comparison_impl.hpp
+++ b/phylanx/plugins/booleans/comparison_impl.hpp
@@ -734,7 +734,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         bool propagate_type = (operands.size() == 3 &&
-            phylanx::execution_tree::extract_boolean_value_scalar(operands[2]));
+            phylanx::execution_tree::extract_scalar_boolean_value(operands[2]));
 
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
             [this_ = std::move(this_), propagate_type](

--- a/phylanx/plugins/matrixops/arange.hpp
+++ b/phylanx/plugins/matrixops/arange.hpp
@@ -1,0 +1,56 @@
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_ARANGE_SEP_05_2018_1214PM)
+#define PHYLANX_PRIMITIVES_ARANGE_SEP_05_2018_1214PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class arange
+      : public primitive_component_base
+      , public std::enable_shared_from_this<arange>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args) const;
+
+        template <typename T>
+        primitive_argument_type arange_helper(
+            primitive_arguments_type&& args) const;
+
+    public:
+        static match_pattern_type const match_data;
+
+        arange() = default;
+
+        arange(primitive_arguments_type&& args,
+            std::string const& name, std::string const& codename);
+
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& args) const override;
+    };
+
+    inline primitive create_arange(hpx::id_type const& locality,
+        primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "arange", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/matrixops/matrixops.hpp
+++ b/phylanx/plugins/matrixops/matrixops.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_PLUGINS_MATRIXOPS_PRIMITIVES_APR_09_2108_0946PM
 
 #include <phylanx/plugins/matrixops/add_dimension.hpp>
+#include <phylanx/plugins/matrixops/arange.hpp>
 #include <phylanx/plugins/matrixops/argmax.hpp>
 #include <phylanx/plugins/matrixops/argmin.hpp>
 #include <phylanx/plugins/matrixops/constant.hpp>

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -988,6 +988,112 @@ namespace phylanx { namespace execution_tree
                 name, codename));
     }
 
+    double extract_scalar_numeric_value(
+        primitive_argument_type const& val, std::string const& name,
+        std::string const& codename)
+    {
+        switch (val.index())
+        {
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
+            if (util::get<1>(val).num_dimensions() == 0)
+                return double(util::get<1>(val)[0]);
+            break;
+
+        case 2:    // ir::node_data<std::int64_t>
+            if (util::get<2>(val).num_dimensions() == 0)
+                return double(util::get<2>(val)[0]);
+            break;
+
+        case 4:    // phylanx::ir::node_data<double>
+            if (util::get<4>(val).num_dimensions() == 0)
+                return util::get<4>(val)[0];
+            break;
+
+        case 6:    // std::vector<ast::expression>
+        {
+            auto const& exprs = util::get<6>(val);
+            if (exprs.size() == 1)
+            {
+                if (ast::detail::is_literal_value(exprs[0]))
+                {
+                    return to_primitive_numeric_type(
+                        ast::detail::literal_value(exprs[0]))[0];
+                }
+            }
+        }
+        break;
+
+        case 0:HPX_FALLTHROUGH;    // nil
+        case 3:HPX_FALLTHROUGH;    // string
+        case 5:HPX_FALLTHROUGH;    // primitive
+        case 7:HPX_FALLTHROUGH;    // phylanx::ir::range
+        case 8:HPX_FALLTHROUGH;    // phylanx::ir::dictionary
+        default:
+            break;
+        }
+
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_scalar_numeric_value",
+            util::generate_error_message(
+                "primitive_argument_type does not hold a floating point "
+                "value type (type held: '" + type + "')",
+                name, codename));
+    }
+
+    double extract_scalar_numeric_value(
+        primitive_argument_type&& val, std::string const& name,
+        std::string const& codename)
+    {
+        switch (val.index())
+        {
+        case 1:    // phylanx::ir::node_data<std::uint8_t>
+            if (util::get<1>(val).num_dimensions() == 0)
+                return double(util::get<1>(std::move(val))[0]);
+            break;
+
+        case 2:    // ir::node_data<std::int64_t>
+            if (util::get<2>(val).num_dimensions() == 0)
+                return double(util::get<2>(std::move(val))[0]);
+            break;
+
+        case 4:    // phylanx::ir::node_data<double>
+            if (util::get<4>(val).num_dimensions() == 0)
+                return util::get<4>(std::move(val))[0];
+            break;
+
+        case 6:    // std::vector<ast::expression>
+        {
+            auto&& exprs = util::get<6>(std::move(val));
+            if (exprs.size() == 1)
+            {
+                if (ast::detail::is_literal_value(exprs[0]))
+                {
+                    return to_primitive_numeric_type(
+                        ast::detail::literal_value(std::move(exprs[0])))[0];
+                }
+            }
+        }
+        break;
+
+        case 0:HPX_FALLTHROUGH;    // nil
+        case 3:HPX_FALLTHROUGH;    // string
+        case 5:HPX_FALLTHROUGH;    // primitive
+        case 7:HPX_FALLTHROUGH;    // phylanx::ir::range
+        case 8:HPX_FALLTHROUGH;    // phylanx::ir::dictionary
+        default:
+            break;
+        }
+
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_scalar_numeric_value",
+            util::generate_error_message(
+                "primitive_argument_type does not hold a floating point "
+                "value type (type held: '" + type + "')",
+                name, codename));
+    }
+
     ir::node_data<double> extract_numeric_value_strict(
         primitive_argument_type&& val, std::string const& name,
         std::string const& codename)
@@ -1818,7 +1924,7 @@ namespace phylanx { namespace execution_tree
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::uint8_t extract_boolean_value_scalar(
+    std::uint8_t extract_scalar_boolean_value(
         primitive_argument_type const& val, std::string const& name,
         std::string const& codename)
     {
@@ -1864,14 +1970,14 @@ namespace phylanx { namespace execution_tree
 
         std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "phylanx::execution_tree::extract_boolean_value_scalar",
+            "phylanx::execution_tree::extract_scalar_boolean_value",
             util::generate_error_message(
                 "primitive_argument_type does not hold a boolean "
                     "value type (type held: '" + type + "')",
                 name, codename));
     }
 
-    std::uint8_t extract_boolean_value_scalar(primitive_argument_type && val,
+    std::uint8_t extract_scalar_boolean_value(primitive_argument_type && val,
         std::string const& name, std::string const& codename)
     {
         switch (val.index())
@@ -1916,7 +2022,7 @@ namespace phylanx { namespace execution_tree
 
         std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "phylanx::execution_tree::extract_boolean_value_scalar",
+            "phylanx::execution_tree::extract_scalar_boolean_value",
             util::generate_error_message(
                 "primitive_argument_type does not hold a boolean "
                     "value type (type held: '" + type + "')",
@@ -3439,19 +3545,19 @@ namespace phylanx { namespace execution_tree
             if (f.is_ready())
             {
                 return hpx::make_ready_future(
-                    extract_boolean_value_scalar(f.get(), name, codename));
+                    extract_scalar_boolean_value(f.get(), name, codename));
             }
 
             return f.then(hpx::launch::sync,
                 [&](hpx::future<primitive_argument_type> && f)
                 {
-                    return extract_boolean_value_scalar(f.get(), name, codename);
+                    return extract_scalar_boolean_value(f.get(), name, codename);
                 });
         }
 
         HPX_ASSERT(valid(val));
         return hpx::make_ready_future(
-            extract_boolean_value_scalar(val, name, codename));
+            extract_scalar_boolean_value(val, name, codename));
     }
 
     std::uint8_t boolean_operand_sync(primitive_argument_type const& val,
@@ -3461,12 +3567,12 @@ namespace phylanx { namespace execution_tree
         primitive const* p = util::get_if<primitive>(&val);
         if (p != nullptr)
         {
-            return extract_boolean_value_scalar(
+            return extract_scalar_boolean_value(
                 p->eval(hpx::launch::sync, args), name, codename);
         }
 
         HPX_ASSERT(valid(val));
-        return extract_boolean_value_scalar(val, name, codename);
+        return extract_scalar_boolean_value(val, name, codename);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/format_string.cpp
+++ b/src/execution_tree/primitives/format_string.cpp
@@ -278,7 +278,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args) const
     {
-        if (operands_.empty())
+        if (operands.empty())
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "format_string::eval",
@@ -323,10 +323,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> format_string::eval(
         primitive_arguments_type const& args) const
     {
-        if (operands_.empty())
+        if (this->no_operands())
         {
             return eval(args, noargs);
         }
-        return eval(operands_, args);
+        return eval(this->operands(), args);
     }
 }}}

--- a/src/plugins/algorithms/lra.cpp
+++ b/src/plugins/algorithms/lra.cpp
@@ -109,7 +109,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         if (args.size() == 5 && valid(args[4]))
         {
             enable_output =
-                extract_boolean_value_scalar(args[4], name_, codename_) != 0;
+                extract_scalar_boolean_value(args[4], name_, codename_) != 0;
         }
 
         using vector_type = ir::node_data<double>::storage1d_type;

--- a/src/plugins/controls/for_each.cpp
+++ b/src/plugins/controls/for_each.cpp
@@ -139,10 +139,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> for_each::eval(
         primitive_arguments_type const& args, eval_mode mode) const
     {
-        if (operands_.empty())
+        if (this->no_operands())
         {
             return eval(args, noargs, mode);
         }
-        return eval(operands_, args, mode);
+        return eval(this->operands(), args, mode);
     }
 }}}

--- a/src/plugins/controls/for_operation.cpp
+++ b/src/plugins/controls/for_operation.cpp
@@ -114,7 +114,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_argument_type> body(
             hpx::future<primitive_argument_type>&& cond)
         {
-            if (extract_boolean_value_scalar(
+            if (extract_scalar_boolean_value(
                     cond.get(), that_->name_, that_->codename_))
             {
                 // Evaluate body of for statement

--- a/src/plugins/controls/while_operation.cpp
+++ b/src/plugins/controls/while_operation.cpp
@@ -96,7 +96,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::future<primitive_argument_type> body(
             hpx::future<primitive_argument_type>&& cond)
         {
-            if (extract_boolean_value_scalar(
+            if (extract_scalar_boolean_value(
                     cond.get(), that_->name_, that_->codename_))
             {
                 // Evaluate body of while statement

--- a/src/plugins/matrixops/arange.cpp
+++ b/src/plugins/matrixops/arange.cpp
@@ -1,0 +1,148 @@
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/matrixops/arange.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const arange::match_data =
+    {
+        hpx::util::make_tuple("arange",
+            std::vector<std::string>{"arange(_1, _2, _3)"},
+            &create_arange, &create_primitive<arange>)
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    arange::arange(primitive_arguments_type&& args,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(args), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    primitive_argument_type arange::arange_helper(
+        primitive_arguments_type&& args) const
+    {
+        T start = extract_scalar_data<T>(args[0], name_, codename_);
+        T stop = extract_scalar_data<T>(args[1], name_, codename_);
+        T step = extract_scalar_data<T>(args[2], name_, codename_);
+
+        if (step == T(0))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::arange_helper",
+                generate_error_message(
+                    "the arange primitive requires a non-zero step"));
+        }
+
+        // because of round-off effects we might end up having one more
+        // element than expected
+        blaze::DynamicVector<T> result(
+            std::max(T((stop - start) / step), T(0)) + T(1));
+
+        std::size_t i = 0;
+
+        if (step > T(0))
+        {
+            for (T val = start; val < stop; val += step, ++i)
+            {
+                result[i] = val;
+            }
+        }
+        else
+        {
+            for (T val = start; val > stop; val += step, ++i)
+            {
+                result[i] = val;
+            }
+        }
+
+        result.resize(i);
+        return primitive_argument_type{std::move(result)};
+    }
+
+    hpx::future<primitive_argument_type> arange::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args) const
+    {
+        if (operands.size() != 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::arange",
+                generate_error_message(
+                    "the arange primitive requires exactly three arguments."));
+        }
+
+        for (std::size_t i = 0; i != operands.size(); ++i)
+        {
+            if (!valid(operands[i]))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "arange::eval",
+                    generate_error_message(
+                        "at least one of the arguments passed to arange is "
+                        "not valid"));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+            [this_](primitive_arguments_type&& args)
+            -> primitive_argument_type
+            {
+                switch (extract_common_type(args))
+                {
+                case node_data_type_bool:
+                    return this_->arange_helper<std::uint8_t>(std::move(args));
+
+                case node_data_type_int64:
+                    return this_->arange_helper<std::int64_t>(std::move(args));
+
+                case node_data_type_double:
+                    return this_->arange_helper<double>(std::move(args));
+
+                default:
+                    break;
+                }
+
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::primitives::arange::eval",
+                    this_->generate_error_message(
+                        "the arange primitive requires for all arguments to "
+                            "be numeric data types"));
+            }),
+            detail::map_operands(
+                operands, functional::value_operand{}, args,
+                name_, codename_));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> arange::eval(
+        primitive_arguments_type const& args) const
+    {
+        if (this->no_operands())
+        {
+            return eval(args, noargs);
+        }
+        return eval(this->operands(), args);
+    }
+}}}

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -13,6 +13,8 @@ PHYLANX_REGISTER_PLUGIN_MODULE();
 
 PHYLANX_REGISTER_PLUGIN_FACTORY(add_dimension_plugin,
     phylanx::execution_tree::primitives::add_dimension::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(arange_plugin,
+    phylanx::execution_tree::primitives::arange::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(
     argmax_plugin, phylanx::execution_tree::primitives::argmax::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(

--- a/src/plugins/matrixops/sum_operation.cpp
+++ b/src/plugins/matrixops/sum_operation.cpp
@@ -215,7 +215,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         if (args.size() == 3)
                         {
                             keep_dims =
-                                execution_tree::extract_boolean_value_scalar(
+                                execution_tree::extract_scalar_boolean_value(
                                     args[2], this_->name_, this_->codename_);
                         }
                     }

--- a/src/plugins/solvers/decomposition.cpp
+++ b/src/plugins/solvers/decomposition.cpp
@@ -163,11 +163,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> decomposition::eval(
         primitive_arguments_type const& args) const
     {
-        if (operands_.empty())
+        if (this->no_operands())
         {
             return eval(args, noargs);
         }
-        return eval(operands_, args);
+        return eval(this->operands(), args);
     }
 }}}
 

--- a/tests/regressions/execution_tree/assign_wrong_variable_245.cpp
+++ b/tests/regressions/execution_tree/assign_wrong_variable_245.cpp
@@ -39,7 +39,7 @@ void test_add()
     auto const& code = phylanx::execution_tree::compile(add_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const sub_code = R"(define(test, block(
@@ -67,7 +67,7 @@ void test_sub()
     auto const& code = phylanx::execution_tree::compile(sub_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const mul_code = R"(define(test, block(
@@ -96,7 +96,7 @@ void test_mul()
     auto const& code = phylanx::execution_tree::compile(mul_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const div_code = R"(define(test, block(
@@ -125,7 +125,7 @@ void test_div()
     auto const& code = phylanx::execution_tree::compile(div_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const equal_code = R"(define(test, block(
@@ -154,7 +154,7 @@ void test_equal()
     auto const& code = phylanx::execution_tree::compile(equal_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const not_equal_code = R"(define(test, block(
@@ -183,7 +183,7 @@ void test_not_equal()
         phylanx::execution_tree::compile(not_equal_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const greater_code = R"(define(test, block(
@@ -211,7 +211,7 @@ void test_greater()
     auto const& code = phylanx::execution_tree::compile(greater_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const greater_equal_code = R"(define(test, block(
@@ -240,7 +240,7 @@ void test_greater_equal()
         phylanx::execution_tree::compile(greater_equal_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const less_code = R"(define(test, block(
@@ -268,7 +268,7 @@ void test_less()
     auto const& code = phylanx::execution_tree::compile(less_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const less_equal_code = R"(define(test, block(
@@ -297,7 +297,7 @@ void test_less_equal()
         phylanx::execution_tree::compile(less_equal_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const dot_code = R"(define(test, block(
@@ -325,7 +325,7 @@ void test_dot()
     auto const& code = phylanx::execution_tree::compile(dot_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const and_code = R"(define(test, block(
@@ -353,7 +353,7 @@ void test_and()
     auto const& code = phylanx::execution_tree::compile(and_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const or_code = R"(define(test, block(
@@ -381,7 +381,7 @@ void test_or()
     auto const& code = phylanx::execution_tree::compile(or_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const linear_solver_code = R"(define(test, block(
@@ -406,7 +406,7 @@ void test_linear_solver()
         phylanx::execution_tree::compile(linear_solver_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()()), 1);
 }
 
 std::string const decomposition_code = R"(block(
@@ -424,7 +424,7 @@ void test_decomposition()
         phylanx::execution_tree::compile(decomposition_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()), 1);
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/execution_tree/generate_tree.cpp
+++ b/tests/unit/execution_tree/generate_tree.cpp
@@ -46,7 +46,7 @@ void test_generate_tree(
     auto f = code.run();
 
     HPX_TEST_EQ(expected_result,
-        phylanx::execution_tree::extract_boolean_value_scalar(
+        phylanx::execution_tree::extract_scalar_boolean_value(
             f()
         ) != 0);
 }

--- a/tests/unit/plugins/booleans/all_operation.cpp
+++ b/tests/unit/plugins/booleans/all_operation.cpp
@@ -27,7 +27,7 @@ void test_all_operation_0d_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_0d_false()
@@ -44,7 +44,7 @@ void test_all_operation_0d_false()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_0d_double_true()
@@ -61,7 +61,7 @@ void test_all_operation_0d_double_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_0d_double_false()
@@ -78,7 +78,7 @@ void test_all_operation_0d_double_false()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d_double()
@@ -99,7 +99,7 @@ void test_all_operation_1d_double()
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
     HPX_TEST_EQ(v.nonZeros() == v.size(),
-        phylanx::execution_tree::extract_boolean_value_scalar(f));
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d()
@@ -120,7 +120,7 @@ void test_all_operation_1d()
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
     HPX_TEST_EQ(v.nonZeros() == v.size(),
-        phylanx::execution_tree::extract_boolean_value_scalar(f));
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d_true()
@@ -140,7 +140,7 @@ void test_all_operation_1d_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d_double_true()
@@ -160,7 +160,7 @@ void test_all_operation_1d_double_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d_numpy_false()
@@ -179,7 +179,7 @@ void test_all_operation_1d_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d_numpy_true()
@@ -198,7 +198,7 @@ void test_all_operation_1d_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d_double_numpy_false()
@@ -217,7 +217,7 @@ void test_all_operation_1d_double_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_1d_double_numpy_true()
@@ -236,7 +236,7 @@ void test_all_operation_1d_double_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d()
@@ -257,7 +257,7 @@ void test_all_operation_2d()
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
     HPX_TEST_EQ(m.nonZeros() == m.rows() * m.columns(),
-        phylanx::execution_tree::extract_boolean_value_scalar(f));
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d_true()
@@ -277,7 +277,7 @@ void test_all_operation_2d_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d_double()
@@ -298,7 +298,7 @@ void test_all_operation_2d_double()
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
     HPX_TEST_EQ(m.nonZeros() == m.rows() * m.columns(),
-        phylanx::execution_tree::extract_boolean_value_scalar(f));
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d_double_true()
@@ -318,7 +318,7 @@ void test_all_operation_2d_double_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d_double_numpy_false()
@@ -337,7 +337,7 @@ void test_all_operation_2d_double_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d_double_numpy_true()
@@ -356,7 +356,7 @@ void test_all_operation_2d_double_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d_numpy_true()
@@ -375,7 +375,7 @@ void test_all_operation_2d_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_all_operation_2d_numpy_false()
@@ -394,7 +394,7 @@ void test_all_operation_2d_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = all.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/plugins/booleans/any_operation.cpp
+++ b/tests/unit/plugins/booleans/any_operation.cpp
@@ -27,7 +27,7 @@ void test_any_operation_0d_true()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(true, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(true, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_0d_false()
@@ -44,7 +44,7 @@ void test_any_operation_0d_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_0d_double_true()
@@ -61,7 +61,7 @@ void test_any_operation_0d_double_true()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_0d_double_false()
@@ -78,7 +78,7 @@ void test_any_operation_0d_double_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d()
@@ -99,7 +99,7 @@ void test_any_operation_1d()
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
     HPX_TEST_EQ(
-        v.nonZeros() != 0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+        v.nonZeros() != 0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d_false()
@@ -117,7 +117,7 @@ void test_any_operation_1d_false()
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d_double()
@@ -138,7 +138,7 @@ void test_any_operation_1d_double()
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
     HPX_TEST_EQ(
-        v.nonZeros() != 0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+        v.nonZeros() != 0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d_double_false()
@@ -156,7 +156,7 @@ void test_any_operation_1d_double_false()
                 std::move(arg1)});
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d_numpy_false()
@@ -175,7 +175,7 @@ void test_any_operation_1d_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d_numpy_true()
@@ -194,7 +194,7 @@ void test_any_operation_1d_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d_double_numpy_false()
@@ -213,7 +213,7 @@ void test_any_operation_1d_double_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_1d_double_numpy_true()
@@ -232,7 +232,7 @@ void test_any_operation_1d_double_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d()
@@ -253,7 +253,7 @@ void test_any_operation_2d()
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
     HPX_TEST_EQ(
-        m.nonZeros() != 0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+        m.nonZeros() != 0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d_false()
@@ -272,7 +272,7 @@ void test_any_operation_2d_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d_double()
@@ -293,7 +293,7 @@ void test_any_operation_2d_double()
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
     HPX_TEST_EQ(
-        m.nonZeros() != 0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+        m.nonZeros() != 0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d_double_false()
@@ -312,7 +312,7 @@ void test_any_operation_2d_double_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d_numpy_false()
@@ -332,7 +332,7 @@ void test_any_operation_2d_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d_numpy_true()
@@ -351,7 +351,7 @@ void test_any_operation_2d_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d_double_numpy_false()
@@ -370,7 +370,7 @@ void test_any_operation_2d_double_numpy_false()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(0, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 void test_any_operation_2d_double_numpy_true()
@@ -389,7 +389,7 @@ void test_any_operation_2d_double_numpy_true()
 
     phylanx::execution_tree::primitive_argument_type f = any.eval().get();
 
-    HPX_TEST_EQ(1, phylanx::execution_tree::extract_boolean_value_scalar(f));
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/plugins/controls/for_operation.cpp
+++ b/tests/unit/plugins/controls/for_operation.cpp
@@ -85,7 +85,7 @@ void test_for_operation_true()
     hpx::future<pe::primitive_argument_type> f =
         for_.eval();
 
-    HPX_TEST(!pe::extract_boolean_value_scalar(f.get()));
+    HPX_TEST(!pe::extract_scalar_boolean_value(f.get()));
 }
 
 // init is stated at zero

--- a/tests/unit/plugins/controls/while_operation.cpp
+++ b/tests/unit/plugins/controls/while_operation.cpp
@@ -63,7 +63,7 @@ void test_while_operation_true()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         while_.eval();
 
-    HPX_TEST(!phylanx::execution_tree::extract_boolean_value_scalar(f.get()));
+    HPX_TEST(!phylanx::execution_tree::extract_scalar_boolean_value(f.get()));
 }
 
 // condition is set to false in first iteration
@@ -98,7 +98,7 @@ void test_while_operation_true_return()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         while_.eval();
 
-    HPX_TEST(phylanx::execution_tree::extract_boolean_value_scalar(f.get()));
+    HPX_TEST(phylanx::execution_tree::extract_scalar_boolean_value(f.get()));
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/plugins/matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/matrixops/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 set(tests
     add_dimension
+    arange
     argmin
     argmax
     column_slicing

--- a/tests/unit/plugins/matrixops/arange.cpp
+++ b/tests/unit/plugins/matrixops/arange.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2017-2018 Bibek Wagle
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
+}
+
+void test_arange(char const* code, char const* expectedstr)
+{
+    auto result = compile_and_run(code);
+    auto expected = compile_and_run(expectedstr);
+
+    HPX_TEST_EQ(result, expected);
+}
+
+int main(int argc, char* argv[])
+{
+    test_arange("arange(0, 5, 1)", "hstack(0, 1, 2, 3, 4)");
+
+    test_arange("arange(0.0, 5, 1)", "hstack(0.0, 1.0, 2.0, 3.0, 4.0)");
+    test_arange("arange(0, 5.0, 1)", "hstack(0.0, 1.0, 2.0, 3.0, 4.0)");
+    test_arange("arange(0, 5, 1.0)", "hstack(0.0, 1.0, 2.0, 3.0, 4.0)");
+
+    test_arange("arange(0, 5, 1.1)", "hstack(0.0, 1.1, 2.2, 3.3, 4.4)");
+
+    test_arange("arange(5.0, 0, -1.0)", "hstack(5.0, 4.0, 3.0, 2.0, 1.0)");
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/plugins/solvers/decomposition.cpp
+++ b/tests/unit/plugins/solvers/decomposition.cpp
@@ -37,7 +37,7 @@ void test_decomposition_lu_PhySL()
     auto const& code = phylanx::execution_tree::compile(lu_code, snippets);
     auto f = code.run();
 
-    HPX_TEST_EQ(phylanx::execution_tree::extract_boolean_value_scalar(f()), 1);
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_boolean_value(f()), 1);
 }
 
 void test_decomposition(std::string const& func_name)


### PR DESCRIPTION
- flyby: renaming functions for consistency
- flyby: fixing some primitives to conform to the coding conventions used

This fixes #553