### PR TITLE
Use Blaze master instead of 4.2

### DIFF
--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -44,11 +44,9 @@ RUN apt-get update &&                                                           
     )                                                                            && \
     rm -rf /pybind11-src                                                         && \
                                                                                     \
-    mkdir /blaze-src                                                             && \
+    git clone --depth=1 https://bitbucket.org/blaze-lib/blaze.git /blaze-src     && \
     (                                                                               \
     cd /blaze-src                                                                && \
-    curl -JL https://bitbucket.org/blaze-lib/blaze/downloads/blaze-3.4.tar.gz |     \
-        tar xz --strip-components=2                                              && \
     cmake -H. -Bbuild -DBLAZE_SMP_THREADS=C++11                                  && \
     cmake --build build -- install                                                  \
     )                                                                            && \


### PR DESCRIPTION
This PR reverts #619 because the new [blaze_tensor](https://github.com/STEllAR-GROUP/blaze_tensor) dependency needs Blaze master.

(This PR affects the Docker base image used by our CircleCI workflows and is not tested by CircleCI itself)