### PR TITLE
Fix incorrect repository name in documentation

### DIFF
--- a/cmake/Phylanx_UpdateGitDocs.cmake
+++ b/cmake/Phylanx_UpdateGitDocs.cmake
@@ -11,7 +11,7 @@ if(NOT GIT_FOUND)
 endif()
 
 if(NOT GIT_REPOSITORY)
-  set(GIT_REPOSITORY git@github.com:justwagle/phylanx.git --branch gh-pages)
+  set(GIT_REPOSITORY git@github.com:STEllAR-GROUP/phylanx.git --branch gh-pages)
 endif()
 
 if(EXISTS "${CMAKE_BINARY_DIR}/gh-pages")


### PR DESCRIPTION
This pull request fixes an error where I had missed changing the location of the Phylanx repository to the correct one.