### PR TITLE
Provide an error on illegal returns

### DIFF
--- a/tests/unit/python/execution_tree/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
     map_numpy
     set_operation
     parallel
+    multi_return
    )
 
 foreach(test ${tests})

--- a/tests/unit/python/execution_tree/multi_return.py
+++ b/tests/unit/python/execution_tree/multi_return.py
@@ -4,8 +4,10 @@
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 from phylanx import Phylanx
+import re
 
 
+@Phylanx
 def recur1(n):
     while n < 2:
         n = n - 1
@@ -13,16 +15,20 @@ def recur1(n):
 
 
 try:
+    @Phylanx
     def recur2(n):
         while n < 2:
             n = n - 1
         # Illegal return
         return 2
         return 5
-except RuntimeError as e:
-    assert str(e) == 'Illegal return'
+    raise Exception("Test Failed")
+except NotImplementedError as e:
+    print(e)
+    assert re.match('Illegal return', str(e))
 
 
+@Phylanx
 def recur3(n):
     if n < 2:
         return 1
@@ -31,16 +37,19 @@ def recur3(n):
 
 
 try:
+    @Phylanx
     def recur4(n):
         k = 1
         # return in for loop illegal
         for i in range(10):
             if i == 4:
                 return k
-except RuntimeError as e:
-    assert str(e) == 'Illegal return'
+    raise Exception("Test Failed")
+except NotImplementedError as e:
+    assert re.match('Illegal return', str(e))
 
 
+@Phylanx
 def recur5(n):
     k = 1
     if k == 1:
@@ -49,15 +58,18 @@ def recur5(n):
 
 
 try:
+    @Phylanx
     def recur6(n):
         if n < 2:
             return 1
         # multiple returns illegal
         return 2
-except RuntimeError as e:
-    assert str(e) == 'Illegal return'
+    raise Exception("Test Failed")
+except NotImplementedError as e:
+    assert re.match('Illegal return', str(e))
 
 
+@Phylanx
 def recur7(n):
     if n < 2:
         return 1
@@ -66,6 +78,7 @@ def recur7(n):
 
 
 try:
+    @Phylanx
     def recur8(n):
         k = 1
         i = 5
@@ -74,21 +87,25 @@ try:
             if i == 4:
                 # return from while loop is illegal
                 return k
-except RuntimeError as e:
-    assert str(e) == 'Illegal return'
+    raise Exception("Test Failed")
+except NotImplementedError as e:
+    assert re.match('Illegal return', str(e))
 
 
 try:
+    @Phylanx
     def recur9(n):
         while n > 0:
             n = n - 1
             if n == 4:
                 # return from while loop is illegal
                 return n
-except RuntimeError as e:
-    assert str(e) == 'Illegal return', e
+    raise Exception("Test Failed")
+except NotImplementedError as e:
+    assert re.match('Illegal return', str(e))
 
 
+@Phylanx
 def recur10(n):
     if n == 66:
         return 66
@@ -100,6 +117,7 @@ def recur10(n):
         return 8
 
 
+@Phylanx
 def recur11(n):
     if n == 66:
         return 66

--- a/tests/unit/python/execution_tree/multi_return.py
+++ b/tests/unit/python/execution_tree/multi_return.py
@@ -1,0 +1,111 @@
+#  Copyright (c) 2018 Steven R. Brandt
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+from phylanx import Phylanx
+
+
+def recur1(n):
+    while n < 2:
+        n = n - 1
+    return 5
+
+
+try:
+    def recur2(n):
+        while n < 2:
+            n = n - 1
+        # Illegal return
+        return 2
+        return 5
+except RuntimeError as e:
+    assert str(e) == 'Illegal return'
+
+
+def recur3(n):
+    if n < 2:
+        return 1
+    else:
+        return 2
+
+
+try:
+    def recur4(n):
+        k = 1
+        # return in for loop illegal
+        for i in range(10):
+            if i == 4:
+                return k
+except RuntimeError as e:
+    assert str(e) == 'Illegal return'
+
+
+def recur5(n):
+    k = 1
+    if k == 1:
+        if n == 4:
+            return n
+
+
+try:
+    def recur6(n):
+        if n < 2:
+            return 1
+        # multiple returns illegal
+        return 2
+except RuntimeError as e:
+    assert str(e) == 'Illegal return'
+
+
+def recur7(n):
+    if n < 2:
+        return 1
+    else:
+        return 2
+
+
+try:
+    def recur8(n):
+        k = 1
+        i = 5
+        while n > 0:
+            n = n - 1
+            if i == 4:
+                # return from while loop is illegal
+                return k
+except RuntimeError as e:
+    assert str(e) == 'Illegal return'
+
+
+try:
+    def recur9(n):
+        while n > 0:
+            n = n - 1
+            if n == 4:
+                # return from while loop is illegal
+                return n
+except RuntimeError as e:
+    assert str(e) == 'Illegal return', e
+
+
+def recur10(n):
+    if n == 66:
+        return 66
+    elif n == 2:
+        return 2
+    elif n == 3:
+        return 4
+    else:
+        return 8
+
+
+def recur11(n):
+    if n == 66:
+        return 66
+    elif n == 2:
+        return 2
+    elif n == 3:
+        return 4
+    else:
+        return 8


### PR DESCRIPTION
Detect illegal use of return statements within a Python code and raise an exception. Illegal uses include (1) use of return inside while/for, or at any place prior to the end of a block.