### PR TITLE
Add parallel_block capability to Phylanx

### DIFF
--- a/python/phylanx/__init__.py
+++ b/python/phylanx/__init__.py
@@ -13,5 +13,3 @@ class parallel:
     @staticmethod
     def is_parallel_block():
         return True
-
-

--- a/python/phylanx/__init__.py
+++ b/python/phylanx/__init__.py
@@ -6,10 +6,4 @@
 from .core import *
 from .core.config import *
 from .ast.transducer import Phylanx
-
-
-class parallel:
-
-    @staticmethod
-    def is_parallel_block():
-        return True
+from .execution_tree import parallel

--- a/python/phylanx/__init__.py
+++ b/python/phylanx/__init__.py
@@ -6,3 +6,12 @@
 from .core import *
 from .core.config import *
 from .ast.transducer import Phylanx
+
+
+class parallel:
+
+    @staticmethod
+    def is_parallel_block():
+        return True
+
+

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -10,6 +10,7 @@ import ast
 import inspect
 import phylanx.execution_tree
 from phylanx import compiler_state
+from phylanx.ast.utils import dump_info
 
 mapped_methods = {
     "add": "__add",
@@ -771,6 +772,20 @@ class PhySL:
         #     else:
         #         return [op, (value, slice_)]
         return [op, (value, slice_)]
+
+    def _With(self, node):
+        if 0 < len(node.items) and type(node.items[0]) == ast.withitem:
+            withitem = node.items[0]
+            if type(withitem.context_expr) == ast.Attribute:
+                attribute = withitem.context_expr
+                if attribute.attr == "parallel":
+                    if self.fglobals[attribute.value.id].parallel.is_parallel_block():
+                        return ["parallel_block", tuple(map(self.apply_rule, node.body))]
+            elif type(withitem.context_expr) == ast.Name:
+                if withitem.context_expr.id == "parallel":
+                    if self.fglobals["parallel"].is_parallel_block():
+                        return ["parallel_block", tuple(map(self.apply_rule, node.body))]
+        raise Exception("Unsupported use of 'With'")
 
     def _Dict(self, node):
         res = []

--- a/python/phylanx/execution_tree/__init__.py
+++ b/python/phylanx/execution_tree/__init__.py
@@ -8,3 +8,10 @@ try:
 
 except Exception:
     from phylanx._phylanxd.execution_tree import *
+
+
+class parallel:
+
+    @staticmethod
+    def is_parallel_block():
+        return True

--- a/src/plugins/matrixops/generic_operation.cpp
+++ b/src/plugins/matrixops/generic_operation.cpp
@@ -75,6 +75,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         PHYLANX_GEN_MATCH_DATA("arctanh"),
         PHYLANX_GEN_MATCH_DATA("erf"),
         PHYLANX_GEN_MATCH_DATA("erfc"),
+        PHYLANX_GEN_MATCH_DATA("sleep"),
     };
 
 #undef PHYLANX_GEN_MATCH_DATA
@@ -111,6 +112,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {"arccos", [](double m) -> double { return blaze::acos(m); }},
             {"arctan", [](double m) -> double { return blaze::atan(m); }},
             {"arcsinh", [](double m) -> double { return blaze::asinh(m); }},
+            {"sleep", [](double m) -> double { return usleep(m*1.0e6); return 1.0; }},
             {"arccosh",
                 [](double m) -> double {
 #if defined(PHYLANX_DEBUG)
@@ -456,6 +458,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     else
                     {
                         m.vector() = blaze::asinh(m.vector());
+                    }
+                    return arg_type(std::move(m));
+                }},
+            {"sleep",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        //m = blaze::asinh(m.vector());
+                        usleep(m.vector()[0]*1.0e6);
+                        m = 1.0;
+                    }
+                    else
+                    {
+                        //m.vector() = blaze::asinh(m.vector());
+                        usleep(m.vector()[0]*1.0e6);
+                        m.vector()[0] = 1.0;
                     }
                     return arg_type(std::move(m));
                 }},
@@ -861,6 +879,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     else
                     {
                         m.matrix() = blaze::asinh(m.matrix());
+                    }
+                    return arg_type(std::move(m));
+                }},
+            {"sleep",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        //m = 1.0; usleep(m.matrix()[0]*1.0e6);
+                    }
+                    else
+                    {
+                        //m.matrix()[0] = 1.0; usleep(m.matrix()[0][0]*1e6);
                     }
                     return arg_type(std::move(m));
                 }},

--- a/src/plugins/matrixops/generic_operation.cpp
+++ b/src/plugins/matrixops/generic_operation.cpp
@@ -75,7 +75,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         PHYLANX_GEN_MATCH_DATA("arctanh"),
         PHYLANX_GEN_MATCH_DATA("erf"),
         PHYLANX_GEN_MATCH_DATA("erfc"),
-        PHYLANX_GEN_MATCH_DATA("sleep"),
     };
 
 #undef PHYLANX_GEN_MATCH_DATA
@@ -112,7 +111,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {"arccos", [](double m) -> double { return blaze::acos(m); }},
             {"arctan", [](double m) -> double { return blaze::atan(m); }},
             {"arcsinh", [](double m) -> double { return blaze::asinh(m); }},
-            {"sleep", [](double m) -> double { return usleep(m*1.0e6); return 1.0; }},
             {"arccosh",
                 [](double m) -> double {
 #if defined(PHYLANX_DEBUG)
@@ -458,22 +456,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     else
                     {
                         m.vector() = blaze::asinh(m.vector());
-                    }
-                    return arg_type(std::move(m));
-                }},
-            {"sleep",
-                [](arg_type&& m) -> arg_type {
-                    if (m.is_ref())
-                    {
-                        //m = blaze::asinh(m.vector());
-                        usleep(m.vector()[0]*1.0e6);
-                        m = 1.0;
-                    }
-                    else
-                    {
-                        //m.vector() = blaze::asinh(m.vector());
-                        usleep(m.vector()[0]*1.0e6);
-                        m.vector()[0] = 1.0;
                     }
                     return arg_type(std::move(m));
                 }},
@@ -879,18 +861,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     else
                     {
                         m.matrix() = blaze::asinh(m.matrix());
-                    }
-                    return arg_type(std::move(m));
-                }},
-            {"sleep",
-                [](arg_type&& m) -> arg_type {
-                    if (m.is_ref())
-                    {
-                        //m = 1.0; usleep(m.matrix()[0]*1.0e6);
-                    }
-                    else
-                    {
-                        //m.matrix()[0] = 1.0; usleep(m.matrix()[0][0]*1e6);
                     }
                     return arg_type(std::move(m));
                 }},

--- a/tests/unit/python/execution_tree/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
     make_array
     map_numpy
     set_operation
+    parallel
    )
 
 foreach(test ${tests})

--- a/tests/unit/python/execution_tree/parallel.py
+++ b/tests/unit/python/execution_tree/parallel.py
@@ -1,0 +1,38 @@
+#  Copyright (c) 2017-2018 Hartmut Kaiser
+#  Copyright (c) 2018 Steven R. Brandt
+#  Copyright (c) 2018 R. Tohid
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx import Phylanx, parallel
+
+
+def fib0(n):
+    if n < 2:
+        return n
+    return fib0(n - 1) + fib0(n - 2)
+
+
+@Phylanx
+def fib_(n, a, b):
+    if n < 2:
+        return n
+    elif n < 12:
+        a[n] = fib_(n - 1, a, b)
+        b[n] = fib_(n - 2, a, b)
+        return a[n] + b[n]
+    else:
+        with parallel:
+            a[n] = fib_(n - 1, a, b)
+            b[n] = fib_(n - 2, a, b)
+        return a[n] + b[n]
+
+
+def fib(n):
+    return fib_(n, np.zeros(n + 1), np.zeros(n + 1))
+
+
+n = 15
+assert fib(n) == fib0(n)


### PR DESCRIPTION
This PR allows one to write code containing parallel blocks. To use it, first import "parallel" from phylanx, then use "with parallel" or "with phylanx.parallel" as appropriate to generate a parallel_block() in physl. See test "parallel.py".