### PR TITLE
Adding the environment variable `PHYLANX_PLUGINS_PATH` 

### DIFF
--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -202,8 +202,8 @@ namespace phylanx { namespace execution_tree
         std::vector<hpx::util::tuple<std::string, match_pattern_type>>;
 
     ///////////////////////////////////////////////////////////////////////////
-    PHYLANX_EXPORT void register_pattern(
-        std::string const&, match_pattern_type const& pattern);
+    PHYLANX_EXPORT void register_pattern(std::string const& name,
+        match_pattern_type const& pattern, std::string const& fullpath);
 
     PHYLANX_EXPORT void show_patterns();
     PHYLANX_EXPORT void show_patterns(std::ostream& ostrm);

--- a/phylanx/plugins/plugin_base.hpp
+++ b/phylanx/plugins/plugin_base.hpp
@@ -8,13 +8,15 @@
 
 #include <phylanx/config.hpp>
 
+#include <string>
+
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace plugin
 {
     struct plugin_base
     {
         virtual ~plugin_base() {}
-        virtual void register_known_primitives() = 0;
+        virtual void register_known_primitives(std::string const& fullpath) = 0;
     };
 }}
 

--- a/phylanx/plugins/plugin_factory.hpp
+++ b/phylanx/plugins/plugin_factory.hpp
@@ -101,14 +101,14 @@ namespace phylanx { namespace plugin
     /**/
 
 #define PHYLANX_REGISTER_PLUGIN_FACTORY_3(pluginname, match_data, name)        \
-    namespace phylanx {                                                        \
-        namespace plugin {                                                     \
+    namespace phylanx { namespace plugin {                                     \
             struct pluginname : plugin_base                                    \
             {                                                                  \
-                void register_known_primitives() override                      \
+                void register_known_primitives(                                \
+                    std::string const& fullpath) override                      \
                 {                                                              \
                     phylanx::execution_tree::register_pattern(                 \
-                        name, match_data);                                     \
+                        name, match_data, fullpath);                           \
                 }                                                              \
             };                                                                 \
         }                                                                      \

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -18,7 +18,8 @@
 namespace phylanx { namespace execution_tree
 {
     ///////////////////////////////////////////////////////////////////////////
-    std::vector<std::pair<std::string, match_pattern_type>> registered_patterns;
+    std::vector<hpx::util::tuple<std::string, match_pattern_type, std::string>>
+        registered_patterns;
 
     void show_patterns()
     {
@@ -95,10 +96,10 @@ namespace phylanx { namespace execution_tree
         return "No help available.";
     }
 
-    void register_pattern(
-        std::string const& name, match_pattern_type const& pattern)
+    void register_pattern(std::string const& name,
+        match_pattern_type const& pattern, std::string const& fullpath)
     {
-        registered_patterns.emplace_back(name, pattern);
+        registered_patterns.emplace_back(name, pattern, fullpath);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -146,8 +147,8 @@ namespace phylanx { namespace execution_tree
             // patterns registered from external primitive plugins
             for (auto const& pattern : registered_patterns)
             {
-                patterns.push_back(
-                    hpx::util::make_tuple(pattern.first, pattern.second));
+                patterns.push_back(hpx::util::make_tuple(
+                    hpx::util::get<0>(pattern), hpx::util::get<1>(pattern)));
             }
 
             return patterns;

--- a/src/plugins/arithmetics/arithmetics.cpp
+++ b/src/plugins/arithmetics/arithmetics.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace plugin
 {
     struct generic_operation_plugin : plugin_base
     {
-        void register_known_primitives() override
+        void register_known_primitives(std::string const& fullpath) override
         {
             namespace pet = phylanx::execution_tree;
 
@@ -36,7 +36,8 @@ namespace phylanx { namespace plugin
             for (auto const& pattern :
                 pet::primitives::generic_operation::match_data)
             {
-                pet::register_pattern(generic_operation_name, pattern);
+                pet::register_pattern(
+                    generic_operation_name, pattern, fullpath);
             }
         }
     };

--- a/src/plugins/listops/listops.cpp
+++ b/src/plugins/listops/listops.cpp
@@ -25,7 +25,7 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(append_operation_plugin,
 namespace phylanx { namespace plugin {
     struct car_cdr_plugin : plugin_base
     {
-        void register_known_primitives() override
+        void register_known_primitives(std::string const& fullpath) override
         {
             namespace pet = phylanx::execution_tree;
 
@@ -33,7 +33,7 @@ namespace phylanx { namespace plugin {
             for (auto const& pattern :
                 pet::primitives::car_cdr_operation::match_data)
             {
-                pet::register_pattern(car_cdr_name, pattern);
+                pet::register_pattern(car_cdr_name, pattern, fullpath);
             }
         }
     };

--- a/src/plugins/load_plugins.cpp
+++ b/src/plugins/load_plugins.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace plugin
     ///////////////////////////////////////////////////////////////////////////
     bool load_plugins(plugin_map_type& plugins)
     {
-        hpx::util::section ini = hpx::get_runtime().get_config();
+        hpx::util::section& ini = hpx::get_runtime().get_config();
 
         // load all components as described in the configuration information
         if (!ini.has_section("phylanx.plugins"))
@@ -55,14 +55,14 @@ namespace phylanx { namespace plugin
             return false;     // something bad happened
         }
 
-        hpx::util::section::section_map const& s = (*sec).get_sections();
-        typedef hpx::util::section::section_map::const_iterator iterator;
+        hpx::util::section::section_map& s = (*sec).get_sections();
+        typedef hpx::util::section::section_map::iterator iterator;
 
         iterator end = s.end();
-        for (iterator i = s.begin (); i != end; ++i)
+        for (iterator i = s.begin(); i != end; ++i)
         {
             // the section name is the instance name of the component
-            hpx::util::section const& sect = i->second;
+            hpx::util::section& sect = i->second;
             std::string instance (sect.get_name());
             std::string component;
 
@@ -160,7 +160,11 @@ namespace phylanx { namespace plugin
                     std::shared_ptr<phylanx::plugin::plugin_base> plugin(
                         factory->create());
 
-                    plugin->register_known_primitives();
+                    plugin->register_known_primitives(lib_path.string());
+
+                    // store the full path of this plugin
+                    sect.add_entry(
+                        std::string("loaded_from_path"), lib_path.string());
                 }
             }
             catch (...) {

--- a/src/plugins/solvers/solvers.cpp
+++ b/src/plugins/solvers/solvers.cpp
@@ -16,7 +16,7 @@ namespace phylanx { namespace plugin
 {
     struct linear_solver_plugin : plugin_base
     {
-        void register_known_primitives() override
+        void register_known_primitives(std::string const& fullpath) override
         {
             namespace pet = phylanx::execution_tree;
 
@@ -24,14 +24,14 @@ namespace phylanx { namespace plugin
             for (auto const& pattern :
                 pet::primitives::linear_solver::match_data)
             {
-                pet::register_pattern(linear_solver_name, pattern);
+                pet::register_pattern(linear_solver_name, pattern, fullpath);
             }
         }
     };
 
     struct decomposition_plugin : plugin_base
     {
-        void register_known_primitives() override
+        void register_known_primitives(std::string const& fullpath) override
         {
             namespace pet = phylanx::execution_tree;
 
@@ -39,7 +39,7 @@ namespace phylanx { namespace plugin
             for (auto const& pattern :
                 pet::primitives::decomposition::match_data)
             {
-                pet::register_pattern(decomposition_name, pattern);
+                pet::register_pattern(decomposition_name, pattern, fullpath);
             }
         }
     };

--- a/tests/unit/distributed/remote_run.cpp
+++ b/tests/unit/distributed/remote_run.cpp
@@ -116,7 +116,8 @@ int hpx_main(int argc, char* argv[])
 int main(int argc, char* argv[])
 {
     phylanx::execution_tree::register_pattern("locality_id_action",
-        phylanx::execution_tree::primitives::locality_id_match_data);
+        phylanx::execution_tree::primitives::locality_id_match_data,
+        argv[0]);
 
     HPX_TEST_EQ(hpx::init(argc, argv), 0);
 


### PR DESCRIPTION
This allows to specify additional search directories for Phylanx plugins.

This environment variable may contain one or more directories that during startup will be searched for Phylanx plugins. The directories should be delimited by `';'` (windows) or `':'` (otherwise).

- note: this depends on https://github.com/STEllAR-GROUP/hpx/pull/3607
- flyby: adding full plugin path to internal configuration registry

This PR is providing the first changes needed to fix #722