### PR TITLE
Modifying reshape primitive, reshape1d_to_2d

### DIFF
--- a/src/plugins/matrixops/reshape_operation.cpp
+++ b/src/plugins/matrixops/reshape_operation.cpp
@@ -156,6 +156,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     primitive_argument_type reshape_operation::reshape1d_2d(
         ir::node_data<T>&& arr, ir::range&& arg) const
     {
+        using phylanx::util::matrix_row_iterator;
         auto a = arr.vector();
 
         auto it = arg.begin();
@@ -164,13 +165,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         blaze::DynamicMatrix<T> result(first, second);
 
-        //const matrix_row_iterator<decltype(a)> a_begin(a);
-        //const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+        const matrix_row_iterator<decltype(result)> r_begin(result);
+        const matrix_row_iterator<decltype(result)> r_end(result, first);
 
-        //auto d = result.data();
-        //for (auto i = 0; i != first; i++)
-            d = std::copy(a.begin(), a.end(), d);
+        auto b = a.begin();
+        auto e = b;
+        std::advance(e, second);
 
+        for (auto i = r_begin; i != r_end; i++)
+        {
+            std::copy(b, e, i->begin());
+            b = e;
+            std::advance(e, second);
+        }
         return primitive_argument_type{std::move(result)};
     }
 

--- a/src/plugins/matrixops/reshape_operation.cpp
+++ b/src/plugins/matrixops/reshape_operation.cpp
@@ -164,8 +164,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         blaze::DynamicMatrix<T> result(first, second);
 
-        auto d = result.data();
-        d = std::copy(a.begin(), a.end(), d);
+        //const matrix_row_iterator<decltype(a)> a_begin(a);
+        //const matrix_row_iterator<decltype(a)> a_end(a, a.rows());
+
+        //auto d = result.data();
+        //for (auto i = 0; i != first; i++)
+            d = std::copy(a.begin(), a.end(), d);
 
         return primitive_argument_type{std::move(result)};
     }


### PR DESCRIPTION
I have modified reshape1d_2d to account for padding for the output matrix. The case that confuses me is that reshape2d_2d copy the data in a for loop on rows of the input matrix (not the output matrix). I think that may cause the problem of padding, too.