### PR TITLE
Propagate dtype

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -325,6 +325,13 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT bool is_integer_operand(primitive_argument_type const& val);
 
+    PHYLANX_EXPORT hpx::future<std::int64_t> scalar_integer_operand(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>",
+        eval_context ctx = eval_context{});
+
     // Extract a ir::node_data<std::int64_t> type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT ir::node_data<std::int64_t> extract_integer_value_strict(
@@ -347,12 +354,6 @@ namespace phylanx { namespace execution_tree
     // Extract an integer value from a primitive_argument_type
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>>
     integer_operand_strict(primitive_argument_type const& val,
-        primitive_arguments_type const& args,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>",
-        eval_context ctx = eval_context{});
-    PHYLANX_EXPORT hpx::future<std::int64_t> scalar_integer_operand_strict(
-        primitive_argument_type const& val,
         primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>",
@@ -390,6 +391,14 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT bool is_integer_operand_strict(
         primitive_argument_type const& val);
+
+    ///////////////////////////////////////////////////////////////////////////
+    PHYLANX_EXPORT hpx::future<std::int64_t> scalar_integer_operand_strict(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>",
+        eval_context ctx = eval_context{});
 
     ///////////////////////////////////////////////////////////////////////////
     // Extract a boolean type from a given primitive_argument_type,

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -352,10 +352,10 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
     PHYLANX_EXPORT hpx::future<std::int64_t> scalar_integer_operand_strict(
-            primitive_argument_type const& val,
-            primitive_arguments_type const& args,
-            std::string const& name = "",
-            std::string const& codename = "<unknown>",
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
     PHYLANX_EXPORT hpx::future<ir::node_data<std::int64_t>>
     integer_operand_strict(primitive_argument_type const& val,
@@ -722,6 +722,12 @@ namespace phylanx { namespace execution_tree
     // Extract a node_data<double> from a primitive_argument_type (that
     // could be a primitive or a literal value).
     PHYLANX_EXPORT hpx::future<ir::node_data<double>> numeric_operand(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>",
+        eval_context ctx = eval_context{});
+    PHYLANX_EXPORT hpx::future<double> scalar_numeric_operand(
         primitive_argument_type const& val,
         primitive_arguments_type const& args,
         std::string const& name = "",

--- a/phylanx/plugins/arithmetics/prod_operation.hpp
+++ b/phylanx/plugins/arithmetics/prod_operation.hpp
@@ -10,18 +10,20 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
-#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/plugins/arithmetics/statistics.hpp>
 
-#include <hpx/lcos/future.hpp>
-#include <hpx/util/optional.hpp>
-
-#include <cstdint>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
-namespace phylanx { namespace execution_tree { namespace primitives {
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        struct statistics_prod_op;
+    }
+
     /// \brief products the values of the elements of a vector or a matrix or
     ///        returns the value of the scalar that was given to it.
     /// \param a         The scalar, vector, or matrix to perform prod over
@@ -34,16 +36,11 @@ namespace phylanx { namespace execution_tree { namespace primitives {
     ///                  anything except nil.
     /// This implementation is intended to behave like [NumPy implementation of prod]
     /// (https://docs.scipy.org/doc/numpy-1.15.0/reference/generated/numpy.prod.html).
-
     class prod_operation
-      : public primitive_component_base
-      , public std::enable_shared_from_this<prod_operation>
+      : public statistics<detail::statistics_prod_op, prod_operation>
     {
-    protected:
-        hpx::future<primitive_argument_type> eval(
-            primitive_arguments_type const& operands,
-            primitive_arguments_type const& args,
-            eval_context ctx) const override;
+        using base_type =
+            statistics<detail::statistics_prod_op, prod_operation>;
 
     public:
         static match_pattern_type const match_data;
@@ -52,31 +49,6 @@ namespace phylanx { namespace execution_tree { namespace primitives {
 
         prod_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
-
-    private:
-        template <typename T>
-        primitive_argument_type prod0d(ir::node_data<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
-        template <typename T>
-        primitive_argument_type prod1d(ir::node_data<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
-        template <typename T>
-        primitive_argument_type prod2d(ir::node_data<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
-        template <typename T>
-        primitive_argument_type prod2d_flat(
-            ir::node_data<T>&& arg, bool keep_dims) const;
-        template <typename T>
-        primitive_argument_type prod2d_axis0(
-            ir::node_data<T>&& arg, bool keep_dims) const;
-        template <typename T>
-        primitive_argument_type prod2d_axis1(
-            ir::node_data<T>&& arg, bool keep_dims) const;
-        template <typename T>
-        primitive_argument_type prodnd(ir::node_data<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
-
-        node_data_type dtype_;
     };
 
     inline primitive create_prod_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/arithmetics/statistics.hpp
+++ b/phylanx/plugins/arithmetics/statistics.hpp
@@ -61,13 +61,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     private:
         template <typename T>
         primitive_argument_type statistics0d(arg_type<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+            hpx::util::optional<std::int64_t> const& axis,
+            bool keep_dims) const;
         template <typename T>
         primitive_argument_type statistics1d(arg_type<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+            hpx::util::optional<std::int64_t> const& axis,
+            bool keep_dims) const;
         template <typename T>
         primitive_argument_type statistics2d(arg_type<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+            hpx::util::optional<std::int64_t> const& axis,
+            bool keep_dims) const;
 
         template <typename T>
         primitive_argument_type statistics2d_flat(
@@ -81,12 +84,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         template <typename T>
         primitive_argument_type statisticsnd(arg_type<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+            hpx::util::optional<std::int64_t> const& axis,
+            bool keep_dims) const;
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
         template <typename T>
         primitive_argument_type statistics3d(arg_type<T>&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+            hpx::util::optional<std::int64_t> const& axis,
+            bool keep_dims) const;
 
         template <typename T>
         primitive_argument_type statistics3d_flat(
@@ -101,6 +106,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type statistics3d_axis2(
             arg_type<T>&& arg, bool keep_dims) const;
 #endif
+
+        primitive_argument_type statisticsnd(primitive_argument_type&& arg,
+            hpx::util::optional<std::int64_t> const& axis,
+            bool keep_dims) const;
+        primitive_argument_type statisticsnd(primitive_argument_type&& arg,
+            ir::range&& axes, bool keep_dims) const;
 
     private:
         node_data_type dtype_;

--- a/phylanx/plugins/arithmetics/statistics.hpp
+++ b/phylanx/plugins/arithmetics/statistics.hpp
@@ -1,0 +1,110 @@
+// Copyright (c) 2018 Shahrzad Shirzad
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_STATISTICS_DEC_24_2018_0227PM)
+#define PHYLANX_PRIMITIVES_STATISTICS_DEC_24_2018_0227PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    template <typename Op, typename Derived>
+    class statistics
+      : public primitive_component_base
+      , public std::enable_shared_from_this<Derived>
+    {
+    private:
+        Derived& derived()
+        {
+            return static_cast<Derived&>(*this);
+        }
+        Derived const& derived() const
+        {
+            return static_cast<Derived const&>(*this);
+        }
+
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+        template <typename T>
+        using arg_type = ir::node_data<T>;
+
+        template <typename T>
+        using args_type =
+            std::vector<arg_type<T>, arguments_allocator<arg_type<T>>>;
+
+    public:
+        statistics() = default;
+
+        statistics(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    private:
+        template <typename T>
+        primitive_argument_type statistics0d(arg_type<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type statistics1d(arg_type<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type statistics2d(arg_type<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+
+        template <typename T>
+        primitive_argument_type statistics2d_flat(
+            arg_type<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type statistics2d_axis0(
+            arg_type<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type statistics2d_axis1(
+            arg_type<T>&& arg, bool keep_dims) const;
+
+        template <typename T>
+        primitive_argument_type statisticsnd(arg_type<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        template <typename T>
+        primitive_argument_type statistics3d(arg_type<T>&& arg,
+            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
+
+        template <typename T>
+        primitive_argument_type statistics3d_flat(
+            arg_type<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type statistics3d_axis0(
+            arg_type<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type statistics3d_axis1(
+            arg_type<T>&& arg, bool keep_dims) const;
+        template <typename T>
+        primitive_argument_type statistics3d_axis2(
+            arg_type<T>&& arg, bool keep_dims) const;
+#endif
+
+    private:
+        node_data_type dtype_;
+    };
+}}}
+
+#endif

--- a/phylanx/plugins/arithmetics/statistics_impl.hpp
+++ b/phylanx/plugins/arithmetics/statistics_impl.hpp
@@ -1,0 +1,509 @@
+// Copyright (c) 2018 Shahrzad Shirzad
+// Copyright (c) 2018 Parsa Amini
+// Copyright (c) 2018 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVE_STATISTICS_IMPL_DEC_24_2018_0342PM)
+#define PHYLANX_PRIMITIVE_STATISTICS_IMPL_DEC_24_2018_0342PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/arithmetics/statistics.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Math.h>
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Op, typename Derived>
+    statistics<Op, Derived>::statistics(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+      , dtype_(extract_dtype(name_))
+    {
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics0d(
+        arg_type<T>&& arg, hpx::util::optional<std::int64_t> axis,
+        bool keep_dims) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "statistics::statistics0d",
+                generate_error_message(
+                    "the statistics_operation primitive requires operand axis "
+                    "to be either 0 or -1 for scalar values."));
+        }
+
+        return primitive_argument_type{arg.scalar()};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics1d(
+        arg_type<T>&& arg, hpx::util::optional<std::int64_t> axis,
+        bool keep_dims) const
+    {
+        if (axis && axis.value() != 0 && axis.value() != -1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "statistics::statistics1d",
+                generate_error_message(
+                    "the statistics_operation primitive requires operand axis "
+                    "to be either 0 or -1 for vectors."));
+        }
+
+        auto v = arg.vector();
+        T result = Op{}(v.begin(), v.end(), Op::template initial<T>());
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{blaze::DynamicVector<T>(1, result)};
+        }
+
+        return primitive_argument_type{result};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics2d_flat(
+        arg_type<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+
+        T result = Op::template initial<T>();
+        for (std::size_t i = 0; i != m.rows(); ++i)
+        {
+            auto row = blaze::row(m, i);
+            result = Op{}(row.begin(), row.end(), result);
+        }
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{blaze::DynamicMatrix<T>(1, 1, result)};
+        }
+
+        return primitive_argument_type{result};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics2d_axis0(
+        arg_type<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+
+        if (keep_dims)
+        {
+            blaze::DynamicMatrix<T> result(1, m.columns());
+            for (std::size_t i = 0; i != m.columns(); ++i)
+            {
+                auto col = blaze::column(m, i);
+                result(1, i) =
+                    Op{}(col.begin(), col.end(), Op::template initial<T>());
+            }
+
+            return primitive_argument_type{std::move(result)};
+        }
+
+        blaze::DynamicVector<T> result(m.columns());
+        for (std::size_t i = 0; i != m.columns(); ++i)
+        {
+            auto col = blaze::column(m, i);
+            result[i] = Op{}(col.begin(), col.end(), Op::template initial<T>());
+        }
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics2d_axis1(
+        arg_type<T>&& arg, bool keep_dims) const
+    {
+        auto m = arg.matrix();
+
+        if (keep_dims)
+        {
+            blaze::DynamicMatrix<T> result(m.rows(), 1);
+            for (std::size_t i = 0; i != m.rows(); ++i)
+            {
+                auto row = blaze::row(m, i);
+                result(i, 0) =
+                    Op{}(row.begin(), row.end(), Op::template initial<T>());
+            }
+
+            return primitive_argument_type{std::move(result)};
+        }
+
+        blaze::DynamicVector<T> result(m.rows());
+        for (std::size_t i = 0; i != m.rows(); ++i)
+        {
+            auto row = blaze::row(m, i);
+            result[i] = Op{}(row.begin(), row.end(), Op::template initial<T>());
+        }
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics2d(
+        arg_type<T>&& arg, hpx::util::optional<std::int64_t> axis,
+        bool keep_dims) const
+    {
+        if (axis)
+        {
+            switch (axis.value())
+            {
+            case -2: HPX_FALLTHROUGH;
+            case 0:
+                return statistics2d_axis0(std::move(arg), keep_dims);
+
+            case -1: HPX_FALLTHROUGH;
+            case 1:
+                return statistics2d_axis1(std::move(arg), keep_dims);
+
+            default:
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "statistics::statistics2d",
+                    generate_error_message(
+                        "the statistics_operation primitive requires operand "
+                        "axis to be between -2 and 1 for matrices."));
+            }
+        }
+        return statistics2d_flat(std::move(arg), keep_dims);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics3d_flat(
+        arg_type<T>&& arg, bool keep_dims) const
+    {
+        auto t = arg.tensor();
+
+        if (keep_dims)
+        {
+            return primitive_argument_type{
+                blaze::DynamicTensor<T>(1, 1, 1, result)};
+        }
+
+        T result = Op::template initial<T>();
+        for (std::size_t k = 0; k != t.pages(); ++k)
+        {
+            auto page = blaze::pageslice(t, k);
+            for (std::size_t i = 0; i != t.rows(); ++i)
+            {
+                auto row = blaze::row(page, i);
+                result = Op{}(row.begin(), row.end(), result);
+            }
+        }
+
+        return primitive_argument_type{result};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics3d_axis0(
+        arg_type<T>&& arg, bool keep_dims) const
+    {
+        auto t = arg.tensor();
+
+        if (keep_dims)
+        {
+            blaze::DynamicTensor<T> result(1, t.rows(), t.columns());
+            for (std::size_t i = 0; i != t.rows(); ++i)
+            {
+                auto slice = blaze::rowslice(t, i);
+                for (std::size_t j = 0; j != t.columns(); ++j)
+                {
+                    auto row = blaze::row(slice, j);
+                    result(0, i, j) =
+                        Op{}(row.begin(), row.end(), Op::template initial<T>());
+                }
+            }
+
+            return primitive_argument_type{std::move(result)};
+        }
+
+        blaze::DynamicMatrix<T> result(t.rows(), t.columns());
+        for (std::size_t i = 0; i != t.rows(); ++i)
+        {
+            auto slice = blaze::rowslice(t, i);
+            for (std::size_t j = 0; j != t.columns(); ++j)
+            {
+                auto row = blaze::row(slice, j);
+                result(i, j) =
+                    Op{}(row.begin(), row.end(), Op::template initial<T>());
+            }
+        }
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics3d_axis1(
+        arg_type<T>&& arg, bool keep_dims) const
+    {
+        auto t = arg.tensor();
+
+        if (keep_dims)
+        {
+            blaze::DynamicTensor<T> result(t.columns(), 1, t.pages());
+            for (std::size_t k = 0; k != t.pages(); ++k)
+            {
+                auto slice = blaze::pageslice(t, k);
+                for (std::size_t j = 0; j != t.columns(); ++j)
+                {
+                    auto col = blaze::column(slice, j);
+                    result(j, 0, k) =
+                        Op{}(col.begin(), col.end(), Op::template initial<T>());
+                }
+            }
+
+            return primitive_argument_type{std::move(result)};
+        }
+
+        blaze::DynamicMatrix<T> result(t.columns(), t.pages());
+        for (std::size_t k = 0; k != t.pages(); ++k)
+        {
+            auto slice = blaze::pageslice(t, k);
+            for (std::size_t j = 0; j != t.columns(); ++j)
+            {
+                auto col = blaze::column(slice, j);
+                result(j, k) =
+                    Op{}(col.begin(), col.end(), Op::template initial<T>());
+            }
+        }
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics3d_axis2(
+        arg_type<T>&& arg, bool keep_dims) const
+    {
+        auto t = arg.tensor();
+
+        if (keep_dims)
+        {
+            blaze::DynamicTensor<T> result(t.pages(), t.rows(), 1);
+            for (std::size_t k = 0; k != t.pages(); ++k)
+            {
+                auto slice = blaze::pageslice(t, k);
+                for (std::size_t i = 0; i != t.rows(); ++i)
+                {
+                    auto row = blaze::row(slice, k);
+                    result(k, i, 0) =
+                        Op{}(row.begin(), row.end(), Op::template initial<T>());
+                }
+            }
+
+            return primitive_argument_type{std::move(result)};
+        }
+
+        blaze::DynamicMatrix<T> result(t.pages(), t.rows());
+        for (std::size_t k = 0; k != t.pages(); ++k)
+        {
+            auto slice = blaze::pageslice(t, k);
+            for (std::size_t i = 0; i != t.rows(); ++i)
+            {
+                auto row = blaze::row(slice, k);
+                result(k, i) =
+                    Op{}(row.begin(), row.end(), Op::template initial<T>());
+            }
+        }
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statistics3d(
+        arg_type<T>&& arg, hpx::util::optional<std::int64_t> axis,
+        bool keep_dims) const
+    {
+        if (axis)
+        {
+            switch (axis.value())
+            {
+            case -3: HPX_FALLTHROUGH;
+            case 0:
+                return statistics3d_axis0(std::move(arg), keep_dims);
+
+            case -2: HPX_FALLTHROUGH;
+            case 1:
+                return statistics3d_axis1(std::move(arg), keep_dims);
+
+            case -1: HPX_FALLTHROUGH;
+            case 2:
+                return statistics3d_axis2(std::move(arg), keep_dims);
+
+            default:
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "statistics::statistics3d",
+                    generate_error_message(
+                        "the statistics_operation primitive requires operand "
+                        "axis to be between -3 and 2 for tensors."));
+            }
+        }
+        return statistics2d_flat(std::move(arg), keep_dims);
+    }
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Op, typename Derived>
+    template <typename T>
+    primitive_argument_type statistics<Op, Derived>::statisticsnd(
+        arg_type<T>&& arg, hpx::util::optional<std::int64_t> axis,
+        bool keep_dims) const
+    {
+        std::size_t a_dims = arg.num_dimensions();
+        switch (a_dims)
+        {
+        case 0:
+            return statistics0d(std::move(arg), axis, keep_dims);
+
+        case 1:
+            return statistics1d(std::move(arg), axis, keep_dims);
+
+        case 2:
+            return statistics2d(std::move(arg), axis, keep_dims);
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        case 3:
+            return statistics3d(std::move(arg), axis, keep_dims);
+#endif
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "statistics::eval",
+                generate_error_message(
+                    "operand a has an invalid number of dimensions"));
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Op, typename Derived>
+    hpx::future<primitive_argument_type> statistics<Op, Derived>::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.empty() || operands.size() > 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "statistics::eval",
+                generate_error_message(
+                    "the statistics primitive requires exactly one, two, or "
+                        "three operands"));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "statistics::eval",
+                    generate_error_message(
+                        "the statistics_operation primitive requires that the "
+                        "arguments given by the operands array are valid"));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+            [this_ = std::move(this_)](primitive_arguments_type&& args)
+                -> primitive_argument_type
+            {
+                // Extract axis and keep_dims
+                // Presence of axis changes behavior for >1d cases
+                hpx::util::optional<std::int64_t> axis;
+                bool keep_dims = false;
+
+                // axis is argument #2
+                if (args.size() > 1)
+                {
+                    if (valid(args[1]))
+                    {
+                        axis = extract_scalar_integer_value(
+                            args[1], this_->name_, this_->codename_);
+                    }
+
+                    // keep_dims is argument #3
+                    if (args.size() == 3)
+                    {
+                        keep_dims = extract_scalar_boolean_value(
+                            args[2], this_->name_, this_->codename_);
+                    }
+                }
+
+                node_data_type t = this_->dtype_;
+                if (t == node_data_type_unknown)
+                {
+                    t = extract_common_type(args[0]);
+                }
+
+                switch (t)
+                {
+                case node_data_type_bool:
+                    return this_->statisticsnd(
+                        extract_boolean_value_strict(std::move(args[0]),
+                            this_->name_, this_->codename_),
+                        axis, keep_dims);
+
+                case node_data_type_int64:
+                    return this_->statisticsnd(
+                        extract_integer_value_strict(std::move(args[0]),
+                            this_->name_, this_->codename_),
+                        axis, keep_dims);
+
+                case node_data_type_unknown: HPX_FALLTHROUGH;
+                case node_data_type_double:
+                    return this_->statisticsnd(
+                        extract_numeric_value(std::move(args[0]),
+                            this_->name_, this_->codename_),
+                        axis, keep_dims);
+
+                default:
+                    break;
+                }
+
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "statistics::eval",
+                    this_->generate_error_message(
+                        "the statistics primitive requires for all arguments "
+                        "to be numeric data types"));
+            }),
+            detail::map_operands(operands, functional::value_operand{}, args,
+                name_, codename_, std::move(ctx)));
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/arithmetics/sum_operation.hpp
+++ b/phylanx/plugins/arithmetics/sum_operation.hpp
@@ -9,19 +9,20 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
-#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/plugins/arithmetics/statistics.hpp>
 
-#include <hpx/lcos/future.hpp>
-#include <hpx/util/optional.hpp>
-
-#include <cstdint>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        struct statistics_sum_op;
+    }
+
     /// \brief Sums the values of the elements of a vector or a matrix or
     ///        returns the value of the scalar that was given to it.
     /// \param a         The scalar, vector, or matrix to perform sum over
@@ -33,18 +34,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///                  number of dimensions as \p a. Ignored if \p axis is
     ///                  anything except nil.
     class sum_operation
-      : public primitive_component_base
-      , public std::enable_shared_from_this<sum_operation>
+      : public statistics<detail::statistics_sum_op, sum_operation>
     {
-    protected:
-        hpx::future<primitive_argument_type> eval(
-            primitive_arguments_type const& operands,
-            primitive_arguments_type const& args,
-            eval_context ctx) const override;
-
-        using val_type = double;
-        using arg_type = ir::node_data<val_type>;
-        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
+        using base_type =
+            statistics<detail::statistics_sum_op, sum_operation>;
 
     public:
         static match_pattern_type const match_data;
@@ -53,18 +46,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         sum_operation(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
-
-    private:
-        primitive_argument_type sum0d(arg_type&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
-        primitive_argument_type sum1d(arg_type&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
-        primitive_argument_type sum2d(arg_type&& arg,
-            hpx::util::optional<std::int64_t> axis, bool keep_dims) const;
-        primitive_argument_type sum2d_flat(
-            arg_type&& arg, bool keep_dims) const;
-        primitive_argument_type sum2d_axis0(arg_type&& arg) const;
-        primitive_argument_type sum2d_axis1(arg_type&& arg) const;
     };
 
     inline primitive create_sum_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/cross_operation.hpp
+++ b/phylanx/plugins/matrixops/cross_operation.hpp
@@ -31,9 +31,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -44,17 +41,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     private:
         primitive_argument_type cross1d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type cross1d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type cross1d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
         primitive_argument_type cross2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
+
+        template <typename T>
+        primitive_argument_type cross1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type cross1d1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type cross1d2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type cross2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type cross2d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type cross2d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
     };
 
     inline primitive create_cross_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/determinant.hpp
+++ b/phylanx/plugins/matrixops/determinant.hpp
@@ -31,9 +31,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -43,8 +40,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type determinant0d(operand_type&& op) const;
-        primitive_argument_type determinant2d(operand_type&& op) const;
+        primitive_argument_type determinant0d(
+            primitive_argument_type&& op) const;
+        primitive_argument_type determinant2d(
+            primitive_argument_type&& op) const;
+
+        template <typename T>
+        primitive_argument_type determinant0d(ir::node_data<T>&& op) const;
+        template <typename T>
+        primitive_argument_type determinant2d(ir::node_data<T>&& op) const;
     };
 
     inline primitive create_determinant(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/diag_operation.hpp
+++ b/phylanx/plugins/matrixops/diag_operation.hpp
@@ -30,11 +30,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
-        using storage1d_type = typename arg_type::storage1d_type;
-        using storage2d_type = typename arg_type::storage2d_type;
-
     public:
         static match_pattern_type const match_data;
 
@@ -67,9 +62,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type diag0d(args_type&& args) const;
-        primitive_argument_type diag1d(args_type&& args) const;
-        primitive_argument_type diag2d(args_type&& args) const;
+        template <typename T>
+        primitive_argument_type diag0d(
+            ir::node_data<T>&& args, std::int64_t k) const;
+        template <typename T>
+        primitive_argument_type diag1d(
+            ir::node_data<T>&& args, std::int64_t k) const;
+        template <typename T>
+        primitive_argument_type diag2d(
+            ir::node_data<T>&& args, std::int64_t k) const;
+
+        primitive_argument_type diag0d(
+            primitive_argument_type&& args, std::int64_t k) const;
+        primitive_argument_type diag1d(
+            primitive_argument_type&& args, std::int64_t k) const;
+        primitive_argument_type diag2d(
+            primitive_argument_type&& args, std::int64_t k) const;
     };
 
     inline primitive create_diag_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/diag_operation.hpp
+++ b/phylanx/plugins/matrixops/diag_operation.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>

--- a/phylanx/plugins/matrixops/dot_operation.hpp
+++ b/phylanx/plugins/matrixops/dot_operation.hpp
@@ -31,9 +31,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -44,29 +41,48 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     private:
         primitive_argument_type dot0d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type dot0d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type dot0d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type dot0d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
         primitive_argument_type dot1d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type dot1d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type dot1d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
-        primitive_argument_type dot1d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
         primitive_argument_type dot2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
+
+        template <typename T>
+        primitive_argument_type dot0d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot0d0d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot0d1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot0d2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot1d0d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot1d1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot1d2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type dot2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type dot2d0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type dot2d1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
         primitive_argument_type dot2d2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
     };
 
     inline primitive create_dot_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/extract_shape.hpp
+++ b/phylanx/plugins/matrixops/extract_shape.hpp
@@ -31,8 +31,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        using arg_type = ir::node_data<double>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -42,13 +40,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type shape0d(arg_type&& arg) const;
-        primitive_argument_type shape1d(arg_type&& arg) const;
-        primitive_argument_type shape2d(arg_type&& arg) const;
+        primitive_argument_type shape0d() const;
+        primitive_argument_type shape0d(std::int64_t index) const;
 
-        primitive_argument_type shape0d(arg_type&& arg, std::int64_t index) const;
-        primitive_argument_type shape1d(arg_type&& arg, std::int64_t index) const;
-        primitive_argument_type shape2d(arg_type&& arg, std::int64_t index) const;
+        primitive_argument_type shape1d(std::int64_t size) const;
+        primitive_argument_type shape1d(
+            std::int64_t size, std::int64_t index) const;
+
+        primitive_argument_type shape2d(
+            std::int64_t rows, std::int64_t columns) const;
+        primitive_argument_type shape2d(
+            std::int64_t rows, std::int64_t columns, std::int64_t index) const;
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        primitive_argument_type shape3d(
+            std::int64_t pages, std::int64_t rows, std::int64_t columns) const;
+        primitive_argument_type shape3d(std::int64_t pages, std::int64_t rows,
+            std::int64_t columns, std::int64_t index) const;
+#endif
     };
 
     inline primitive create_extract_shape(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/gradient_operation.hpp
+++ b/phylanx/plugins/matrixops/gradient_operation.hpp
@@ -30,10 +30,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        using operand_type = ir::node_data<double>;
-        using operands_type =
-            std::vector<operand_type, arguments_allocator<operand_type>>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -58,9 +54,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type gradient0d(operands_type&& ops) const;
-        primitive_argument_type gradient1d(operands_type&& ops) const;
-        primitive_argument_type gradient2d(operands_type&& ops) const;
+        primitive_argument_type gradient0d(primitive_arguments_type&& ops) const;
+        primitive_argument_type gradient1d(primitive_arguments_type&& ops) const;
+        primitive_argument_type gradient2d(primitive_arguments_type&& ops) const;
+
+        template <typename T>
+        primitive_argument_type gradient1d(ir::node_data<T>&& arg) const;
+        template <typename T>
+        primitive_argument_type gradient2d(
+            ir::node_data<T>&& arg, std::int64_t axis) const;
     };
 
     inline primitive create_gradient_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/gradient_operation.hpp
+++ b/phylanx/plugins/matrixops/gradient_operation.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>

--- a/phylanx/plugins/matrixops/inverse_operation.hpp
+++ b/phylanx/plugins/matrixops/inverse_operation.hpp
@@ -25,9 +25,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public std::enable_shared_from_this<inverse_operation>
     {
     protected:
-        using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
-
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
@@ -42,8 +39,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type inverse0d(operand_type&& ops) const;
-        primitive_argument_type inverse2d(operand_type&& ops) const;
+        primitive_argument_type inverse0d(primitive_argument_type&& ops) const;
+        primitive_argument_type inverse2d(primitive_argument_type&& ops) const;
+        template <typename T>
+        primitive_argument_type inverse0d(ir::node_data<T>&& ops) const;
+        template <typename T>
+        primitive_argument_type inverse2d(ir::node_data<T>&& ops) const;
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        primitive_argument_type inverse3d(primitive_argument_type&& ops) const;
+        template <typename T>
+        primitive_argument_type inverse3d(ir::node_data<T>&& ops) const;
+#endif
     };
 
     inline primitive create_inverse_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/linearmatrix.hpp
+++ b/phylanx/plugins/matrixops/linearmatrix.hpp
@@ -14,6 +14,7 @@
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>

--- a/phylanx/plugins/matrixops/linearmatrix.hpp
+++ b/phylanx/plugins/matrixops/linearmatrix.hpp
@@ -8,6 +8,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
@@ -25,10 +26,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
      , public std::enable_shared_from_this<linearmatrix>
     {
     protected:
-        using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
-        using matrix_type = blaze::DynamicMatrix<double>;
-
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
@@ -43,7 +40,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type linmatrix(args_type&& args) const;
+        primitive_argument_type linmatrix(std::int64_t nx, std::int64_t ny,
+            primitive_argument_type&& x0, primitive_argument_type&& dx,
+            primitive_argument_type&& dy) const;
+
+        template <typename T>
+        primitive_argument_type linmatrix(
+            std::int64_t nx, std::int64_t ny, T x0, T dx, T dy) const;
+
+    private:
+        node_data_type dtype_;
     };
 
     inline primitive create_linearmatrix(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/linspace.hpp
+++ b/phylanx/plugins/matrixops/linspace.hpp
@@ -8,11 +8,13 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -34,10 +36,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public std::enable_shared_from_this<linspace>
     {
     protected:
-        using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
-        using vector_type = blaze::DynamicVector<double>;
-
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
@@ -65,7 +63,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type linspace1d(args_type&& args) const;
+        primitive_argument_type linspace1d(primitive_argument_type&& start,
+            primitive_argument_type&& end, std::int64_t nelements) const;
+
+        template <typename T>
+        primitive_argument_type linspace1d(
+            T start, T end, std::int64_t nelements) const;
+
+    private:
+        node_data_type dtype_;
     };
 
     inline primitive create_linspace(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/mean_operation.hpp
+++ b/phylanx/plugins/matrixops/mean_operation.hpp
@@ -8,11 +8,13 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -23,7 +25,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///
     /// \brief Mean Operation Primitive
     ///
-    /// This primitive computes the arithmatic mean along the specified axis.
+    /// This primitive computes the arithmetic mean along the specified axis.
     /// \param operands Vector of phylanx node data objects
     ///
     /// If used inside PhySL:
@@ -38,10 +40,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public std::enable_shared_from_this<mean_operation>
     {
     protected:
-        using val_type = double;
-        using arg_type = ir::node_data<val_type>;
-        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
-
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
@@ -56,12 +54,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type mean0d(args_type&& args) const;
-        primitive_argument_type mean1d(args_type&& args) const;
-        primitive_argument_type mean2d_flatten(arg_type&& arg_a) const;
-        primitive_argument_type mean2d_x_axis(arg_type&& arg_a) const;
-        primitive_argument_type mean2d_y_axis(arg_type&& arg_a) const;
-        primitive_argument_type mean2d(args_type&& args) const;
+        primitive_argument_type mean0d(primitive_argument_type&& arg,
+            bool has_axis = false, std::int64_t axis = 0) const;
+        primitive_argument_type mean1d(primitive_argument_type&& arg,
+            bool has_axis = false, std::int64_t axis = 0) const;
+        primitive_argument_type mean2d(primitive_argument_type&& arg,
+            bool has_axis = false, std::int64_t axis = 0) const;
+
+        template <typename T>
+        primitive_argument_type mean1d(ir::node_data<T>&& arg) const;
+
+        template <typename T>
+        primitive_argument_type mean2d_flatten(ir::node_data<T>&& arg) const;
+        template <typename T>
+        primitive_argument_type mean2d_x_axis(ir::node_data<T>&& arg) const;
+        template <typename T>
+        primitive_argument_type mean2d_y_axis(ir::node_data<T>&& arg) const;
+        template <typename T>
+        primitive_argument_type mean2d(ir::node_data<T>&& arg,
+            bool has_axis, std::int64_t axis) const;
+
+    private:
+        node_data_type dtype_;
     };
 
     inline primitive create_mean_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/power_operation.hpp
+++ b/phylanx/plugins/matrixops/power_operation.hpp
@@ -8,6 +8,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
@@ -24,10 +25,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public primitive_component_base
       , public std::enable_shared_from_this<power_operation>
     {
-    protected:
-        using operand_type = ir::node_data<double>;
-        using operands_type = std::vector<operand_type>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -38,16 +35,37 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     private:
         primitive_argument_type power0d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
         primitive_argument_type power1d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
         primitive_argument_type power2d(
-            operand_type&& lhs, operand_type&& rhs) const;
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
+
+        template <typename T>
+        primitive_argument_type power0d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type power1d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+        template <typename T>
+        primitive_argument_type power2d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        primitive_argument_type power3d(
+            primitive_argument_type&& lhs, primitive_argument_type&& rhs) const;
+        template <typename T>
+        primitive_argument_type power3d(
+            ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const;
+#endif
 
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
             eval_context ctx) const override;
+
+    private:
+        node_data_type dtype_;
     };
 
     inline primitive create_power_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/shuffle_operation.hpp
+++ b/phylanx/plugins/matrixops/shuffle_operation.hpp
@@ -40,9 +40,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        using arg_type = ir::node_data<double>;
-        using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
-
     public:
         static match_pattern_type const match_data;
 
@@ -52,8 +49,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type shuffle_1d(arg_type&& arg) const;
-        primitive_argument_type shuffle_2d(arg_type&& arg) const;
+        primitive_argument_type shuffle_1d(primitive_argument_type&& arg) const;
+        primitive_argument_type shuffle_2d(primitive_argument_type&& arg) const;
+
+        template <typename T>
+        primitive_argument_type shuffle_1d(ir::node_data<T>&& arg) const;
+        template <typename T>
+        primitive_argument_type shuffle_2d(ir::node_data<T>&& arg) const;
     };
 
     inline primitive create_shuffle_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/matrixops/transpose_operation.hpp
+++ b/phylanx/plugins/matrixops/transpose_operation.hpp
@@ -24,10 +24,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public std::enable_shared_from_this<transpose_operation>
     {
     protected:
-        using operand_type = ir::node_data<double>;
-        using operands_type =
-            std::vector<operand_type, arguments_allocator<operand_type>>;
-
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
@@ -42,8 +38,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type transpose0d1d(operands_type&& ops) const;
-        primitive_argument_type transpose2d(operands_type && ops) const;
+        primitive_argument_type transpose0d1d(primitive_argument_type&& arg) const;
+        primitive_argument_type transpose2d(primitive_argument_type && arg) const;
+
+        template <typename T>
+        primitive_argument_type transpose2d(ir::node_data<T>&& arg) const;
     };
 
     inline primitive create_transpose_operation(hpx::id_type const& locality,

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -33,6 +33,7 @@ methods_supporting_dtype = [
     'eye',
     'hstack',
     'identity',
+    'linearmatrix',
     'prod',
     'stack',
     'vstack',

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -34,6 +34,7 @@ methods_supporting_dtype = [
     'hstack',
     'identity',
     'linearmatrix',
+    'linspace',
     'prod',
     'stack',
     'vstack',

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -36,6 +36,7 @@ methods_supporting_dtype = [
     'linearmatrix',
     'linspace',
     'mean',
+    'power',
     'prod',
     'stack',
     'vstack',

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -35,6 +35,7 @@ methods_supporting_dtype = [
     'identity',
     'linearmatrix',
     'linspace',
+    'mean',
     'prod',
     'stack',
     'vstack',

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -3349,7 +3349,6 @@ namespace phylanx { namespace execution_tree
             extract_integer_value_strict(val, name, codename));
     }
 
-    //make extract_shape.cpp error happy
     hpx::future<std::int64_t> scalar_integer_operand_strict(
         primitive_argument_type const& val,
         primitive_arguments_type const& args, std::string const& name,
@@ -3376,7 +3375,7 @@ namespace phylanx { namespace execution_tree
 
         HPX_ASSERT(valid(val));
         return hpx::make_ready_future(
-            extract_integer_value_strict(val, name, codename)[0]);
+            extract_scalar_integer_value_strict(val, name, codename));
     }
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
@@ -3588,6 +3587,35 @@ namespace phylanx { namespace execution_tree
 
         HPX_ASSERT(valid(val));
         return extract_numeric_value(val, name, codename);
+    }
+
+    hpx::future<double> scalar_numeric_operand(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args, std::string const& name,
+        std::string const& codename, eval_context ctx)
+    {
+        primitive const* p = util::get_if<primitive>(&val);
+        if (p != nullptr)
+        {
+            hpx::future<primitive_argument_type> f =
+                p->eval(args, std::move(ctx));
+            if (f.is_ready())
+            {
+                return hpx::make_ready_future(
+                    extract_scalar_numeric_value(f.get(), name, codename));
+            }
+
+            return f.then(hpx::launch::sync,
+                [&](hpx::future<primitive_argument_type> && f)
+                {
+                    return extract_scalar_numeric_value(
+                        f.get(), name, codename);
+                });
+        }
+
+        HPX_ASSERT(valid(val));
+        return hpx::make_ready_future(
+            extract_scalar_numeric_value(val, name, codename));
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -3319,6 +3319,36 @@ namespace phylanx { namespace execution_tree
             extract_integer_value(std::move(val), name, codename));
     }
 
+    hpx::future<std::int64_t> scalar_integer_operand(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args, std::string const& name,
+        std::string const& codename, eval_context ctx)
+    {
+        primitive const* p = util::get_if<primitive>(&val);
+        if (p != nullptr)
+        {
+            hpx::future<primitive_argument_type> f =
+                p->eval(args, std::move(ctx));
+            if (f.is_ready())
+            {
+                return hpx::make_ready_future(
+                    extract_scalar_integer_value(f.get(), name, codename));
+            }
+
+            return f.then(hpx::launch::sync,
+                [&](hpx::future<primitive_argument_type> && f)
+                {
+                    return extract_scalar_integer_value(
+                        f.get(), name, codename);
+                });
+        }
+
+        HPX_ASSERT(valid(val));
+        return hpx::make_ready_future(
+            extract_scalar_integer_value(val, name, codename));
+    }
+
+    //////////////////////////////////////////////////////////////////////////
     // Extract an integer value from a primitive_argument_type
     hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
         primitive_argument_type const& val,
@@ -3347,35 +3377,6 @@ namespace phylanx { namespace execution_tree
         HPX_ASSERT(valid(val));
         return hpx::make_ready_future(
             extract_integer_value_strict(val, name, codename));
-    }
-
-    hpx::future<std::int64_t> scalar_integer_operand_strict(
-        primitive_argument_type const& val,
-        primitive_arguments_type const& args, std::string const& name,
-        std::string const& codename, eval_context ctx)
-    {
-        primitive const* p = util::get_if<primitive>(&val);
-        if (p != nullptr)
-        {
-            hpx::future<primitive_argument_type> f =
-                p->eval(args, std::move(ctx));
-            if (f.is_ready())
-            {
-                return hpx::make_ready_future(
-                    extract_scalar_integer_value_strict(f.get(), name, codename));
-            }
-
-            return f.then(hpx::launch::sync,
-                [&](hpx::future<primitive_argument_type> && f)
-                {
-                    return extract_scalar_integer_value_strict(
-                        f.get(), name, codename);
-                });
-        }
-
-        HPX_ASSERT(valid(val));
-        return hpx::make_ready_future(
-            extract_scalar_integer_value_strict(val, name, codename));
     }
 
     hpx::future<ir::node_data<std::int64_t>> integer_operand_strict(
@@ -3459,6 +3460,35 @@ namespace phylanx { namespace execution_tree
         HPX_ASSERT(valid(val));
         return hpx::make_ready_future(
             extract_integer_value_strict(std::move(val), name, codename));
+    }
+
+    hpx::future<std::int64_t> scalar_integer_operand_strict(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args, std::string const& name,
+        std::string const& codename, eval_context ctx)
+    {
+        primitive const* p = util::get_if<primitive>(&val);
+        if (p != nullptr)
+        {
+            hpx::future<primitive_argument_type> f =
+                p->eval(args, std::move(ctx));
+            if (f.is_ready())
+            {
+                return hpx::make_ready_future(
+                    extract_scalar_integer_value_strict(f.get(), name, codename));
+            }
+
+            return f.then(hpx::launch::sync,
+                [&](hpx::future<primitive_argument_type> && f)
+                {
+                    return extract_scalar_integer_value_strict(
+                        f.get(), name, codename);
+                });
+        }
+
+        HPX_ASSERT(valid(val));
+        return hpx::make_ready_future(
+            extract_scalar_integer_value_strict(val, name, codename));
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/plugins/arithmetics/prod_operation.cpp
+++ b/src/plugins/arithmetics/prod_operation.cpp
@@ -6,300 +6,63 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
-#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
-#include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/prod_operation.hpp>
-
-#include <hpx/include/lcos.hpp>
-#include <hpx/include/naming.hpp>
-#include <hpx/include/util.hpp>
-#include <hpx/throw_exception.hpp>
-#include <hpx/util/optional.hpp>
+#include <phylanx/plugins/arithmetics/statistics_impl.hpp>
 
 #include <algorithm>
-#include <cstddef>
-#include <cstdint>
 #include <functional>
-#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-    match_pattern_type const prod_operation::match_data = {
-        match_pattern_type{"prod",
+    namespace detail
+    {
+        struct statistics_prod_op
+        {
+            template <typename T>
+            static constexpr T initial()
+            {
+                return T(1);
+            }
+
+            template <typename Iter, typename T>
+            T operator()(Iter b, Iter e, T initial) const
+            {
+                return std::accumulate(b, e, initial, std::multiplies<T>());
+            }
+        };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const prod_operation::match_data =
+    {
+        match_pattern_type{
+            "prod",
             std::vector<std::string>{
                 "prod(_1)", "prod(_1, _2)", "prod(_1, _2, _3)"},
             &create_prod_operation, &create_primitive<prod_operation>, R"(
-            v, a1, a2
+            v, axis, keep_dim
             Args:
 
                 v (vector or matrix) : a vector or matrix
-                a1 (optional, integer): a axis to prod along
-                a2 (optional, integer): a second axis to prod along
+                axis (optional, integer): a axis to sum along
+                keep_dim (optional, boolean): keep dimension of input
 
             Returns:
 
-            The product of all values along the specified axes.
-            )",
-            true}};
+            The product of all values along the specified axis.)",
+            true
+        }
+    };
 
     ///////////////////////////////////////////////////////////////////////////
     prod_operation::prod_operation(primitive_arguments_type&& operands,
-        std::string const& name, std::string const& codename)
-      : primitive_component_base(std::move(operands), name, codename)
-      , dtype_(extract_dtype(name_))
+            std::string const& name, std::string const& codename)
+      : base_type(std::move(operands), name, codename)
     {
     }
-
-    template <typename T>
-    primitive_argument_type prod_operation::prod0d(ir::node_data<T>&& arg,
-        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
-    {
-        if (axis && axis.value() != 0 && axis.value() != -1)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "prod_operation::prod0d",
-                generate_error_message(
-                    "the prod_operation primitive requires operand axis to be "
-                    "either 0 or -1 for scalar values."));
-        }
-
-        return primitive_argument_type{arg.scalar()};
-    }
-
-    template <typename T>
-    primitive_argument_type prod_operation::prod1d(ir::node_data<T>&& arg,
-        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
-    {
-        if (axis && axis.value() != 0 && axis.value() != -1)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "prod_operation::prod1d",
-                generate_error_message(
-                    "the prod_operation primitive requires operand axis to be "
-                    "either 0 or -1 for vectors."));
-        }
-
-        auto v = arg.vector();
-        T result =
-            std::accumulate(v.begin(), v.end(), (T) 1, std::multiplies<T>());
-
-        if (keep_dims)
-        {
-            return primitive_argument_type{blaze::DynamicVector<T>{result}};
-        }
-        return primitive_argument_type{result};
-    }
-
-    template <typename T>
-    primitive_argument_type prod_operation::prod2d(ir::node_data<T>&& arg,
-        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
-    {
-        if (axis)
-        {
-            switch (axis.value())
-            {
-            case -2:
-                HPX_FALLTHROUGH;
-            case 0:
-                return prod2d_axis0(std::move(arg), keep_dims);
-
-            case -1:
-                HPX_FALLTHROUGH;
-            case 1:
-                return prod2d_axis1(std::move(arg), keep_dims);
-
-            default:
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "prod_operation::prod1d",
-                    generate_error_message(
-                        "the prod_operation primitive requires operand axis "
-                        "to be between -2 and 1 for matrices."));
-            }
-        }
-        return prod2d_flat(std::move(arg), keep_dims);
-    }
-
-    template <typename T>
-    primitive_argument_type prod_operation::prod2d_flat(
-        ir::node_data<T>&& arg, bool keep_dims) const
-    {
-        auto m = arg.matrix();
-        T result = 1;
-        for (std::size_t i = 0; i < m.columns(); ++i)
-        {
-            auto col = blaze::column(m, i);
-            result *= std::accumulate(
-                col.begin(), col.end(), T(1), std::multiplies<T>());
-        }
-
-        if (keep_dims)
-        {
-            return primitive_argument_type{blaze::DynamicMatrix<T>{{result}}};
-        }
-        return primitive_argument_type{result};
-    }
-
-    template <typename T>
-    primitive_argument_type prod_operation::prod2d_axis0(
-        ir::node_data<T>&& arg, bool keep_dims) const
-    {
-        auto m = arg.matrix();
-        blaze::DynamicVector<T> result(m.columns());
-        for (std::size_t i = 0; i < m.columns(); ++i)
-        {
-            auto col = blaze::column(m, i);
-            result[i] = std::accumulate(
-                col.begin(), col.end(), T(1), std::multiplies<T>());
-        }
-
-        if (keep_dims)
-        {
-            return primitive_argument_type{
-                blaze::DynamicMatrix<T>{1, result.size(), result.data()}};
-        }
-        return primitive_argument_type{result};
-    }
-
-    template <typename T>
-    primitive_argument_type prod_operation::prod2d_axis1(
-        ir::node_data<T>&& arg, bool keep_dims) const
-    {
-        auto m = arg.matrix();
-        blaze::DynamicVector<T> result(m.rows());
-        for (std::size_t i = 0; i < m.rows(); ++i)
-        {
-            auto col = blaze::row(m, i);
-            result[i] = std::accumulate(
-                col.begin(), col.end(), T(1), std::multiplies<T>());
-        }
-
-        if (keep_dims)
-        {
-            return primitive_argument_type{
-                blaze::DynamicMatrix<T>{1, result.size(), result.data()}};
-        }
-        return primitive_argument_type{result};
-    }
-
-    template <typename T>
-    primitive_argument_type prod_operation::prodnd(ir::node_data<T>&& arg,
-        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
-    {
-        std::size_t a_dims = arg.num_dimensions();
-        switch (a_dims)
-        {
-        case 0:
-            return prod0d(std::move(arg), axis, keep_dims);
-
-        case 1:
-            return prod1d(std::move(arg), axis, keep_dims);
-
-        case 2:
-            return prod2d(std::move(arg), axis, keep_dims);
-
-        default:
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "prod_operation::eval",
-                generate_error_message(
-                    "operand a has an invalid number of dimensions"));
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    hpx::future<primitive_argument_type> prod_operation::eval(
-        primitive_arguments_type const& operands,
-        primitive_arguments_type const& args, eval_context ctx) const
-    {
-        if (operands.empty() || operands.size() > 3)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "prod_operation::eval",
-                generate_error_message("the prod_operation primitive requires "
-                                       "exactly one, two, or "
-                                       "three operands"));
-        }
-
-        for (auto const& i : operands)
-        {
-            if (!valid(i))
-            {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "prod_operation::eval",
-                    generate_error_message(
-                        "the prod_operation primitive requires that the "
-                        "arguments given by the operands array are valid"));
-            }
-        }
-
-        auto this_ = this->shared_from_this();
-        return hpx::dataflow(hpx::launch::sync,
-            hpx::util::unwrapping(
-                [this_ = std::move(this_)](primitive_arguments_type&& args)
-                    -> primitive_argument_type {
-                    // Extract axis and keep_dims
-                    // Presence of axis changes behavior for >1d cases
-                    hpx::util::optional<std::int64_t> axis;
-                    bool keep_dims = false;
-
-                    // axis is argument #2
-                    if (args.size() > 1)
-                    {
-                        if (valid(args[1]))
-                        {
-                            axis = extract_scalar_integer_value(
-                                args[1], this_->name_, this_->codename_);
-                        }
-
-                        // keep_dims is argument #3
-                        if (args.size() == 3)
-                        {
-                            keep_dims = extract_scalar_boolean_value(
-                                args[2], this_->name_, this_->codename_);
-                        }
-                    }
-
-                    node_data_type t = this_->dtype_;
-                    if (t == node_data_type_unknown)
-                    {
-                        t = extract_common_type(args[0]);
-                    }
-
-                    switch (t)
-                    {
-                    case node_data_type_bool:
-                        return this_->prodnd(
-                            extract_boolean_value(std::move(args[0]),
-                                this_->name_, this_->codename_),
-                            axis, keep_dims);
-                    case node_data_type_int64:
-                        return this_->prodnd(
-                            extract_integer_value(std::move(args[0]),
-                                this_->name_, this_->codename_),
-                            axis, keep_dims);
-                    case node_data_type_double:
-                        return this_->prodnd(
-                            extract_numeric_value(std::move(args[0]),
-                                this_->name_, this_->codename_),
-                            axis, keep_dims);
-                    default:
-                        break;
-                    }
-
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "prod::eval",
-                        this_->generate_error_message(
-                            "the prod primitive requires for all arguments "
-                            "to be numeric data types"));
-                }),
-            detail::map_operands(operands, functional::value_operand{}, args,
-                name_, codename_, std::move(ctx)));
-    }
-}}
-}
+}}}

--- a/src/plugins/arithmetics/sum_operation.cpp
+++ b/src/plugins/arithmetics/sum_operation.cpp
@@ -5,243 +5,63 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
-#include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/sum_operation.hpp>
-#include <phylanx/util/matrix_iterators.hpp>
-
-#include <hpx/include/lcos.hpp>
-#include <hpx/include/naming.hpp>
-#include <hpx/include/util.hpp>
-#include <hpx/throw_exception.hpp>
-#include <hpx/util/iterator_facade.hpp>
-#include <hpx/util/optional.hpp>
+#include <phylanx/plugins/arithmetics/statistics_impl.hpp>
 
 #include <algorithm>
-#include <cstddef>
-#include <cstdint>
-#include <memory>
+#include <functional>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        struct statistics_sum_op
+        {
+            template <typename T>
+            static constexpr T initial()
+            {
+                return T(0);
+            }
+
+            template <typename Iter, typename T>
+            T operator()(Iter b, Iter e, T initial) const
+            {
+                return std::accumulate(b, e, initial, std::plus<T>());
+            }
+        };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     match_pattern_type const sum_operation::match_data =
     {
-        hpx::util::make_tuple("sum",
-        std::vector<std::string>{"sum(_1)", "sum(_1, _2)", "sum(_1, _2, _3)"},
-        &create_sum_operation, &create_primitive<sum_operation>,
-        "v, a1, a2\n"
-        "Args:\n"
-        "\n"
-        "    v (vector or matrix) : a vector or matrix\n"
-        "    a1 (optional, integer): a axis to sum along\n"
-        "    a2 (optional, integer): a second axis to sum along\n"
-        "\n"
-        "Returns:\n"
-        "\n"
-        "The sum of all values along the specified axes.")
+        match_pattern_type{
+            "sum",
+            std::vector<std::string>{
+                "sum(_1)", "sum(_1, _2)", "sum(_1, _2, _3)"},
+            &create_sum_operation, &create_primitive<sum_operation>, R"(
+            v, axis, keep_dim
+            Args:
+
+                v (vector or matrix) : a vector or matrix
+                axis (optional, integer): a axis to sum along
+                keep_dim (optional, boolean): keep dimension of input
+
+            Returns:
+
+            The sum of all values along the specified axis.)",
+            true
+        }
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    sum_operation::sum_operation(
-        primitive_arguments_type&& operands,
-        std::string const& name, std::string const& codename)
-      : primitive_component_base(std::move(operands), name, codename)
-    {}
-
-    primitive_argument_type sum_operation::sum0d(arg_type&& arg,
-        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
+    sum_operation::sum_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename)
+      : base_type(std::move(operands), name, codename)
     {
-        if (axis && axis.value() != 0 && axis.value() != -1)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "sum_operation::sum0d",
-                generate_error_message(
-                    "the sum_operation primitive requires operand axis to be "
-                    "either 0 or -1 for scalar values."));
-        }
-
-        return primitive_argument_type{arg.scalar()};
-    }
-
-    primitive_argument_type sum_operation::sum1d(arg_type&& arg,
-        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
-    {
-        if (axis && axis.value() != 0 && axis.value() != -1)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "sum_operation::sum1d",
-                generate_error_message(
-                    "the sum_operation primitive requires operand axis to be "
-                    "either 0 or -1 for vectors."));
-        }
-
-        auto v = arg.vector();
-        double result = std::accumulate(v.begin(), v.end(), 0.);
-
-        if (keep_dims)
-        {
-            return primitive_argument_type{
-                blaze::DynamicVector<val_type>{result}};
-        }
-        return primitive_argument_type{result};
-    }
-
-    primitive_argument_type sum_operation::sum2d(arg_type&& arg,
-        hpx::util::optional<std::int64_t> axis, bool keep_dims) const
-    {
-        if (axis)
-        {
-            switch (axis.value())
-            {
-            case -2: HPX_FALLTHROUGH;
-            case 0:
-                return sum2d_axis0(std::move(arg));
-
-            case -1: HPX_FALLTHROUGH;
-            case 1:
-                return sum2d_axis1(std::move(arg));
-
-            default:
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "sum_operation::sum1d",
-                    generate_error_message(
-                        "the sum_operation primitive requires operand axis "
-                        "to be between -2 and 1 for matrices."));
-            }
-        }
-        return sum2d_flat(std::move(arg), keep_dims);
-    }
-
-    primitive_argument_type sum_operation::sum2d_flat(
-        arg_type&& arg, bool keep_dims) const
-    {
-        auto m = arg.matrix();
-        double result = 0.;
-        for (std::size_t i = 0; i < m.columns(); ++i)
-        {
-            auto col = blaze::column(m, i);
-            result += std::accumulate(col.begin(), col.end(), 0.);
-        }
-
-        if (keep_dims)
-        {
-            return primitive_argument_type{
-                blaze::DynamicMatrix<val_type>{{result}}};
-        }
-        return primitive_argument_type{result};
-    }
-
-    primitive_argument_type sum_operation::sum2d_axis0(arg_type&& arg) const
-    {
-        auto m = arg.matrix();
-        blaze::DynamicVector<double> result(m.columns());
-        for (std::size_t i = 0; i < m.columns(); ++i)
-        {
-            auto col = blaze::column(m, i);
-            result[i] = std::accumulate(col.begin(), col.end(), 0.);
-        }
-
-        return primitive_argument_type{result};
-    }
-
-    primitive_argument_type sum_operation::sum2d_axis1(arg_type&& arg) const
-    {
-        auto m = arg.matrix();
-        blaze::DynamicVector<double> result(m.rows());
-        for (std::size_t i = 0; i < m.rows(); ++i)
-        {
-            auto col = blaze::row(m, i);
-            result[i] = std::accumulate(col.begin(), col.end(), 0.);
-        }
-
-        return primitive_argument_type{result};
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    hpx::future<primitive_argument_type> sum_operation::eval(
-        primitive_arguments_type const& operands,
-        primitive_arguments_type const& args, eval_context ctx) const
-    {
-        if (operands.empty() || operands.size() > 3)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "sum_operation::eval",
-                generate_error_message(
-                    "the sum_operation primitive requires exactly one, two, or "
-                    "three operands"));
-        }
-
-        for (auto const& i : operands)
-        {
-            if (!valid(i))
-            {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "sum_operation::eval",
-                    generate_error_message(
-                        "the sum_operation primitive requires that the "
-                        "arguments given by the operands array are valid"));
-            }
-        }
-
-        auto this_ = this->shared_from_this();
-        return hpx::dataflow(hpx::launch::sync,
-            hpx::util::unwrapping(
-                [this_ = std::move(this_)](primitive_arguments_type&& args)
-                    -> primitive_argument_type
-                {
-                    // Extract axis and keep_dims
-                    // Presence of axis changes behavior for >2d cases
-                    hpx::util::optional<std::int64_t> axis;
-                    bool keep_dims = false;
-
-                    // axis is argument #2
-                    if (args.size() > 1)
-                    {
-                        if (valid(args[1]))
-                        {
-                            axis = extract_scalar_integer_value(
-                                args[1], this_->name_, this_->codename_);
-                        }
-
-                        // keep_dims is argument #3
-                        if (args.size() == 3)
-                        {
-                            keep_dims = extract_scalar_boolean_value(
-                                args[2], this_->name_, this_->codename_);
-                        }
-                    }
-
-                    // Extract the matrix
-                    arg_type a = extract_numeric_value(
-                        args[0], this_->name_, this_->codename_);
-
-                    std::size_t a_dims = a.num_dimensions();
-                    switch (a_dims)
-                    {
-                    case 0:
-                        return this_->sum0d(std::move(a), axis, keep_dims);
-
-                    case 1:
-                        return this_->sum1d(std::move(a), axis, keep_dims);
-
-                    case 2:
-                        return this_->sum2d(std::move(a), axis, keep_dims);
-
-                    default:
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "sum_operation::eval",
-                            this_->generate_error_message(
-                                "operand a has an invalid number of dimensions"));
-                    }
-                }),
-            detail::map_operands(
-                operands, functional::value_operand{}, args,
-                name_, codename_, std::move(ctx)));
     }
 }}}

--- a/src/plugins/matrixops/cross_operation.cpp
+++ b/src/plugins/matrixops/cross_operation.cpp
@@ -6,6 +6,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/plugins/matrixops/cross_operation.hpp>
 
 #include <hpx/include/lcos.hpp>
@@ -26,19 +27,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     match_pattern_type const cross_operation::match_data =
     {
-        hpx::util::make_tuple("cross",
+        match_pattern_type{"cross",
             std::vector<std::string>{"cross(_1, _2)"},
-            &create_cross_operation, &create_primitive<cross_operation>,
-            "v1, v2\n"
-            "Args:\n"
-            "\n"
-            "    v1 (vector) : a vector\n"
-            "    v2 (vector) : a vector\n"
-            "\n"
-            "Returns:\n"
-            "\n"
-            "The cross product of `v1` and `v2`."
-            )
+            &create_cross_operation, &create_primitive<cross_operation>, R"(
+            v1, v2
+            Args:
+
+                v1 (vector) : a vector
+                v2 (vector) : a vector
+
+            Returns:
+
+            The cross product of `v1` and `v2`.)"
+        }
     };
 
     cross_operation::cross_operation(
@@ -48,28 +49,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive_argument_type cross_operation::cross1d(
-        operand_type&& lhs, operand_type&& rhs) const
-    {
-        switch (rhs.num_dimensions())
-        {
-        case 1:
-            return cross1d1d(std::move(lhs), std::move(rhs));
-
-        case 2:
-            return cross1d2d(std::move(lhs), std::move(rhs));
-
-        default:
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "cross_operation::cross1d",
-                generate_error_message(
-                    "right hand side operand has unsupported number of "
-                        "dimensions"));
-        }
-    }
-
+    template <typename T>
     primitive_argument_type cross_operation::cross1d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         std::size_t lhs_vector_dims = lhs.size();
         std::size_t rhs_vector_dims = rhs.size();
@@ -87,7 +69,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             if (lhs.is_ref())
             {
-                blaze::DynamicVector<double> temp = lhs.vector();
+                blaze::DynamicVector<T> temp = lhs.vector();
                 temp.resize(3ul);
                 temp[2ul] = 0.0;
                 lhs = std::move(temp);
@@ -98,13 +80,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 lhs[2ul] = 0.0;
             }
         }
+        else if (lhs_vector_dims > 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "cross_operation::cross1d1d",
+                generate_error_message(
+                    "left hand side operand has more than 3 elements"));
+        }
 
         // Only rhs has 2 elements
         if (rhs_vector_dims < 3ul)
         {
             if (rhs.is_ref())
             {
-                blaze::DynamicVector<double> temp = rhs.vector();
+                blaze::DynamicVector<T> temp = rhs.vector();
                 temp.resize(3ul);
                 temp[2ul] = 0.0;
                 rhs = std::move(temp);
@@ -115,21 +104,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 rhs[2ul] = 0.0;
             }
         }
+        else if (rhs_vector_dims > 3)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "cross_operation::cross1d1d",
+                generate_error_message(
+                    "right hand side operand has more than 3 elements"));
+        }
 
         // Both vectors have 3 elements
         lhs.vector() %= rhs.vector();
-        return primitive_argument_type{
-            ir::node_data<double>{std::move(lhs)}};
+        return primitive_argument_type{ir::node_data<T>{std::move(lhs)}};
     }
 
+    template <typename T>
     primitive_argument_type cross_operation::cross1d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         if (lhs.size() == 2ul)
         {
             if (lhs.is_ref())
             {
-                blaze::DynamicVector<double> temp = lhs.vector();
+                blaze::DynamicVector<T> temp = lhs.vector();
                 temp.resize(3ul);
                 temp[2ul] = 0.0;
                 lhs = std::move(temp);
@@ -149,7 +145,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (rhs.is_ref())
                 {
-                    blaze::DynamicMatrix<double> temp = rhs.matrix();
+                    blaze::DynamicMatrix<T> temp = rhs.matrix();
                     temp.resize(rhs.dimension(0), 3ul);
                     blaze::column(temp, 2ul) = 0.0;
                     rhs = std::move(temp);
@@ -163,18 +159,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             for (std::size_t i = 0ul; i != rhs.dimension(0); ++i)
             {
-                blaze::DynamicVector<double> rhs_op_vec{
-                    rhs[{i, 0ul}], rhs[{i, 1ul}], rhs[{i, 2ul}]};
+                blaze::DynamicVector<T> rhs_op_vec{
+                    rhs.at(i, 0ul), rhs.at(i, 1ul), rhs.at(i, 2ul)};
 
                 auto i_vector = lhs.vector() % rhs_op_vec;
 
-                rhs[{i, 0ul}] = i_vector[0ul];
-                rhs[{i, 1ul}] = i_vector[1ul];
-                rhs[{i, 2ul}] = i_vector[2ul];
+                rhs.at(i, 0ul) = i_vector[0ul];
+                rhs.at(i, 1ul) = i_vector[1ul];
+                rhs.at(i, 2ul) = i_vector[2ul];
             }
 
-            return primitive_argument_type{
-                ir::node_data<double>{std::move(rhs)}};
+            return primitive_argument_type{ir::node_data<T>{std::move(rhs)}};
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -183,34 +178,37 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "operand vectors have an invalid number of elements"));
     }
 
-    primitive_argument_type cross_operation::cross2d(
-        operand_type&& lhs, operand_type&& rhs) const
+    template <typename T>
+    primitive_argument_type cross_operation::cross1d(
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         switch (rhs.num_dimensions())
         {
         case 1:
-            return cross2d1d(std::move(lhs), std::move(rhs));
+            return cross1d1d(std::move(lhs), std::move(rhs));
 
         case 2:
-            return cross2d2d(std::move(lhs), std::move(rhs));
+            return cross1d2d(std::move(lhs), std::move(rhs));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "cross_operation::cross2d",
+                "cross_operation::cross1d",
                 generate_error_message(
                     "right hand side operand has unsupported number of "
                         "dimensions"));
         }
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type cross_operation::cross2d1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         if (rhs.size() == 2ul)
         {
             if (rhs.is_ref())
             {
-                blaze::DynamicVector<double> temp = rhs.vector();
+                blaze::DynamicVector<T> temp = rhs.vector();
                 temp.resize(3ul);
                 temp[2ul] = 0.0;
                 rhs = std::move(temp);
@@ -230,7 +228,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (lhs.is_ref())
                 {
-                    blaze::DynamicMatrix<double> temp = lhs.matrix();
+                    blaze::DynamicMatrix<T> temp = lhs.matrix();
                     temp.resize(lhs.dimension(0), 3ul);
                     blaze::column(temp, 2ul) = 0.0;
                     lhs = std::move(temp);
@@ -243,9 +241,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
 
             auto lhsm = lhs.matrix();
-            blaze::DynamicMatrix<double> rhs_op_mat{
-                {rhs[0ul], rhs[1ul], rhs[2ul]}};
-            blaze::DynamicMatrix<double> temp = lhs.matrix();
+            blaze::DynamicMatrix<T> rhs_op_mat{{rhs[0ul], rhs[1ul], rhs[2ul]}};
+            blaze::DynamicMatrix<T> temp = lhs.matrix();
 
             for (std::size_t i = 0ul; i != lhs.dimension(0); ++i)
             {
@@ -254,8 +251,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::row(rhs_op_mat, 0ul));
             }
 
-            return primitive_argument_type{
-                ir::node_data<double>{std::move(temp)}};
+            return primitive_argument_type{ir::node_data<T>{std::move(temp)}};
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -264,8 +260,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "operand vectors have an invalid number of elements"));
     }
 
+    template <typename T>
     primitive_argument_type cross_operation::cross2d2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         // Both matrices have to have the same number of rows
         if (lhs.dimension(0) != rhs.dimension(0))
@@ -284,11 +281,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 auto lhsm = lhs.matrix();
                 auto rhsm = rhs.matrix();
-                blaze::DynamicMatrix<double> temp = lhs.matrix();
+                blaze::DynamicMatrix<T> temp = lhs.matrix();
 
-                for (std::size_t idx_row = 0;
-                        idx_row != lhs.dimension(0);
-                        ++idx_row)
+                for (std::size_t idx_row = 0; idx_row != lhs.dimension(0);
+                     ++idx_row)
                 {
                     blaze::row(temp, idx_row) = blaze::cross(
                         blaze::row(lhsm, idx_row),
@@ -296,7 +292,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 return primitive_argument_type{
-                    ir::node_data<double>{std::move(temp)}};
+                    ir::node_data<T>{std::move(temp)}};
             }
 
             // If only lhs has 2 elements per vector
@@ -304,7 +300,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (rhs.is_ref())
                 {
-                    blaze::DynamicMatrix<double> temp = lhs.matrix();
+                    blaze::DynamicMatrix<T> temp = lhs.matrix();
                     temp.resize(lhs.dimension(0), 3ul);
                     blaze::column(temp, 2ul) = 0.0;
                     lhs = std::move(temp);
@@ -325,7 +321,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             {
                 if (rhs.is_ref())
                 {
-                    blaze::DynamicMatrix<double> temp = rhs.matrix();
+                    blaze::DynamicMatrix<T> temp = rhs.matrix();
                     temp.resize(rhs.dimension(0), 3ul);
                     blaze::column(temp, 2ul) = 0.0;
                     rhs = std::move(temp);
@@ -340,7 +336,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             // Both have 3 elements per vector
             auto lhsm = lhs.matrix();
             auto rhsm = rhs.matrix();
-            blaze::DynamicMatrix<double> temp = lhs.matrix();
+            blaze::DynamicMatrix<T> temp = lhs.matrix();
 
             for (std::size_t idx_row = 0; idx_row != lhs.dimension(0);
                 ++idx_row)
@@ -350,8 +346,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     blaze::row(rhsm, idx_row));
             }
 
-            return primitive_argument_type{
-                ir::node_data<double>{std::move(temp)}};
+            return primitive_argument_type{ir::node_data<T>{std::move(temp)}};
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -360,6 +355,93 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "operand vectors have an invalid number of elements"));
     }
 
+    template <typename T>
+    primitive_argument_type cross_operation::cross2d(
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        switch (rhs.num_dimensions())
+        {
+        case 1:
+            return cross2d1d(std::move(lhs), std::move(rhs));
+
+        case 2:
+            return cross2d2d(std::move(lhs), std::move(rhs));
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "cross_operation::cross2d",
+                generate_error_message(
+                    "right hand side operand has unsupported number of "
+                        "dimensions"));
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type cross_operation::cross1d(
+        primitive_argument_type&& lhs, primitive_argument_type&& rhs) const
+    {
+        switch (extract_common_type(lhs, rhs))
+        {
+        case node_data_type_bool:
+            return cross1d(
+                extract_boolean_value(std::move(lhs), name_, codename_),
+                extract_boolean_value(std::move(rhs), name_, codename_));
+
+        case node_data_type_int64:
+            return cross1d(
+                extract_integer_value(std::move(lhs), name_, codename_),
+                extract_integer_value(std::move(rhs), name_, codename_));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return cross1d(
+                extract_numeric_value(std::move(lhs), name_, codename_),
+                extract_numeric_value(std::move(rhs), name_, codename_));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "cross_operation::cross1d",
+            generate_error_message(
+                "the cross primitive requires for all arguments to "
+                    "be numeric data types"));
+    }
+
+    primitive_argument_type cross_operation::cross2d(
+        primitive_argument_type&& lhs, primitive_argument_type&& rhs) const
+    {
+        switch (extract_common_type(lhs, rhs))
+        {
+        case node_data_type_bool:
+            return cross2d(
+                extract_boolean_value(std::move(lhs), name_, codename_),
+                extract_boolean_value(std::move(rhs), name_, codename_));
+
+        case node_data_type_int64:
+            return cross2d(
+                extract_integer_value(std::move(lhs), name_, codename_),
+                extract_integer_value(std::move(rhs), name_, codename_));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return cross2d(
+                extract_numeric_value(std::move(lhs), name_, codename_),
+                extract_numeric_value(std::move(rhs), name_, codename_));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "cross_operation::cross2d",
+            generate_error_message(
+                "the cross primitive requires for all arguments to "
+                    "be numeric data types"));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> cross_operation::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
@@ -384,10 +466,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](operand_type&& op1, operand_type&& op2)
+            [this_ = std::move(this_)](
+                    primitive_argument_type&& op1,
+                    primitive_argument_type&& op2)
             ->  primitive_argument_type
             {
-                switch (op1.num_dimensions())
+                switch (extract_numeric_value_dimension(
+                    op1, this_->name_, this_->codename_))
                 {
                 case 1:
                     return this_->cross1d(std::move(op1), std::move(op2));
@@ -403,8 +488,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "number of dimensions"));
                 }
             }),
-            numeric_operand(operands[0], args, name_, codename_, ctx),
-            numeric_operand(operands[1], args, name_, codename_, ctx));
+            value_operand(operands[0], args, name_, codename_, ctx),
+            value_operand(operands[1], args, name_, codename_, ctx));
     }
 }}}
 

--- a/src/plugins/matrixops/diag_operation.cpp
+++ b/src/plugins/matrixops/diag_operation.cpp
@@ -14,6 +14,7 @@
 #include <hpx/throw_exception.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <cmath>
 #include <memory>
 #include <numeric>

--- a/src/plugins/matrixops/diag_operation.cpp
+++ b/src/plugins/matrixops/diag_operation.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/matrixops/diag_operation.hpp>
 
@@ -30,16 +31,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         hpx::util::make_tuple("diag",
             std::vector<std::string>{"diag(_1)", "diag(_1, _2)"},
-            &create_diag_operation, &create_primitive<diag_operation>,
-            "m\n"
-            "Args:\n"
-            "\n"
-            "    m (matrix) : a square matrix\n"
-            "\n"
-            "Returns:\n"
-            "\n"
-            "A vector created from the diagonal elements of `m`."
-            )
+            &create_diag_operation, &create_primitive<diag_operation>, R"(
+            m
+            Args:
+
+                m (matrix) : a square matrix
+
+            Returns:
+
+            A vector created from the diagonal elements of `m`.)"
+        )
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -50,55 +51,141 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-
-    primitive_argument_type diag_operation::diag0d(args_type&& args) const
+    template <typename T>
+    primitive_argument_type diag_operation::diag0d(
+        ir::node_data<T>&& arg, std::int64_t k) const
     {
-        return primitive_argument_type(std::move(args[0]));
+        return primitive_argument_type(std::move(arg));
     }
 
-    primitive_argument_type diag_operation::diag1d(args_type&& args) const
+    template <typename T>
+    primitive_argument_type diag_operation::diag1d(
+        ir::node_data<T>&& arg, std::int64_t k) const
     {
-        auto vecsize = args[0].dimension(0);
-        auto k = 0;
-        auto incr = 0;
+        auto vecsize = arg.dimension(0);
+        auto incr = std::abs(k);
 
-        if (args.size() == 2)
+        blaze::DynamicMatrix<T> result(vecsize + incr, vecsize + incr, 0);
+        blaze::band(result, k) = arg.vector();
+
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
+    }
+
+    template <typename T>
+    primitive_argument_type diag_operation::diag2d(
+        ir::node_data<T>&& arg, std::int64_t k) const
+    {
+        blaze::DynamicVector<T> result(blaze::band(arg.matrix(), k));
+        return primitive_argument_type{ir::node_data<T>{std::move(result)}};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type diag_operation::diag0d(
+        primitive_argument_type&& arg, std::int64_t k) const
+    {
+        switch (extract_common_type(arg))
         {
-            k = args[1].scalar();
-            incr = std::abs(k);
+        case node_data_type_bool:
+            return diag0d(
+                extract_boolean_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_int64:
+            return diag0d(
+                extract_integer_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_double:
+            return diag0d(
+                extract_numeric_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_unknown:
+            return diag0d(
+                extract_numeric_value(std::move(arg), name_, codename_), k);
+
+        default:
+            break;
         }
 
-        blaze::DynamicMatrix<double> result(
-            vecsize + incr, vecsize + incr, 0);
-
-        blaze::Band<blaze::DynamicMatrix<double>> diag =
-            blaze::band(result, k);
-
-        diag = args[0].vector();
-
-        return primitive_argument_type{ ir::node_data<double>{
-            storage2d_type{std::move(result)}} };
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "diag_operation::diag0d",
+            generate_error_message(
+                "the diag primitive requires for all arguments to "
+                    "be numeric data types"));
     }
 
-    primitive_argument_type diag_operation::diag2d(args_type&& args) const
+    primitive_argument_type diag_operation::diag1d(
+        primitive_argument_type&& arg, std::int64_t k) const
     {
-        auto k = 0;
-
-        if (args.size() == 2)
+        switch (extract_common_type(arg))
         {
-            k = args[1].scalar();
+        case node_data_type_bool:
+            return diag1d(
+                extract_boolean_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_int64:
+            return diag1d(
+                extract_integer_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_double:
+            return diag1d(
+                extract_numeric_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_unknown:
+            return diag1d(
+                extract_numeric_value(std::move(arg), name_, codename_), k);
+
+        default:
+            break;
         }
 
-        auto input_matrix = args[0].matrix();
-        blaze::Band<blaze::CustomMatrix<double, true, true>> diag =
-            blaze::band(input_matrix, k);
-
-        blaze::DynamicVector<double> result(diag);
-
-        return primitive_argument_type{ ir::node_data<double>{
-            storage1d_type{std::move(result)}} };
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "diag_operation::diag1d",
+            generate_error_message(
+                "the diag primitive requires for all arguments to "
+                    "be numeric data types"));
     }
 
+    primitive_argument_type diag_operation::diag2d(
+        primitive_argument_type&& arg, std::int64_t k) const
+    {
+        switch (extract_common_type(arg))
+        {
+        case node_data_type_bool:
+            return diag2d(
+                extract_boolean_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_int64:
+            return diag2d(
+                extract_integer_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_double:
+            return diag2d(
+                extract_numeric_value_strict(std::move(arg), name_, codename_),
+                k);
+
+        case node_data_type_unknown:
+            return diag2d(
+                extract_numeric_value(std::move(arg), name_, codename_), k);
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "diag_operation::diag2d",
+            generate_error_message(
+                "the diag primitive requires for all arguments to "
+                    "be numeric data types"));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> diag_operation::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
@@ -132,21 +219,61 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         auto this_ = this->shared_from_this();
-        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](args_type&& args)
+        if (operands.size() == 1)
+        {
+            return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+                [this_ = std::move(this_)](primitive_argument_type&& arg)
                 -> primitive_argument_type
+                {
+                    switch (extract_numeric_value_dimension(
+                        arg, this_->name_, this_->codename_))
+                    {
+                    case 0:
+                        return this_->diag0d(std::move(arg), 0);
+
+                    case 1:
+                        return this_->diag1d(std::move(arg), 0);
+
+                    case 2:
+                        return this_->diag2d(std::move(arg), 0);
+
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "diag_operation::eval",
+                            this_->generate_error_message(
+                                "left hand side operand has unsupported "
+                                "number of dimensions"));
+                    }
+                }),
+                value_operand(operands[0], args, name_, codename_,
+                    std::move(ctx)));
+        }
+
+        auto arg1 = value_operand(operands[0], args, name_, codename_, ctx);
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+            [this_ = std::move(this_)](primitive_argument_type&& arg1,
+                ir::node_data<std::int64_t>&& arg2)
+            -> primitive_argument_type
             {
-                std::size_t matrix_dims = args[0].num_dimensions();
-                switch (matrix_dims)
+                if (arg2.size() != 1)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "diag_operation::eval",
+                        this_->generate_error_message(
+                            "second operand has to be a scalar value"));
+                }
+
+                switch (extract_numeric_value_dimension(
+                    arg1, this_->name_, this_->codename_))
                 {
                 case 0:
-                    return this_->diag0d(std::move(args));
+                    return this_->diag0d(std::move(arg1), arg2[0]);
 
                 case 1:
-                    return this_->diag1d(std::move(args));
+                    return this_->diag1d(std::move(arg1), arg2[0]);
 
                 case 2:
-                    return this_->diag2d(std::move(args));
+                    return this_->diag2d(std::move(arg1), arg2[0]);
 
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -156,8 +283,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "number of dimensions"));
                 }
             }),
-            detail::map_operands(
-                operands, functional::numeric_operand{}, args,
-                name_, codename_, std::move(ctx)));
+            arg1,
+            integer_operand(operands[1], args, name_, codename_,
+                std::move(ctx)));
     }
 }}}

--- a/src/plugins/matrixops/gradient_operation.cpp
+++ b/src/plugins/matrixops/gradient_operation.cpp
@@ -38,10 +38,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
             Args:
 
                 m (vector or matrix) : values to take the gradient of
-                axis (optional, integer) : the axis along which to take
-                                the gradient
+                axis (optional, integer) : the axis along which to take the gradient
 
-            Returns:\n"
+            Returns:
 
             The numerical gradient, i.e., differences of adjacent values
             along the specified axis.)")
@@ -60,24 +59,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ir::node_data<T>&& arg) const
     {
         auto input = arg.vector();
-        std::size_t length = input.size();
-        blaze::DynamicVector<T> gradient(length);
+        std::size_t last = input.size() - 1;
+        blaze::DynamicVector<T> gradient(last + 1);
 
-        for (std::size_t i = 0; i != length; i++)
+        gradient[0] = input[1] - input[0];
+        for (std::size_t i = 1; i != last; i++)
         {
-            if (i == 0)
-            {
-                gradient[i] = input[i + 1] - input[i];
-            }
-            else if (i == length - 1)
-            {
-                gradient[i] = input[i] - input[i - 1];
-            }
-            else
-            {
-                gradient[i] = (input[i + 1] - input[i - 1]) / 2;
-            }
+            gradient[i] = (input[i + 1] - input[i - 1]) / 2;
         }
+        gradient[last] = input[last] - input[last - 1];
 
         return primitive_argument_type{ir::node_data<T>{std::move(gradient)}};
     }
@@ -101,7 +91,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     auto temp = blaze::column(input, i);
                     gradient(0, i) = temp[1] - temp[0];
-                    for (std::size_t j = 0; j != last; j++)
+                    for (std::size_t j = 1; j != last; j++)
                     {
                         gradient(j, i) = (temp[j + 1] - temp[j - 1]) / 2;
                     }
@@ -115,7 +105,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     auto temp = blaze::row(input, i);
                     gradient(i, 0) = temp[1] - temp[0];
-                    for (std::size_t j = 0; j != last; j++)
+                    for (std::size_t j = 1; j != last; j++)
                     {
                         gradient(i, j) = (temp[j + 1] - temp[j - 1]) / 2;
                     }

--- a/src/plugins/matrixops/gradient_operation.cpp
+++ b/src/plugins/matrixops/gradient_operation.cpp
@@ -5,6 +5,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/plugins/matrixops/gradient_operation.hpp>
 
 #include <hpx/include/lcos.hpp>
@@ -32,19 +33,18 @@ namespace phylanx { namespace execution_tree { namespace primitives
         hpx::util::make_tuple("gradient",
             std::vector<std::string>{"gradient(_1, _2)", "gradient(_1)"},
             &create_gradient_operation,
-            &create_primitive<gradient_operation>,
-            "m, axis\n"
-            "Args:\n"
-            "\n"
-            "    m (vector or matrix) : values to take the gradient of\n"
-            "    axis (optional, integer) : the axis along whic to take\n"
-            "                    the gradient.\n"
-            "\n"
-            "Returns:\n"
-            "\n"
-            "The numerical gradient, i.e., differences of adjacent values "
-            "along the specified axis."
-            )
+            &create_primitive<gradient_operation>, R"(
+            m, axis
+            Args:
+
+                m (vector or matrix) : values to take the gradient of
+                axis (optional, integer) : the axis along which to take
+                                the gradient
+
+            Returns:\n"
+
+            The numerical gradient, i.e., differences of adjacent values
+            along the specified axis.)")
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -55,29 +55,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    using arg_type = ir::node_data<double>;
-    using args_type = std::vector<arg_type, arguments_allocator<arg_type>>;
-    using storage1d_type = typename arg_type::storage1d_type;
-    using storage2d_type = typename arg_type::storage2d_type;
-
-    primitive_argument_type gradient_operation::gradient0d(
-        args_type&& args) const
-    {
-        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "gradient_operation::gradient0d",
-            util::generate_error_message(
-                "gradient operation is not supported on 0d input", this->name_,
-                this->codename_));
-    }
-
+    template <typename T>
     primitive_argument_type gradient_operation::gradient1d(
-        args_type&& args) const
+        ir::node_data<T>&& arg) const
     {
-        blaze::DynamicVector<double> input = args[0].vector();
+        auto input = arg.vector();
         std::size_t length = input.size();
-        blaze::DynamicVector<double> gradient(length);
+        blaze::DynamicVector<T> gradient(length);
 
-        for (std::size_t i = 0; i < length; i++)
+        for (std::size_t i = 0; i != length; i++)
         {
             if (i == 0)
             {
@@ -93,105 +79,164 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
         }
 
-        return primitive_argument_type{
-            ir::node_data<double>{storage1d_type{std::move(gradient)}}};
+        return primitive_argument_type{ir::node_data<T>{std::move(gradient)}};
+    }
+
+    template <typename T>
+    primitive_argument_type gradient_operation::gradient2d(
+        ir::node_data<T>&& arg, std::int64_t axis) const
+    {
+        auto input = arg.matrix();
+        std::size_t num_rows = input.rows();
+        std::size_t num_cols = input.columns();
+
+        blaze::DynamicMatrix<T> gradient(num_rows, num_cols);
+
+        if (axis >= 0)
+        {
+            if (axis == 0)
+            {
+                auto last = num_rows - 1;
+                for (std::size_t i = 0; i != num_cols; i++)
+                {
+                    auto temp = blaze::column(input, i);
+                    gradient(0, i) = temp[1] - temp[0];
+                    for (std::size_t j = 0; j != last; j++)
+                    {
+                        gradient(j, i) = (temp[j + 1] - temp[j - 1]) / 2;
+                    }
+                    gradient(last, i) = temp[last] - temp[last - 1];
+                }
+            }
+            else    // axis = 1
+            {
+                auto last = num_cols - 1;
+                for (std::size_t i = 0; i != num_rows; i++)
+                {
+                    auto temp = blaze::row(input, i);
+                    gradient(i, 0) = temp[1] - temp[0];
+                    for (std::size_t j = 0; j != last; j++)
+                    {
+                        gradient(i, j) = (temp[j + 1] - temp[j - 1]) / 2;
+                    }
+                    gradient(i, last) = temp[last] - temp[last - 1];
+                }
+            }
+
+            return primitive_argument_type{
+                ir::node_data<T>{std::move(gradient)}};
+        }
+
+        // args_size = 1
+        blaze::DynamicMatrix<T> gradient_1(num_rows, num_cols);
+        auto last = num_rows - 1;
+        for (std::size_t i = 0; i != num_cols; i++)
+        {
+            auto temp = blaze::column(input, i);
+            auto temp_1 = blaze::row(input, i);
+
+            gradient(0, i) = temp[1] - temp[0];
+            gradient_1(i, 0) = temp_1[1] - temp_1[0];
+
+            for (std::size_t j = 1; j != last; j++)
+            {
+                gradient(j, i) = (temp[j + 1] - temp[j - 1]) / 2;
+                gradient_1(i, j) = (temp_1[j + 1] - temp_1[j - 1]) / 2;
+            }
+
+            gradient(last, i) = temp[last] - temp[last - 1];
+            gradient_1(i, last) = temp_1[last] - temp_1[last - 1];
+        }
+
+        return primitive_argument_type{primitive_arguments_type{
+            primitive_argument_type{ir::node_data<T>{std::move(gradient)}},
+            primitive_argument_type{ir::node_data<T>{std::move(gradient_1)}}
+        }};
+    }
+
+    primitive_argument_type gradient_operation::gradient0d(
+        primitive_arguments_type&& args) const
+    {
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "gradient_operation::gradient0d",
+            generate_error_message(
+                "gradient operation is not supported on 0d input"));
+    }
+
+    primitive_argument_type gradient_operation::gradient1d(
+        primitive_arguments_type&& args) const
+    {
+        switch (extract_common_type(args[0]))
+        {
+        case node_data_type_bool:
+            return gradient1d(
+                extract_boolean_value(std::move(args[0]), name_, codename_));
+
+        case node_data_type_int64:
+            return gradient1d(
+                extract_integer_value(std::move(args[0]), name_, codename_));
+
+        case node_data_type_double:
+            return gradient1d(extract_numeric_value_strict(
+                std::move(args[0]), name_, codename_));
+
+        case node_data_type_unknown:
+            return gradient1d(
+                extract_numeric_value(std::move(args[0]), name_, codename_));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "gradient_operation::gradient1d",
+            generate_error_message(
+                "the gradient primitive requires for all arguments to "
+                    "be numeric data types"));
     }
 
     primitive_argument_type gradient_operation::gradient2d(
-        args_type&& args) const
+        primitive_arguments_type&& args) const
     {
-        blaze::DynamicMatrix<double> input = args[0].matrix();
-        std::size_t num_rows = input.rows();
-        std::size_t num_cols = input.columns();
-        std::size_t args_size = args.size();
-
-        blaze::DynamicMatrix<double> gradient(num_rows, num_cols);
-
-        if (args_size == 2)
+        std::int64_t axis = -1;
+        if (args.size() == 2)
         {
-            std::int64_t axis = args[1].scalar();
+            axis = extract_scalar_integer_value(args[1], name_, codename_);
+        }
 
-            if (axis == 0)
-            {
-                for (std::size_t i = 0; i < num_cols; i++)
-                {
-                    auto temp = blaze::column(input, i);
-                    for (std::size_t j = 0; j < num_rows; j++)
-                    {
-                        if (j == 0)
-                        {
-                            gradient(j, i) = temp[j + 1] - temp[j];
-                        }
-                        else if (j == num_rows - 1)
-                        {
-                            gradient(j, i) = temp[j] - temp[j - 1];
-                        }
-                        else
-                        {
-                            gradient(j, i) = (temp[j + 1] - temp[j - 1]) / 2;
-                        }
-                    }
-                }
-            }
-            else    //axis = 1
-            {
-                for (std::size_t i = 0; i < num_rows; i++)
-                {
-                    auto temp = blaze::row(input, i);
-                    for (std::size_t j = 0; j < num_cols; j++)
-                    {
-                        if (j == 0)
-                        {
-                            gradient(i, j) = temp[j + 1] - temp[j];
-                        }
-                        else if (j == num_rows - 1)
-                        {
-                            gradient(i, j) = temp[j] - temp[j - 1];
-                        }
-                        else
-                        {
-                            gradient(i, j) = (temp[j + 1] - temp[j - 1]) / 2;
-                        }
-                    }
-                }
-            }
-            return primitive_argument_type{
-                ir::node_data<double>{storage2d_type{std::move(gradient)}}};
-        }
-        else    // args_size = 1
+        switch (extract_common_type(args[0]))
         {
-            blaze::DynamicMatrix<double> gradient_1(num_rows, num_cols);
-            for (std::size_t i = 0; i < num_cols; i++)
-            {
-                auto temp = blaze::column(input, i);
-                auto temp_1 = blaze::row(input, i);
-                for (std::size_t j = 0; j < num_rows; j++)
-                {
-                    if (j == 0)
-                    {
-                        gradient(j, i) = temp[j + 1] - temp[j];
-                        gradient_1(i, j) = temp_1[j + 1] - temp_1[j];
-                    }
-                    else if (j == num_rows - 1)
-                    {
-                        gradient(j, i) = temp[j] - temp[j - 1];
-                        gradient_1(i, j) = temp_1[j] - temp_1[j - 1];
-                    }
-                    else
-                    {
-                        gradient(j, i) = (temp[j + 1] - temp[j - 1]) / 2;
-                        gradient_1(i, j) = (temp_1[j + 1] - temp_1[j - 1]) / 2;
-                    }
-                }
-            }
-            return primitive_argument_type{primitive_arguments_type{
-                primitive_argument_type{
-                    ir::node_data<double>{storage2d_type{std::move(gradient)}}},
-                primitive_argument_type{ir::node_data<double>{
-                    storage2d_type{std::move(gradient_1)}}}}};
+        case node_data_type_bool:
+            return gradient2d(
+                extract_boolean_value(std::move(args[0]), name_, codename_),
+                axis);
+
+        case node_data_type_int64:
+            return gradient2d(
+                extract_integer_value(std::move(args[0]), name_, codename_),
+                axis);
+
+        case node_data_type_double:
+            return gradient2d(extract_numeric_value_strict(
+                std::move(args[0]), name_, codename_), axis);
+
+        case node_data_type_unknown:
+            return gradient2d(
+                extract_numeric_value(std::move(args[0]), name_, codename_),
+                axis);
+
+        default:
+            break;
         }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "gradient_operation::gradient2d",
+            generate_error_message(
+                "the gradient primitive requires for all arguments to "
+                    "be numeric data types"));
     }
 
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> gradient_operation::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
@@ -227,11 +272,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync,
             hpx::util::unwrapping(
-                [this_ = std::move(this_)](args_type&& args)
+                [this_ = std::move(this_)](primitive_arguments_type&& args)
                 -> primitive_argument_type
                 {
-                    std::size_t matrix_dims = args[0].num_dimensions();
-                    switch (matrix_dims)
+                    switch (extract_numeric_value_dimension(
+                        args[0], this_->name_, this_->codename_))
                     {
                     case 0:
                         return this_->gradient0d(std::move(args));
@@ -245,14 +290,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     default:
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
                             "gradient_operation::eval",
-                            util::generate_error_message(
+                            this_->generate_error_message(
                                 "left hand side operand has unsupported "
-                                    "number of dimensions",
-                                this_->name_, this_->codename_));
+                                    "number of dimensions"));
                     }
                 }),
             detail::map_operands(
-                operands, functional::numeric_operand{}, args,
+                operands, functional::value_operand{}, args,
                 name_, codename_, std::move(ctx)));
     }
 }}}

--- a/src/plugins/matrixops/inverse_operation.cpp
+++ b/src/plugins/matrixops/inverse_operation.cpp
@@ -111,7 +111,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto& t = op.tensor_non_ref();
         for (std::size_t p = 0; p != t.pages(); ++p)
         {
-            blaze::invert(blaze::pageslice(t, p));
+            auto ps = blaze::pageslice(t, p);
+            blaze::invert(ps);
         }
         return primitive_argument_type{std::move(op)};
     }

--- a/src/plugins/matrixops/inverse_operation.cpp
+++ b/src/plugins/matrixops/inverse_operation.cpp
@@ -5,6 +5,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/plugins/matrixops/inverse_operation.hpp>
 
 #include <hpx/include/lcos.hpp>
@@ -19,6 +20,11 @@
 #include <utility>
 #include <vector>
 
+#include <blaze/Math.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Math.h>
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree { namespace primitives
 {
@@ -27,16 +33,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         hpx::util::make_tuple("inverse",
             std::vector<std::string>{"inverse(_1)"},
-            &create_inverse_operation, &create_primitive<inverse_operation>,
-            "m\n"
-            "Args:\n"
-            "\n"
-            "    m (matrix): a matrix\n"
-            "\n"
-            "Returns:\n"
-            "\n"
-            "The inverse of m."
-            )
+            &create_inverse_operation,
+            &create_primitive<inverse_operation>, R"(
+            m
+            Args:
+
+                m (matrix): a scalar, matrix, or tensor
+
+            Returns:
+
+            The multiplicative inverse of m.)")
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -47,23 +53,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type inverse_operation::inverse0d(
-        operand_type&& op) const
+        ir::node_data<T>&& op) const
     {
         op.scalar() = 1 / op.scalar();
         return primitive_argument_type{std::move(op)};
     }
 
+    template <typename T>
     primitive_argument_type inverse_operation::inverse2d(
-        operand_type&& op) const
+        ir::node_data<T>&& op) const
     {
         if (op.dimension(0) != op.dimension(1))
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "inverse::inverse2d",
-                util::generate_error_message(
-                    "matrices to inverse have to be quadratic",
-                    name_, codename_));
+                generate_error_message(
+                    "matrices to inverse have to be quadratic"));
         }
 
         if (op.is_ref())
@@ -76,6 +83,126 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
         return primitive_argument_type{std::move(op)};
     }
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    template <typename T>
+    primitive_argument_type inverse_operation::inverse3d(
+        ir::node_data<T>&& op) const
+    {
+        if (op.dimension(1) != op.dimension(2))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "inverse::inverse3d",
+                generate_error_message(
+                    "matrices to inverse have to be quadratic"));
+        }
+
+        if (op.is_ref())
+        {
+            auto t = op.tensor();
+            blaze::DynamicTensor<T> result(t.pages(), t.rows(), t.columns());
+            for (std::size_t p = 0; p != t.pages(); ++p)
+            {
+                blaze::pageslice(result, p) = blaze::inv(blaze::pageslice(t, p));
+            }
+            return primitive_argument_type{std::move(result)};
+        }
+
+        auto& t = op.tensor_non_ref();
+        for (std::size_t p = 0; p != t.pages(); ++p)
+        {
+            blaze::invert(blaze::pageslice(t, p));
+        }
+        return primitive_argument_type{std::move(op)};
+    }
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type inverse_operation::inverse0d(
+        primitive_argument_type&& op) const
+    {
+        switch (extract_common_type(op))
+        {
+        case node_data_type_bool:
+            return inverse0d(
+                extract_boolean_value(std::move(op), name_, codename_));
+
+        case node_data_type_int64:
+            return inverse0d(
+                extract_integer_value(std::move(op), name_, codename_));
+
+        case node_data_type_double:
+            return inverse0d(extract_numeric_value_strict(
+                std::move(op), name_, codename_));
+
+        case node_data_type_unknown:
+            return inverse0d(
+                extract_numeric_value(std::move(op), name_, codename_));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "inverse_operation::inverse0d",
+            generate_error_message(
+                "the inverse primitive requires for all arguments to "
+                    "be numeric data types"));
+    }
+
+    primitive_argument_type inverse_operation::inverse2d(
+        primitive_argument_type&& op) const
+    {
+        switch (extract_common_type(op))
+        {
+        case node_data_type_double:
+            return inverse2d(extract_numeric_value_strict(
+                std::move(op), name_, codename_));
+
+        case node_data_type_bool:
+        case node_data_type_int64:
+        case node_data_type_unknown:
+            return inverse2d(extract_numeric_value(
+                std::move(op), name_, codename_));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "inverse_operation::inverse2d",
+            generate_error_message(
+                "the inverse primitive requires for all arguments to "
+                    "be numeric data types"));
+    }
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    primitive_argument_type inverse_operation::inverse3d(
+        primitive_argument_type&& op) const
+    {
+        switch (extract_common_type(op))
+        {
+        case node_data_type_double:
+            return inverse3d(extract_numeric_value_strict(
+                std::move(op), name_, codename_));
+
+        case node_data_type_bool:
+        case node_data_type_int64:
+        case node_data_type_unknown:
+            return inverse3d(extract_numeric_value(
+                std::move(op), name_, codename_));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "inverse_operation::inverse3d",
+            generate_error_message(
+                "the inverse primitive requires for all arguments to "
+                    "be numeric data types"));
+    }
+#endif
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> inverse_operation::eval(
@@ -102,11 +229,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](operand_type&& op)
+            [this_ = std::move(this_)](primitive_argument_type&& op)
             -> primitive_argument_type
             {
-                std::size_t dims = op.num_dimensions();
-                switch (dims)
+                switch (extract_numeric_value_dimension(
+                    op, this_->name_, this_->codename_))
                 {
                 case 0:
                     return this_->inverse0d(std::move(op));
@@ -114,6 +241,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 case 2:
                     return this_->inverse2d(std::move(op));
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+                case 3:
+                    return this_->inverse3d(std::move(op));
+#endif
                 case 1: HPX_FALLTHROUGH;
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -123,7 +254,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "number of dimensions"));
                 }
             }),
-            numeric_operand(operands[0], args,
+            value_operand(operands[0], args,
                 name_, codename_, std::move(ctx)));
     }
 }}}

--- a/src/plugins/matrixops/linearmatrix.cpp
+++ b/src/plugins/matrixops/linearmatrix.cpp
@@ -14,6 +14,7 @@
 #include <hpx/throw_exception.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -167,10 +168,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 return this_->linmatrix(nx, ny, std::move(x0),
                     std::move(dx), std::move(dy));
             }),
-            scalar_integer_operand_strict(
-                operands[0], args, name_, codename_, ctx),
-            scalar_integer_operand_strict(
-                operands[1], args, name_, codename_, ctx),
+            scalar_integer_operand(operands[0], args, name_, codename_, ctx),
+            scalar_integer_operand(operands[1], args, name_, codename_, ctx),
             value_operand(operands[2], args, name_, codename_, ctx),
             value_operand(operands[3], args, name_, codename_, ctx),
             value_operand(operands[4], args, name_, codename_, ctx));

--- a/src/plugins/matrixops/linearmatrix.cpp
+++ b/src/plugins/matrixops/linearmatrix.cpp
@@ -5,6 +5,7 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/plugins/matrixops/linearmatrix.hpp>
 
 #include <hpx/include/lcos.hpp>
@@ -26,53 +27,43 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     match_pattern_type const linearmatrix::match_data =
     {
-        hpx::util::make_tuple("linearmatrix",
+        match_pattern_type{
+            "linearmatrix",
             std::vector<std::string>{"linearmatrix(_1, _2, _3, _4, _5)"},
-            &create_linearmatrix, &create_primitive<linearmatrix>,
-            "nx, ny, x0, dx, dy\n"
-            "Args:\n"
-            "\n"
-            "    nx (int) : number of rows\n"
-            "    ny (int) : number of columns\n"
-            "    x0 (float) : value of the 0,0 element\n"
-            "    dx (float) : increment in value in the x-direction\n"
-            "    dy (float) : increment in value in the x-direction\n"
-            "\n"
-            "Returns:\n"
-            "\n"
-            "A matrix of size `nx` by `ny` with values beginning at `x0` "
-            "and increasing by `dx` (or `dy`) as x (or y) is increased."
-            )
+            &create_linearmatrix, &create_primitive<linearmatrix>, R"(
+            nx, ny, x0, dx, dy
+            Args:
+
+                nx (int) : number of rows
+                ny (int) : number of columns
+                x0 (number) : value of the 0,0 element
+                dx (number) : increment in value in the x-direction
+                dy (number) : increment in value in the y-direction
+
+            Returns:
+
+            A matrix of size `nx` by `ny` with values beginning at `x0`
+            and increasing by `dx` (or `dy`) as x (or y) is increased.)",
+            true
+        }
     };
 
     ///////////////////////////////////////////////////////////////////////////
     linearmatrix::linearmatrix(primitive_arguments_type&& args,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(args), name, codename)
+      , dtype_(extract_dtype(name_))
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive_argument_type linearmatrix::linmatrix(args_type&& args) const
+    template <typename T>
+    primitive_argument_type linearmatrix::linmatrix(
+        std::int64_t nx, std::int64_t ny, T x0, T dx, T dy) const
     {
-        if (5 != args.size())
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "linearmatrix::linmatrix",
-                generate_error_message(
-                    "linearmatrix primitive requires five arguments."));
-        }
-
-        std::size_t nx = extract_scalar_integer_value(args[0]);
-        std::size_t ny = extract_scalar_integer_value(args[1]);
-        double base_value = args[2].scalar();
-        double dx = args[3].scalar();
-        double dy = args[4].scalar();
-
         if (nx < 1)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "phylanx::execution_tree::primitives::"
-                    "detail::linearmatrix",
+                "phylanx::execution_tree::primitives::linearmatrix::linmatrix",
                 generate_error_message(
                     "the size of matrix in dimension x must at "
                         "least be one."));
@@ -81,26 +72,64 @@ namespace phylanx { namespace execution_tree { namespace primitives
         if (ny < 1)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "phylanx::execution_tree::primitives::"
-                    "detail::linearmatrix",
+                "phylanx::execution_tree::primitives::linearmatrix::linmatrix",
                 generate_error_message(
                     "the size of matrix in dimension y must at "
                         "least be one."));
         }
 
-        matrix_type result{nx, ny};
+        blaze::DynamicMatrix<T> result(nx, ny);
 
-        for(int x = 0; x < nx; x++)
+        for (std::int64_t x = 0; x < nx; ++x)
         {
-            for(int y = 0; y < ny; y++)
+            T base = x0 + dx * x;
+            for (std::int64_t y = 0; y < ny; ++y)
             {
-                result(x, y) = base_value + dx * x + dy * y;
+                result(x, y) = base + dy * y;
             }
         }
 
-        return arg_type{std::move(result)};
+        return primitive_argument_type{std::move(result)};
     }
 
+    primitive_argument_type linearmatrix::linmatrix(std::int64_t nx,
+        std::int64_t ny, primitive_argument_type&& x0,
+        primitive_argument_type&& dx, primitive_argument_type&& dy) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = extract_common_type(x0, dx, dy);
+        }
+
+        switch (t)
+        {
+        case node_data_type_int64:
+            return linmatrix(nx, ny,
+                extract_scalar_integer_value(std::move(x0), name_, codename_),
+                extract_scalar_integer_value(std::move(dx), name_, codename_),
+                extract_scalar_integer_value(std::move(dy), name_, codename_));
+
+        case node_data_type_bool:   HPX_FALLTHROUGH;
+        case node_data_type_double: HPX_FALLTHROUGH;
+        case node_data_type_unknown:
+            return linmatrix(nx, ny,
+                extract_scalar_numeric_value(std::move(x0), name_, codename_),
+                extract_scalar_numeric_value(std::move(dx), name_, codename_),
+                extract_scalar_numeric_value(std::move(dy), name_, codename_));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "linearmatrix::linmatrix",
+            generate_error_message(
+                "the linearmatrix primitive requires for all arguments to "
+                    "be numeric data types"));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> linearmatrix::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
@@ -129,13 +158,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](args_type&& args)
+            [this_ = std::move(this_)](std::int64_t nx, std::int64_t ny,
+                    primitive_argument_type&& x0,
+                    primitive_argument_type&& dx,
+                    primitive_argument_type&& dy)
             -> primitive_argument_type
             {
-                return this_->linmatrix(std::move(args));
+                return this_->linmatrix(nx, ny, std::move(x0),
+                    std::move(dx), std::move(dy));
             }),
-            detail::map_operands(
-                operands, functional::numeric_operand{}, args,
-                name_, codename_, std::move(ctx)));
+            scalar_integer_operand_strict(
+                operands[0], args, name_, codename_, ctx),
+            scalar_integer_operand_strict(
+                operands[1], args, name_, codename_, ctx),
+            value_operand(operands[2], args, name_, codename_, ctx),
+            value_operand(operands[3], args, name_, codename_, ctx),
+            value_operand(operands[4], args, name_, codename_, ctx));
     }
 }}}

--- a/src/plugins/matrixops/linspace.cpp
+++ b/src/plugins/matrixops/linspace.cpp
@@ -156,7 +156,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }),
             value_operand(operands[0], args, name_, codename_, ctx),
             value_operand(operands[1], args, name_, codename_, ctx),
-            scalar_integer_operand_strict(
-                operands[2], args, name_, codename_, ctx));
+            scalar_integer_operand(operands[2], args, name_, codename_, ctx));
     }
 }}}

--- a/src/plugins/matrixops/power_operation.cpp
+++ b/src/plugins/matrixops/power_operation.cpp
@@ -26,19 +26,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     match_pattern_type const power_operation::match_data =
     {
-        hpx::util::make_tuple("power",
+        match_pattern_type{
+            "power",
             std::vector<std::string>{"power(_1, _2)"},
-            &create_power_operation, &create_primitive<power_operation>,
-            "base, pow\n"
-            "Args:\n"
-            "\n"
-            "    base (float) : the base of the exponent\n"
-            "    pow (float) : the power of the exponent\n"
-            "\n"
-            "Returns:\n"
-            "\n"
-            "The value `base`**`pow`."
-            )
+            &create_power_operation, &create_primitive<power_operation>, R"(
+            base, pow
+            Args:
+
+                base (float) : the base of the exponent
+                pow (float) : the power of the exponent
+
+            Returns:
+
+            The value `base`**`pow`.)",
+            true
+        }
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -46,18 +48,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
+      , dtype_(extract_dtype(name_))
     {}
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
     primitive_argument_type power_operation::power0d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
-        lhs = double(std::pow(lhs.scalar(), rhs[0]));
+        if (lhs.is_ref())
+        {
+            lhs = T(std::pow(lhs.scalar(), rhs[0]));
+        }
+        else
+        {
+            lhs.scalar() = T(std::pow(lhs.scalar(), rhs[0]));
+        }
         return primitive_argument_type{std::move(lhs)};
     }
 
+    template <typename T>
     primitive_argument_type power_operation::power1d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         if (lhs.is_ref())
         {
@@ -70,8 +82,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return primitive_argument_type{std::move(lhs)};
     }
 
+    template <typename T>
     primitive_argument_type power_operation::power2d(
-        operand_type&& lhs, operand_type&& rhs) const
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
     {
         if (lhs.is_ref())
         {
@@ -84,6 +97,166 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return primitive_argument_type{std::move(lhs)};
     }
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    template <typename T>
+    primitive_argument_type power_operation::power3d(
+        ir::node_data<T>&& lhs, ir::node_data<T>&& rhs) const
+    {
+        if (lhs.is_ref())
+        {
+            lhs = blaze::pow(lhs.tensor(), rhs[0]);
+        }
+        else
+        {
+            lhs.tensor() = blaze::pow(lhs.tensor(), rhs[0]);
+        }
+        return primitive_argument_type{std::move(lhs)};
+    }
+#endif
+
+    primitive_argument_type power_operation::power0d(
+        primitive_argument_type&& lhs, primitive_argument_type&& rhs) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = extract_common_type(lhs, rhs);
+        }
+
+        switch (t)
+        {
+        case node_data_type_bool:
+            return power0d(extract_boolean_value(std::move(lhs)),
+                extract_boolean_value(std::move(rhs)));
+
+        case node_data_type_int64:
+            return power0d(extract_integer_value(std::move(lhs)),
+                extract_integer_value(std::move(rhs)));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return power0d(extract_numeric_value(std::move(lhs)),
+                extract_numeric_value(std::move(rhs)));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "power_operation::power0d",
+            generate_error_message(
+                "the power primitive requires for its argument to "
+                    "be numeric data type"));
+    }
+
+    primitive_argument_type power_operation::power1d(
+        primitive_argument_type&& lhs, primitive_argument_type&& rhs) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = extract_common_type(lhs, rhs);
+        }
+
+        switch (t)
+        {
+        case node_data_type_bool:
+            return power1d(extract_boolean_value(std::move(lhs)),
+                extract_boolean_value(std::move(rhs)));
+
+        case node_data_type_int64:
+            return power1d(extract_integer_value(std::move(lhs)),
+                extract_integer_value(std::move(rhs)));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return power1d(extract_numeric_value(std::move(lhs)),
+                extract_numeric_value(std::move(rhs)));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "power_operation::power1d",
+            generate_error_message(
+                "the power primitive requires for its argument to "
+                    "be numeric data type"));
+    }
+
+    primitive_argument_type power_operation::power2d(
+        primitive_argument_type&& lhs, primitive_argument_type&& rhs) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = extract_common_type(lhs, rhs);
+        }
+
+        switch (t)
+        {
+        case node_data_type_bool:
+            return power2d(extract_boolean_value(std::move(lhs)),
+                extract_boolean_value(std::move(rhs)));
+
+        case node_data_type_int64:
+            return power2d(extract_integer_value(std::move(lhs)),
+                extract_integer_value(std::move(rhs)));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return power2d(extract_numeric_value(std::move(lhs)),
+                extract_numeric_value(std::move(rhs)));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "power_operation::power2d",
+            generate_error_message(
+                "the power primitive requires for its argument to "
+                    "be numeric data type"));
+    }
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    primitive_argument_type power_operation::power3d(
+        primitive_argument_type&& lhs, primitive_argument_type&& rhs) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = extract_common_type(lhs, rhs);
+        }
+
+        switch (t)
+        {
+        case node_data_type_bool:
+            return power3d(extract_boolean_value(std::move(lhs)),
+                extract_boolean_value(std::move(rhs)));
+
+        case node_data_type_int64:
+            return power3d(extract_integer_value(std::move(lhs)),
+                extract_integer_value(std::move(rhs)));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return power3d(extract_numeric_value(std::move(lhs)),
+                extract_numeric_value(std::move(rhs)));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "power_operation::power3d",
+            generate_error_message(
+                "the power primitive requires for its argument to "
+                    "be numeric data type"));
+    }
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> power_operation::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
@@ -109,10 +282,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](operand_type&& op1, operand_type&& op2)
+            [this_ = std::move(this_)](
+                    primitive_argument_type&& op1, primitive_argument_type&& op2)
             ->  primitive_argument_type
             {
-                if (op2.num_dimensions() != 0)
+                if (extract_numeric_value_dimension(
+                        op2, this_->name_, this_->codename_) != 0)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "power_operation::eval",
@@ -120,7 +295,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "right hand side operand has to be a scalar value"));
                 }
 
-                switch (op1.num_dimensions())
+                switch (extract_numeric_value_dimension(
+                    op2, this_->name_, this_->codename_))
                 {
                 case 0:
                     return this_->power0d(std::move(op1), std::move(op2));
@@ -131,6 +307,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 case 2:
                     return this_->power2d(std::move(op1), std::move(op2));
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+                case 3:
+                    return this_->power3d(std::move(op1), std::move(op2));
+#endif
                 default:
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "power_operation::eval",
@@ -139,7 +319,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "number of dimensions"));
                 }
             }),
-            numeric_operand(operands[0], args, name_, codename_, ctx),
-            numeric_operand(operands[1], args, name_, codename_, ctx));
+            value_operand(operands[0], args, name_, codename_, ctx),
+            value_operand(operands[1], args, name_, codename_, ctx));
     }
 }}}

--- a/src/plugins/matrixops/power_operation.cpp
+++ b/src/plugins/matrixops/power_operation.cpp
@@ -280,7 +280,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
 
                 switch (extract_numeric_value_dimension(
-                    op2, this_->name_, this_->codename_))
+                    op1, this_->name_, this_->codename_))
                 {
                 case 0:
                     return this_->power0d(std::move(op1), std::move(op2));

--- a/src/plugins/matrixops/power_operation.cpp
+++ b/src/plugins/matrixops/power_operation.cpp
@@ -123,16 +123,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             t = extract_common_type(lhs, rhs);
         }
 
+        // #FIXME: for now, map all power operations on the double dtype (Blaze
+        // throws compilation error for int64_t)
         switch (t)
         {
-        case node_data_type_bool:
-            return power0d(extract_boolean_value(std::move(lhs)),
-                extract_boolean_value(std::move(rhs)));
-
-        case node_data_type_int64:
-            return power0d(extract_integer_value(std::move(lhs)),
-                extract_integer_value(std::move(rhs)));
-
+        case node_data_type_bool:    HPX_FALLTHROUGH;
+        case node_data_type_int64:   HPX_FALLTHROUGH;
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return power0d(extract_numeric_value(std::move(lhs)),
@@ -158,16 +154,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             t = extract_common_type(lhs, rhs);
         }
 
+        // #FIXME: for now, map all power operations on the double dtype (Blaze
+        // throws compilation error for int64_t)
         switch (t)
         {
-        case node_data_type_bool:
-            return power1d(extract_boolean_value(std::move(lhs)),
-                extract_boolean_value(std::move(rhs)));
-
-        case node_data_type_int64:
-            return power1d(extract_integer_value(std::move(lhs)),
-                extract_integer_value(std::move(rhs)));
-
+        case node_data_type_bool:    HPX_FALLTHROUGH;
+        case node_data_type_int64:   HPX_FALLTHROUGH;
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return power1d(extract_numeric_value(std::move(lhs)),
@@ -193,16 +185,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             t = extract_common_type(lhs, rhs);
         }
 
+        // #FIXME: for now, map all power operations on the double dtype (Blaze
+        // throws compilation error for int64_t)
         switch (t)
         {
-        case node_data_type_bool:
-            return power2d(extract_boolean_value(std::move(lhs)),
-                extract_boolean_value(std::move(rhs)));
-
-        case node_data_type_int64:
-            return power2d(extract_integer_value(std::move(lhs)),
-                extract_integer_value(std::move(rhs)));
-
+        case node_data_type_bool:    HPX_FALLTHROUGH;
+        case node_data_type_int64:   HPX_FALLTHROUGH;
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return power2d(extract_numeric_value(std::move(lhs)),
@@ -229,16 +217,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             t = extract_common_type(lhs, rhs);
         }
 
+        // #FIXME: for now, map all power operations on the double dtype (Blaze
+        // throws compilation error for int64_t)
         switch (t)
         {
-        case node_data_type_bool:
-            return power3d(extract_boolean_value(std::move(lhs)),
-                extract_boolean_value(std::move(rhs)));
-
-        case node_data_type_int64:
-            return power3d(extract_integer_value(std::move(lhs)),
-                extract_integer_value(std::move(rhs)));
-
+        case node_data_type_bool:    HPX_FALLTHROUGH;
+        case node_data_type_int64:   HPX_FALLTHROUGH;
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return power3d(extract_numeric_value(std::move(lhs)),

--- a/src/plugins/matrixops/shuffle_operation.cpp
+++ b/src/plugins/matrixops/shuffle_operation.cpp
@@ -5,6 +5,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/plugins/matrixops/shuffle_operation.hpp>
 #include <phylanx/util/matrix_iterators.hpp>
 #include <phylanx/util/random.hpp>
@@ -71,17 +72,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         hpx::util::make_tuple("shuffle",
             std::vector<std::string>{"shuffle(_1)"},
-            &create_shuffle_operation, &create_primitive<shuffle_operation>,
-            "args\n"
-            "Args:\n"
-            "\n"
-            "    args (list) : a list of values\n"
-            "\n"
-            "Returns:\n"
-            "\n"
-            "A shuffled version of the list. Note that `args` itself will be "
-            "shuffled by this call."
-            )
+            &create_shuffle_operation,
+            &create_primitive<shuffle_operation>, R"(
+            args
+            Args:
+
+                args (list) : a list of values
+
+            Returns:
+
+            A shuffled version of the list. Note that `args` itself will be "
+            shuffled by this call.)")
     };
 
     ///////////////////////////////////////////////////////////////////////////
@@ -92,22 +93,79 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    primitive_argument_type shuffle_operation::shuffle_1d(arg_type && arg) const
+    template <typename T>
+    primitive_argument_type shuffle_operation::shuffle_1d(
+        ir::node_data<T>&& arg) const
     {
         auto x = arg.vector();
         std::shuffle(x.begin(), x.end(), util::rng_);
 
-        return primitive_argument_type{ir::node_data<double>{std::move(x)}};
+        return primitive_argument_type{std::move(arg)};
     }
 
-    primitive_argument_type shuffle_operation::shuffle_2d(arg_type&& arg) const
+    template <typename T>
+    primitive_argument_type shuffle_operation::shuffle_2d(
+        ir::node_data<T>&& arg) const
     {
         auto x = arg.matrix();
-        auto x_begin = util::matrix_row_iterator<decltype(x)>(x);
-        auto x_end = util::matrix_row_iterator<decltype(x)>(x, x.rows());
+
+        util::matrix_row_iterator<decltype(x)> x_begin(x);
+        util::matrix_row_iterator<decltype(x)> x_end(x, x.rows());
         std::shuffle(x_begin, x_end, util::rng_);
 
-        return primitive_argument_type{ir::node_data<double>{std::move(x)}};
+        return primitive_argument_type{std::move(arg)};
+    }
+
+    primitive_argument_type shuffle_operation::shuffle_1d(
+        primitive_argument_type&& arg) const
+    {
+        switch (extract_common_type(arg))
+        {
+        case node_data_type_bool:
+            return shuffle_1d(extract_boolean_value_strict(std::move(arg)));
+
+        case node_data_type_int64:
+            return shuffle_1d(extract_integer_value_strict(std::move(arg)));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return shuffle_1d(extract_numeric_value(std::move(arg)));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "shuffle_operation::shuffle_1d",
+            generate_error_message(
+                "the shuffle primitive requires for its argument to "
+                    "be numeric data type"));
+    }
+
+    primitive_argument_type shuffle_operation::shuffle_2d(
+        primitive_argument_type&& arg) const
+    {
+        switch (extract_common_type(arg))
+        {
+        case node_data_type_bool:
+            return shuffle_2d(extract_boolean_value_strict(std::move(arg)));
+
+        case node_data_type_int64:
+            return shuffle_2d(extract_integer_value_strict(std::move(arg)));
+
+        case node_data_type_unknown: HPX_FALLTHROUGH;
+        case node_data_type_double:
+            return shuffle_2d(extract_numeric_value(std::move(arg)));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "shuffle_operation::shuffle_2d",
+            generate_error_message(
+                "the shuffle primitive requires for its argument to "
+                    "be numeric data type"));
     }
 
     //////////////////////////////////////////////////////////////////////////
@@ -134,29 +192,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         auto this_ = this->shared_from_this();
-        return hpx::dataflow(hpx::launch::sync,
-            hpx::util::unwrapping(
-                [this_ = std::move(this_)](arg_type&& arg)
-                -> primitive_argument_type
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+            [this_ = std::move(this_)](primitive_argument_type&& arg)
+            -> primitive_argument_type
+            {
+                switch (extract_numeric_value_dimension(
+                    arg, this_->name_, this_->codename_))
                 {
-                    std::size_t lhs_dims = arg.num_dimensions();
-                    switch (lhs_dims)
-                    {
-                    case 1:
-                        return this_->shuffle_1d(std::move(arg));
+                case 1:
+                    return this_->shuffle_1d(std::move(arg));
 
-                    case 2:
-                        return this_->shuffle_2d(std::move(arg));
+                case 2:
+                    return this_->shuffle_2d(std::move(arg));
 
-                    default:
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "shuffle_operation::eval",
-                            this_->generate_error_message(
-                                "operand has an unsupported number of "
-                                    "dimensions. Only possible values are: "
-                                    "1 or 2."));
-                    }
-                }),
-            numeric_operand(operands[0], args, name_, codename_, std::move(ctx)));
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "shuffle_operation::eval",
+                        this_->generate_error_message(
+                            "operand has an unsupported number of "
+                                "dimensions. Only possible values are: "
+                                "1 or 2."));
+                }
+            }),
+            value_operand(operands[0], args, name_, codename_, std::move(ctx)));
     }
 }}}

--- a/tests/unit/plugins/arithmetics/prod_operation.cpp
+++ b/tests/unit/plugins/arithmetics/prod_operation.cpp
@@ -16,6 +16,9 @@
 #include <vector>
 
 #include <blaze/Math.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Math.h>
+#endif
 
 void test_0d()
 {
@@ -416,7 +419,7 @@ void test_2d_axis1_keep_dims_true()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         prod.eval();
 
-    blaze::DynamicMatrix<double> expected{{54., 6., 1.}};
+    blaze::DynamicMatrix<double> expected{{54.}, {6.}, {1.}};
 
     HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
         phylanx::execution_tree::extract_numeric_value(f.get()));
@@ -478,12 +481,649 @@ void test_2d_axis1_keep_dims_false()
         phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_2d_axes(std::int64_t axis1, std::int64_t axis2)
+{
+    blaze::DynamicMatrix<double> subject{{6., 9.}, {2., 3.}, {-1., -1.}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_argument_type{
+                phylanx::execution_tree::primitive_arguments_type{
+                    phylanx::ir::node_data<std::int64_t>(axis1),
+                    phylanx::ir::node_data<std::int64_t>(axis2)
+                }
+            });
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    double expected = 324.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_2d_axes_keep_dims_true(std::int64_t axis1, std::int64_t axis2)
+{
+    blaze::DynamicMatrix<double> subject{{6., 9.}, {2., 3.}, {-1., -1.}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_argument_type{
+                phylanx::execution_tree::primitive_arguments_type{
+                    phylanx::ir::node_data<std::int64_t>(axis1),
+                    phylanx::ir::node_data<std::int64_t>(axis2)
+                }
+            });
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<double> expected({{324.}});
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_3d()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg0)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    double expected = -116640.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_int()
+{
+    blaze::DynamicTensor<std::int64_t> subject{
+        {{6, 9}, {2, 3}, {-1, -1}}, {{3, 4}, {1, 5}, {-2, 3}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg0)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    std::int64_t expected = -116640;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis0()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(0));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<double> expected{{18., 36.}, {2., 15.}, {2., -3.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis0_int()
+{
+    blaze::DynamicTensor<std::int64_t> subject{
+        {{6, 9}, {2, 3}, {-1, -1}}, {{3, 4}, {1, 5}, {-2, 3}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(0));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<std::int64_t> expected{{18, 36}, {2, 15}, {2, -3}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+
+void test_3d_axis1()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<double> expected{{-12., -27.}, {-6., 60.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis1_int()
+{
+    blaze::DynamicTensor<std::int64_t> subject{
+        {{6, 9}, {2, 3}, {-1, -1}}, {{3, 4}, {1, 5}, {-2, 3}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<std::int64_t> expected{{-12, -27}, {-6, 60}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+
+void test_3d_axis2()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(2));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<double> expected{{54., 6., 1.}, {12., 5., -6.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis2_int()
+{
+    blaze::DynamicTensor<std::int64_t> subject{
+        {{6, 9}, {2, 3}, {-1, -1}}, {{3, 4}, {1, 5}, {-2, 3}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(2));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<std::int64_t> expected{{54, 6, 1}, {12, 5, -6}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+
+void test_3d_keep_dims_true()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicTensor<double> expected{{{-116640.}}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_keep_dims_false()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    double expected = -116640.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis0_keep_dims_true()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(0));
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicTensor<double> expected{{{18., 36.}, {2., 15.}, {2., -3.}}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis1_keep_dims_true()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicTensor<double> expected{{{-12., -27.}}, {{-6., 60.}}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis2_keep_dims_true()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(2));
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicTensor<double> expected{
+        {{54.}, {6.}, {1.}}, {{12.}, {5.}, {-6.}}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis0_keep_dims_false()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(0));
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<double> expected{{18., 36.}, {2., 15.}, {2., -3.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis1_keep_dims_false()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<double> expected{{-12., -27.}, {-6., 60.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis2_keep_dims_false()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(2));
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicMatrix<double> expected{{54., 6., 1.}, {12., 5., -6.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axes(std::int64_t axis1, std::int64_t axis2,
+    blaze::DynamicVector<double> expected)
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_argument_type{
+                phylanx::execution_tree::primitive_arguments_type{
+                    phylanx::ir::node_data<std::int64_t>(axis1),
+                    phylanx::ir::node_data<std::int64_t>(axis2)
+                }
+            });
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axes(std::int64_t axis1, std::int64_t axis2, std::int64_t axis3)
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_argument_type{
+                phylanx::execution_tree::primitive_arguments_type{
+                    phylanx::ir::node_data<std::int64_t>(axis1),
+                    phylanx::ir::node_data<std::int64_t>(axis2),
+                    phylanx::ir::node_data<std::int64_t>(axis3)
+                }
+            });
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    double expected = -116640.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axes_keep_dims_true(std::int64_t axis1, std::int64_t axis2,
+    blaze::DynamicTensor<double> expected)
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_argument_type{
+                phylanx::execution_tree::primitive_arguments_type{
+                    phylanx::ir::node_data<std::int64_t>(axis1),
+                    phylanx::ir::node_data<std::int64_t>(axis2)
+                }
+            });
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axes_keep_dims_true(
+    std::int64_t axis1, std::int64_t axis2, std::int64_t axis3)
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}, {2., 3.}, {-1., -1.}}, {{3., 4.}, {1., 5.}, {-2., 3.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_argument_type{
+                phylanx::execution_tree::primitive_arguments_type{
+                    phylanx::ir::node_data<std::int64_t>(axis1),
+                    phylanx::ir::node_data<std::int64_t>(axis2),
+                    phylanx::ir::node_data<std::int64_t>(axis3)
+                }
+            });
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive prod =
+        phylanx::execution_tree::primitives::create_prod_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        prod.eval();
+
+    blaze::DynamicTensor<double> expected{{{-116640.}}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+#endif
+
 int main(int argc, char* argv[])
 {
     test_0d();
+
     test_1d();
     test_1d_keep_dims_true();
     test_1d_keep_dims_false();
+
     test_2d();
     test_2d_axis0();
     test_2d_axis1();
@@ -496,6 +1136,65 @@ int main(int argc, char* argv[])
     test_2d_int();
     test_2d_axis0_int();
     test_2d_axis1_int();
+
+    test_2d_axes(0, 1);
+    test_2d_axes(1, 0);
+
+    test_2d_axes_keep_dims_true(0, 1);
+    test_2d_axes_keep_dims_true(1, 0);
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_3d();
+    test_3d_axis0();
+    test_3d_axis1();
+    test_3d_axis2();
+    test_3d_keep_dims_true();
+    test_3d_keep_dims_false();
+    test_3d_axis0_keep_dims_true();
+    test_3d_axis1_keep_dims_true();
+    test_3d_axis2_keep_dims_true();
+    test_3d_axis0_keep_dims_false();
+    test_3d_axis1_keep_dims_false();
+    test_3d_axis2_keep_dims_false();
+    test_3d_int();
+    test_3d_axis0_int();
+    test_3d_axis1_int();
+    test_3d_axis2_int();
+
+    test_3d_axes(0, 1, blaze::DynamicVector<double>({72., -1620.}));
+    test_3d_axes(1, 0, blaze::DynamicVector<double>({72., -1620.}));
+    test_3d_axes(0, 2, blaze::DynamicVector<double>({648., 30., -6.}));
+    test_3d_axes(2, 0, blaze::DynamicVector<double>({648., 30., -6.}));
+    test_3d_axes(1, 2, blaze::DynamicVector<double>({324., -360.}));
+    test_3d_axes(2, 1, blaze::DynamicVector<double>({324., -360.}));
+
+    test_3d_axes_keep_dims_true(
+        0, 1, blaze::DynamicTensor<double>({{{72., -1620.}}}));
+    test_3d_axes_keep_dims_true(
+        1, 0, blaze::DynamicTensor<double>({{{72., -1620.}}}));
+    test_3d_axes_keep_dims_true(
+        0, 2, blaze::DynamicTensor<double>({{{648.}, {30.}, {-6.}}}));
+    test_3d_axes_keep_dims_true(
+        2, 0, blaze::DynamicTensor<double>({{{648.}, {30.}, {-6.}}}));
+    test_3d_axes_keep_dims_true(
+        1, 2, blaze::DynamicTensor<double>({{{324.}}, {{-360.}}}));
+    test_3d_axes_keep_dims_true(
+        2, 1, blaze::DynamicTensor<double>({{{324.}}, {{-360.}}}));
+
+    test_3d_axes(0, 1, 2);
+    test_3d_axes(1, 2, 0);
+    test_3d_axes(2, 0, 1);
+    test_3d_axes(0, 2, 1);
+    test_3d_axes(2, 1, 0);
+    test_3d_axes(1, 0, 2);
+
+    test_3d_axes_keep_dims_true(0, 1, 2);
+    test_3d_axes_keep_dims_true(1, 2, 0);
+    test_3d_axes_keep_dims_true(2, 0, 1);
+    test_3d_axes_keep_dims_true(0, 2, 1);
+    test_3d_axes_keep_dims_true(2, 1, 0);
+    test_3d_axes_keep_dims_true(1, 0, 2);
+#endif
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/matrixops/extract_shape.cpp
+++ b/tests/unit/plugins/matrixops/extract_shape.cpp
@@ -1,4 +1,4 @@
-//   Copyright (c) 2017 Hartmut Kaiser
+//   Copyright (c) 2017-2018 Hartmut Kaiser
 //   Copyright (c) 2018 Shahrzad Shirzad
 //
 //   Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,6 +13,11 @@
 #include <cstdint>
 #include <utility>
 #include <vector>
+
+#include <blaze/Math.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Math.h>
+#endif
 
 void test_extract_shape_0d()
 {
@@ -52,10 +57,10 @@ void test_extract_shape_1d()
     HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(1007), *result.begin());
 }
 
-void test_extract_shape_2d_1()
+void test_extract_shape_2d()
 {
     blaze::Rand<blaze::DynamicMatrix<double>> gen{};
-    blaze::DynamicMatrix<double> m = gen.generate(101UL, 101UL);
+    blaze::DynamicMatrix<double> m = gen.generate(101UL, 117UL);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
@@ -72,13 +77,14 @@ void test_extract_shape_2d_1()
     auto result = phylanx::execution_tree::extract_list_value(f);
     auto it = result.begin();
     HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(101), *it++);
-    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(101), *it);
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(117), *it++);
+    HPX_TEST(it == result.end());
 }
 
-void test_extract_shape_2d_2()
+void test_extract_shape_2d_axis(std::int64_t axis, std::int64_t expected)
 {
     blaze::Rand<blaze::DynamicMatrix<double>> gen{};
-    blaze::DynamicMatrix<double> m = gen.generate(101UL, 101UL);
+    blaze::DynamicMatrix<double> m = gen.generate(101UL, 117UL);
 
     phylanx::execution_tree::primitive arg1 =
         phylanx::execution_tree::primitives::create_variable(
@@ -86,7 +92,7 @@ void test_extract_shape_2d_2()
 
     phylanx::execution_tree::primitive arg2 =
         phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(axis));
 
     phylanx::execution_tree::primitive shape =
         phylanx::execution_tree::primitives::create_extract_shape(
@@ -96,11 +102,63 @@ void test_extract_shape_2d_2()
 
     phylanx::execution_tree::primitive_argument_type f = shape.eval().get();
 
-    auto result = phylanx::execution_tree::extract_numeric_value(f);
-    auto it = result.begin();
-    HPX_TEST_EQ(101, *it++);
-    HPX_TEST_EQ(101, *it);
+    auto result =
+        phylanx::execution_tree::extract_scalar_integer_value_strict(f);
+    HPX_TEST_EQ(expected, result);
 }
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_extract_shape_3d()
+{
+    blaze::Rand<blaze::DynamicTensor<double>> gen{};
+    blaze::DynamicTensor<double> m = gen.generate(11UL, 17UL, 13UL);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive shape =
+        phylanx::execution_tree::primitives::create_extract_shape(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = shape.eval().get();
+
+    auto result = phylanx::execution_tree::extract_list_value(f);
+    auto it = result.begin();
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(11), *it++);
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(17), *it++);
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(13), *it++);
+    HPX_TEST(it == result.end());
+}
+
+void test_extract_shape_3d_axis(std::int64_t axis, std::int64_t expected)
+{
+    blaze::Rand<blaze::DynamicTensor<double>> gen{};
+    blaze::DynamicTensor<double> m = gen.generate(11UL, 17UL, 13UL);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(axis));
+
+    phylanx::execution_tree::primitive shape =
+        phylanx::execution_tree::primitives::create_extract_shape(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg1), std::move(arg2)});
+
+    phylanx::execution_tree::primitive_argument_type f = shape.eval().get();
+
+    auto result =
+        phylanx::execution_tree::extract_scalar_integer_value_strict(f);
+    HPX_TEST_EQ(expected, result);
+}
+#endif
 
 int main(int argc, char* argv[])
 {
@@ -108,8 +166,16 @@ int main(int argc, char* argv[])
 
     test_extract_shape_1d();
 
-    test_extract_shape_2d_1();
-    test_extract_shape_2d_2();
+    test_extract_shape_2d();
+    test_extract_shape_2d_axis(0, 101);
+    test_extract_shape_2d_axis(1, 117);
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_extract_shape_3d();
+    test_extract_shape_3d_axis(0, 11);
+    test_extract_shape_3d_axis(1, 17);
+    test_extract_shape_3d_axis(2, 13);
+#endif
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
Changing primitives to properly propagate the dtype of its arguments to the result or to avoid converting all arguments to numeric types internally. 

The following primitives have been adapted:

- `cross`
- `determinant`
- `diag`
- `dot`
- `shape`
- `gradient`
- `inverse`
- `linearmatrix`
- `linspace`
- `mean`
- `power`
- `shuffle`
- `sum`
- `transpose`

This also adds 3D support for `shape`, `inverse`, `power`, `sum`, and `prod`.

This fixes #659.