### PR TITLE
Fixing minor issues with extract_shape and generic operations primitives

### DIFF
--- a/src/plugins/matrixops/generic_operation.cpp
+++ b/src/plugins/matrixops/generic_operation.cpp
@@ -75,6 +75,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         PHYLANX_GEN_MATCH_DATA("arctanh"),
         PHYLANX_GEN_MATCH_DATA("erf"),
         PHYLANX_GEN_MATCH_DATA("erfc"),
+        PHYLANX_GEN_MATCH_DATA("normalize"),
+        PHYLANX_GEN_MATCH_DATA("trace")
     };
 
 #undef PHYLANX_GEN_MATCH_DATA


### PR DESCRIPTION
Shape should return a list of the vector size and nil for vectors:
```np.shape([1.0, 2.0]) = (2,)``` while ```shape([1.0, 2.0]) returns (2)``` in phylanx.
