### PR TITLE
First steps towards allowing assignments to function arguments

### DIFF
--- a/phylanx/execution_tree/primitives/access_argument.hpp
+++ b/phylanx/execution_tree/primitives/access_argument.hpp
@@ -33,6 +33,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& params,
             eval_mode) const override;
 
+        void store(primitive_arguments_type&& data,
+            primitive_arguments_type&& params) override;
+
+        void store(primitive_argument_type&& data,
+            primitive_arguments_type&& params) override;
+
     private:
         std::size_t argnum_;
     };

--- a/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
@@ -315,7 +315,11 @@ namespace phylanx { namespace execution_tree
                     "row-step can not be zero", name, codename));
         }
 
-        HPX_ASSERT(false);      // not implemented yet
+        HPX_THROW_EXCEPTION(hpx::not_implemented,
+            "phylanx::execution_tree::slice2d_basic_boolean",
+            util::generate_error_message(
+                "this operation is not supported (yet)", name, codename));
+
         return {};
     }
 
@@ -523,7 +527,11 @@ namespace phylanx { namespace execution_tree
                     "column-step can not be zero", name, codename));
         }
 
-        HPX_ASSERT(false);      // not implemented yet
+        HPX_THROW_EXCEPTION(hpx::not_implemented,
+            "phylanx::execution_tree::slice2d_boolean_basic",
+            util::generate_error_message(
+                "this operation is not supported (yet)", name, codename));
+
         return {};
     }
 
@@ -609,7 +617,11 @@ namespace phylanx { namespace execution_tree
                 detail::check_index(rows[i], numrows, name, codename);
         }
 
-        HPX_ASSERT(false);      // not implemented yet
+        HPX_THROW_EXCEPTION(hpx::not_implemented,
+            "phylanx::execution_tree::slice2d_integer_boolean",
+            util::generate_error_message(
+                "this operation is not supported (yet)", name, codename));
+
         return {};
     }
 
@@ -627,7 +639,11 @@ namespace phylanx { namespace execution_tree
                 detail::check_index(columns[i], numcols, name, codename);
         }
 
-        HPX_ASSERT(false);      // not implemented yet
+        HPX_THROW_EXCEPTION(hpx::not_implemented,
+            "phylanx::execution_tree::slice2d_boolean_integer",
+            util::generate_error_message(
+                "this operation is not supported (yet)", name, codename));
+
         return {};
     }
 
@@ -637,7 +653,11 @@ namespace phylanx { namespace execution_tree
         ir::node_data<std::uint8_t> && columns, F const& f,
         std::string const& name, std::string const& codename)
     {
-        HPX_ASSERT(false);      // not implemented yet
+        HPX_THROW_EXCEPTION(hpx::not_implemented,
+            "phylanx::execution_tree::slice2d_boolean_boolean",
+            util::generate_error_message(
+                "this operation is not supported (yet)", name, codename));
+
         return {};
     }
 
@@ -867,7 +887,11 @@ namespace phylanx { namespace execution_tree
             }
             if (!valid(columns))
             {
-                HPX_ASSERT(false);      // not implemented yet
+                HPX_THROW_EXCEPTION(hpx::not_implemented,
+                    "phylanx::execution_tree::slice2d",
+                    util::generate_error_message(
+                        "this operation is not supported (yet)",
+                        name, codename));
             }
         }
         else if (is_integer_operand(rows))
@@ -890,7 +914,11 @@ namespace phylanx { namespace execution_tree
             }
             if (!valid(columns))
             {
-                HPX_ASSERT(false);      // not implemented yet
+                HPX_THROW_EXCEPTION(hpx::not_implemented,
+                    "phylanx::execution_tree::slice2d",
+                    util::generate_error_message(
+                        "this operation is not supported (yet)",
+                        name, codename));
 //                 return slice1d<T>(
 //                     input_matrix.matrix(), rows, f, name, codename);
             }

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -234,6 +234,9 @@ class PhySL:
         if node.vararg or node.kwarg:
             raise (Exception("Phylanx does not support *args and **kwargs"))
         args = tuple(map(self.apply_rule, node.args))
+        for arg in args:
+            symbol_name = re.sub(r'\$\d+', '', arg)
+            self.defined.add(symbol_name)
         return args
 
     def _Assign(self, node):

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -125,18 +125,28 @@ namespace phylanx { namespace bindings
     template <typename T>
     std::string as_string(T const& value)
     {
-        std::stringstream strm;
-        strm << value;
-        return strm.str();
+        pybind11::gil_scoped_release release;       // release GIL
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> std::string
+            {
+                std::stringstream strm;
+                strm << value;
+                return strm.str();
+            });
     }
 
     // support for __repr__
     template <typename T>
     std::string repr(T const& value)
     {
-        std::stringstream strm;
-        strm << phylanx::util::repr << value << phylanx::util::norepr;
-        return strm.str();
+        pybind11::gil_scoped_release release;       // release GIL
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> std::string
+            {
+                std::stringstream strm;
+                strm << phylanx::util::repr << value << phylanx::util::norepr;
+                return strm.str();
+            });
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -145,17 +155,24 @@ namespace phylanx { namespace bindings
     std::vector<char> pickle_helper(Ast const& ast)
     {
         pybind11::gil_scoped_release release;       // release GIL
-        return phylanx::util::serialize(ast);
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> std::vector<char>
+            {
+                return phylanx::util::serialize(ast);
+            });
     }
 
     template <typename Ast>
-    Ast unpickle_helper(std::vector<char> data)
+    Ast unpickle_helper(std::vector<char> const& data)
     {
         pybind11::gil_scoped_release release;       // release GIL
-
-        Ast ast;
-        phylanx::util::detail::unserialize(data, ast);
-        return ast;
+        return hpx::threads::run_as_hpx_thread(
+            [&]() -> Ast
+            {
+                Ast ast;
+                phylanx::util::detail::unserialize(data, ast);
+                return ast;
+            });
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -481,7 +481,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 auto at = cf->target<access_target>();
                 if (at == nullptr || at->target_name_ != "access-variable")
                 {
-//                     if (cf->target<access_argument>() == nullptr)
+                    if (cf->target<access_argument>() == nullptr)
                     {
                         return false;
                     }

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -189,8 +189,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 return;
 
             case 1:
+                {
+                    HPX_THROW_EXCEPTION(hpx::not_implemented,
+                        "phylanx::execution_tree::primitives::access_argument::"
+                            "store",
+                        generate_error_message(
+                            "assignment to (non-sliced) function argument is "
+                            "not supported (yet)"));
+                }
+                break;
+
             default:
-                HPX_ASSERT(false);
                 break;
             }
         }
@@ -270,8 +279,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 return;
 
             case 1:
+                {
+                    HPX_THROW_EXCEPTION(hpx::not_implemented,
+                        "phylanx::execution_tree::primitives::access_argument::"
+                            "store",
+                        generate_error_message(
+                            "assignment to (non-sliced) function argument is "
+                            "not supported (yet)"));
+                }
+
             default:
-                HPX_ASSERT(false);
                 break;
             }
         }

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -10,6 +10,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/throw_exception.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <memory>
 #include <string>
@@ -34,20 +35,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename, true)
     {
-        if (operands_.size() != 1)
+        // operands_[0] is expected to be the actual variable, operands_[1] and
+        // operands_[2] are optional slicing arguments
+
+        if (operands_.empty() || operands_.size() > 3)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "access_argument::access_argument",
                 generate_error_message(
-                    "the access_argument primitive expects to be initialized "
-                    "with exactly one argument"));
+                    "the access_argument primitive requires at least one "
+                    "and at most three operands"));
         }
 
         argnum_ = extract_integer_value(operands_[0])[0];
     }
 
     hpx::future<primitive_argument_type> access_argument::eval(
-        primitive_arguments_type const& params, eval_mode) const
+        primitive_arguments_type const& params, eval_mode mode) const
     {
         if (argnum_ >= params.size())
         {
@@ -60,7 +64,223 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         argnum_ + 1, params.size())));
         }
 
+        // handle slicing, we can replace the params with our slicing
+        // parameters as argument evaluation can't depend on those anyways
+        switch (operands_.size())
+        {
+        case 2:
+        case 3:
+            {
+                // one slicing parameter
+                if (is_primitive_operand(params[argnum_]))
+                {
+                    primitive_arguments_type fargs;
+                    fargs.reserve(operands_.size() - 1);
+                    for (auto it = operands_.begin() + 1; it != operands_.end();
+                         ++it)
+                    {
+                        fargs.emplace_back(
+                            extract_ref_value(*it, name_, codename_));
+                    }
+
+                    mode = eval_mode(mode | eval_dont_wrap_functions);
+                    return value_operand(params[argnum_], std::move(fargs),
+                        name_, codename_, mode);
+                }
+
+                if (operands_.size() > 2)
+                {
+                    // handle row/column-slicing
+                    auto this_ = this->shared_from_this();
+                    return hpx::dataflow(
+                        hpx::launch::sync,
+                        [   this_ = std::move(this_), mode,
+                            target = params[argnum_]
+                        ](hpx::future<primitive_argument_type>&& rows,
+                                hpx::future<primitive_argument_type>&& cols)
+                        ->  primitive_argument_type
+                        {
+                            return slice(target, rows.get(), cols.get(),
+                                this_->name_, this_->codename_);
+                        },
+                        value_operand(operands_[1], params, name_, codename_),
+                        value_operand(operands_[2], params, name_, codename_));
+                }
+
+                // handle row-slicing
+                auto this_ = this->shared_from_this();
+                return value_operand(operands_[1], params, name_, codename_)
+                    .then(hpx::launch::sync,
+                        [   this_ = std::move(this_), mode,
+                            target = params[argnum_]
+                        ](hpx::future<primitive_argument_type>&& rows)
+                        -> primitive_argument_type
+                        {
+                            return slice(target, rows.get(), this_->name_,
+                                this_->codename_);
+                        });
+            }
+
+        default:
+            break;
+        }
+
         return hpx::make_ready_future(
             extract_value(params[argnum_], name_, codename_));
+    }
+
+    void access_argument::store(primitive_arguments_type&& data,
+        primitive_arguments_type&& params)
+    {
+        if (data.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "access_argument::store",
+                generate_error_message(
+                    "invoking store with slicing parameters is not supported"));
+        }
+
+        if (argnum_ >= params.size())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::access_argument::store",
+                generate_error_message(hpx::util::format(
+                    "argument count out of bounds, expected at least "
+                    PHYLANX_FORMAT_SPEC(1) " argument(s) while only "
+                    PHYLANX_FORMAT_SPEC(2) " argument(s) were supplied",
+                    argnum_ + 1, params.size())));
+        }
+
+        if (is_primitive_operand(params[argnum_]))
+        {
+            // handle slicing, simply append the slicing parameters to the end
+            // of the argument list
+            data.reserve(data.size() + operands_.size() - 1);
+            for (auto it = operands_.begin() + 1; it != operands_.end(); ++it)
+            {
+                data.emplace_back(extract_ref_value(*it, name_, codename_));
+            }
+
+            primitive* p = util::get_if<primitive>(&operands_[0]);
+            HPX_ASSERT(p != nullptr);
+
+            p->store(hpx::launch::sync, std::move(data), std::move(params));
+        }
+        else if (is_ref_value(params[argnum_]))
+        {
+            switch (operands_.size())
+            {
+            case 2:
+                slice(std::move(params[argnum_]),
+                    value_operand_sync(std::move(operands_[1]),
+                        std::move(params), name_, codename_),
+                    std::move(data[0]), name_, codename_);
+                return;
+
+            case 3:
+                {
+                    auto data1 = value_operand_sync(
+                        operands_[1], params, name_, codename_);
+                    slice(std::move(params[argnum_]), std::move(data1),
+                        value_operand_sync(
+                            operands_[2], std::move(params), name_, codename_),
+                        std::move(data[0]), name_, codename_);
+                }
+                return;
+
+            case 1:
+            default:
+                HPX_ASSERT(false);
+                break;
+            }
+        }
+        else
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::access_argument::store",
+                generate_error_message(
+                    "storing a value to a local value has no effect"));
+        }
+    }
+
+    void access_argument::store(primitive_argument_type&& data,
+        primitive_arguments_type&& params)
+    {
+        if (argnum_ >= params.size())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::access_argument::store",
+                generate_error_message(hpx::util::format(
+                    "argument count out of bounds, expected at least "
+                        PHYLANX_FORMAT_SPEC(1) " argument(s) while only "
+                        PHYLANX_FORMAT_SPEC(2) " argument(s) were supplied",
+                        argnum_ + 1, params.size())));
+        }
+
+        if (is_primitive_operand(params[argnum_]))
+        {
+            if (operands_.size() > 1)
+            {
+                // handle slicing, simply append the slicing parameters to the
+                // end of the argument list
+                primitive_arguments_type vals;
+                vals.reserve(operands_.size());
+                vals.emplace_back(std::move(data));
+
+                for (auto it = operands_.begin() + 1; it != operands_.end();
+                     ++it)
+                {
+                    vals.emplace_back(extract_ref_value(*it, name_, codename_));
+                }
+
+                primitive* p = util::get_if<primitive>(&params[argnum_]);
+                HPX_ASSERT(p != nullptr);
+
+                p->store(hpx::launch::sync, std::move(vals), std::move(params));
+            }
+            else
+            {
+                // no slicing parameters given, simply dispatch request
+                primitive* p = util::get_if<primitive>(&operands_[0]);
+                HPX_ASSERT(p != nullptr);
+
+                p->store(hpx::launch::sync, std::move(data), std::move(params));
+            }
+        }
+        else if (is_ref_value(params[argnum_]))
+        {
+            switch (operands_.size())
+            {
+            case 2:
+                slice(std::move(params[argnum_]),
+                    value_operand_sync(std::move(operands_[1]),
+                        std::move(params), name_, codename_),
+                    std::move(data), name_, codename_);
+                return;
+
+            case 3:
+                {
+                    auto data1 = value_operand_sync(
+                        operands_[1], params, name_, codename_);
+                    slice(std::move(params[argnum_]), std::move(data1),
+                        value_operand_sync(operands_[2], std::move(params),
+                            name_, codename_),
+                        std::move(data), name_, codename_);
+                }
+                return;
+
+            case 1:
+            default:
+                HPX_ASSERT(false);
+                break;
+            }
+        }
+        else
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::access_argument::store",
+                generate_error_message(
+                    "storing a value to a local value has no effect"));
+        }
     }
 }}}

--- a/src/execution_tree/primitives/access_variable.cpp
+++ b/src/execution_tree/primitives/access_variable.cpp
@@ -70,7 +70,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         eval_mode mode) const
     {
         // handle slicing, we can replace the params with our slicing
-        // parameter as variable evaluation can't depend on those anyways
+        // parameters as variable evaluation can't depend on those anyways
         mode = eval_mode(mode | eval_dont_wrap_functions);
         switch (operands_.size())
         {

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -136,8 +136,7 @@ namespace phylanx { namespace execution_tree
     }
 
     hpx::future<primitive_argument_type> primitive::eval(
-        primitive_arguments_type const& params,
-        eval_mode mode) const
+        primitive_arguments_type const& params, eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
         hpx::future<primitive_argument_type> f = hpx::async<action_type>(
@@ -145,8 +144,7 @@ namespace phylanx { namespace execution_tree
         return detail::lazy_trace("eval", *this, std::move(f));
     }
     hpx::future<primitive_argument_type> primitive::eval(
-        primitive_arguments_type&& params,
-        eval_mode mode) const
+        primitive_arguments_type&& params, eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
         hpx::future<primitive_argument_type> f = hpx::async<action_type>(
@@ -165,16 +163,14 @@ namespace phylanx { namespace execution_tree
         return detail::lazy_trace("eval", *this, std::move(f));
     }
 
-    hpx::future<primitive_argument_type> primitive::eval(
-        eval_mode mode) const
+    hpx::future<primitive_argument_type> primitive::eval(eval_mode mode) const
     {
         static primitive_arguments_type params;
         return eval(params, mode);
     }
 
     primitive_argument_type primitive::eval(hpx::launch::sync_policy,
-        primitive_arguments_type const& params,
-        eval_mode mode) const
+        primitive_arguments_type const& params, eval_mode mode) const
     {
         using action_type = primitives::primitive_component::eval_action;
         hpx::future<primitive_argument_type> f = hpx::async<action_type>(
@@ -213,8 +209,7 @@ namespace phylanx { namespace execution_tree
         return detail::trace("eval", *this, f.get());
     }
 
-    hpx::future<void> primitive::store(
-        primitive_arguments_type&& data,
+    hpx::future<void> primitive::store(primitive_arguments_type&& data,
         primitive_arguments_type&& params)
     {
         using action_type = primitives::primitive_component::store_action;
@@ -231,8 +226,7 @@ namespace phylanx { namespace execution_tree
     }
 
     void primitive::store(hpx::launch::sync_policy,
-        primitive_arguments_type&& data,
-        primitive_arguments_type&& params)
+        primitive_arguments_type&& data, primitive_arguments_type&& params)
     {
         using action_type = primitives::primitive_component::store_action;
         hpx::sync<action_type>(
@@ -240,8 +234,7 @@ namespace phylanx { namespace execution_tree
     }
 
     void primitive::store(hpx::launch::sync_policy,
-        primitive_argument_type&& data,
-        primitive_arguments_type&& params)
+        primitive_argument_type&& data, primitive_arguments_type&& params)
     {
         using action_type = primitives::primitive_component::store_single_action;
         hpx::sync<action_type>(

--- a/src/execution_tree/primitives/slice.cpp
+++ b/src/execution_tree/primitives/slice.cpp
@@ -61,8 +61,8 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
-                "target object does not hold a numeric, range, or dictionary type and "
-                "as such does not support slicing", name, codename));
+                "target object does not hold a numeric, range, or dictionary "
+                "type and as such does not support slicing", name, codename));
     }
 
     primitive_argument_type slice(primitive_argument_type const& data,

--- a/src/execution_tree/primitives/slice.cpp
+++ b/src/execution_tree/primitives/slice.cpp
@@ -54,8 +54,8 @@ namespace phylanx { namespace execution_tree
         }
         if (is_dictionary_operand(data))
         {
-            auto f = phylanx::execution_tree::extract_dictionary_value(data);
-            return f[indices].get();
+            auto dict = phylanx::execution_tree::extract_dictionary_value(data);
+            return dict[indices].get();
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
@@ -109,48 +109,76 @@ namespace phylanx { namespace execution_tree
                 indices, extract_value(std::move(value), name, codename), name,
                 codename)};
         }
-        else if (is_numeric_operand(data))
+        else if (is_integer_operand_strict(data))
         {
             if (is_integer_operand_strict(value))
             {
                 return primitive_argument_type{slice_assign(
-                    extract_integer_value(std::move(data), name, codename),
+                    extract_integer_value_strict(
+                        std::move(data), name, codename),
                     indices,
                     extract_integer_value_strict(
                         std::move(value), name, codename),
                     name, codename)};
             }
+
+            return primitive_argument_type{slice_assign(
+                extract_integer_value_strict(std::move(data), name, codename),
+                indices,
+                extract_integer_value(std::move(value), name, codename),
+                name, codename)};
+        }
+        else if (is_numeric_operand_strict(data))
+        {
             if (is_numeric_operand_strict(value))
             {
                 return primitive_argument_type{slice_assign(
-                    extract_numeric_value(std::move(data), name, codename),
+                    extract_numeric_value_strict(
+                        std::move(data), name, codename),
                     indices,
                     extract_numeric_value_strict(
                         std::move(value), name, codename),
                     name, codename)};
             }
+
+            return primitive_argument_type{slice_assign(
+                extract_numeric_value_strict(std::move(data), name, codename),
+                indices,
+                extract_numeric_value(std::move(value), name, codename),
+                name, codename)};
+        }
+        else if (is_boolean_operand_strict(data))
+        {
             if (is_boolean_operand_strict(value))
             {
                 return primitive_argument_type{slice_assign(
-                    extract_boolean_value(std::move(data), name, codename),
+                    extract_boolean_value_strict(
+                        std::move(data), name, codename),
                     indices,
                     extract_boolean_value_strict(
                         std::move(value), name, codename),
                     name, codename)};
             }
+
+            return primitive_argument_type{slice_assign(
+                extract_boolean_value_strict(std::move(data), name, codename),
+                indices,
+                extract_boolean_value(std::move(value), name, codename),
+                name, codename)};
         }
-        if (is_dictionary_operand(data))
+        else if (is_dictionary_operand(data))
         {
-            auto&& f = phylanx::execution_tree::extract_dictionary_value(data);
-            f[indices] = value;
-            return primitive_argument_type{f};
+            auto&& dict = phylanx::execution_tree::extract_dictionary_value(
+                std::move(data));
+            dict[indices] = value;
+            return primitive_argument_type{std::move(dict)};
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
-                "target object does not hold a numeric, range, or dictionary type and "
-                "as such does not support slicing", name, codename));
+                "target object does not hold a numeric, range, or dictionary "
+                "type and as such does not support slicing", name, codename));
     }
 
     primitive_argument_type slice(primitive_argument_type&& data,
@@ -158,28 +186,64 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type const& columns, primitive_argument_type&& value,
         std::string const& name, std::string const& codename)
     {
-        if (is_integer_operand_strict(value))
+        if (is_integer_operand_strict(data))
         {
+            if (is_integer_operand_strict(value))
+            {
+                return primitive_argument_type{
+                    slice_assign(
+                        extract_integer_value_strict(
+                            std::move(data), name, codename),
+                        rows, columns,
+                        extract_integer_value_strict(
+                            std::move(value), name, codename),
+                        name, codename)};
+            }
+
             return primitive_argument_type{slice_assign(
-                extract_integer_value(std::move(data), name, codename), rows,
-                columns,
-                extract_integer_value_strict(std::move(value), name, codename),
+                extract_integer_value_strict(std::move(data), name, codename),
+                rows, columns,
+                extract_integer_value(std::move(value), name, codename),
                 name, codename)};
         }
-        if (is_numeric_operand_strict(value))
+        if (is_numeric_operand_strict(data))
         {
+            if (is_numeric_operand_strict(value))
+            {
+                return primitive_argument_type{
+                    slice_assign(
+                        extract_numeric_value_strict(
+                            std::move(data), name, codename),
+                        rows, columns,
+                        extract_numeric_value_strict(
+                            std::move(value), name, codename),
+                        name, codename)};
+            }
+
             return primitive_argument_type{slice_assign(
-                extract_numeric_value(std::move(data), name, codename), rows,
-                columns,
-                extract_numeric_value_strict(std::move(value), name, codename),
+                extract_numeric_value_strict(std::move(data), name, codename),
+                rows, columns,
+                extract_numeric_value(std::move(value), name, codename),
                 name, codename)};
         }
-        if (is_boolean_operand_strict(value))
+        if (is_boolean_operand_strict(data))
         {
+            if (is_boolean_operand_strict(value))
+            {
+                return primitive_argument_type{
+                    slice_assign(
+                        extract_boolean_value_strict(
+                            std::move(data), name, codename),
+                        rows, columns,
+                        extract_boolean_value_strict(
+                            std::move(value), name, codename),
+                        name, codename)};
+            }
+
             return primitive_argument_type{slice_assign(
-                extract_boolean_value(std::move(data), name, codename), rows,
-                columns,
-                extract_boolean_value_strict(std::move(value), name, codename),
+                extract_boolean_value_strict(std::move(data), name, codename),
+                rows, columns,
+                extract_boolean_value(std::move(value), name, codename),
                 name, codename)};
         }
 

--- a/src/execution_tree/primitives/slice_node_data.cpp
+++ b/src/execution_tree/primitives/slice_node_data.cpp
@@ -94,8 +94,8 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
-                "target ir::node_data object holds data type that does not support "
-                "2d slicing",
+                "target ir::node_data object holds data type that does not "
+                "support 2d slicing",
                 name, codename));
     }
 

--- a/src/execution_tree/primitives/slice_range.cpp
+++ b/src/execution_tree/primitives/slice_range.cpp
@@ -253,7 +253,7 @@ namespace phylanx { namespace execution_tree
 //             }
 //         }
 
-        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+        HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice_list",
             util::generate_error_message(
                 "assignment to list elements based on an index list is not "

--- a/src/execution_tree/primitives/variable.cpp
+++ b/src/execution_tree/primitives/variable.cpp
@@ -191,7 +191,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto data1 =
             value_operand_sync(data[1], params, name_, codename_);
-        auto result = slice(std::move(bound_value_), data1,
+        auto result = slice(std::move(bound_value_), std::move(data1),
             value_operand_sync(
                 data[2], std::move(params), name_, codename_),
             std::move(data[0]), name_, codename_);

--- a/tests/regressions/python/466_compiler_problems.py
+++ b/tests/regressions/python/466_compiler_problems.py
@@ -1,0 +1,55 @@
+#  Copyright (c) 2018 Steven R. Brandt
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #466: ast compiler hangs and gives the wrong answer
+
+import numpy as np
+from phylanx import Phylanx
+
+
+@Phylanx
+def kernel1(a, b):
+    for i in range(1, np.shape(a)[0] - 1):
+        for j in range(1, np.shape(a)[1] - 1):
+            v1 = b[i + 1, j] + b[i - 1, j]
+            v2 = b[i, j + 1] + b[i, j - 1]
+            a[i, j] = v1 + v2
+    return a
+
+
+@Phylanx
+def kernel2(a, b):
+    for i in range(1, np.shape(a)[0] - 1):
+        for j in range(1, np.shape(a)[1] - 1):
+            a[i, j] = b[i + 1, j] + b[i - 1, j] + b[i, j + 1] + b[i, j - 1]
+    return a
+
+
+@Phylanx
+def kernel3(a, b):
+    result = a
+    for i in range(1, np.shape(a)[0] - 1):
+        for j in range(1, np.shape(a)[1] - 1):
+            result[i, j] = b[i + 1, j] + b[i - 1, j] + b[i, j + 1] + b[i, j - 1]
+    return result
+
+
+expected = np.array([[1, 2, 3, 4],
+                     [2, 12, 8, 1],
+                     [3, 8, 12, 2],
+                     [4, 1, 2, 3]])
+
+a = np.array([[1, 2, 3, 4],
+              [2, 3, 4, 1],
+              [3, 4, 1, 2],
+              [4, 1, 2, 3]])
+b = np.array([[1, 2, 3, 4],
+              [2, 3, 4, 1],
+              [3, 4, 1, 2],
+              [4, 1, 2, 3]])
+
+assert((kernel1(a, b) == expected).all())
+assert((kernel2(a, b) == expected).all())
+assert((kernel3(a, b) == expected).all())

--- a/tests/regressions/python/640_function_argument.py
+++ b/tests/regressions/python/640_function_argument.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2018 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx import Phylanx
+
+
+@Phylanx
+def test_assign(x):
+    x = 1
+    return x
+
+
+assert(test_assign.__src__ ==
+        'define$11$0(test_assign$11$0, x$11$16, ' + \       # noqa: W504
+        'block(store$12$4(x$12$4, 1), x$13$11))')

--- a/tests/regressions/python/640_function_argument.py
+++ b/tests/regressions/python/640_function_argument.py
@@ -3,6 +3,8 @@
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+# flake8: noqa
+
 import numpy as np
 from phylanx import Phylanx
 
@@ -14,5 +16,5 @@ def test_assign(x):
 
 
 assert(test_assign.__src__ ==
-        'define$11$0(test_assign$11$0, x$11$16, ' + \       # noqa: W504
-        'block(store$12$4(x$12$4, 1), x$13$11))')
+        'define$13$0(test_assign$13$0, x$13$16, ' + \
+        'block(store$14$4(x$14$4, 1), x$15$11))')

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    466_compiler_problems
     508_unknown_named_argument
     522_multidimension_np_arrays
     530_augmented_assignment_indexed_lhs
@@ -11,6 +12,7 @@ set(tests
     624_advanced_indexing
     635_arange_args
     636_boolean_array
+    640_function_argument
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tools/VS/primitive_argument_type.natvis
+++ b/tools/VS/primitive_argument_type.natvis
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<!-- Copyright (c) 2017 Hartmut Kaiser                                      -->
+<!-- Copyright (c) 2017-2018 Hartmut Kaiser                                 -->
 
 <!-- Use, modification and distribution are subject to the Boost Software   -->
 <!-- License, Version 1.0. (See accompanying file LICENSE_1_0.txt           -->
@@ -10,22 +10,24 @@
 
     <Type Name="phylanx::execution_tree::primitive_argument_type">
         <DisplayString Condition="(var.impl_.index_ == 0)">nil</DisplayString>
-        <DisplayString Condition="(var.impl_.index_ == 1)">phylanx::ir::node_data&lt;bool&gt;({var.impl_.data_.tail_.head_.value})</DisplayString>
-        <DisplayString Condition="(var.impl_.index_ == 2)">std::int64_t({var.impl_.data_.tail_.tail_.head_.value})</DisplayString>
+        <DisplayString Condition="(var.impl_.index_ == 1)">phylanx::ir::node_data&lt;std::uint8_t&gt;({var.impl_.data_.tail_.head_.value})</DisplayString>
+        <DisplayString Condition="(var.impl_.index_ == 2)">phylanx::ir::node_data&lt;std::int64_t&gt;({var.impl_.data_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 3)">std::string({var.impl_.data_.tail_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 4)">phylanx::ir::node_data&lt;double&gt;({var.impl_.data_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 5)">phylanx::execution_tree::primitive({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 6)">std::vector&lt;phylanx::ast::expression&gt;({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <DisplayString Condition="(var.impl_.index_ == 7)">phylanx::ir::range({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
+        <DisplayString Condition="(var.impl_.index_ == 8)">phylanx::ir::dictionary({var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value})</DisplayString>
         <Expand>
             <Item Name="[nil]" Condition="(var.impl_.index_ == 0)">"nil"</Item>
             <Item Name="[node_data(bool)]" Condition="(var.impl_.index_ == 1)">var.impl_.data_.tail_.head_.value</Item>
-            <Item Name="[std::int64_t]" Condition="(var.impl_.index_ == 2)">var.impl_.data_.tail_.tail_.head_.value</Item>
+            <Item Name="[node_data(std::int64_t)]" Condition="(var.impl_.index_ == 2)">var.impl_.data_.tail_.tail_.head_.value</Item>
             <Item Name="[std::string]" Condition="(var.impl_.index_ == 3)">var.impl_.data_.tail_.tail_.tail_.head_.value</Item>
             <Item Name="[node_data(double)]" Condition="(var.impl_.index_ == 4)">var.impl_.data_.tail_.tail_.tail_.tail_.head_.value</Item>
             <Item Name="[primitive]" Condition="(var.impl_.index_ == 5)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
             <Item Name="[expressionlist]" Condition="(var.impl_.index_ == 6)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
             <Item Name="[range]" Condition="(var.impl_.index_ == 7)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
+            <Item Name="[dict]" Condition="(var.impl_.index_ == 8)">var.impl_.data_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.tail_.head_.value</Item>
         </Expand>
     </Type>
 


### PR DESCRIPTION
- flyby: fixed natvis for primititive_argument_type
- flyby: fixed #466, added test
- flyby: fixed #640, added test
- flyby: running python print/pickling operations of Phylanx data on HPX thread
- flyby: fixes assignment to slice to retain data type of left hand side