### PR TITLE
Adding Min primitive

### DIFF
--- a/phylanx/plugins/matrixops/matrixops.hpp
+++ b/phylanx/plugins/matrixops/matrixops.hpp
@@ -27,6 +27,7 @@
 #include <phylanx/plugins/matrixops/linearmatrix.hpp>
 #include <phylanx/plugins/matrixops/linspace.hpp>
 #include <phylanx/plugins/matrixops/mean_operation.hpp>
+#include <phylanx/plugins/matrixops/min_operation.hpp>
 #include <phylanx/plugins/matrixops/power_operation.hpp>
 #include <phylanx/plugins/matrixops/random.hpp>
 #include <phylanx/plugins/matrixops/reshape_operation.hpp>

--- a/phylanx/plugins/matrixops/min_operation.hpp
+++ b/phylanx/plugins/matrixops/min_operation.hpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_MATRIXOPS_MIN_OPERATION)
+#define PHYLANX_MATRIXOPS_MIN_OPERATION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives {
+    /// \brief Calculates the minimum of an array or minimum along an axis.
+    /// \param a         The scalar, vector, or matrix to perform min over
+    /// \param axis      Optional. If provided, min is calculated along the
+    ///                  provided axis and a vector of results is returned.
+    /// \param keep_dims Optional. If true the min value has to have the same
+    ///                  number of dimensions as a. Otherwise, the axes with
+    ///                  size one will be reduced.
+
+
+    class min_operation
+      : public primitive_component_base
+      , public std::enable_shared_from_this<min_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+    public:
+        static match_pattern_type const match_data;
+
+        min_operation() = default;
+
+        min_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    private:
+        template <typename T>
+        primitive_argument_type min0d(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis) const;
+        template <typename T>
+        primitive_argument_type min1d(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type min2d(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type min2d_flat(
+            ir::node_data<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type min2d_axis0(
+            ir::node_data<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type min2d_axis1(
+            ir::node_data<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type minnd(ir::node_data<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+
+    private:
+        node_data_type dtype_;
+    };
+
+    inline primitive create_min_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "min", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -55,6 +55,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(
     linspace_plugin, phylanx::execution_tree::primitives::linspace::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(mean_operation_plugin,
     phylanx::execution_tree::primitives::mean_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(min_operation_plugin,
+    phylanx::execution_tree::primitives::min_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(power_operation_plugin,
     phylanx::execution_tree::primitives::power_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(

--- a/src/plugins/matrixops/min_operation.cpp
+++ b/src/plugins/matrixops/min_operation.cpp
@@ -16,6 +16,9 @@
 #include <hpx/util/iterator_facade.hpp>
 #include <hpx/util/optional.hpp>
 
+#include <boost/config.hpp>
+
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -83,7 +86,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "either 0 or -1 for vectors."));
         }
         auto v = arg.vector();
-        T result = blaze::min(v);
+        T result = blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(v);
 
         if (keep_dims)
         {
@@ -126,7 +129,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ir::node_data<T>&& arg, bool keep_dims) const
     {
         auto m = arg.matrix();
-        T result = blaze::min(m);
+        T result = blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(m);
 
         if (keep_dims)
         {
@@ -143,7 +146,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicVector<T> result(m.columns());
         for (std::size_t i = 0; i < m.columns(); ++i)
         {
-            result[i] = blaze::min(column(m, i));
+            result[i] =
+                blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(column(m, i));
         }
 
         if (keep_dims)
@@ -162,7 +166,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicVector<T> result(m.rows());
         for (std::size_t i = 0; i < m.rows(); ++i)
         {
-            result[i] = blaze::min(row(m, i));
+            result[i] = blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(row(m, i));
         }
 
         if (keep_dims)

--- a/src/plugins/matrixops/min_operation.cpp
+++ b/src/plugins/matrixops/min_operation.cpp
@@ -16,8 +16,6 @@
 #include <hpx/util/iterator_facade.hpp>
 #include <hpx/util/optional.hpp>
 
-#include <boost/config.hpp>
-
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -86,13 +84,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "either 0 or -1 for vectors."));
         }
         auto v = arg.vector();
-        T result = blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(v);
+        T result = (blaze::min)(v);
 
         if (keep_dims)
         {
-            return primitive_argument_type{blaze::DynamicVector<T>{result}};
+            return primitive_argument_type{
+                blaze::DynamicVector<T>{std::move(result)}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>
@@ -129,13 +128,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ir::node_data<T>&& arg, bool keep_dims) const
     {
         auto m = arg.matrix();
-        T result = blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(m);
+        T result = (blaze::min)(m);
 
         if (keep_dims)
         {
-            return primitive_argument_type{blaze::DynamicMatrix<T>{{result}}};
+            return primitive_argument_type{
+                blaze::DynamicMatrix<T>{{std::move(result)}}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>
@@ -146,8 +146,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicVector<T> result(m.columns());
         for (std::size_t i = 0; i < m.columns(); ++i)
         {
-            result[i] =
-                blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(column(m, i));
+            result[i] = (blaze::min)(column(m, i));
         }
 
         if (keep_dims)
@@ -155,7 +154,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{
                 blaze::DynamicMatrix<T>{1, result.size(), result.data()}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>
@@ -166,7 +165,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicVector<T> result(m.rows());
         for (std::size_t i = 0; i < m.rows(); ++i)
         {
-            result[i] = blaze::min BOOST_PREVENT_MACRO_SUBSTITUTION(row(m, i));
+            result[i] = (blaze::min)(row(m, i));
         }
 
         if (keep_dims)
@@ -174,7 +173,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{
                 blaze::DynamicMatrix<T>{result.size(), 1, result.data()}};
         }
-        return primitive_argument_type{ir::node_data<T>{result}};
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
     }
 
     template <typename T>

--- a/src/plugins/matrixops/min_operation.cpp
+++ b/src/plugins/matrixops/min_operation.cpp
@@ -1,0 +1,280 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/matrixops/min_operation.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/iterator_facade.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const min_operation::match_data =
+    {
+        hpx::util::make_tuple("min",
+        std::vector<std::string>{"min(_1)", "min(_1,_2)", "min(_1,_2,_3)"},
+        &create_min_operation, &create_primitive<min_operation>,
+        "a, axis, keepdims\n"
+        "Args:\n"
+        "\n"
+        "    a (vector or matrix) : a scalar, a vector or a matrix\n"
+        "    axis (optional, integer): an axis to min along. By default, "
+        "       flattened input is used.\n"
+        "    keepdims (optional, bool): If this is set to True, the axes which "
+        "       are reduced are left in the result as dimensions with size "
+        "       one. False by default \n"
+        "\n"
+        "Returns:\n"
+        "\n"
+        "Returns the minimum of an array or minimum along an axis.")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    min_operation::min_operation(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+        : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    template <typename T>
+    primitive_argument_type min_operation::min0d(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "min_operation::min0d",
+                generate_error_message(
+                    "the min_operation primitive requires operand axis to be "
+                    "either 0 or -1 for scalar values."));
+        }
+
+        return primitive_argument_type{arg.scalar()};
+    }
+
+    template <typename T>
+    primitive_argument_type min_operation::min1d(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "min_operation::min1d",
+                generate_error_message(
+                    "the min_operation primitive requires operand axis to be "
+                    "either 0 or -1 for vectors."));
+        }
+        auto v = arg.vector();
+        T result = blaze::min(v);
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{blaze::DynamicVector<T>{result}};
+        }
+        return primitive_argument_type{ir::node_data<T>{result}};
+    }
+
+    template <typename T>
+    primitive_argument_type min_operation::min2d(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        if (axis)
+        {
+            switch (axis.value())
+            {
+            case -2:
+                HPX_FALLTHROUGH;
+            case 0:
+                return min2d_axis0(std::move(arg), keep_dims);
+
+            case -1:
+                HPX_FALLTHROUGH;
+            case 1:
+                return min2d_axis1(std::move(arg), keep_dims);
+
+            default:
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "min_operation::min2d",
+                    generate_error_message(
+                        "the min_operation primitive requires operand axis "
+                        "to be between -2 and 1 for matrices."));
+            }
+        }
+        return min2d_flat(std::move(arg), keep_dims);
+    }
+
+    template <typename T>
+    primitive_argument_type min_operation::min2d_flat(
+        ir::node_data<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+        T result = blaze::min(m);
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{blaze::DynamicMatrix<T>{{result}}};
+        }
+        return primitive_argument_type{ir::node_data<T>{result}};
+    }
+
+    template <typename T>
+    primitive_argument_type min_operation::min2d_axis0(
+        ir::node_data<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+        blaze::DynamicVector<T> result(m.columns());
+        for (std::size_t i = 0; i < m.columns(); ++i)
+        {
+            result[i] = blaze::min(column(m, i));
+        }
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{
+                blaze::DynamicMatrix<T>{1, result.size(), result.data()}};
+        }
+        return primitive_argument_type{ir::node_data<T>{result}};
+    }
+
+    template <typename T>
+    primitive_argument_type min_operation::min2d_axis1(
+        ir::node_data<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+        blaze::DynamicVector<T> result(m.rows());
+        for (std::size_t i = 0; i < m.rows(); ++i)
+        {
+            result[i] = blaze::min(row(m, i));
+        }
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{
+                blaze::DynamicMatrix<T>{result.size(), 1, result.data()}};
+        }
+        return primitive_argument_type{ir::node_data<T>{result}};
+    }
+
+    template <typename T>
+    primitive_argument_type min_operation::minnd(ir::node_data<T>&& arg,
+        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    {
+        std::size_t a_dims = arg.num_dimensions();
+        switch (a_dims)
+        {
+        case 0:
+            return min0d(std::move(arg), axis);
+
+        case 1:
+            return min1d(std::move(arg), axis, keep_dims);
+
+        case 2:
+            return min2d(std::move(arg), axis, keep_dims);
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "min_operation::eval",
+                generate_error_message(
+                    "operand a has an invalid number of dimensions"));
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> min_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.empty() || operands.size() > 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "min_operation::eval",
+                generate_error_message("the min_operation primitive requires "
+                                       "exactly one, two, or "
+                                       "three operands"));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "min_operation::eval",
+                    generate_error_message(
+                        "the min_operation primitive requires that the "
+                        "arguments given by the operands array are valid"));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping(
+                [this_ = std::move(this_)](primitive_arguments_type&& args)
+                ->primitive_argument_type {
+            // Extract axis and keep_dims
+            // Presence of axis changes behavior for >0d cases
+            hpx::util::optional<std::int64_t> axis;
+            bool keep_dims = false;
+
+            // axis is argument #2
+            if (args.size() > 1)
+            {
+                if (valid(args[1]))
+                {
+                    axis = extract_scalar_integer_value_strict(
+                        args[1], this_->name_, this_->codename_);
+                }
+
+                // keep_dims is argument #3
+                if (args.size() == 3)
+                {
+                    keep_dims = extract_scalar_boolean_value(
+                        args[2], this_->name_, this_->codename_);
+                }
+            }
+
+            switch (extract_common_type(args[0]))
+            {
+            case node_data_type_bool:
+                return this_->minnd(extract_boolean_value(std::move(args[0]),
+                                        this_->name_, this_->codename_),
+                    axis, keep_dims);
+            case node_data_type_int64:
+                return this_->minnd(extract_integer_value(std::move(args[0]),
+                                        this_->name_, this_->codename_),
+                    axis, keep_dims);
+            case node_data_type_double:
+                return this_->minnd(extract_numeric_value(std::move(args[0]),
+                                        this_->name_, this_->codename_),
+                    axis, keep_dims);
+            default:
+                break;
+            }
+
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "min::eval",
+                this_->generate_error_message(
+                    "the min primitive requires for all arguments "
+                    "to be numeric data types"));
+        }),
+            detail::map_operands(operands, functional::value_operand{}, args,
+                name_, codename_, std::move(ctx)));
+    }
+}}}

--- a/tests/unit/plugins/matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/matrixops/CMakeLists.txt
@@ -18,7 +18,8 @@ set(tests
     extract_shape
     eye_operation
     flatten
-    generic_operation    gradient_operation
+    generic_operation
+    gradient_operation
     hstack_operation
     identity
     inverse_operation

--- a/tests/unit/plugins/matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/matrixops/CMakeLists.txt
@@ -18,8 +18,7 @@ set(tests
     extract_shape
     eye_operation
     flatten
-    generic_operation
-    gradient_operation
+    generic_operation    gradient_operation
     hstack_operation
     identity
     inverse_operation
@@ -27,6 +26,7 @@ set(tests
     linspace
     list_slicing_operation
     mean_operation
+    min_operation
     power_operation
     random
     random_distributions

--- a/tests/unit/plugins/matrixops/min_operation.cpp
+++ b/tests/unit/plugins/matrixops/min_operation.cpp
@@ -11,7 +11,7 @@
 
 #include <cstdint>
 #include <string>
-
+#include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(
@@ -62,18 +62,24 @@ void test_2d_keep_dims_true()
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
-    test_min_operation("min(42.)",                                          "42.");
-    test_min_operation("min(42., 0, true)",                                 "42.");
-    test_min_operation("min([13., 42., 33.])",                              "13.");
-    test_min_operation("min([13., 42., 33.], -1)",                          "13.");
-    test_min_operation("min([13., 42., 33.],  0, true)",                    "hstack(13.)");
-    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]])",           "12.");
-    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  0)",       "hstack(13. ,12., 33.)");
-    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]], -2)",       "hstack(13. ,12., 33.)");
-    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  1)",       "hstack(13. ,12.)");
-    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]], -1)",       "hstack(13. ,12.)");
-    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  0, true)", "vstack(hstack(13. ,12., 33.))");
-    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  1, true)", "vstack(hstack(13.), hstack(12.))");
+    test_min_operation("min(42.)", "42.");
+    test_min_operation("min(42., 0, true)", "42.");
+    test_min_operation("min([13., 42., 33.])", "13.");
+    test_min_operation("min([13., 42., 33.], -1)", "13.");
+    test_min_operation("min([13., 42., 33.],  0, true)", "hstack(13.)");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]])", "12.");
+    test_min_operation(
+        "min([[13., 42., 33.],[101., 12., 65.]],  0)", "hstack(13. ,12., 33.)");
+    test_min_operation(
+        "min([[13., 42., 33.],[101., 12., 65.]], -2)", "hstack(13. ,12., 33.)");
+    test_min_operation(
+        "min([[13., 42., 33.],[101., 12., 65.]],  1)", "hstack(13. ,12.)");
+    test_min_operation(
+        "min([[13., 42., 33.],[101., 12., 65.]], -1)", "hstack(13. ,12.)");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  0, true)",
+        "vstack(hstack(13. ,12., 33.))");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  1, true)",
+        "vstack(hstack(13.), hstack(12.))");
     test_2d_keep_dims_true();
 
     return hpx::util::report_errors();

--- a/tests/unit/plugins/matrixops/min_operation.cpp
+++ b/tests/unit/plugins/matrixops/min_operation.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <string>
+
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_min_operation(std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(code), compile_and_run(expected_str));
+}
+
+void test_2d_keep_dims_true()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{13, 42, 33}, {101, 12, 65}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive min =
+        phylanx::execution_tree::primitives::create_min_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2) });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        min.eval();
+
+    blaze::DynamicMatrix<std::int64_t> expected{{12}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_min_operation("min(42.)",                                          "42.");
+    test_min_operation("min(42., 0, true)",                                 "42.");
+    test_min_operation("min([13., 42., 33.])",                              "13.");
+    test_min_operation("min([13., 42., 33.], -1)",                          "13.");
+    test_min_operation("min([13., 42., 33.],  0, true)",                    "hstack(13.)");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]])",           "12.");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  0)",       "hstack(13. ,12., 33.)");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]], -2)",       "hstack(13. ,12., 33.)");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  1)",       "hstack(13. ,12.)");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]], -1)",       "hstack(13. ,12.)");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  0, true)", "vstack(hstack(13. ,12., 33.))");
+    test_min_operation("min([[13., 42., 33.],[101., 12., 65.]],  1, true)", "vstack(hstack(13.), hstack(12.))");
+    test_2d_keep_dims_true();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Although there is an `amin` in generic_operations, having `axis` and `keepdims` options come handy in many cases. Therefore, min_primitive has a part of the functionality of [NumPy amax](https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.amin.html)
`min(a,axis,keepdims)`