### PR TITLE
Add astpretty to the CircleCI base image

### DIFF
--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update &&                                                           
     pip3 --no-cache-dir install setuptools                                       && \
     pip3 --no-cache-dir install pytest                                           && \
     pip3 --no-cache-dir install numpy                                            && \
+    pip3 --no-cache-dir install astpretty                                        && \
     pip3 --no-cache-dir install flake8                                           && \
                                                                                     \
     git clone --depth=1 https://github.com/pybind/pybind11.git /pybind11-src     && \


### PR DESCRIPTION
This PR adds [astpretty](https://github.com/asottile/astpretty) to the [Docker image](https://hub.docker.com/r/stellargroup/phylanx_base/) used by our CircleCI infrastructure, which is a dependency introduced in #718.