### PR TITLE
Change constant() to support ...like and empty operations

### DIFF
--- a/phylanx/plugins/matrixops/constant.hpp
+++ b/phylanx/plugins/matrixops/constant.hpp
@@ -35,7 +35,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         using operands_type = std::vector<operand_type>;
 
     public:
-        static match_pattern_type const match_data;
+        static std::vector<match_pattern_type> const match_data;
 
         constant() = default;
 
@@ -63,6 +63,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     private:
         node_data_type dtype_;
+        bool implements_like_operations_;
     };
 
     inline primitive create_constant(hpx::id_type const& locality,

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -1087,11 +1087,11 @@ namespace phylanx { namespace execution_tree
         }
         break;
 
-        case 0:HPX_FALLTHROUGH;    // nil
-        case 3:HPX_FALLTHROUGH;    // string
-        case 5:HPX_FALLTHROUGH;    // primitive
-        case 7:HPX_FALLTHROUGH;    // phylanx::ir::range
-        case 8:HPX_FALLTHROUGH;    // phylanx::ir::dictionary
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 7: HPX_FALLTHROUGH;    // phylanx::ir::range
+        case 8: HPX_FALLTHROUGH;    // phylanx::ir::dictionary
         default:
             break;
         }
@@ -1140,11 +1140,11 @@ namespace phylanx { namespace execution_tree
         }
         break;
 
-        case 0:HPX_FALLTHROUGH;    // nil
-        case 3:HPX_FALLTHROUGH;    // string
-        case 5:HPX_FALLTHROUGH;    // primitive
-        case 7:HPX_FALLTHROUGH;    // phylanx::ir::range
-        case 8:HPX_FALLTHROUGH;    // phylanx::ir::dictionary
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 3: HPX_FALLTHROUGH;    // string
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 7: HPX_FALLTHROUGH;    // phylanx::ir::range
+        case 8: HPX_FALLTHROUGH;    // phylanx::ir::dictionary
         default:
             break;
         }

--- a/src/plugins/matrixops/arange.cpp
+++ b/src/plugins/matrixops/arange.cpp
@@ -166,6 +166,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 case node_data_type_int64:
                     return this_->arange_helper<std::int64_t>(std::move(args));
 
+                case node_data_type_unknown: HPX_FALLTHROUGH;
                 case node_data_type_double:
                     return this_->arange_helper<double>(std::move(args));
 

--- a/src/plugins/matrixops/constant.cpp
+++ b/src/plugins/matrixops/constant.cpp
@@ -37,19 +37,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         std::array<std::size_t, 2> extract_dimensions(ir::range const& shape)
         {
-            std::array<std::size_t, 2> result = {0, 0};
-            result[0] = extract_scalar_integer_value(*shape.begin());
-            if (shape.size() > 1)
+            std::array<std::size_t, 2> result = {1, 1};
+            if (!shape.empty())
             {
-                auto elem_1 = shape.begin();
-                result[1] = extract_scalar_integer_value(*++elem_1);
+                if (shape.size() == 1)
+                {
+                    result[1] = extract_scalar_integer_value(*shape.begin());
+                }
+                else if (shape.size() == 2)
+                {
+                    auto elem_1 = shape.begin();
+                    result[0] = extract_scalar_integer_value(*elem_1);
+                    result[1] = extract_scalar_integer_value(*++elem_1);
+                }
             }
             return result;
         }
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    match_pattern_type const constant::match_data =
+    std::vector<match_pattern_type> const constant::match_data =
     {
         match_pattern_type{"constant",
             std::vector<std::string>{"constant(_1, _2)", "constant(_1)"},
@@ -58,20 +65,51 @@ namespace phylanx { namespace execution_tree { namespace primitives
             Args:
 
                 arg1 (float): a constant value
-                arg2 (int, optional): the number of values
+                arg2 (int or shape, optional): the number of values
 
             Returns:
 
             An array of size arg2 with each element equal to arg1.)",
             true
+        },
+        match_pattern_type{"constant_like",
+            std::vector<std::string>{
+                "constant_like(_1, _2)", "constant_like(_1)"
+            },
+            &create_constant, &create_primitive<constant>, R"(
+            arg1, arg2
+            Args:
+
+                arg1 (float): a constant value
+                arg2 (array-like): the shape of this array-like will be used as
+                                   to determine the shape of the result
+
+            Returns:
+
+            An array of the same size as arg2 with each element equal to arg1.)",
+            true
         }
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        bool extract_if_like(std::string const& name)
+        {
+            compiler::primitive_name_parts name_parts;
+            if (compiler::parse_primitive_name(name, name_parts))
+            {
+                return name_parts.primitive.find("constant_like") == 0;
+            }
+            return name.find("constant_like") == 0;
+        }
+    }
+
     constant::constant(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
       , dtype_(extract_dtype(name_))
+      , implements_like_operations_(detail::extract_if_like(name_))
     {}
 
     ///////////////////////////////////////////////////////////////////////////
@@ -79,8 +117,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ir::node_data<T> constant::constant0d_helper(
         primitive_argument_type&& op) const
     {
-        return ir::node_data<T>{
-            extract_scalar_data<T>(std::move(op), name_, codename_)};
+        if (valid(op))
+        {
+            return ir::node_data<T>{
+                extract_scalar_data<T>(std::move(op), name_, codename_)};
+        }
+
+        // create an empty scalar
+        return ir::node_data<T>{T{}};
     }
 
     primitive_argument_type constant::constant0d(
@@ -100,6 +144,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         case node_data_type_int64:
             return constant0d_helper<std::int64_t>(std::move(op));
 
+        case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant0d_helper<double>(std::move(op));
 
@@ -110,10 +155,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::primitives::"
                 "constant::constant0d",
-            util::generate_error_message(
-                "the contsnat primitive requires for all arguments to "
-                    "be numeric data types",
-                name_, codename_));
+            generate_error_message(
+                "the constant primitive requires for all arguments to "
+                    "be numeric data types"));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -121,8 +165,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ir::node_data<T> constant::constant1d_helper(
         primitive_argument_type&& op, std::size_t dim) const
     {
-        return ir::node_data<T>{blaze::DynamicVector<T>(
-            dim, extract_scalar_data<T>(std::move(op), name_, codename_))};
+        if (valid(op))
+        {
+            return ir::node_data<T>{blaze::DynamicVector<T>(
+                dim, extract_scalar_data<T>(std::move(op), name_, codename_))};
+        }
+
+        // create an empty vector
+        return ir::node_data<T>{blaze::DynamicVector<T>(dim)};
     }
 
     primitive_argument_type constant::constant1d(
@@ -142,6 +192,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         case node_data_type_int64:
             return constant1d_helper<std::int64_t>(std::move(op), dim);
 
+        case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant1d_helper<double>(std::move(op), dim);
 
@@ -152,10 +203,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::primitives::"
                 "constant::constant1d",
-            util::generate_error_message(
-                "the contsnat primitive requires for all arguments to "
-                    "be numeric data types",
-                name_, codename_));
+            generate_error_message(
+                "the constant primitive requires for all arguments to "
+                    "be numeric data types"));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -163,8 +213,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ir::node_data<T> constant::constant2d_helper(primitive_argument_type&& op,
         operand_type::dimensions_type const& dim) const
     {
-        return ir::node_data<T>{blaze::DynamicMatrix<T>(dim[0], dim[1],
-            extract_scalar_data<T>(std::move(op), name_, codename_))};
+        if (valid(op))
+        {
+            return ir::node_data<T>{blaze::DynamicMatrix<T>(dim[0], dim[1],
+                extract_scalar_data<T>(std::move(op), name_, codename_))};
+        }
+
+        // create an empty matrix
+        return ir::node_data<T>{blaze::DynamicMatrix<T>(dim[0], dim[1])};
     }
 
     primitive_argument_type constant::constant2d(primitive_argument_type&& op,
@@ -184,6 +240,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         case node_data_type_int64:
             return constant2d_helper<std::int64_t>(std::move(op), dim);
 
+        case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant2d_helper<double>(std::move(op), dim);
 
@@ -194,10 +251,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::primitives::"
                 "constant::constant2d",
-            util::generate_error_message(
-                "the contsnat primitive requires for all arguments to "
-                    "be numeric data types",
-                name_, codename_));
+            generate_error_message(
+                "the constant primitive requires for all arguments to "
+                    "be numeric data types"));
     }
 
     hpx::future<primitive_argument_type> constant::eval(
@@ -208,10 +264,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "constant::eval",
-                util::generate_error_message(
+                generate_error_message(
                     "the constant primitive requires "
-                        "at least one and at most 2 operands",
-                    name_, codename_));
+                        "at least one and at most 2 operands"));
         }
 
         if (!valid(operands[0]) ||
@@ -219,59 +274,88 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "constant::eval",
-                util::generate_error_message(
+                generate_error_message(
                     "the constant primitive requires that the "
-                    "arguments given by the operands array are valid",
-                    name_, codename_));
+                    "arguments given by the operands array are valid"));
         }
 
         auto this_ = this->shared_from_this();
         if (operands.size() == 2)
         {
             return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-                [this_ = std::move(this_)](
-                        primitive_argument_type&& op0, ir::range&& op1)
+                [this_ = std::move(this_)](primitive_argument_type&& op0,
+                        primitive_argument_type&& op1)
                 ->  primitive_argument_type
                 {
                     if (extract_numeric_value_dimension(op0) != 0)
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
                             "constant::eval",
-                            util::generate_error_message(
+                            this_->generate_error_message(
                                 "the first argument must be a literal "
-                                    "scalar value",
-                                this_->name_, this_->codename_));
+                                    "scalar value"));
                     }
 
-                    if (op1.empty())
+                    std::array<std::size_t, 2> dims;
+                    std::size_t numdims = 0;
+                    if (is_list_operand_strict(op1))
                     {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "constant::extract_num_dimensions",
-                            util::generate_error_message(
-                                "the constant primitive requires "
-                                    "for the shape not to be empty",
-                                this_->name_, this_->codename_));
-                    }
+                        if (this_->implements_like_operations_)
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "constant::eval",
+                                this_->generate_error_message(
+                                    "for constant_like, the second argument "
+                                        "must be an array-like value"));
+                        }
 
-                    if (op1.size() > 2)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "constant::extract_num_dimensions",
-                            util::generate_error_message(
-                                "the constant primitive requires "
+                        ir::range&& r = extract_list_value_strict(
+                            std::move(op1), this_->name_, this_->codename_);
+                        if (r.size() > 2)
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "constant::eval",
+                                this_->generate_error_message(
+                                    "the constant primitive requires "
                                     "for the shape not to have more than "
-                                    "two entries",
-                                this_->name_, this_->codename_));
+                                    "two entries"));
+                        }
+
+                        dims = detail::extract_dimensions(r);
+                        numdims = detail::extract_num_dimensions(r);
+                    }
+                    else if (is_numeric_operand(op1))
+                    {
+                        if (this_->implements_like_operations_)
+                        {
+                            // support ..._like operations
+                            dims = extract_numeric_value_dimensions(op1);
+                            numdims = extract_numeric_value_dimension(op1);
+                        }
+                        else
+                        {
+                            dims[1] = extract_scalar_integer_value(
+                                std::move(op1), this_->name_, this_->codename_);
+                            numdims = 1;
+                        }
+                    }
+                    else
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "constant::eval",
+                            this_->generate_error_message(
+                                "the constant primitive requires "
+                                "for the second argument to be either a shape "
+                                "or a numeric reference value"));
                     }
 
-                    auto dims = detail::extract_dimensions(op1);
-                    switch (detail::extract_num_dimensions(op1))
+                    switch (numdims)
                     {
                     case 0:
                         return this_->constant0d(std::move(op0));
 
                     case 1:
-                        return this_->constant1d(std::move(op0), dims[0]);
+                        return this_->constant1d(std::move(op0), dims[1]);
 
                     case 2:
                         return this_->constant2d(std::move(op0), dims);
@@ -279,19 +363,98 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     default:
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
                             "constant::eval",
-                            util::generate_error_message(
+                            this_->generate_error_message(
                                 "left hand side operand has unsupported "
-                                    "number of dimensions",
-                                this_->name_, this_->codename_));
+                                    "number of dimensions"));
                     }
                 }),
                 value_operand(operands[0], args, name_, codename_),
-                list_operand(operands[1], args, name_, codename_));
+                value_operand(operands[1], args, name_, codename_));
         }
 
-        // if constant() was invoked with one argument, we simply
-        // provide the argument as the desired result
-        return value_operand(operands[0], args, name_, codename_);
+        // support empty/empty_like
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+            [this_ = std::move(this_)](primitive_argument_type&& op0)
+            ->  primitive_argument_type
+            {
+                primitive_argument_type value;
+                std::array<std::size_t, 2> dims{1, 1};
+                std::size_t numdims = 0;
+
+                if (is_list_operand_strict(op0))
+                {
+                    // if the first argument is a list of up to two values
+                    // (shape) this creates an empty array of the given size
+                    if (this_->implements_like_operations_)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "constant::eval",
+                            this_->generate_error_message(
+                                "for constant_like, the first argument "
+                                "must be an array-like value"));
+                    }
+
+                    ir::range&& r = extract_list_value_strict(
+                        std::move(op0), this_->name_, this_->codename_);
+
+                    if (r.size() > 2)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "constant::eval",
+                            this_->generate_error_message(
+                                "the constant primitive requires "
+                                "for the shape not to have more than "
+                                "two entries"));
+                    }
+
+                    dims = detail::extract_dimensions(r);
+                    numdims = detail::extract_num_dimensions(r);
+                }
+                else if (is_numeric_operand(op0))
+                {
+                    if (this_->implements_like_operations_)
+                    {
+                        // support empty_like operations
+                        dims = extract_numeric_value_dimensions(op0);
+                        numdims = extract_numeric_value_dimension(op0);
+                    }
+                    else
+                    {
+                        // support constant(42) == 42
+                        numdims = 0;
+                        value = std::move(op0);
+                    }
+                }
+                else
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "constant::eval",
+                        this_->generate_error_message(
+                            "the constant primitive requires "
+                            "for the second argument to be either a shape "
+                            "or a numeric reference value"));
+                }
+
+                switch (numdims)
+                {
+                case 0:
+                    return this_->constant0d(std::move(value));
+
+                case 1:
+                    return this_->constant1d(std::move(value), dims[1]);
+
+                case 2:
+                    return this_->constant2d(std::move(value), dims);
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "constant::eval",
+                        this_->generate_error_message(
+                            "left hand side operand has unsupported "
+                                "number of dimensions"));
+                }
+            }),
+            value_operand(operands[0], args, name_, codename_));
     }
 
     hpx::future<primitive_argument_type> constant::eval(

--- a/src/plugins/matrixops/cumsum.cpp
+++ b/src/plugins/matrixops/cumsum.cpp
@@ -291,6 +291,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 case node_data_type_int64:
                     return this_->cumsum_helper<std::int64_t>(std::move(ops));
 
+                case node_data_type_unknown: HPX_FALLTHROUGH;
                 case node_data_type_double:
                     return this_->cumsum_helper<double>(std::move(ops));
 

--- a/src/plugins/matrixops/hstack_operation.cpp
+++ b/src/plugins/matrixops/hstack_operation.cpp
@@ -132,6 +132,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         case node_data_type_int64:
             return hstack0d1d_helper<std::int64_t>(std::move(args));
 
+        case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return hstack0d1d_helper<double>(std::move(args));
 

--- a/src/plugins/matrixops/identity.cpp
+++ b/src/plugins/matrixops/identity.cpp
@@ -89,6 +89,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         case node_data_type_int64:
             return identity_helper<std::int64_t>(std::move(op));
 
+        case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return identity_helper<double>(std::move(op));
 

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -25,8 +25,10 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(column_slicing_operation_plugin,
     phylanx::execution_tree::primitives::slicing_operation::match_data[2]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(cumsum_operation_plugin,
     phylanx::execution_tree::primitives::cumsum::match_data);
-PHYLANX_REGISTER_PLUGIN_FACTORY(
-    constant_plugin, phylanx::execution_tree::primitives::constant::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(constant_plugin,
+    phylanx::execution_tree::primitives::constant::match_data[0]);
+PHYLANX_REGISTER_PLUGIN_FACTORY(constant_like_plugin,
+    phylanx::execution_tree::primitives::constant::match_data[1]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(cross_operation_plugin,
     phylanx::execution_tree::primitives::cross_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(determinant_plugin,

--- a/src/plugins/matrixops/vstack_operation.cpp
+++ b/src/plugins/matrixops/vstack_operation.cpp
@@ -103,6 +103,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         case node_data_type_int64:
             return vstack0d_helper<std::int64_t>(std::move(args));
 
+        case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return vstack0d_helper<double>(std::move(args));
 

--- a/tests/unit/plugins/matrixops/constant.cpp
+++ b/tests/unit/plugins/matrixops/constant.cpp
@@ -10,7 +10,9 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <array>
 #include <cstdint>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -71,10 +73,11 @@ void test_constant_2d()
         phylanx::execution_tree::primitives::create_constant(hpx::find_here(),
             phylanx::execution_tree::primitive_arguments_type{
                 std::move(val),
-                phylanx::execution_tree::primitive_argument_type{std::vector<
-                    phylanx::execution_tree::primitive_argument_type>{
-                    phylanx::ir::node_data<std::int64_t>(105),
-                    phylanx::ir::node_data<std::int64_t>(101)}}});
+                phylanx::execution_tree::primitive_argument_type{
+                    phylanx::execution_tree::primitive_arguments_type{
+                        phylanx::ir::node_data<std::int64_t>(105),
+                        phylanx::ir::node_data<std::int64_t>(101)}
+                    }});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         const_.eval();
@@ -89,11 +92,66 @@ void test_constant_2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), result);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
+}
+
+void test_constant_operation(std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(code), compile_and_run(expected_str));
+}
+
+void test_empty_operation(std::string const& code,
+    std::array<int, 2> const& dims)
+{
+    auto f = compile_and_run(code);
+    auto result_dims =
+        phylanx::execution_tree::extract_numeric_value_dimensions(f());
+
+    HPX_TEST_EQ(dims[0], result_dims[0]);
+    HPX_TEST_EQ(dims[1], result_dims[1]);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
     test_constant_0d();
     test_constant_1d();
     test_constant_2d();
+
+    // zeros, ones, full
+    test_constant_operation("constant(42, list())", "42");
+    test_constant_operation("constant(42, list(4))", "hstack(42, 42, 42, 42)");
+    test_constant_operation(
+        "constant(42, list(2, 2))", "hstack(vstack(42, 42), vstack(42, 42))");
+
+    // ...like operations
+    test_constant_operation("constant_like(42, 1)", "42");
+    test_constant_operation("constant_like(42, hstack(1, 2, 3, 4))",
+        "hstack(42, 42, 42, 42)");
+    test_constant_operation(
+        "constant_like(42, hstack(vstack(1, 2), vstack(3, 4)))",
+        "hstack(vstack(42, 42), vstack(42, 42))");
+
+    // empty
+    test_empty_operation("constant__int(list())", {1, 1});
+    test_empty_operation("constant__int(list(4))", {1, 4});
+    test_empty_operation("constant__int(list(2, 2))", {2, 2});
+
+    // empty_like
+    test_empty_operation("constant_like__int(1)", {1, 1});
+    test_empty_operation("constant_like__int(hstack(1, 2, 3, 4))", {1, 4});
+    test_empty_operation(
+        "constant_like__int(hstack(vstack(1, 2), vstack(3, 4)))", {2, 2});
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
This fixes the constant primitive to support `empty` and all `...like` operations.

This fixes #638