### PR TITLE
Expose performance information (CSV, DOT) to Python

### DIFF
--- a/phylanx/util/performance_data.hpp
+++ b/phylanx/util/performance_data.hpp
@@ -33,6 +33,36 @@ namespace phylanx { namespace util
     PHYLANX_EXPORT std::vector<std::string> enable_measurements(
         std::map<std::string, hpx::id_type> const& primitive_instances);
 
+    /// Enable the collection of performance data for the given list of
+    /// primitives.
+    ///
+    /// \param primitive_instances The primitives for which performance counter
+    ///                 data is required
+    ///
+    /// \note This has to be called after compilation of a PhySL code block and
+    ///       before its execution.
+    ///
+    /// \returns The list of primitives for which the collection of performance
+    ///          data was enabled
+    ///
+    PHYLANX_EXPORT std::vector<std::string> enable_measurements(
+        std::vector<std::string> const& primitive_instances);
+
+    /// Enable the collection of performance data for the given list of
+    /// primitives.
+    ///
+    /// \param primitive_instance The primitive for which performance counter
+    ///                 data is required
+    ///
+    /// \note This has to be called after compilation of a PhySL code block and
+    ///       before its execution.
+    ///
+    /// \returns The primitive for which the collection of performance
+    ///          data was enabled
+    ///
+    PHYLANX_EXPORT std::string enable_measurements(
+        std::string const& primitive_instance);
+
     /// Enable the collection of performance data for all existing primitives.
     ///
     /// \note This has to be called after compilation of a PhySL code block and

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -103,8 +103,8 @@ class PhySL:
                 self.numpy_aliases.add(key)
         self.file_name = self.fglobals['__file__']
 
-        self.performance = not (kwargs.get('performance') is None)
-        self.__perfdata__ = (None, None)
+        self.performance = kwargs.get('performance')
+        self.__perfdata__ = (None, None, None)
 
         # Add arguments of the function to the list of discovered variables.
         if inspect.isfunction(tree.body[0]):
@@ -165,7 +165,7 @@ class PhySL:
     def call(self, args):
         func_name = self.wrapped_function.__name__
 
-        self.__perfdata__ = (None, None)
+        self.__perfdata__ = (None, None, None)
         self.performance_primitives = None
 
         if self.performance:
@@ -177,11 +177,12 @@ class PhySL:
             self.file_name, func_name, PhySL.compiler_state, *args)
 
         if self.performance:
+            treedata = phylanx.execution_tree.retrieve_tree_topology(
+                self.file_name, func_name, PhySL.compiler_state)
             self.__perfdata__ = (
                 phylanx.execution_tree.retrieve_counter_data(
                     PhySL.compiler_state),
-                phylanx.execution_tree.retrieve_tree_topology(
-                    self.file_name, func_name, PhySL.compiler_state)
+                treedata[0], treedata[1]
             )
 
         return result

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -22,13 +22,13 @@ def Phylanx(__phylanx_arg=None, **kwargs):
             """
             :function:f the decorated funtion.
             """
-            valid_kwargs = ['debug', 'target', 'compiler_state']
+            valid_kwargs = ['debug', 'target', 'compiler_state', 'performance']
 
             self.backends_map = {'PhySL': PhySL, 'OpenSCoP': OpenSCoP}
             self.backend = self.get_backend(kwargs.get('target'))
             for key in kwargs.keys():
                 if key not in valid_kwargs:
-                    raise NotImplementedError("Uknown Phylanx argument '%s'." % key)
+                    raise NotImplementedError("Unknown Phylanx argument '%s'." % key)
 
             # Obtain global environment if the object is a function.
             if inspect.isclass(f):
@@ -78,7 +78,12 @@ def Phylanx(__phylanx_arg=None, **kwargs):
             if self.backend == 'OpenSCoP':
                 raise NotImplementedError(
                     "OpenSCoP kernels are not yet callable.")
-            return self.backend.call(args)
+
+            result = self.backend.call(args)
+
+            self.__perfdata__ = self.backend.__perfdata__
+
+            return result
 
         def generate_ast(self):
             return generate_phylanx_ast(self.__src__)

--- a/python/src/bindings/binding_helpers.cpp
+++ b/python/src/bindings/binding_helpers.cpp
@@ -1,0 +1,191 @@
+//  Copyright (c) 2017-2018 Hartmut Kaiser
+//  Copyright (c) 2018 R. Tohid
+//  Copyright (c) 2018 Steven R. Brandt
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <bindings/binding_helpers.hpp>
+#include <bindings/type_casters.hpp>
+#include <pybind11/pybind11.h>
+
+#include <algorithm>
+#include <iterator>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace bindings
+{
+    ///////////////////////////////////////////////////////////////////////////
+    std::string expression_compiler(std::string const& file_name,
+        std::string const& xexpr_str, compiler_state& c)
+    {
+        pybind11::gil_scoped_release release;       // release GIL
+
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> std::string
+            {
+                auto const& code = phylanx::execution_tree::compile(
+                    file_name, xexpr_str, c.eval_snippets, c.eval_env);
+
+                if (c.enable_measurements)
+                {
+                    c.primitive_instances.push_back(
+                        phylanx::util::enable_measurements(
+                            code.entry_point().name_));
+                }
+
+                return code.entry_point().name_;
+            });
+    }
+
+    phylanx::execution_tree::primitive_argument_type
+    expression_evaluator(
+        std::string const& file_name, std::string const& xexpr_str,
+        compiler_state& c, pybind11::args args)
+    {
+        pybind11::gil_scoped_release release;       // release GIL
+
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> phylanx::execution_tree::primitive_argument_type
+            {
+                auto const& code_x = phylanx::execution_tree::compile(
+                    file_name, xexpr_str, c.eval_snippets, c.eval_env);
+
+                if (c.enable_measurements)
+                {
+                    c.primitive_instances.push_back(
+                        phylanx::util::enable_measurements(
+                            code_x.entry_point().name_));
+                }
+
+                auto x = code_x.run();
+
+                phylanx::execution_tree::primitive_arguments_type keep_alive;
+                keep_alive.reserve(args.size());
+                phylanx::execution_tree::primitive_arguments_type fargs;
+                fargs.reserve(args.size());
+
+                {
+                    pybind11::gil_scoped_acquire acquire;
+                    for (auto const& item : args)
+                    {
+                        phylanx::execution_tree::primitive_argument_type value =
+                            item.cast<
+                            phylanx::execution_tree::primitive_argument_type>();
+                        keep_alive.emplace_back(std::move(value));
+                        fargs.emplace_back(extract_ref_value(keep_alive.back()));
+                    }
+                }
+
+                return x(std::move(fargs));
+            });
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // initialize measurements for tree evaluations
+    std::vector<std::string> enable_measurements(compiler_state& c,
+        bool reset_counters)
+    {
+        pybind11::gil_scoped_release release;       // release GIL
+
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> std::vector<std::string>
+        {
+            // measurements have been enabled
+            c.enable_measurements = true;
+
+            c.primitive_instances =
+                phylanx::util::enable_measurements(c.primitive_instances);
+
+            if (reset_counters)
+            {
+                hpx::reset_active_counters();
+            }
+
+            return c.primitive_instances;
+        });
+    }
+
+    // retrieve performance data from all active performance counters
+    std::string retrieve_counter_data(compiler_state& c)
+    {
+        if (!c.enable_measurements)
+        {
+            return std::string{};
+        }
+
+        pybind11::gil_scoped_release release;       // release GIL
+
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> std::string
+            {
+                // make sure all counters 'know' about all primitives
+                hpx::reinit_active_counters();
+
+                std::ostringstream os;
+
+                // CSV Header
+                os << "primitive_instance,display_name,count,time,eval_direct\n";
+
+                // Print performance data
+                for (auto const& entry :
+                    phylanx::util::retrieve_counter_data(c.primitive_instances))
+                {
+                    os << "\"" << entry.first << "\",\""
+                       << phylanx::execution_tree::compiler::
+                              primitive_display_name(entry.first)
+                       << "\"";
+                    for (auto const& counter_value : entry.second)
+                    {
+                        os << "," << counter_value;
+                    }
+                    os << "\n";
+                }
+
+                os << "\n";
+                return os.str();
+            });
+    }
+
+    // retrieve tree topology in DOT format for given expression
+    std::string retrieve_tree_topology(std::string const& file_name,
+        std::string const& xexpr_str, compiler_state& c)
+    {
+        pybind11::gil_scoped_release release;       // release GIL
+
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> std::string
+            {
+                auto const& code = phylanx::execution_tree::compile(
+                    file_name, xexpr_str, c.eval_snippets, c.eval_env);
+
+                if (c.enable_measurements)
+                {
+                    c.primitive_instances.push_back(
+                        phylanx::util::enable_measurements(
+                            code.entry_point().name_));
+                }
+
+                std::set<std::string> resolve_children;
+                for (auto const& f : code.entry_points())
+                {
+                    resolve_children.insert(f.name_);
+                }
+                for (auto const& f : code.scratchpad())
+                {
+                    resolve_children.insert(f.name_);
+                }
+
+                auto topology = code.get_expression_topology(
+                    std::set<std::string>{}, std::move(resolve_children));
+
+                return phylanx::execution_tree::dot_tree(file_name, topology);
+            });
+    }
+}}

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -16,6 +16,7 @@
 
 #include <cstdint>
 #include <exception>
+#include <list>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -176,7 +177,16 @@ namespace phylanx { namespace bindings
     std::string retrieve_counter_data(compiler_state& c);
 
     // retrieve tree topology in DOT format for given expression
-    std::string retrieve_tree_topology(std::string const& file_name,
+    std::list<std::string> retrieve_tree_topology(
+        std::string const& file_name, std::string const& xexpr_str,
+        compiler_state& c);
+
+    // retrieve tree topology in DOT format for given expression
+    std::string retrieve_dot_tree_topology(std::string const& file_name,
+        std::string const& xexpr_str, compiler_state& c);
+
+    // retrieve tree topology in Newick format for given expression
+    std::string retrieve_newick_tree_topology(std::string const& file_name,
         std::string const& xexpr_str, compiler_state& c);
 }}
 

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -18,8 +18,8 @@
 #include <exception>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace bindings
@@ -39,6 +39,10 @@ namespace phylanx { namespace bindings
         phylanx::execution_tree::compiler::environment eval_env;
         phylanx::execution_tree::compiler::function_list eval_snippets;
 
+        // data related to measurement status
+        bool enable_measurements;
+        std::vector<std::string> primitive_instances;
+
         static pybind11::object import_phylanx()
         {
 #if defined(_DEBUG)
@@ -52,6 +56,7 @@ namespace phylanx { namespace bindings
           : m(import_phylanx())
           , eval_env(phylanx::execution_tree::compiler::default_environment())
           , eval_snippets()
+          , enable_measurements(false)
         {
         }
     };
@@ -153,54 +158,26 @@ namespace phylanx { namespace bindings
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    inline void expression_compiler(std::string const& file_name, std::string xexpr_str,
-        compiler_state& c)
-    {
-        pybind11::gil_scoped_release release;       // release GIL
+    // compile expression
+    std::string expression_compiler(std::string const& file_name,
+        std::string const& xexpr_str, compiler_state& c);
 
-        return hpx::threads::run_as_hpx_thread(
-            [&]() -> void
-            {
-                phylanx::execution_tree::compile(
-                    file_name, phylanx::ast::generate_ast(xexpr_str), c.eval_snippets,
-                    c.eval_env);
-            });
-    };
+    // evaluate compiled expression
+    phylanx::execution_tree::primitive_argument_type expression_evaluator(
+        std::string const& file_name, std::string const& xexpr_str,
+        compiler_state& c, pybind11::args args);
 
     ///////////////////////////////////////////////////////////////////////////
-    inline phylanx::execution_tree::primitive_argument_type
-    expression_evaluator(
-        std::string xexpr_str, compiler_state& c, pybind11::args args)
-    {
-        pybind11::gil_scoped_release release;       // release GIL
+    // initialize measurements for tree evaluations
+    std::vector<std::string> enable_measurements(
+        compiler_state& c, bool reset_counters);
 
-        return hpx::threads::run_as_hpx_thread(
-            [&]() -> phylanx::execution_tree::primitive_argument_type
-            {
-                pybind11::gil_scoped_acquire acquire;
-                auto xexpr = phylanx::ast::generate_ast(xexpr_str);
-                auto const& code_x = phylanx::execution_tree::compile(
-                    xexpr, c.eval_snippets, c.eval_env);
-                auto x = code_x.run();
+    // retrieve performance data from all active performance counters
+    std::string retrieve_counter_data(compiler_state& c);
 
-                phylanx::execution_tree::primitive_arguments_type keep_alive;
-                keep_alive.reserve(args.size());
-                phylanx::execution_tree::primitive_arguments_type fargs;
-                fargs.reserve(args.size());
-
-                for (auto const& item : args)
-                {
-                    phylanx::execution_tree::primitive_argument_type value =
-                        item.cast<
-                            phylanx::execution_tree::primitive_argument_type>();
-                    keep_alive.emplace_back(std::move(value));
-                    fargs.emplace_back(extract_ref_value(keep_alive.back()));
-                }
-
-                pybind11::gil_scoped_release release;       // release GIL
-                return x(std::move(fargs));
-            });
-    };
+    // retrieve tree topology in DOT format for given expression
+    std::string retrieve_tree_topology(std::string const& file_name,
+        std::string const& xexpr_str, compiler_state& c);
 }}
 
 #endif

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -11,6 +11,7 @@
 #include <bindings/type_casters.hpp>
 
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 #include <string>
 #include <vector>
@@ -92,9 +93,18 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
         phylanx::bindings::retrieve_counter_data,
         "retrieve performance data from all active performance counters");
 
+    execution_tree.def("retrieve_dot_tree_topology",
+        phylanx::bindings::retrieve_dot_tree_topology,
+        "retrieve the DOT tree topology for the given execution tree");
+
+    execution_tree.def("retrieve_newick_tree_topology",
+        phylanx::bindings::retrieve_newick_tree_topology,
+        "retrieve the Newick tree topology for the given execution tree");
+
     execution_tree.def("retrieve_tree_topology",
         phylanx::bindings::retrieve_tree_topology,
-        "retrieve the tree topology for the given execution tree");
+        "retrieve the Newick and DOT tree topologies for the given "
+        "execution tree");
 
     // phylanx.execution_tree.primitive
     pybind11::class_<phylanx::execution_tree::primitive>(execution_tree,

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -74,6 +74,29 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
     execution_tree.def("eval", phylanx::bindings::expression_evaluator,
         "compile and evaluate a numerical expression in PhySL");
 
+    execution_tree.def("eval",
+        [](std::string const& xexpr, compiler_state& c, pybind11::args args)
+        ->  phylanx::execution_tree::primitive_argument_type
+        {
+            return phylanx::bindings::expression_evaluator(
+                "<unknown>", xexpr, c, args);
+        },
+        "compile and evaluate a numerical expression in PhySL");
+
+    // expose functionalities needed for accessing performance data
+    execution_tree.def("enable_measurements",
+        phylanx::bindings::enable_measurements,
+        "enable all performance counters for the current execution tree");
+
+    execution_tree.def("retrieve_counter_data",
+        phylanx::bindings::retrieve_counter_data,
+        "retrieve performance data from all active performance counters");
+
+    execution_tree.def("retrieve_tree_topology",
+        phylanx::bindings::retrieve_tree_topology,
+        "retrieve the tree topology for the given execution tree");
+
+    // phylanx.execution_tree.primitive
     pybind11::class_<phylanx::execution_tree::primitive>(execution_tree,
         "primitive", "type representing an arbitrary execution tree")
         .def(pybind11::init<>())


### PR DESCRIPTION
This adds a new option to the @PhySL decorator (`performance=…`, the value of this decorator argument is ignored, currently). If this is set, then a decorated function object `func` will expose `func.__perfdata__`, which is a tuple containing the CSV data and the DOT tree structure (both strings).
