### PR TITLE
Disable direct actions on POWER8/clang

### DIFF
--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -271,7 +271,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         static std::int64_t exec_upper_threshold =
             std::stol(hpx::get_config_entry(
-                "phylanx.exec_time_upper_threshold", "500000"));
+                "phylanx.exec_time_upper_threshold",
+/* What's going on here?  Well, direct actions cause problems on POWER8
+ * with Clang 5.0. That's because the call stack gets too deep.  Changing
+ * this threshold to 0 will disable direct actions on that platform. 
+ * There is also a github issue #584 that explains this in detail. */
+#if defined(__POWERPC__) && defined(__clang_version__)
+                "0"
+#else
+                "500000"
+#endif
+                ));
         return exec_upper_threshold;
     }
 

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -274,7 +274,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "phylanx.exec_time_upper_threshold",
 /* What's going on here?  Well, direct actions cause problems on POWER8
  * with Clang 5.0. That's because the call stack gets too deep.  Changing
- * this threshold to 0 will disable direct actions on that platform. 
+ * this threshold to 0 will disable direct actions on that platform.
  * There is also a github issue #584 that explains this in detail. */
 #if defined(__POWERPC__) && defined(__clang_version__)
                 "0"


### PR DESCRIPTION
Recursive functions (fibonacci) eventually crash on power8/clang
with direct actions, so this change will prevent that crash from
happening.  Issue #584 still needs to be fixed.