### PR TITLE
Fmap primitive

### DIFF
--- a/examples/algorithms/kmeans/kmeans.phylanx.py
+++ b/examples/algorithms/kmeans/kmeans.phylanx.py
@@ -43,7 +43,7 @@ def closest_centroid(points, centroids):
 
 @Phylanx
 def move_centroids(points, closest, centroids):
-    return map(
+    return fmap(
         lambda k: mean(points * add_dim(closest == k), 1),
         range(shape(centroids, 0))
     )

--- a/examples/algorithms/kmeans/kmeans.physl
+++ b/examples/algorithms/kmeans/kmeans.physl
@@ -43,7 +43,7 @@ define(closest_centroids, points, centroids, block(
 ))
 
 define(move_centroids, points, closest, centroids, block(
-    map(lambda(k, block(
+    fmap(lambda(k, block(
                 define(x, closest == k),
                 mean(points * add_dim(x), 1)
     )),
@@ -65,9 +65,9 @@ define(kmeans, points, k, iterations, block(
 
 define(program, iterations, block(
     define(points, vstack(
-        apply(vstack, map(lambda(x, random(2) * .75), range(150))) + [1., 0.],
-        apply(vstack, map(lambda(x, random(2) * .25), range(50))) + [-.5, .5],
-        apply(vstack, map(lambda(x, random(2) * .5), range(50))) + [-.5, -.5]
+        apply(vstack, fmap(lambda(x, random(2) * .75), range(150))) + [1., 0.],
+        apply(vstack, fmap(lambda(x, random(2) * .25), range(50))) + [-.5, .5],
+        apply(vstack, fmap(lambda(x, random(2) * .5), range(50))) + [-.5, -.5]
     )),
     define(k, 3),
     kmeans(points, k, iterations)

--- a/phylanx/plugins/controls/controls.hpp
+++ b/phylanx/plugins/controls/controls.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/plugins/controls/for_each.hpp>
 #include <phylanx/plugins/controls/for_operation.hpp>
 #include <phylanx/plugins/controls/if_conditional.hpp>
-#include <phylanx/plugins/controls/map_operation.hpp>
+#include <phylanx/plugins/controls/fmap_operation.hpp>
 #include <phylanx/plugins/controls/parallel_block_operation.hpp>
 #include <phylanx/plugins/controls/parallel_map_operation.hpp>
 #include <phylanx/plugins/controls/range_operation.hpp>

--- a/phylanx/plugins/controls/fmap_operation.hpp
+++ b/phylanx/plugins/controls/fmap_operation.hpp
@@ -19,16 +19,16 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class map_operation
+    class fmap_operation
       : public primitive_component_base
-      , public std::enable_shared_from_this<map_operation>
+      , public std::enable_shared_from_this<fmap_operation>
     {
     public:
         static match_pattern_type const match_data;
 
-        map_operation() = default;
+        fmap_operation() = default;
 
-        map_operation(primitive_arguments_type&& operands,
+        fmap_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
         hpx::future<primitive_argument_type> eval(
@@ -39,37 +39,37 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args) const;
 
-        hpx::future<primitive_argument_type> map_1(
+        hpx::future<primitive_argument_type> fmap_1(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args) const;
-        hpx::future<primitive_argument_type> map_n(
+        hpx::future<primitive_argument_type> fmap_n(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args) const;
 
-        primitive_argument_type map_1_scalar(
+        primitive_argument_type fmap_1_scalar(
             primitive const* p, primitive_argument_type&& arg) const;
-        primitive_argument_type map_1_vector(
+        primitive_argument_type fmap_1_vector(
             primitive const* p, primitive_argument_type&& arg) const;
-        primitive_argument_type map_1_matrix(
+        primitive_argument_type fmap_1_matrix(
             primitive const* p, primitive_argument_type&& arg) const;
 
-        primitive_argument_type map_n_lists(primitive const* p,
+        primitive_argument_type fmap_n_lists(primitive const* p,
             primitive_arguments_type&& args) const;
 
-        primitive_argument_type map_n_scalar(primitive const* p,
+        primitive_argument_type fmap_n_scalar(primitive const* p,
             primitive_arguments_type&& args) const;
-        primitive_argument_type map_n_vector(primitive const* p,
+        primitive_argument_type fmap_n_vector(primitive const* p,
             primitive_arguments_type&& args) const;
-        primitive_argument_type map_n_matrix(primitive const* p,
+        primitive_argument_type fmap_n_matrix(primitive const* p,
             primitive_arguments_type&& args) const;
     };
 
-    inline primitive create_map_operation(hpx::id_type const& locality,
+    inline primitive create_fmap_operation(hpx::id_type const& locality,
         primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(
-            locality, "map", std::move(operands), name, codename);
+            locality, "fmap", std::move(operands), name, codename);
     }
 }}}
 

--- a/src/plugins/controls/controls.cpp
+++ b/src/plugins/controls/controls.cpp
@@ -25,8 +25,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(for_operation_plugin,
     phylanx::execution_tree::primitives::for_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(if_conditional_plugin,
     phylanx::execution_tree::primitives::if_conditional::match_data);
-PHYLANX_REGISTER_PLUGIN_FACTORY(map_operation_plugin,
-    phylanx::execution_tree::primitives::map_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(fmap_operation_plugin,
+    phylanx::execution_tree::primitives::fmap_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(parallel_block_operation_plugin,
     phylanx::execution_tree::primitives::parallel_block_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(parallel_map_operation_plugin,

--- a/src/plugins/controls/fmap_operation.cpp
+++ b/src/plugins/controls/fmap_operation.cpp
@@ -4,7 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
-#include <phylanx/plugins/controls/map_operation.hpp>
+#include <phylanx/plugins/controls/fmap_operation.hpp>
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
@@ -27,11 +27,11 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-    match_pattern_type const map_operation::match_data =
+    match_pattern_type const fmap_operation::match_data =
     {
-        hpx::util::make_tuple("map",
-            std::vector<std::string>{"map(_1, __2)"},
-            &create_map_operation, &create_primitive<map_operation>,
+        hpx::util::make_tuple("fmap",
+            std::vector<std::string>{"fmap(_1, __2)"},
+            &create_fmap_operation, &create_primitive<fmap_operation>,
             "func, listv\n"
             "\n"
             "Args:\n"
@@ -47,14 +47,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    map_operation::map_operation(
+    fmap_operation::fmap_operation(
             primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive_argument_type map_operation::map_1_scalar(
+    primitive_argument_type fmap_operation::fmap_1_scalar(
         primitive const* p, primitive_argument_type&& arg) const
     {
         return p->eval(hpx::launch::sync, std::move(arg));
@@ -63,7 +63,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     namespace detail
     {
         template <typename T>
-        struct map_1_vector
+        struct fmap_1_vector
         {
             using vector_type = typename ir::node_data<T>::storage1d_type;
             using vector_view_type =
@@ -89,7 +89,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         if (num_result.num_dimensions() != 0)
                         {
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "detail::map_1_vector::call",
+                                "detail::fmap_1_vector::call",
                                 util::generate_error_message(
                                     "the invoked lambda returned an unexpected "
                                     "type ("
@@ -106,7 +106,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         };
     }
 
-    primitive_argument_type map_operation::map_1_vector(
+    primitive_argument_type fmap_operation::fmap_1_vector(
         primitive const* p, primitive_argument_type&& arg) const
     {
         if (is_numeric_operand(arg))
@@ -114,7 +114,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             auto v = extract_numeric_value(std::move(arg), name_, codename_);
             HPX_ASSERT(v.num_dimensions() == 1);
             return primitive_argument_type{
-                ir::node_data<double>{detail::map_1_vector<double>::call(
+                ir::node_data<double>{detail::fmap_1_vector<double>::call(
                     p, v.vector(), name_, codename_)}};
         }
 
@@ -123,7 +123,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             auto v = extract_integer_value(std::move(arg), name_, codename_);
             HPX_ASSERT(v.num_dimensions() == 1);
             return primitive_argument_type{ir::node_data<std::int64_t>{
-                detail::map_1_vector<std::int64_t>::call(
+                detail::fmap_1_vector<std::int64_t>::call(
                     p, v.vector(), name_, codename_)}};
         }
 
@@ -132,19 +132,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
             auto v = extract_boolean_value(std::move(arg), name_, codename_);
             HPX_ASSERT(v.num_dimensions() == 1);
             return primitive_argument_type{ir::node_data<std::uint8_t>{
-                detail::map_1_vector<std::uint8_t>::call(
+                detail::fmap_1_vector<std::uint8_t>::call(
                     p, v.vector(), name_, codename_)}};
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "map_operation::map_1_vector",
+            "fmap_operation::fmap_1_vector",
             generate_error_message("unexpected numeric type"));
     }
 
     namespace detail
     {
         template <typename T>
-        struct map_1_matrix
+        struct fmap_1_matrix
         {
             using vector_type = typename ir::node_data<T>::storage1d_type;
 
@@ -173,7 +173,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         if (num_result.num_dimensions() != 1)
                         {
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "detail::map_1_matrix::call",
+                                "detail::fmap_1_matrix::call",
                                 util::generate_error_message(
                                     "the invoked lambda returned an unexpected "
                                     "type (should be a vector value)",
@@ -190,7 +190,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         };
     }
 
-    primitive_argument_type map_operation::map_1_matrix(
+    primitive_argument_type fmap_operation::fmap_1_matrix(
         primitive const* p, primitive_argument_type&& arg) const
     {
         if (is_numeric_operand(arg))
@@ -198,7 +198,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             auto m = extract_numeric_value(std::move(arg), name_, codename_);
             HPX_ASSERT(m.num_dimensions() == 2);
             return primitive_argument_type{
-                ir::node_data<double>{detail::map_1_matrix<double>::call(
+                ir::node_data<double>{detail::fmap_1_matrix<double>::call(
                     p, m.matrix(), name_, codename_)}};
         }
 
@@ -207,7 +207,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             auto m = extract_integer_value(std::move(arg), name_, codename_);
             HPX_ASSERT(m.num_dimensions() == 2);
             return primitive_argument_type{ir::node_data<std::int64_t>{
-                detail::map_1_matrix<std::int64_t>::call(
+                detail::fmap_1_matrix<std::int64_t>::call(
                     p, m.matrix(), name_, codename_)}};
         }
 
@@ -216,17 +216,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
             auto m = extract_boolean_value(std::move(arg), name_, codename_);
             HPX_ASSERT(m.num_dimensions() == 2);
             return primitive_argument_type{ir::node_data<std::uint8_t>{
-                detail::map_1_matrix<std::uint8_t>::call(
+                detail::fmap_1_matrix<std::uint8_t>::call(
                     p, m.matrix(), name_, codename_)}};
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "map_operation::map_1_matrix",
+            "fmap_operation::fmap_1_matrix",
             generate_error_message("unexpected numeric type"));
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<primitive_argument_type> map_operation::map_1(
+    hpx::future<primitive_argument_type> fmap_operation::fmap_1(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args) const
     {
@@ -243,9 +243,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (p == nullptr)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "map_operation::eval",
+                        "fmap_operation::eval",
                         this_->generate_error_message(
-                            "the first argument to map must be an invocable "
+                            "the first argument to fmap must be an invocable "
                                 "object"));
                 }
 
@@ -276,13 +276,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     switch (dim)
                     {
                     case 0:
-                        return this_->map_1_scalar(p, std::move(arg));
+                        return this_->fmap_1_scalar(p, std::move(arg));
 
                     case 1:
-                        return this_->map_1_vector(p, std::move(arg));
+                        return this_->fmap_1_vector(p, std::move(arg));
 
                     case 2:
-                        return this_->map_1_matrix(p, std::move(arg));
+                        return this_->fmap_1_matrix(p, std::move(arg));
 
                     default:
                         break;
@@ -290,9 +290,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "map_operation::map_1",
+                    "fmap_operation::fmap_1",
                     this_->generate_error_message(
-                        "the second argument to map must be an iterable "
+                        "the second argument to fmap must be an iterable "
                             "object (a list or a numeric type)"));
             },
             value_operand_fov(operands[0], args, name_, codename_,
@@ -344,7 +344,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
-    primitive_argument_type map_operation::map_n_lists(
+    primitive_argument_type fmap_operation::fmap_n_lists(
         primitive const* p, primitive_arguments_type&& args) const
     {
         std::vector<ir::range> lists;
@@ -363,7 +363,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             if (list.size() != size)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "map_operation::map_n_lists",
+                    "fmap_operation::fmap_n_lists",
                     generate_error_message(
                         "all list arguments must have the same length"));
             }
@@ -401,13 +401,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return primitive_argument_type{std::move(result)};
     }
 
-    primitive_argument_type map_operation::map_n_scalar(primitive const* p,
+    primitive_argument_type fmap_operation::fmap_n_scalar(primitive const* p,
         primitive_arguments_type&& args) const
     {
         return p->eval(hpx::launch::sync, std::move(args));
     }
 
-    primitive_argument_type map_operation::map_n_vector(primitive const* p,
+    primitive_argument_type fmap_operation::fmap_n_vector(primitive const* p,
         primitive_arguments_type&& args) const
     {
         std::vector<ir::node_data<double>> values;
@@ -439,7 +439,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (num_result.num_dimensions() != 0)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "map_operation::map_n_vector",
+                        "fmap_operation::fmap_n_vector",
                         generate_error_message(
                             "the invoked lambda returned an unexpected type ("
                             "should be a scalar value)"));
@@ -452,7 +452,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return primitive_argument_type{std::move(result)};
     }
 
-    primitive_argument_type map_operation::map_n_matrix(primitive const* p,
+    primitive_argument_type fmap_operation::fmap_n_matrix(primitive const* p,
         primitive_arguments_type&& args) const
     {
         std::vector<ir::node_data<double>> values;
@@ -489,7 +489,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (num_result.num_dimensions() != 1)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "map_operation::map_n_matrix",
+                        "fmap_operation::fmap_n_matrix",
                         generate_error_message(
                             "the invoked lambda returned an unexpected type ("
                             "should be a vector value)"));
@@ -503,7 +503,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<primitive_argument_type> map_operation::map_n(
+    hpx::future<primitive_argument_type> fmap_operation::fmap_n(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args) const
     {
@@ -522,15 +522,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (p == nullptr)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "map_operation::eval",
+                        "fmap_operation::eval",
                         this_->generate_error_message(
-                            "the first argument to map must be an invocable "
+                            "the first argument to fmap must be an invocable "
                                 "object"));
                 }
 
                 if (detail::all_list_operands(args))
                 {
-                    return this_->map_n_lists(p, std::move(args));
+                    return this_->fmap_n_lists(p, std::move(args));
                 }
 
                 if (detail::all_numeric_operands(args))
@@ -541,13 +541,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     switch (dim)
                     {
                     case 0:
-                        return this_->map_n_scalar(p, std::move(args));
+                        return this_->fmap_n_scalar(p, std::move(args));
 
                     case 1:
-                        return this_->map_n_vector(p, std::move(args));
+                        return this_->fmap_n_vector(p, std::move(args));
 
                     case 2:
-                        return this_->map_n_matrix(p, std::move(args));
+                        return this_->fmap_n_matrix(p, std::move(args));
 
                     default:
                         break;
@@ -555,9 +555,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "map_operation::map_n",
+                    "fmap_operation::fmap_n",
                     this_->generate_error_message(
-                        "all but the first arguments to map must be "
+                        "all but the first arguments to fmap must be "
                             "compatible iterable objects (all lists or all "
                             "numeric)"));
             }),
@@ -567,16 +567,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 lists, functional::value_operand{}, args, name_, codename_));
     }
 
-    hpx::future<primitive_argument_type> map_operation::eval(
+    hpx::future<primitive_argument_type> fmap_operation::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args) const
     {
         if (operands.size() < 2)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "map_operation::eval",
+                "fmap_operation::eval",
                 generate_error_message(
-                    "the map_operation primitive requires "
+                    "the fmap_operation primitive requires "
                         "at least two operands"));
         }
 
@@ -592,9 +592,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         if (!arguments_valid)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "map_operation::eval",
+                "fmap_operation::eval",
                 generate_error_message(
-                    "the map_operation primitive requires that the "
+                    "the fmap_operation primitive requires that the "
                         "arguments given by the operands array are valid"));
         }
 
@@ -602,22 +602,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
         if (util::get_if<primitive>(&operands_[0]) == nullptr)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "map_operation::eval",
+                "fmap_operation::eval",
                 generate_error_message(
-                    "the first argument to map must be an invocable object"));
+                    "the first argument to fmap must be an invocable object"));
         }
 
         // handle common case separately
         if (operands.size() == 2)
         {
-            return map_1(operands, args);
+            return fmap_1(operands, args);
         }
 
-        return map_n(operands, args);
+        return fmap_n(operands, args);
     }
 
     // Start iteration over given for statement
-    hpx::future<primitive_argument_type> map_operation::eval(
+    hpx::future<primitive_argument_type> fmap_operation::eval(
         primitive_arguments_type const& args) const
     {
         if (this->no_operands())

--- a/tests/regressions/execution_tree/list_iter_space_429.cpp
+++ b/tests/regressions/execution_tree/list_iter_space_429.cpp
@@ -19,7 +19,7 @@ std::string const codestr = R"(block(
         f,
         block(
             define(a, 0),
-            map(
+            fmap(
                 lambda(
                     i,
                     block(

--- a/tests/unit/plugins/controls/CMakeLists.txt
+++ b/tests/unit/plugins/controls/CMakeLists.txt
@@ -10,7 +10,7 @@ set(tests
     fold_right_operation
     for_operation
     if_conditional
-    map_operation
+    fmap_operation
     parallel_block_operation
     parallel_map_operation
     range_operation

--- a/tests/unit/plugins/controls/fmap_operation.cpp
+++ b/tests/unit/plugins/controls/fmap_operation.cpp
@@ -24,10 +24,10 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_map_operation_lambda()
+void test_fmap_operation_lambda()
 {
     std::string const code = R"(
-            map(lambda(x, x + 1), list(1, 2, 3))
+            fmap(lambda(x, x + 1), list(1, 2, 3))
         )";
 
     auto result =
@@ -44,11 +44,11 @@ void test_map_operation_lambda()
         phylanx::execution_tree::extract_numeric_value(*it)[0], 4.0);
 }
 
-void test_map_operation_func()
+void test_fmap_operation_func()
 {
     std::string const code = R"(block(
             define(f, x, x + 1),
-            map(f, list(1, 2, 3))
+            fmap(f, list(1, 2, 3))
         ))";
 
     auto result =
@@ -65,11 +65,11 @@ void test_map_operation_func()
         phylanx::execution_tree::extract_numeric_value(*it)[0], 4.0);
 }
 
-void test_map_operation_func_lambda()
+void test_fmap_operation_func_lambda()
 {
     std::string const code = R"(block(
             define(f, lambda(x, x + 1)),
-            map(f, list(1, 2, 3))
+            fmap(f, list(1, 2, 3))
         ))";
 
     auto result =
@@ -87,10 +87,10 @@ void test_map_operation_func_lambda()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_map_operation_lambda_arg()
+void test_fmap_operation_lambda_arg()
 {
     std::string const code_str = R"(block(
-            define(f, a, map(lambda(x, x + a), list(1, 2, 3))),
+            define(f, a, fmap(lambda(x, x + a), list(1, 2, 3))),
             f
         ))";
 
@@ -121,12 +121,12 @@ void test_map_operation_lambda_arg()
         phylanx::execution_tree::extract_numeric_value(*it)[0], 5.0);
 }
 
-void test_map_operation_func_arg()
+void test_fmap_operation_func_arg()
 {
     std::string const code_str = R"(block(
             define(f, a, block(
-                define(fmap, x, x + a),
-                map(fmap, list(1, 2, 3))
+                define(ffmap, x, x + a),
+                fmap(ffmap, list(1, 2, 3))
             )),
             f
         ))";
@@ -159,14 +159,14 @@ void test_map_operation_func_arg()
         phylanx::execution_tree::extract_numeric_value(*it)[0], 5.0);
 }
 
-/// <image url="$(ItemDir)/images/test_map_operation_func_lambda_arg.dot.png" />
+/// <image url="$(ItemDir)/images/test_fmap_operation_func_lambda_arg.dot.png" />
 //
-void test_map_operation_func_lambda_arg()
+void test_fmap_operation_func_lambda_arg()
 {
     std::string const code_str = R"(block(
             define(f, a, block(
-                define(fmap, lambda(x, x + a)),
-                map(fmap, list(1, 2, 3))
+                define(ffmap, lambda(x, x + a)),
+                fmap(ffmap, list(1, 2, 3))
             )),
             f
         ))";
@@ -199,10 +199,10 @@ void test_map_operation_func_lambda_arg()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_map_operation_lambda2()
+void test_fmap_operation_lambda2()
 {
     std::string const code = R"(
-            map(lambda(x, y, x + y), list(1, 2, 3), list(1, 2, 3))
+            fmap(lambda(x, y, x + y), list(1, 2, 3), list(1, 2, 3))
         )";
 
     auto result =
@@ -219,10 +219,10 @@ void test_map_operation_lambda2()
         phylanx::execution_tree::extract_numeric_value(*it)[0], 6.0);
 }
 
-void test_map_operation_builtin2()
+void test_fmap_operation_builtin2()
 {
     std::string const code = R"(
-            map(__add, list(1, 2, 3), list(1, 2, 3))
+            fmap(__add, list(1, 2, 3), list(1, 2, 3))
         )";
 
     auto result =
@@ -239,11 +239,11 @@ void test_map_operation_builtin2()
         phylanx::execution_tree::extract_numeric_value(*it)[0], 6.0);
 }
 
-void test_map_operation_func2()
+void test_fmap_operation_func2()
 {
     std::string const code = R"(block(
             define(f, x, y, x + y),
-            map(f, list(1, 2, 3), list(1, 2, 3))
+            fmap(f, list(1, 2, 3), list(1, 2, 3))
         ))";
 
     auto result =
@@ -260,11 +260,11 @@ void test_map_operation_func2()
         phylanx::execution_tree::extract_numeric_value(*it)[0], 6.0);
 }
 
-void test_map_operation_func_lambda2()
+void test_fmap_operation_func_lambda2()
 {
     std::string const code = R"(block(
             define(f, lambda(x, y, x + y)),
-            map(f, list(1, 2, 3), list(1, 2, 3))
+            fmap(f, list(1, 2, 3), list(1, 2, 3))
         ))";
 
     auto result =
@@ -284,18 +284,18 @@ void test_map_operation_func_lambda2()
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    test_map_operation_lambda();
-    test_map_operation_func();
-    test_map_operation_func_lambda();
+    test_fmap_operation_lambda();
+    test_fmap_operation_func();
+    test_fmap_operation_func_lambda();
 
-    test_map_operation_lambda_arg();
-    test_map_operation_func_arg();
-    test_map_operation_func_lambda_arg();
+    test_fmap_operation_lambda_arg();
+    test_fmap_operation_func_arg();
+    test_fmap_operation_func_lambda_arg();
 
-    test_map_operation_lambda2();
-    test_map_operation_builtin2();
-    test_map_operation_func2();
-    test_map_operation_func_lambda2();
+    test_fmap_operation_lambda2();
+    test_fmap_operation_builtin2();
+    test_fmap_operation_func2();
+    test_fmap_operation_func_lambda2();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/controls/range_operation.cpp
+++ b/tests/unit/plugins/controls/range_operation.cpp
@@ -28,7 +28,7 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
 //////////////////////////////////////////////////////////////////////////
 void test_range_stop()
 {
-    char const* const code = "map(lambda(x, x), range(2))";
+    char const* const code = "fmap(lambda(x, x), range(2))";
 
     auto result =
         phylanx::execution_tree::extract_list_value(compile_and_run(code));
@@ -44,7 +44,7 @@ void test_range_stop()
 
 void test_range_start_stop()
 {
-    char const* const code = "map(lambda(x, x), range(-1, 2))";
+    char const* const code = "fmap(lambda(x, x), range(-1, 2))";
 
     auto result =
         phylanx::execution_tree::extract_list_value(compile_and_run(code));
@@ -60,7 +60,7 @@ void test_range_start_stop()
 
 void test_range_start_stop_step()
 {
-    char const* const code = "map(lambda(x, x), range(-3, 2, 4))";
+    char const* const code = "fmap(lambda(x, x), range(-3, 2, 4))";
 
     auto result =
         phylanx::execution_tree::extract_list_value(compile_and_run(code));

--- a/tests/unit/python/execution_tree/primitives/lambda.py
+++ b/tests/unit/python/execution_tree/primitives/lambda.py
@@ -11,7 +11,7 @@ import numpy as np
 
 @Phylanx
 def f(a, b):
-    return map(lambda x, y: x * y, a, b)
+    return fmap(lambda x, y: x * y, a, b)  # noqa: F821
 
 
 assert f([1, 2], [3, 4]) == [3, 8]
@@ -27,7 +27,7 @@ assert (f(np.array([[1., 2.], [3., 4.]]), np.array(
 
 @Phylanx
 def f(a):
-    return map(lambda x: x * 2, a)
+    return fmap(lambda x: x * 2, a)  # noqa: F821
 
 
 assert f([1, 2]) == [2, 4]
@@ -42,7 +42,7 @@ assert (f(np.array([[1., 2.], [3., 4.]])) == np.array([[2., 4.], [6.,
 
 @Phylanx
 def f(a):
-    return map(lambda x: not x, a)
+    return fmap(lambda x: not x, a)  # noqa: F821
 
 
 assert f([True, False]) == [False, True]


### PR DESCRIPTION
This PR renames `map` primitive to `fmap`. This is done because the `map` function in Python returns an iterable instead of a list, as Phylanx `map` does.