### PR TITLE
Adding Max primitive

### DIFF
--- a/phylanx/plugins/matrixops/matrixops.hpp
+++ b/phylanx/plugins/matrixops/matrixops.hpp
@@ -26,6 +26,7 @@
 #include <phylanx/plugins/matrixops/inverse_operation.hpp>
 #include <phylanx/plugins/matrixops/linearmatrix.hpp>
 #include <phylanx/plugins/matrixops/linspace.hpp>
+#include <phylanx/plugins/matrixops/max_operation.hpp>
 #include <phylanx/plugins/matrixops/mean_operation.hpp>
 #include <phylanx/plugins/matrixops/power_operation.hpp>
 #include <phylanx/plugins/matrixops/random.hpp>

--- a/phylanx/plugins/matrixops/max_operation.hpp
+++ b/phylanx/plugins/matrixops/max_operation.hpp
@@ -22,15 +22,13 @@
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives {
-    /// \brief
+    /// \brief Calculates the maximum of an array or maximum along an axis.
     /// \param a         The scalar, vector, or matrix to perform max over
     /// \param axis      Optional. If provided, max is calculated along the
     ///                  provided axis and a vector of results is returned.
-    ///                  \p keep_dims is ignored if \p axis present. Must be
-    ///                  nil if \p keep_dims is set
-    /// \param keep_dims Optional. Whether the max value has to have the same
-    ///                  number of dimensions as \p a. Ignored if \p axis is
-    ///                  anything except nil.
+    /// \param keep_dims Optional. If true the max value has to have the same
+    ///                  number of dimensions as a. Otherwise, the axes with
+    ///                  size one will be reduced.
 
 
     class max_operation

--- a/phylanx/plugins/matrixops/max_operation.hpp
+++ b/phylanx/plugins/matrixops/max_operation.hpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_MATRIXOPS_MAX_OPERATION)
+#define PHYLANX_MATRIXOPS_MAX_OPERATION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives {
+    /// \brief
+    /// \param a         The scalar, vector, or matrix to perform max over
+    /// \param axis      Optional. If provided, max is calculated along the
+    ///                  provided axis and a vector of results is returned.
+    ///                  \p keep_dims is ignored if \p axis present. Must be
+    ///                  nil if \p keep_dims is set
+    /// \param keep_dims Optional. Whether the max value has to have the same
+    ///                  number of dimensions as \p a. Ignored if \p axis is
+    ///                  anything except nil.
+
+
+    class max_operation
+      : public primitive_component_base
+      , public std::enable_shared_from_this<max_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+    public:
+        static match_pattern_type const match_data;
+
+        max_operation() = default;
+
+        max_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    private:
+        template <typename T>
+        primitive_argument_type max0d(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis) const;
+        template <typename T>
+        primitive_argument_type max1d(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type max2d(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type max2d_flat(
+            ir::node_data<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type max2d_axis0(
+            ir::node_data<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type max2d_axis1(
+            ir::node_data<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type maxnd(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+
+    private:
+        node_data_type dtype_;
+    };
+
+    inline primitive create_max_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "max", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -53,6 +53,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(linearmatrix_plugin,
     phylanx::execution_tree::primitives::linearmatrix::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(
     linspace_plugin, phylanx::execution_tree::primitives::linspace::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(max_operation_plugin,
+    phylanx::execution_tree::primitives::max_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(mean_operation_plugin,
     phylanx::execution_tree::primitives::mean_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(power_operation_plugin,

--- a/src/plugins/matrixops/max_operation.cpp
+++ b/src/plugins/matrixops/max_operation.cpp
@@ -1,0 +1,289 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/matrixops/max_operation.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/iterator_facade.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const max_operation::match_data =
+    {
+        hpx::util::make_tuple("max",
+        std::vector<std::string>{"max(_1)", "max(_1,_2)", "max(_1,_2,_3)"},
+        &create_max_operation, &create_primitive<max_operation>,
+        "a, axis, keepdims\n"
+        "Args:\n"
+        "\n"
+        "    a (vector or matrix) : a scalar, a vector or a matrix\n"
+        "    axis (optional, integer): an axis to max along. By default, "
+        "       flattened input is used.\n"
+        "    keepdims (optional, bool): If this is set to True, the axes which "
+        "       are reduced are left in the result as dimensions with size "
+        "       one. False by default \n"
+        "\n"
+        "Returns:\n"
+        "\n"
+        "Returns the maximum of an array or maximum along an axis.")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    max_operation::max_operation(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+        : primitive_component_base(std::move(operands), name, codename)
+        , dtype_(extract_dtype(name_))
+    {}
+
+    template <typename T>
+    primitive_argument_type max_operation::max0d(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "max_operation::max0d",
+                generate_error_message(
+                    "the max_operation primitive requires operand axis to be "
+                    "either 0 or -1 for scalar values."));
+        }
+
+        return primitive_argument_type{arg.scalar()};
+    }
+
+    template <typename T>
+    primitive_argument_type max_operation::max1d(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "max_operation::max1d",
+                generate_error_message(
+                    "the max_operation primitive requires operand axis to be "
+                    "either 0 or -1 for vectors."));
+        }
+        auto v = arg.vector();
+        T result = blaze::max(v);
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{blaze::DynamicVector<T>{result}};
+        }
+        return primitive_argument_type{result};
+    }
+
+    template <typename T>
+    primitive_argument_type max_operation::max2d(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        if (axis)
+        {
+            switch (axis.value())
+            {
+            case -2:
+                HPX_FALLTHROUGH;
+            case 0:
+                return max2d_axis0(std::move(arg), keep_dims);
+
+            case -1:
+                HPX_FALLTHROUGH;
+            case 1:
+                return max2d_axis1(std::move(arg), keep_dims);
+
+            default:
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "max_operation::max2d",
+                    generate_error_message(
+                        "the max_operation primitive requires operand axis "
+                        "to be between -2 and 1 for matrices."));
+            }
+        }
+        return max2d_flat(std::move(arg), keep_dims);
+    }
+
+    template <typename T>
+    primitive_argument_type max_operation::max2d_flat(
+        ir::node_data<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+        T result = blaze::max(m);
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{blaze::DynamicMatrix<T>{{result}}};
+        }
+        return primitive_argument_type{result};
+    }
+
+    template <typename T>
+    primitive_argument_type max_operation::max2d_axis0(
+        ir::node_data<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+        blaze::DynamicVector<T> result(m.columns());
+        for (std::size_t i = 0; i < m.columns(); ++i)
+        {
+            result[i] = blaze::max(column(m, i));
+        }
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{
+                blaze::DynamicMatrix<T>{1, result.size(), result.data()}};
+        }
+        return primitive_argument_type{result};
+    }
+
+    template <typename T>
+    primitive_argument_type max_operation::max2d_axis1(
+        ir::node_data<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+        blaze::DynamicVector<T> result(m.rows());
+        for (std::size_t i = 0; i < m.rows(); ++i)
+        {
+            result[i] = blaze::max(row(m, i));
+        }
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{
+                blaze::DynamicMatrix<T>{result.size(), 1, result.data()}};
+        }
+        return primitive_argument_type{result};
+    }
+
+    template <typename T>
+    primitive_argument_type max_operation::maxnd(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        std::size_t a_dims = arg.num_dimensions();
+        switch (a_dims)
+        {
+        case 0:
+            return max0d(std::move(arg), axis);
+
+        case 1:
+            return max1d(std::move(arg), axis, keep_dims);
+
+        case 2:
+            return max2d(std::move(arg), axis, keep_dims);
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "max_operation::eval",
+                generate_error_message(
+                    "operand a has an invalid number of dimensions"));
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> max_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.empty() || operands.size() > 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "max_operation::eval",
+                generate_error_message("the max_operation primitive requires "
+                                       "exactly one, two, or "
+                                       "three operands"));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "max_operation::eval",
+                    generate_error_message(
+                        "the max_operation primitive requires that the "
+                        "arguments given by the operands array are valid"));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping(
+                [this_ = std::move(this_)](primitive_arguments_type&& args)
+                ->primitive_argument_type {
+            // Extract axis and keep_dims
+            // Presence of axis changes behavior for >0d cases
+            hpx::util::optional<std::int64_t> axis;
+            bool keep_dims = false;
+
+            // axis is argument #2
+            if (args.size() > 1)
+            {
+                if (valid(args[1]))
+                {
+                    axis = extract_scalar_integer_value_strict(
+                        args[1], this_->name_, this_->codename_);
+                }
+
+                // keep_dims is argument #3
+                if (args.size() == 3)
+                {
+                    keep_dims = extract_scalar_boolean_value(
+                        args[2], this_->name_, this_->codename_);
+                }
+            }
+
+            node_data_type t = this_->dtype_;
+            if (t == node_data_type_unknown)
+            {
+                t = extract_common_type(args[0]);
+            }
+
+            switch (t)
+            {
+            case node_data_type_bool:
+                return this_->maxnd(extract_boolean_value(std::move(args[0]),
+                                        this_->name_, this_->codename_),
+                    axis, keep_dims);
+            case node_data_type_int64:
+                return this_->maxnd(extract_integer_value(std::move(args[0]),
+                                        this_->name_, this_->codename_),
+                    axis, keep_dims);
+            case node_data_type_double:
+                return this_->maxnd(extract_numeric_value(std::move(args[0]),
+                                        this_->name_, this_->codename_),
+                    axis, keep_dims);
+            default:
+                break;
+            }
+
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "max::eval",
+                this_->generate_error_message(
+                    "the max primitive requires for all arguments "
+                    "to be numeric data types"));
+        }),
+            detail::map_operands(operands, functional::value_operand{}, args,
+                name_, codename_, std::move(ctx)));
+    }
+}}}

--- a/src/plugins/matrixops/max_operation.cpp
+++ b/src/plugins/matrixops/max_operation.cpp
@@ -16,8 +16,6 @@
 #include <hpx/util/iterator_facade.hpp>
 #include <hpx/util/optional.hpp>
 
-#include <algorithm>
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -54,7 +52,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
     max_operation::max_operation(primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
         : primitive_component_base(std::move(operands), name, codename)
-        , dtype_(extract_dtype(name_))
     {}
 
     template <typename T>
@@ -92,7 +89,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             return primitive_argument_type{blaze::DynamicVector<T>{result}};
         }
-        return primitive_argument_type{result};
+        return primitive_argument_type{ir::node_data<T>{result}};
     }
 
     template <typename T>
@@ -135,7 +132,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             return primitive_argument_type{blaze::DynamicMatrix<T>{{result}}};
         }
-        return primitive_argument_type{result};
+        return primitive_argument_type{ir::node_data<T>{result}};
     }
 
     template <typename T>
@@ -154,7 +151,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{
                 blaze::DynamicMatrix<T>{1, result.size(), result.data()}};
         }
-        return primitive_argument_type{result};
+        return primitive_argument_type{ir::node_data<T>{result}};
     }
 
     template <typename T>
@@ -173,7 +170,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{
                 blaze::DynamicMatrix<T>{result.size(), 1, result.data()}};
         }
-        return primitive_argument_type{result};
+        return primitive_argument_type{ir::node_data<T>{result}};
     }
 
     template <typename T>
@@ -253,13 +250,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
             }
 
-            node_data_type t = this_->dtype_;
-            if (t == node_data_type_unknown)
-            {
-                t = extract_common_type(args[0]);
-            }
-
-            switch (t)
+            switch (extract_common_type(args[0]))
             {
             case node_data_type_bool:
                 return this_->maxnd(extract_boolean_value(std::move(args[0]),

--- a/src/plugins/matrixops/max_operation.cpp
+++ b/src/plugins/matrixops/max_operation.cpp
@@ -16,6 +16,7 @@
 #include <hpx/util/iterator_facade.hpp>
 #include <hpx/util/optional.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -83,13 +84,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "either 0 or -1 for vectors."));
         }
         auto v = arg.vector();
-        T result = blaze::max(v);
+        T result = (blaze::max)(v);
 
         if (keep_dims)
         {
-            return primitive_argument_type{blaze::DynamicVector<T>{result}};
+            return primitive_argument_type{blaze::DynamicVector<T>{std::move(result)}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>
@@ -126,13 +127,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ir::node_data<T>&& arg, bool keep_dims) const
     {
         auto m = arg.matrix();
-        T result = blaze::max(m);
+        T result = (blaze::max)(m);
 
         if (keep_dims)
         {
-            return primitive_argument_type{blaze::DynamicMatrix<T>{{result}}};
+            return primitive_argument_type{
+                blaze::DynamicMatrix<T>{{std::move(result)}}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>
@@ -143,7 +145,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicVector<T> result(m.columns());
         for (std::size_t i = 0; i < m.columns(); ++i)
         {
-            result[i] = blaze::max(column(m, i));
+            result[i] = (blaze::max)(column(m, i));
         }
 
         if (keep_dims)
@@ -151,7 +153,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{
                 blaze::DynamicMatrix<T>{1, result.size(), result.data()}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>
@@ -162,7 +164,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicVector<T> result(m.rows());
         for (std::size_t i = 0; i < m.rows(); ++i)
         {
-            result[i] = blaze::max(row(m, i));
+            result[i] = (blaze::max)(row(m, i));
         }
 
         if (keep_dims)
@@ -170,7 +172,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{
                 blaze::DynamicMatrix<T>{result.size(), 1, result.data()}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>

--- a/tests/unit/plugins/matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/matrixops/CMakeLists.txt
@@ -26,6 +26,7 @@ set(tests
     linearmatrix
     linspace
     list_slicing_operation
+    max_operation
     mean_operation
     power_operation
     random

--- a/tests/unit/plugins/matrixops/max_operation.cpp
+++ b/tests/unit/plugins/matrixops/max_operation.cpp
@@ -11,7 +11,7 @@
 
 #include <cstdint>
 #include <string>
-
+#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(
@@ -62,18 +62,24 @@ void test_2d_keep_dims_true()
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    test_max_operation("max(42.)",                                       "42.");
-    test_max_operation("max(42., 0, true)",                              "42.");
-    test_max_operation("max([13., 42., 33.])",                           "42.");
-    test_max_operation("max([13., 42., 33.], -1)",                       "42.");
-    test_max_operation("max([13., 42., 33.],  0, true)",                 "hstack(42.)");
-    test_max_operation("max([[13., 42., 33.],[101, 12, 65]])",           "101.");
-    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  0)",       "hstack(101. ,42., 65.)");
-    test_max_operation("max([[13., 42., 33.],[101, 12, 65]], -2)",       "hstack(101. ,42., 65.)");
-    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  1)",       "hstack(42., 101.)");
-    test_max_operation("max([[13., 42., 33.],[101, 12, 65]], -1)",       "hstack(42., 101.)");
-    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  0, true)", "vstack(hstack(101. ,42., 65.))");
-    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  1, true)", "vstack(hstack(42.), hstack(101.))");
+    test_max_operation("max(42.)", "42.");
+    test_max_operation("max(42., 0, true)", "42.");
+    test_max_operation("max([13., 42., 33.])", "42.");
+    test_max_operation("max([13., 42., 33.], -1)", "42.");
+    test_max_operation("max([13., 42., 33.],  0, true)", "hstack(42.)");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]])", "101.");
+    test_max_operation(
+        "max([[13., 42., 33.],[101, 12, 65]],  0)", "hstack(101. ,42., 65.)");
+    test_max_operation(
+        "max([[13., 42., 33.],[101, 12, 65]], -2)", "hstack(101. ,42., 65.)");
+    test_max_operation(
+        "max([[13., 42., 33.],[101, 12, 65]],  1)", "hstack(42., 101.)");
+    test_max_operation(
+        "max([[13., 42., 33.],[101, 12, 65]], -1)", "hstack(42., 101.)");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  0, true)",
+        "vstack(hstack(101. ,42., 65.))");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  1, true)",
+        "vstack(hstack(42.), hstack(101.))");
     test_2d_keep_dims_true();
 
     return hpx::util::report_errors();

--- a/tests/unit/plugins/matrixops/max_operation.cpp
+++ b/tests/unit/plugins/matrixops/max_operation.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <string>
+
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_max_operation(std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(code), compile_and_run(expected_str));
+}
+
+void test_2d_keep_dims_true()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{13, 42, 33}, {101, 12, 65}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive max =
+        phylanx::execution_tree::primitives::create_max_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2) });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        max.eval();
+
+    blaze::DynamicMatrix<std::int64_t> expected {{101}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_max_operation("max(42.)",                                       "42.");
+    test_max_operation("max(42., 0, true)",                              "42.");
+    test_max_operation("max([13., 42., 33.])",                           "42.");
+    test_max_operation("max([13., 42., 33.], -1)",                       "42.");
+    test_max_operation("max([13., 42., 33.],  0, true)",                 "hstack(42.)");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]])",           "101.");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  0)",       "hstack(101. ,42., 65.)");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]], -2)",       "hstack(101. ,42., 65.)");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  1)",       "hstack(42., 101.)");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]], -1)",       "hstack(42., 101.)");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  0, true)", "vstack(hstack(101. ,42., 65.))");
+    test_max_operation("max([[13., 42., 33.],[101, 12, 65]],  1, true)", "vstack(hstack(42.), hstack(101.))");
+    test_2d_keep_dims_true();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Although there is an `amax` in generic_operations, having `axis` and `keepdims` options come handy in many cases. Therefore, max_primitive has a part of the functionality of [NumPy amax](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.amax.html) 
`max(a,axis,keepdims)`