### PR TITLE
Modifying expand dims and tile primitives

### DIFF
--- a/phylanx/plugins/matrixops/expand_dims.hpp
+++ b/phylanx/plugins/matrixops/expand_dims.hpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2018 Parsa Amini
 // Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018 Bita Hasheminezhad
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -22,9 +23,11 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    /// \brief Creates a vector from scalar values and a column matrix from
-    /// vectors
-    /// \param a may either be a scalar or a vector
+/// \brief Expands the shape of an array by adding a dimension along the given
+///        axis.
+/// \param a     The scalar, vector, or matrix to be expanded.
+/// \param axis  The axis which the dimension is expanded along.
+
     class expand_dims
       : public primitive_component_base
       , public std::enable_shared_from_this<expand_dims>

--- a/src/plugins/matrixops/tile_operation.cpp
+++ b/src/plugins/matrixops/tile_operation.cpp
@@ -156,7 +156,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicVector<T> result(rep * v.size());
         for (auto i = 0; i < rep; ++i)
         {
-            subvector(result, i * v.size(), v.size()) = v;
+            blaze::subvector(result, i * v.size(), v.size()) = v;
         }
         return primitive_argument_type{std::move(result)};
     }
@@ -179,7 +179,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicMatrix<T> result(row, column * v.size());
         for (auto r = 0; r < row; ++r)
             for (auto c = 0; c < column; ++c)
-                blaze::row(submatrix(result, r, c * v.size(), 1, v.size()), 0) =
+                blaze::row(
+                    blaze::submatrix(result, r, c * v.size(), 1, v.size()), 0) =
                     blaze::trans(v);
 
         return primitive_argument_type{std::move(result)};
@@ -257,7 +258,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicMatrix<T> result(m.rows(), rep * m.columns());
         for (auto i = 0; i < rep; ++i)
         {
-            submatrix(result, 0, i * m.columns(), m.rows(), m.columns()) = m;
+            blaze::submatrix(
+                result, 0, i * m.columns(), m.rows(), m.columns()) = m;
         }
         return primitive_argument_type{std::move(result)};
     }
@@ -280,8 +282,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         blaze::DynamicMatrix<T> result(row * m.rows(), column * m.columns());
         for (auto r = 0; r < row; ++r)
             for (auto c = 0; c < column; ++c)
-                submatrix(result, r * m.rows(), c * m.columns(), m.rows(),
-                    m.columns()) = m;
+                blaze::submatrix(result, r * m.rows(), c * m.columns(),
+                    m.rows(), m.columns()) = m;
 
         return primitive_argument_type{std::move(result)};
     }

--- a/tests/unit/plugins/matrixops/expand_dims.cpp
+++ b/tests/unit/plugins/matrixops/expand_dims.cpp
@@ -48,15 +48,25 @@ int main(int argc, char* argv[])
     test_expand_dims_operation("expand_dims(42., -1)", "[42.]");
     test_expand_dims_operation("expand_dims(33, 0)", "[33]");
     test_expand_dims_operation(
+        "expand_dims([42., 13., 33.], 1)", "[[ 42.],[ 13.],[ 33.]]");
+    test_expand_dims_operation(
         "expand_dims([42., 13., 33.], -1)", "[[ 42.],[ 13.],[ 33.]]");
+    test_expand_dims_operation(
+        "expand_dims([42., 13., 33.], 0)", "[[42., 13., 33.]]");
     test_expand_dims_operation(
         "expand_dims([42., 13., 33.], -2)", "[[42., 13., 33.]]");
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], 0)",
+        "[[[ 42.,  13.], [  2.,  33.]]]");
     test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], -3)",
         "[[[ 42.,  13.], [  2.,  33.]]]");
     test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], 2)",
         "[[[ 42.],[ 13.]], [[  2.],[ 33.]]]");
+    test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], -1)",
+        "[[[ 42.],[ 13.]], [[  2.],[ 33.]]]");
     test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], 1)",
+        "[[[ 42.,  13.]], [[  2.,  33.]]]");
+    test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], -2)",
         "[[[ 42.,  13.]], [[  2.,  33.]]]");
 
 #endif

--- a/tests/unit/plugins/matrixops/expand_dims.cpp
+++ b/tests/unit/plugins/matrixops/expand_dims.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2018 Parsa Amini
 // Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2019 Bita Hasheminezhad
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -8,12 +9,11 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/lcos.hpp>
 #include <hpx/util/lightweight_test.hpp>
 
 #include <cstdint>
+#include <string>
 #include <utility>
-#include <vector>
 
 #include <blaze/Math.h>
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
@@ -21,170 +21,44 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_0d()
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
 {
-    phylanx::execution_tree::primitive lhs =
-        phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
 
-    phylanx::execution_tree::primitive expand_dims =
-        phylanx::execution_tree::primitives::create_expand_dims(
-            hpx::find_here(),
-            phylanx::execution_tree::primitive_arguments_type{
-        std::move(lhs)});
-
-    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
-        expand_dims.eval();
-
-    blaze::DynamicVector<double> expected{ 42. };
-
-    HPX_TEST_EQ(
-        expected, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_1d()
+void test_expand_dims_operation(std::string const& code,
+    std::string const& expected_str)
 {
-    blaze::DynamicVector<double> subject{6., 9., 13., 42., 54.};
-    phylanx::execution_tree::primitive lhs =
-        phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<double>(subject));
-
-    phylanx::execution_tree::primitive expand_dims =
-        phylanx::execution_tree::primitives::create_expand_dims(
-            hpx::find_here(),
-            phylanx::execution_tree::primitive_arguments_type{
-        std::move(lhs)});
-
-    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
-        expand_dims.eval();
-
-    blaze::DynamicMatrix<double> expected{{6., 9., 13., 42., 54.}};
-
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-        phylanx::execution_tree::extract_numeric_value(f.get()));
+    HPX_TEST_EQ(compile_and_run(code), compile_and_run(expected_str));
 }
 
-void test_1d_axis(std::int64_t axis)
-{
-    blaze::DynamicVector<double> subject{6., 9., 13., 42., 54.};
-    phylanx::execution_tree::primitive lhs =
-        phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<double>(subject));
 
-    phylanx::execution_tree::primitive expand_dims =
-        phylanx::execution_tree::primitives::create_expand_dims(
-            hpx::find_here(),
-            phylanx::execution_tree::primitive_arguments_type{
-                std::move(lhs),
-                phylanx::execution_tree::primitive_argument_type{axis}
-            }
-        );
-
-    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
-        expand_dims.eval();
-
-    if (axis == 0 || axis == -2)
-    {
-        blaze::DynamicMatrix<double> expected{{6., 9., 13., 42., 54.}};
-        HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-            phylanx::execution_tree::extract_numeric_value(f.get()));
-    }
-    else
-    {
-        blaze::DynamicMatrix<double> expected{{6.}, {9.}, {13.}, {42.}, {54.}};
-        HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-            phylanx::execution_tree::extract_numeric_value(f.get()));
-    }
-}
-
-#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
 ///////////////////////////////////////////////////////////////////////////////
-void test_2d()
-{
-    blaze::DynamicMatrix<double> subject{{6., 9.}, {13., 42.}};
-    phylanx::execution_tree::primitive lhs =
-        phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<double>(subject));
-
-    phylanx::execution_tree::primitive expand_dims =
-        phylanx::execution_tree::primitives::create_expand_dims(
-            hpx::find_here(),
-            phylanx::execution_tree::primitive_arguments_type{
-        std::move(lhs)});
-
-    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
-        expand_dims.eval();
-
-    blaze::DynamicTensor<double> expected{{{6., 9.}, {13., 42.}}};
-
-    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-        phylanx::execution_tree::extract_numeric_value(f.get()));
-}
-
-void test_2d_axis(std::int64_t axis)
-{
-    blaze::DynamicMatrix<double> subject{{6., 9.}, {13., 42.}};
-    phylanx::execution_tree::primitive lhs =
-        phylanx::execution_tree::primitives::create_variable(
-            hpx::find_here(), phylanx::ir::node_data<double>(subject));
-
-    phylanx::execution_tree::primitive expand_dims =
-        phylanx::execution_tree::primitives::create_expand_dims(
-            hpx::find_here(),
-            phylanx::execution_tree::primitive_arguments_type{
-                std::move(lhs),
-                phylanx::execution_tree::primitive_argument_type{axis}
-            }
-        );
-
-    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
-        expand_dims.eval();
-
-    if (axis == 0 || axis == -3)
-    {
-        blaze::DynamicTensor<double> expected{{{6., 9.}, {13., 42.}}};
-
-        HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-            phylanx::execution_tree::extract_numeric_value(f.get()));
-    }
-    else if (axis == 1 || axis == -2)
-    {
-        blaze::DynamicTensor<double> expected{{{6., 9.}}, {{13., 42.}}};
-
-        HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-            phylanx::execution_tree::extract_numeric_value(f.get()));
-    }
-    else
-    {
-        blaze::DynamicTensor<double> expected{{{6.}, {9.}}, {{13.}, {42.}}};
-
-        HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
-            phylanx::execution_tree::extract_numeric_value(f.get()));
-    }
-}
-#endif
 
 int main(int argc, char* argv[])
 {
-//     test_0d();
-//
-    test_1d();
-    test_1d_axis(0);
-    test_1d_axis(-2);
 
-    test_1d_axis(1);
-    test_1d_axis(-1);
-
+    test_expand_dims_operation("expand_dims(42., -1)", "[42.]");
+    test_expand_dims_operation("expand_dims(33, 0)", "[33]");
+    test_expand_dims_operation(
+        "expand_dims([42., 13., 33.], -1)", "[[ 42.],[ 13.],[ 33.]]");
+    test_expand_dims_operation(
+        "expand_dims([42., 13., 33.], -2)", "[[42., 13., 33.]]");
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
-//     test_2d();
-//
-//     test_2d_axis(0);
-//     test_2d_axis(-3);
-    test_2d_axis(1);
-    test_2d_axis(-2);
-    test_2d_axis(2);
-    test_2d_axis(-1);
+    test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], -3)",
+        "[[[ 42.,  13.], [  2.,  33.]]]");
+    test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], 2)",
+        "[[[ 42.],[ 13.]], [[  2.],[ 33.]]]");
+    test_expand_dims_operation("expand_dims([[42., 13.],[2., 33.]], 1)",
+        "[[[ 42.,  13.]], [[  2.,  33.]]]");
+
 #endif
 
     return hpx::util::report_errors();


### PR DESCRIPTION
The first commit addresses issue #727.
The second commit adds the `blaze` decorator where it is forgotten in the current version of the tile primitive.