### PR TITLE
Adding Softmax operation

### DIFF
--- a/phylanx/plugins/matrixops/matrixops.hpp
+++ b/phylanx/plugins/matrixops/matrixops.hpp
@@ -31,6 +31,7 @@
 #include <phylanx/plugins/matrixops/random.hpp>
 #include <phylanx/plugins/matrixops/shuffle_operation.hpp>
 #include <phylanx/plugins/matrixops/slicing_operation.hpp>
+#include <phylanx/plugins/matrixops/softmax_operation.hpp>
 #include <phylanx/plugins/matrixops/squeeze_operation.hpp>
 #include <phylanx/plugins/matrixops/transpose_operation.hpp>
 #include <phylanx/plugins/matrixops/unique.hpp>

--- a/phylanx/plugins/matrixops/softmax_operation.hpp
+++ b/phylanx/plugins/matrixops/softmax_operation.hpp
@@ -21,11 +21,14 @@
 #include <vector>
 
 namespace phylanx {  namespace execution_tree {  namespace primitives  {
-    /// \brief
-    ///
-    /// \param a         The scalar, vector, or matrix to perform softmax over
-    /// \param axis      Optional. If provided,
-    ///
+/// \brief Returns an array of the same shape which is the normalized exponential
+///        function of the given array.  The resulting array consists of real
+///        values in the range (0..1], which add up to 1 in direction of the
+///        given axis
+///
+/// \param a      The scalar, vector, or matrix to perform softmax over
+/// \param axis   Optional. The default is the last axis (axis == -1). Effective
+///               when the array is >1d
 
     class softmax_operation
         : public primitive_component_base
@@ -48,10 +51,12 @@ namespace phylanx {  namespace execution_tree {  namespace primitives  {
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type softmax0d(arg_type&& arg) const;
-        //primitive_argument_type softmax1d(primitive_argument_type&& arg) const;
-        //primitive_argument_type softmax2d(primitive_argument_type&& arg) const;
-
+        primitive_argument_type softmax0d() const;
+        primitive_argument_type softmax1d(arg_type&& arg) const;
+        primitive_argument_type softmax2d(
+            arg_type&& arg, std::int64_t axis) const;
+        primitive_argument_type softmax2d_axis0(arg_type&& arg) const;
+        primitive_argument_type softmax2d_axis1(arg_type&& arg) const;
     };
     inline primitive create_softmax_operation(hpx::id_type const& locality,
         primitive_arguments_type&& operands,

--- a/phylanx/plugins/matrixops/softmax_operation.hpp
+++ b/phylanx/plugins/matrixops/softmax_operation.hpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PLUGINS_MATRIXOPS_SOFTMAX_OPERATION)
+#define PHYLANX_PLUGINS_MATRIXOPS_SOFTMAX_OPERATION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx {  namespace execution_tree {  namespace primitives  {
+    /// \brief
+    ///
+    /// \param a         The scalar, vector, or matrix to perform softmax over
+    /// \param axis      Optional. If provided,
+    ///
+
+    class softmax_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<softmax_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+        using val_type = double;
+        using arg_type = ir::node_data<val_type>;
+
+    public:
+        static match_pattern_type const match_data;
+
+        softmax_operation() = default;
+
+        softmax_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    private:
+        primitive_argument_type softmax0d(arg_type&& arg) const;
+        //primitive_argument_type softmax1d(primitive_argument_type&& arg) const;
+        //primitive_argument_type softmax2d(primitive_argument_type&& arg) const;
+
+    };
+    inline primitive create_softmax_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "softmax", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -65,6 +65,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(shuffle_operation_plugin,
     phylanx::execution_tree::primitives::shuffle_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(slicing_operation_plugin,
     phylanx::execution_tree::primitives::slicing_operation::match_data[0]);
+PHYLANX_REGISTER_PLUGIN_FACTORY(softmax_operation_plugin,
+    phylanx::execution_tree::primitives::softmax_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(squeeze_operation_plugin,
     phylanx::execution_tree::primitives::squeeze_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(transpose_operation_plugin,

--- a/src/plugins/matrixops/softmax_operation.cpp
+++ b/src/plugins/matrixops/softmax_operation.cpp
@@ -74,7 +74,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicMatrix<double> result(m.rows(), m.columns());
         for (std::size_t i = 0; i < m.columns(); ++i)
         {
-            column(result, i) = softmax(column(m, i));
+            blaze::column(result, i) = blaze::softmax(blaze::column(m, i));
         } // sum(result,axis=0) is a vector containing m.columns() ones
         return primitive_argument_type{result};
     }
@@ -86,7 +86,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicMatrix<double> result(m.rows(), m.columns());
         for (std::size_t i = 0; i < m.rows(); ++i)
         {
-            row(result, i) = softmax(row(m, i));
+            blaze::row(result, i) = blaze::softmax(blaze::row(m, i));
         } // sum(result,axis=1) is a vector containing m.rows() ones
         return primitive_argument_type{result};
     }
@@ -154,7 +154,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 if (args.size() > 1)
                 {
                     if (valid(args[1]))
-                        axis = execution_tree::extract_scalar_integer_value(
+                        axis = execution_tree::extract_scalar_integer_value_strict(
                             args[1], this_->name_, this_->codename_);
                 }
 

--- a/src/plugins/matrixops/softmax_operation.cpp
+++ b/src/plugins/matrixops/softmax_operation.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/matrixops/softmax_operation.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/iterator_facade.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const softmax_operation::match_data =
+    {
+        hpx::util::make_tuple("softmax",
+        std::vector<std::string>{"softmax(_1)","softmax(_1,_2)"},
+        &create_softmax_operation, &create_primitive<softmax_operation>,
+        "a, axis\n"
+        "Args:\n"
+        "\n"
+        "    a (vector or matrix) : a vector or matrix\n"
+        "    axis (optional, integer): an axis to softmax along\n"
+        "\n"
+        "Returns:\n"
+        "\n"
+        "")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    softmax_operation::softmax_operation(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    primitive_argument_type softmax_operation::softmax0d(arg_type&& arg) const
+    {
+
+
+        return primitive_argument_type{ arg.scalar() };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> softmax_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args,
+        eval_context ctx) const
+    {
+        if (operands.empty() || operands.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "softmax_operation::eval",
+                util::generate_error_message(
+                    "the softmax_operation primitive requires exactly one, or "
+                    "two operands",
+                    name_, codename_));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "softmax_operation::eval",
+                    util::generate_error_message(
+                        "the softmax_operation primitive requires that the "
+                        "arguments given by the operands array are "
+                        "valid",
+                        name_, codename_));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping([this_ = std::move(this_)](
+                                      primitive_arguments_type&& args)
+                                      -> primitive_argument_type {
+                // Extract axis
+                hpx::util::optional<std::int64_t> axis =
+                    static_cast<std::int64_t>(1); // column-wise operation
+
+                // axis is the second argument
+                if (args.size() > 1)
+                {
+                    if (valid(args[1]))
+                        axis = execution_tree::extract_scalar_integer_value(
+                            args[1], this_->name_, this_->codename_);
+                }
+
+                // Extract the matrix
+                arg_type a = extract_numeric_value(
+                    args[0], this_->name_, this_->codename_);
+
+                std::size_t a_dims = a.num_dimensions();
+
+                switch (a_dims)
+                {
+                case 0:
+                    return this_->softmax0d(std::move(a));
+                //case 1:
+                //    return this_->softmax1d(std::move(a));
+                //case 2:
+                //    return this_->softmax2d(std::move(a),axis);
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "softmax_operation::eval",
+                        util::generate_error_message("operand a has an invalid "
+                                                        "number of dimensions",
+                            this_->name_, this_->codename_));
+                }
+            }),
+            detail::map_operands(
+                operands, functional::value_operand{}, args,
+                name_, codename_, std::move(ctx)));
+    }
+}}}

--- a/tests/unit/plugins/matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/matrixops/CMakeLists.txt
@@ -31,6 +31,7 @@ set(tests
     row_slicing
     shuffle_operation
     slicing_operation
+    softmax_operation
     squeeze_operation
     transpose_operation
     unique

--- a/tests/unit/plugins/matrixops/softmax_operation.cpp
+++ b/tests/unit/plugins/matrixops/softmax_operation.cpp
@@ -19,7 +19,7 @@
 //////////////////////////////////////////////////////////////////////////
 void test_softmax_operation_0d()
 {
-    phylanx::execution_tree::primitive first =
+    phylanx::execution_tree::primitive arg =
         phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<double>(42.0));
 
@@ -27,7 +27,7 @@ void test_softmax_operation_0d()
         phylanx::execution_tree::primitives::create_softmax_operation(
             hpx::find_here(),
             phylanx::execution_tree::primitive_arguments_type{
-                std::move(first)});
+                std::move(arg)});
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         softmax.eval();
@@ -36,15 +36,115 @@ void test_softmax_operation_0d()
         1.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
 }
 
+void test_softmax_operation_1d()
+{
+    blaze::DynamicVector<double> subject{41., 42., 43.};
+    phylanx::execution_tree::primitive arg =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
 
+    phylanx::execution_tree::primitive softmax =
+        phylanx::execution_tree::primitives::create_softmax_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        softmax.eval();
+
+    blaze::DynamicVector<double> expected{0.09003057, 0.24472847, 0.66524096};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_softmax_operation_2d()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {4, 1, 2},
+                                               {3, 4, 1}};
+    phylanx::execution_tree::primitive arg =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive softmax =
+        phylanx::execution_tree::primitives::create_softmax_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        softmax.eval();
+
+    blaze::DynamicMatrix<double> expected{{0.09003057,  0.24472847,  0.66524096},
+                                          {0.84379473,  0.04201007,  0.1141952 },
+                                          {0.25949646,  0.70538451,  0.03511903}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_softmax_operation_2d_column()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {3, 4, 1}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+
+    phylanx::execution_tree::primitive softmax =
+        phylanx::execution_tree::primitives::create_softmax_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        softmax.eval();
+
+    blaze::DynamicMatrix<double> expected{{0.09003057,  0.24472847,  0.66524096},
+                                          {0.25949646,  0.70538451,  0.03511903}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_softmax_operation_2d_row()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {3, 4, 1}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(0));
+
+    phylanx::execution_tree::primitive softmax =
+        phylanx::execution_tree::primitives::create_softmax_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        softmax.eval();
+
+    blaze::DynamicMatrix<double> expected{{0.11920292, 0.11920292, 0.88079708},
+                                          {0.88079708, 0.88079708, 0.11920292}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
 
 int main(int argc, char* argv[])
 {
     test_softmax_operation_0d();
-    //test_softmax_operation_1d();
-    //test_softmax_operation_2d();
-    //test_softmax_operation_2d_column();
-    //test_softmax_operation_2d_row();
+    test_softmax_operation_1d();
+    test_softmax_operation_2d();
+    test_softmax_operation_2d_column();
+    test_softmax_operation_2d_row();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/matrixops/softmax_operation.cpp
+++ b/tests/unit/plugins/matrixops/softmax_operation.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+//////////////////////////////////////////////////////////////////////////
+void test_softmax_operation_0d()
+{
+    phylanx::execution_tree::primitive first =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+
+    phylanx::execution_tree::primitive softmax =
+        phylanx::execution_tree::primitives::create_softmax_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(first)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        softmax.eval();
+
+    HPX_TEST_EQ(
+        1.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+
+
+int main(int argc, char* argv[])
+{
+    test_softmax_operation_0d();
+    //test_softmax_operation_1d();
+    //test_softmax_operation_2d();
+    //test_softmax_operation_2d_column();
+    //test_softmax_operation_2d_row();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Softmax returns the normalized exponential function of the given array. Since blaze has this operation, I think we can have softmax primitive, too.
It will be updated when issue #218 in blaze (https://bitbucket.org/blaze-lib/blaze/issues/218/provide-a-softmax-overload-with-support) is resolved.