### PR TITLE
Generic_Operation: sinh, cosh and tanh are added

### DIFF
--- a/phylanx/plugins/matrixops/generic_operation.hpp
+++ b/phylanx/plugins/matrixops/generic_operation.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Tianyi Zhang
+// Copyright (c) 2018 Bita Hasheminezhad
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/src/plugins/matrixops/generic_operation.cpp
+++ b/src/plugins/matrixops/generic_operation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Tianyi Zhang
+// Copyright (c) 2018 Bita Hasheminezhad
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -67,6 +68,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         PHYLANX_GEN_MATCH_DATA("sin"),
         PHYLANX_GEN_MATCH_DATA("cos"),
         PHYLANX_GEN_MATCH_DATA("tan"),
+        PHYLANX_GEN_MATCH_DATA("sinh"),
+        PHYLANX_GEN_MATCH_DATA("cosh"),
+        PHYLANX_GEN_MATCH_DATA("tanh"),
         PHYLANX_GEN_MATCH_DATA("arcsin"),
         PHYLANX_GEN_MATCH_DATA("arccos"),
         PHYLANX_GEN_MATCH_DATA("arctan"),
@@ -107,6 +111,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {"sin", [](double m) -> double { return blaze::sin(m); }},
             {"cos", [](double m) -> double { return blaze::cos(m); }},
             {"tan", [](double m) -> double { return blaze::tan(m); }},
+            {"sinh", [](double m) -> double { return blaze::sinh(m); }},
+            {"cosh", [](double m) -> double { return blaze::cosh(m); }},
+            {"tanh", [](double m) -> double { return blaze::tanh(m); }},
             {"arcsin", [](double m) -> double { return blaze::asin(m); }},
             {"arccos", [](double m) -> double { return blaze::acos(m); }},
             {"arctan", [](double m) -> double { return blaze::atan(m); }},
@@ -408,6 +415,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     else
                     {
                         m.vector() = blaze::tan(m.vector());
+                    }
+                    return arg_type(std::move(m));
+                }},
+            { "sinh",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        m = blaze::sinh(m.vector());
+                    }
+                    else
+                    {
+                        m.vector() = blaze::sinh(m.vector());
+                    }
+                    return arg_type(std::move(m));
+                }},
+            { "cosh",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        m = blaze::cosh(m.vector());
+                    }
+                    else
+                    {
+                        m.vector() = blaze::cosh(m.vector());
+                    }
+                    return arg_type(std::move(m));
+                    }},
+            { "tanh",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        m = blaze::tanh(m.vector());
+                    }
+                    else
+                    {
+                        m.vector() = blaze::tanh(m.vector());
                     }
                     return arg_type(std::move(m));
                 }},
@@ -813,6 +856,42 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     else
                     {
                         m.matrix() = blaze::tan(m.matrix());
+                    }
+                    return arg_type(std::move(m));
+                }},
+            {"sinh",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        m = blaze::sinh(m.matrix());
+                    }
+                    else
+                    {
+                        m.matrix() = blaze::sinh(m.matrix());
+                    }
+                    return arg_type(std::move(m));
+                }},
+            {"cosh",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        m = blaze::cosh(m.matrix());
+                    }
+                    else
+                    {
+                        m.matrix() = blaze::cosh(m.matrix());
+                    }
+                    return arg_type(std::move(m));
+                }},
+            {"tanh",
+                [](arg_type&& m) -> arg_type {
+                    if (m.is_ref())
+                    {
+                        m = blaze::tanh(m.matrix());
+                    }
+                    else
+                    {
+                        m.matrix() = blaze::tanh(m.matrix());
                     }
                     return arg_type(std::move(m));
                 }},

--- a/tests/unit/plugins/matrixops/generic_operation.cpp
+++ b/tests/unit/plugins/matrixops/generic_operation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Tianyi Zhang
+// Copyright (c) 2018 Bita Hasheminezhad
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -183,6 +184,9 @@ int main(int argc, char* argv[])
     test_generic_operation_0d("sin", std::sin);
     test_generic_operation_0d("cos", std::cos);
     test_generic_operation_0d("tan", std::tan);
+    test_generic_operation_0d("sinh", std::sinh);
+    test_generic_operation_0d("cosh", std::cosh);
+    test_generic_operation_0d("tanh", std::tanh);
     test_generic_operation_0d("arcsin", std::asin);
     test_generic_operation_0d("arccos", std::acos);
     test_generic_operation_0d("arctan", std::atan);
@@ -254,6 +258,15 @@ int main(int argc, char* argv[])
     test_generic_operation_1d("tan",
         [](blaze::CustomVector<double, blaze::aligned, blaze::padded> m)
             -> blaze::DynamicVector<double> { return blaze::tan(m); });
+    test_generic_operation_1d("sinh",
+        [](blaze::CustomVector<double, blaze::aligned, blaze::padded> m)
+        -> blaze::DynamicVector<double> { return blaze::sinh(m); });
+    test_generic_operation_1d("cosh",
+        [](blaze::CustomVector<double, blaze::aligned, blaze::padded> m)
+        -> blaze::DynamicVector<double> { return blaze::cosh(m); });
+    test_generic_operation_1d("tanh",
+        [](blaze::CustomVector<double, blaze::aligned, blaze::padded> m)
+        -> blaze::DynamicVector<double> { return blaze::tanh(m); });
     test_generic_operation_1d("arcsin",
         [](blaze::CustomVector<double, blaze::aligned, blaze::padded> m)
             -> blaze::DynamicVector<double> { return blaze::asin(m); });
@@ -337,6 +350,15 @@ int main(int argc, char* argv[])
     test_generic_operation_2d("tan",
         [](blaze::CustomMatrix<double, blaze::aligned, blaze::padded> m)
             -> blaze::DynamicMatrix<double> { return blaze::tan(m); });
+    test_generic_operation_2d("sinh",
+        [](blaze::CustomMatrix<double, blaze::aligned, blaze::padded> m)
+        -> blaze::DynamicMatrix<double> { return blaze::sinh(m); });
+    test_generic_operation_2d("cosh",
+        [](blaze::CustomMatrix<double, blaze::aligned, blaze::padded> m)
+        -> blaze::DynamicMatrix<double> { return blaze::cosh(m); });
+    test_generic_operation_2d("tanh",
+        [](blaze::CustomMatrix<double, blaze::aligned, blaze::padded> m)
+        -> blaze::DynamicMatrix<double> { return blaze::tanh(m); });
     test_generic_operation_2d("arcsin",
         [](blaze::CustomMatrix<double, blaze::aligned, blaze::padded> m)
             -> blaze::DynamicMatrix<double> { return blaze::asin(m); });


### PR DESCRIPTION
I planned to add `tanh` and `round` to the generic_operation primitive in Phylanx. I found out `round` already exists as `rint`. Therefore, here I added `sinh`, `cosh` and `tanh`.