### PR TITLE
Use Blaze 3.4 instead of master

### DIFF
--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -44,9 +44,11 @@ RUN apt-get update &&                                                           
     )                                                                            && \
     rm -rf /pybind11-src                                                         && \
                                                                                     \
-    git clone --depth=1 https://bitbucket.org/blaze-lib/blaze.git /blaze-src     && \
-    (                                                                               \
+    (                                                                               \                                                                                \
+    mkdir /blaze-src                                                             && \
     cd /blaze-src                                                                && \
+    curl -JL https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.4.tar.gz |     \
+        tar xz --strip-components=2                                              && \
     cmake -H. -Bbuild -DBLAZE_SMP_THREADS=C++11                                  && \
     cmake --build build -- install                                                  \
     )                                                                            && \


### PR DESCRIPTION
This PR uses Blaze 3.4 instead of master for Phylanx's CircleCI base image.

This is done because of the following errors caused by Blaze using C++17 functionality that is not compatible with Clang 5 we use (see https://circleci.com/gh/STEllAR-GROUP/phylanx/8805):
```
In file included from /usr/local/include/blaze/math/views/Subvector.h:77:
/usr/local/include/blaze/util/SmallArray.h:357:7: error: no member named 'uninitialized_move' in namespace 'std'; did you mean 'boost::uninitialized_move'?
      std::uninitialized_move( sa.begin_, sa.end_, begin_ );
      ^~~~~
/usr/include/boost/move/algo/move.hpp:111:3: note: 'boost::uninitialized_move' declared here
F uninitialized_move(I f, I l, F r
  ^
```