### PR TITLE
Fixing how identity handles non-integer inputs

### DIFF
--- a/phylanx/plugins/matrixops/identity.hpp
+++ b/phylanx/plugins/matrixops/identity.hpp
@@ -14,6 +14,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -45,9 +46,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     private:
         template <typename T>
-        primitive_argument_type identity_helper(
-            primitive_argument_type&& op) const;
-        primitive_argument_type identity_nd(primitive_argument_type&& op) const;
+        primitive_argument_type identity_helper(std::int64_t&& op) const;
+        primitive_argument_type identity_nd(std::int64_t&& op) const;
 
     private:
         node_data_type dtype_;

--- a/tests/unit/plugins/matrixops/identity.cpp
+++ b/tests/unit/plugins/matrixops/identity.cpp
@@ -9,6 +9,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -16,7 +17,7 @@ void test_identity()
 {
     phylanx::execution_tree::primitive val =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<double>(5.0));
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(5));
 
     phylanx::execution_tree::primitive identity =
         phylanx::execution_tree::primitives::create_identity(


### PR DESCRIPTION
The input to np.identity should be non-negative integers. Also, If dtype is not specified identity should return double. 