### PR TITLE
Adding Tile primitive

### DIFF
--- a/phylanx/plugins/matrixops/matrixops.hpp
+++ b/phylanx/plugins/matrixops/matrixops.hpp
@@ -12,6 +12,7 @@
 #include <phylanx/plugins/matrixops/constant.hpp>
 #include <phylanx/plugins/matrixops/count_nonzero_operation.hpp>
 #include <phylanx/plugins/matrixops/cross_operation.hpp>
+
 #include <phylanx/plugins/matrixops/determinant.hpp>
 #include <phylanx/plugins/matrixops/diag_operation.hpp>
 #include <phylanx/plugins/matrixops/dot_operation.hpp>
@@ -32,6 +33,8 @@
 #include <phylanx/plugins/matrixops/shuffle_operation.hpp>
 #include <phylanx/plugins/matrixops/slicing_operation.hpp>
 #include <phylanx/plugins/matrixops/squeeze_operation.hpp>
+
+#include <phylanx/plugins/matrixops/tile_operation.hpp>
 #include <phylanx/plugins/matrixops/transpose_operation.hpp>
 #include <phylanx/plugins/matrixops/unique.hpp>
 #include <phylanx/plugins/matrixops/vstack_operation.hpp>

--- a/phylanx/plugins/matrixops/matrixops.hpp
+++ b/phylanx/plugins/matrixops/matrixops.hpp
@@ -12,7 +12,6 @@
 #include <phylanx/plugins/matrixops/constant.hpp>
 #include <phylanx/plugins/matrixops/count_nonzero_operation.hpp>
 #include <phylanx/plugins/matrixops/cross_operation.hpp>
-
 #include <phylanx/plugins/matrixops/determinant.hpp>
 #include <phylanx/plugins/matrixops/diag_operation.hpp>
 #include <phylanx/plugins/matrixops/dot_operation.hpp>
@@ -33,7 +32,6 @@
 #include <phylanx/plugins/matrixops/shuffle_operation.hpp>
 #include <phylanx/plugins/matrixops/slicing_operation.hpp>
 #include <phylanx/plugins/matrixops/squeeze_operation.hpp>
-
 #include <phylanx/plugins/matrixops/tile_operation.hpp>
 #include <phylanx/plugins/matrixops/transpose_operation.hpp>
 #include <phylanx/plugins/matrixops/unique.hpp>

--- a/phylanx/plugins/matrixops/tile_operation.hpp
+++ b/phylanx/plugins/matrixops/tile_operation.hpp
@@ -45,7 +45,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
         tile_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
+    private:
+        primitive_argument_type tile0d(
+            primitive_argument_type&& arr, ir::range&& arg) const;
 
+        template <typename T>
+        primitive_argument_type tile0d(ir::node_data<T>&& arr,
+            ir::range&& arg) const;
 
     private:
         node_data_type dtype_;

--- a/phylanx/plugins/matrixops/tile_operation.hpp
+++ b/phylanx/plugins/matrixops/tile_operation.hpp
@@ -26,8 +26,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 {
 /// \brief Constructs an array by repeating a, the number of times given by reps.
 ///
-/// \param a     The scalar, vector, or matrix
-/// \param reps  Integer or tuple of integers.
+/// \param a     The scalar, vector, or matrix as the tile to repeat
+/// \param reps  Integer or tuple of integers. Number of repetitions of a along
+///              each axis
     class tile_operation
         : public primitive_component_base
         , public std::enable_shared_from_this<tile_operation>
@@ -51,24 +52,35 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_argument_type&& arr, ir::range&& arg) const;
         primitive_argument_type tile1d(
             primitive_argument_type&& arr, ir::range&& arg) const;
+        primitive_argument_type tile2d(
+            primitive_argument_type&& arr, ir::range&& arg) const;
 
         template <typename T>
-        primitive_argument_type tile0d_1d(
+        primitive_argument_type tile0d_1arg(
             ir::node_data<T>&& arr, ir::range&& arg) const;
         template <typename T>
-        primitive_argument_type tile0d_2d(
+        primitive_argument_type tile0d_2args(
             ir::node_data<T>&& arr, ir::range&& arg) const;
         template <typename T>
         primitive_argument_type tile0d(ir::node_data<T>&& arr,
             ir::range&& arg) const;
         template <typename T>
-        primitive_argument_type tile1d_1d(
+        primitive_argument_type tile1d_1arg(
             ir::node_data<T>&& arr, ir::range&& arg) const;
         template <typename T>
-        primitive_argument_type tile1d_2d(
+        primitive_argument_type tile1d_2args(
             ir::node_data<T>&& arr, ir::range&& arg) const;
         template <typename T>
         primitive_argument_type tile1d(ir::node_data<T>&& arr,
+            ir::range&& arg) const;
+        template <typename T>
+        primitive_argument_type tile2d_1arg(
+            ir::node_data<T>&& arr, ir::range&& arg) const;
+        template <typename T>
+        primitive_argument_type tile2d_2args(
+            ir::node_data<T>&& arr, ir::range&& arg) const;
+        template <typename T>
+        primitive_argument_type tile2d(ir::node_data<T>&& arr,
             ir::range&& arg) const;
 
     private:

--- a/phylanx/plugins/matrixops/tile_operation.hpp
+++ b/phylanx/plugins/matrixops/tile_operation.hpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Parsa Amini
 // Copyright (c) 2018 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -48,9 +49,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         primitive_argument_type tile0d(
             primitive_argument_type&& arr, ir::range&& arg) const;
+        primitive_argument_type tile1d(
+            primitive_argument_type&& arr, ir::range&& arg) const;
 
         template <typename T>
+        primitive_argument_type tile0d_1d(
+            ir::node_data<T>&& arr, ir::range&& arg) const;
+        template <typename T>
+        primitive_argument_type tile0d_2d(
+            ir::node_data<T>&& arr, ir::range&& arg) const;
+        template <typename T>
         primitive_argument_type tile0d(ir::node_data<T>&& arr,
+            ir::range&& arg) const;
+        template <typename T>
+        primitive_argument_type tile1d_1d(
+            ir::node_data<T>&& arr, ir::range&& arg) const;
+        template <typename T>
+        primitive_argument_type tile1d_2d(
+            ir::node_data<T>&& arr, ir::range&& arg) const;
+        template <typename T>
+        primitive_argument_type tile1d(ir::node_data<T>&& arr,
             ir::range&& arg) const;
 
     private:

--- a/phylanx/plugins/matrixops/tile_operation.hpp
+++ b/phylanx/plugins/matrixops/tile_operation.hpp
@@ -83,8 +83,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type tile2d(ir::node_data<T>&& arr,
             ir::range&& arg) const;
 
-    private:
-        node_data_type dtype_;
     };
 
     inline primitive create_tile_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/tile_operation.hpp
+++ b/phylanx/plugins/matrixops/tile_operation.hpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef PHYLANX_TILE_OPERATION
+#define PHYLANX_TILE_OPERATION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+/// \brief Constructs an array by repeating a, the number of times given by reps.
+///
+/// \param a     The scalar, vector, or matrix
+/// \param reps  Integer or tuple of integers.
+    class tile_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<tile_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+    public:
+        static match_pattern_type const match_data;
+
+        tile_operation() = default;
+
+        tile_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+
+
+    private:
+        node_data_type dtype_;
+    };
+
+    inline primitive create_tile_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "tile", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -67,7 +67,6 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(slicing_operation_plugin,
     phylanx::execution_tree::primitives::slicing_operation::match_data[0]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(squeeze_operation_plugin,
     phylanx::execution_tree::primitives::squeeze_operation::match_data);
-
 PHYLANX_REGISTER_PLUGIN_FACTORY(tile_operation_plugin,
     phylanx::execution_tree::primitives::tile_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(transpose_operation_plugin,

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -67,6 +67,9 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(slicing_operation_plugin,
     phylanx::execution_tree::primitives::slicing_operation::match_data[0]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(squeeze_operation_plugin,
     phylanx::execution_tree::primitives::squeeze_operation::match_data);
+
+PHYLANX_REGISTER_PLUGIN_FACTORY(tile_operation_plugin,
+    phylanx::execution_tree::primitives::tile_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(transpose_operation_plugin,
     phylanx::execution_tree::primitives::transpose_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(unique_operation_plugin,

--- a/src/plugins/matrixops/tile_operation.cpp
+++ b/src/plugins/matrixops/tile_operation.cpp
@@ -1,0 +1,228 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/matrixops/tile_operation.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/iterator_facade.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const tile_operation::match_data =
+    {
+        hpx::util::make_tuple("tile",
+        std::vector<std::string>{"tile(_1,_2)"},
+        &create_tile_operation, &create_primitive<tile_operation>,
+         R"(
+            a, reps
+            Args:
+                a (array_like) : input array
+                reps (integer or tuple of integers):
+            Returns:
+            Constructs an array by repeating a, the number of times given by reps."
+            )") };
+
+    ///////////////////////////////////////////////////////////////////////////
+    tile_operation::tile_operation(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+        : primitive_component_base(std::move(operands), name, codename)
+        , dtype_(extract_dtype(name_))
+    {}
+
+     ///////////////////////////////////////////////////////////////////////////
+
+
+ /*   primitive_argument_type tile_operation::tile0d(
+        primitive_argument_type&& arr, ir::range&& arg) const
+    {
+        switch (extract_common_type(arr))
+        {
+        case node_data_type_bool:
+            return tile0d(
+                extract_boolean_value_strict(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        case node_data_type_int64:
+            return tile0d(
+                extract_integer_value_strict(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        case node_data_type_double:
+            return tile0d(
+                extract_numeric_value_strict(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        case node_data_type_unknown:
+            return tile0d(
+                extract_numeric_value(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::primitives::tile_operation::tile0d",
+            generate_error_message(
+                "the tile primitive requires for all arguments to "
+                "be numeric data types"));
+    }*/
+
+    ///////////////////////////////////////////////////////////////////////////
+    //primitive_argument_type tile_operation::tile1d(
+    //    primitive_argument_type&& arr, ir::range&& arg) const
+    //{
+    //    switch (extract_common_type(arr))
+    //    {
+    //    case node_data_type_bool:
+    //        return tile1d(
+    //            extract_boolean_value_strict(std::move(arr), name_, codename_),
+    //            std::move(arg));
+
+    //    case node_data_type_int64:
+    //        return tile1d(
+    //            extract_integer_value_strict(std::move(arr), name_, codename_),
+    //            std::move(arg));
+
+    //    case node_data_type_double:
+    //        return tile1d(
+    //            extract_numeric_value_strict(std::move(arr), name_, codename_),
+    //            std::move(arg));
+
+    //    case node_data_type_unknown:
+    //        return tile1d(
+    //            extract_numeric_value(std::move(arr), name_, codename_),
+    //            std::move(arg));
+
+    //    default:
+    //        break;
+    //    }
+
+    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+    //        "phylanx::execution_tree::primitives::tile_operation::tile1d",
+    //        generate_error_message(
+    //            "the tile primitive requires for all arguments to "
+    //            "be numeric data types"));
+    //}
+
+    ///////////////////////////////////////////////////////////////////////////
+
+
+ /*   primitive_argument_type tile_operation::tile2d(
+        primitive_argument_type&& arr, ir::range&& arg) const
+    {
+        switch (extract_common_type(arr))
+        {
+        case node_data_type_bool:
+            return tile2d(
+                extract_boolean_value_strict(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        case node_data_type_int64:
+            return tile2d(
+                extract_integer_value_strict(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        case node_data_type_double:
+            return tile2d(
+                extract_numeric_value_strict(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        case node_data_type_unknown:
+            return tile2d(
+                extract_numeric_value(std::move(arr), name_, codename_),
+                std::move(arg));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::primitives::tile_operation::tile2d",
+            generate_error_message(
+                "the tile primitive requires for all arguments to "
+                "be numeric data types"));
+    }*/
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> tile_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args,
+        eval_context ctx) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "tile_operation::eval",
+                util::generate_error_message(
+                    "the tile_operation primitive requires exactly two "
+                    "operands",
+                    name_, codename_));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "tile_operation::eval",
+                    util::generate_error_message(
+                        "the tile_operation primitive requires that the "
+                        "arguments given by the operands array are valid",
+                        name_, codename_));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping([this_ = std::move(this_)](
+                                      primitive_argument_type&& arr,
+                                      ir::range&& arg)
+                                      -> primitive_argument_type {
+                auto arr_dims_num = extract_numeric_value_dimension(
+                    arr, this_->name_, this_->codename_);
+
+
+                switch (arr_dims_num)
+                {
+                //case 0:
+                //    return this_->tile0d(std::move(arr), std::move(arg));
+
+                //case 1:
+                //    return this_->tile1d(std::move(arr), std::move(arg));
+
+                //case 2:
+                //    return this_->tile2d(std::move(arr), std::move(arg));
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "tile_operation::eval",
+                        util::generate_error_message("operand a has an invalid "
+                            "number of dimensions",
+                            this_->name_, this_->codename_));
+                }
+
+            }),
+            value_operand(operands[0], args, name_, codename_, ctx),
+            list_operand(operands[1], args, name_, codename_, ctx));
+    }
+}}}

--- a/src/plugins/matrixops/tile_operation.cpp
+++ b/src/plugins/matrixops/tile_operation.cpp
@@ -48,7 +48,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
     tile_operation::tile_operation(primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
         : primitive_component_base(std::move(operands), name, codename)
-        , dtype_(extract_dtype(name_))
     {}
 
      ///////////////////////////////////////////////////////////////////////////

--- a/tests/unit/plugins/matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/matrixops/CMakeLists.txt
@@ -16,7 +16,9 @@ set(tests
     dot_operation
     expand_dims
     extract_shape
-    eye_operation    flatten    generic_operation
+    eye_operation
+    flatten
+    generic_operation
     gradient_operation
     hstack_operation
     identity
@@ -32,6 +34,7 @@ set(tests
     shuffle_operation
     slicing_operation
     squeeze_operation
+    tile_operation
     transpose_operation
     unique
     vstack_operation

--- a/tests/unit/plugins/matrixops/tile_operation.cpp
+++ b/tests/unit/plugins/matrixops/tile_operation.cpp
@@ -128,11 +128,71 @@ void test_tile_operation_1d_matrix()
         phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_tile_operation_2d_vector()
+{
+    blaze::DynamicMatrix<std::int64_t> mat{{42, 13}, {33, 5}, {6, 4}};
+
+    phylanx::execution_tree::primitive arr =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(mat));
+
+    phylanx::execution_tree::primitive v1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(3));
+
+    phylanx::execution_tree::primitive tile =
+        phylanx::execution_tree::primitives::create_tile_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                phylanx::execution_tree::primitive_argument_type{
+                    std::move(arr)},
+                phylanx::execution_tree::primitive_argument_type{
+                    std::move(v1)} });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        tile.eval();
+
+    blaze::DynamicMatrix<std::int64_t> expected{
+        {42, 13, 42, 13, 42, 13}, {33, 5, 33, 5, 33, 5}, {6, 4, 6, 4, 6, 4}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+
+void test_tile_operation_2d_matrix()
+{
+    blaze::DynamicMatrix<double> mat{{1., 2.}, {3., 4.}};
+
+    phylanx::execution_tree::primitive arr =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(mat));
+
+    phylanx::execution_tree::primitive tile =
+        phylanx::execution_tree::primitives::create_tile_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{ std::move(arr),
+                phylanx::execution_tree::primitive_argument_type{
+                    phylanx::execution_tree::primitive_arguments_type{
+                        phylanx::ir::node_data<std::int64_t>(2),
+                        phylanx::ir::node_data<std::int64_t>(2)}} });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        tile.eval();
+
+    blaze::DynamicMatrix<double> expected{
+        {1., 2., 1., 2.}, {3., 4., 3., 4.}, {1., 2., 1., 2.}, {3., 4., 3., 4.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
 int main(int argc, char* argv[])
 {
     test_tile_operation_0d_vector();
     test_tile_operation_0d_matrix();
     test_tile_operation_1d_vector();
     test_tile_operation_1d_matrix();
+    test_tile_operation_2d_vector();
+    test_tile_operation_2d_matrix();
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/matrixops/tile_operation.cpp
+++ b/tests/unit/plugins/matrixops/tile_operation.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Parsa Amini
 // Copyright (c) 2018 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -27,8 +28,8 @@ void test_tile_operation_0d_vector()
         phylanx::execution_tree::primitives::create_variable(
             hpx::find_here(), phylanx::ir::node_data<std::int64_t>(3));
 
-    phylanx::execution_tree::primitive reshape =
-        phylanx::execution_tree::primitives::create_reshape_operation(
+    phylanx::execution_tree::primitive tile =
+        phylanx::execution_tree::primitives::create_tile_operation(
             hpx::find_here(),
             phylanx::execution_tree::primitive_arguments_type{
                 phylanx::execution_tree::primitive_argument_type{
@@ -37,7 +38,7 @@ void test_tile_operation_0d_vector()
                     std::move(v1)} });
 
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
-        reshape.eval();
+        tile.eval();
 
     blaze::DynamicVector<double> expected{42., 42., 42.};
 
@@ -45,10 +46,93 @@ void test_tile_operation_0d_vector()
         phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_tile_operation_0d_matrix()
+{
+    phylanx::execution_tree::primitive arr =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
 
+    phylanx::execution_tree::primitive tile =
+        phylanx::execution_tree::primitives::create_tile_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arr),
+                phylanx::execution_tree::primitive_argument_type{
+                    phylanx::execution_tree::primitive_arguments_type{
+                        phylanx::ir::node_data<std::int64_t>(3),
+                        phylanx::ir::node_data<std::int64_t>(2)}}});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        tile.eval();
+
+    blaze::DynamicMatrix<double> expected{{42., 42.}, {42., 42.}, {42., 42.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_tile_operation_1d_vector()
+{
+    blaze::DynamicVector<std::int64_t> vec{42, 13, 33};
+    phylanx::execution_tree::primitive arr =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(vec));
+
+    phylanx::execution_tree::primitive v1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(3));
+
+    phylanx::execution_tree::primitive tile =
+        phylanx::execution_tree::primitives::create_tile_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                phylanx::execution_tree::primitive_argument_type{
+                    std::move(arr)},
+                phylanx::execution_tree::primitive_argument_type{
+                    std::move(v1)}});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        tile.eval();
+
+    blaze::DynamicVector<std::int64_t> expected{
+        42, 13, 33, 42, 13, 33, 42, 13, 33};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+
+void test_tile_operation_1d_matrix()
+{
+    blaze::DynamicVector<double> vec{42., 13., 33.};
+
+    phylanx::execution_tree::primitive arr =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(vec));
+
+    phylanx::execution_tree::primitive tile =
+        phylanx::execution_tree::primitives::create_tile_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{ std::move(arr),
+                phylanx::execution_tree::primitive_argument_type{
+                    phylanx::execution_tree::primitive_arguments_type{
+                        phylanx::ir::node_data<std::int64_t>(2),
+                        phylanx::ir::node_data<std::int64_t>(3)}} });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        tile.eval();
+
+    blaze::DynamicMatrix<double> expected{
+        {42., 13., 33., 42., 13., 33., 42., 13., 33.},
+        {42., 13., 33., 42., 13., 33., 42., 13., 33.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
 
 int main(int argc, char* argv[])
 {
     test_tile_operation_0d_vector();
+    test_tile_operation_0d_matrix();
+    test_tile_operation_1d_vector();
+    test_tile_operation_1d_matrix();
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/matrixops/tile_operation.cpp
+++ b/tests/unit/plugins/matrixops/tile_operation.cpp
@@ -19,7 +19,30 @@
 //////////////////////////////////////////////////////////////////////////
 void test_tile_operation_0d_vector()
 {
+    phylanx::execution_tree::primitive arr =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
 
+    phylanx::execution_tree::primitive v1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(3));
+
+    phylanx::execution_tree::primitive reshape =
+        phylanx::execution_tree::primitives::create_reshape_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                phylanx::execution_tree::primitive_argument_type{
+                    std::move(arr)},
+                phylanx::execution_tree::primitive_argument_type{
+                    std::move(v1)} });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        reshape.eval();
+
+    blaze::DynamicVector<double> expected{42., 42., 42.};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
 

--- a/tests/unit/plugins/matrixops/tile_operation.cpp
+++ b/tests/unit/plugins/matrixops/tile_operation.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+//////////////////////////////////////////////////////////////////////////
+void test_tile_operation_0d_vector()
+{
+
+}
+
+
+
+int main(int argc, char* argv[])
+{
+    test_tile_operation_0d_vector();
+    return hpx::util::report_errors();
+}

--- a/tests/unit/plugins/matrixops/tile_operation.cpp
+++ b/tests/unit/plugins/matrixops/tile_operation.cpp
@@ -12,8 +12,6 @@
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstdint>
-#include <iostream>
-#include <string>
 #include <utility>
 #include <vector>
 


### PR DESCRIPTION
Tile primitive has the functionality of `numpy.tile`. It constructs an array by repeating the input array, the number of times given by repetitions.