### PR TITLE
Fix int strict helper

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -378,7 +378,7 @@ namespace phylanx { namespace execution_tree
             template <typename... Ts>
             hpx::future<ir::node_data<std::int64_t>> operator()(Ts&&... ts) const
             {
-                return execution_tree::integer_operand(std::forward<Ts>(ts)...);
+                return execution_tree::integer_operand_strict(std::forward<Ts>(ts)...);
             }
         };
     }


### PR DESCRIPTION
This PR addresses a corner-case in which a strict cast from a `primitive_argument_type` holding non-integer numeric values (`integer_operand_strict`) are cast to integers by disallowing non-integer types.