### PR TITLE
Adding logsumexp primitive

### DIFF
--- a/phylanx/plugins/statistics/logsumexp_operation.hpp
+++ b/phylanx/plugins/statistics/logsumexp_operation.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_STATISTICS_LOGSUMEXP_OPERATION)
+#define PHYLANX_STATISTICS_LOGSUMEXP_OPERATION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/plugins/statistics/statistics_base.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename T>
+        struct statistics_logsumexp_op;
+    }
+
+    /// \brief Compute the log of the sum of exponentials of input elements.
+    /// \param a          The scalar, vector, or matrix to perform calculations
+    ///                   over
+    /// \param axis       Optional. If provided, logsumexp is calculated along
+    ///                   the provided axis.
+    /// \param keep_dims  Optional. If true the output has to have the same
+    ///                   number of dimensions as a. Otherwise, the axes with
+    ///                   size one will be reduced.
+    class logsumexp_operation
+      : public statistics<detail::statistics_logsumexp_op, logsumexp_operation>
+    {
+        using base_type =
+            statistics<detail::statistics_logsumexp_op, logsumexp_operation>;
+
+    public:
+        static match_pattern_type const match_data;
+
+        logsumexp_operation() = default;
+
+        logsumexp_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+    };
+
+    inline primitive create_logsumexp_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "logsumexp", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/statistics/statistics.hpp
+++ b/phylanx/plugins/statistics/statistics.hpp
@@ -6,6 +6,7 @@
 #if !defined(PHYLANX_PLUGINS_STATISTICS_PRIMITIVES_DEC_25_2018_0703PM)
 #define PHYLANX_PLUGINS_STATISTICS_PRIMITIVES_DEC_25_2018_0703PM
 
+#include <phylanx/plugins/statistics/logsumexp_operation.hpp>
 #include <phylanx/plugins/statistics/max_operation.hpp>
 #include <phylanx/plugins/statistics/mean_operation.hpp>
 #include <phylanx/plugins/statistics/min_operation.hpp>

--- a/src/plugins/statistics/logsumexp_operation.cpp
+++ b/src/plugins/statistics/logsumexp_operation.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/plugins/statistics/logsumexp_operation.hpp>
+#include <phylanx/plugins/statistics/statistics_base_impl.hpp>
+#include <phylanx/util/blaze_traits.hpp>
+
+#include <hpx/util/optional.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Math.h>
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename T>
+        struct statistics_logsumexp_op
+        {
+            statistics_logsumexp_op(std::string const& name,
+                std::string const& codename)
+            {}
+
+            static constexpr T initial()
+            {
+                return T(0);
+            }
+
+            template <typename Scalar>
+            typename std::enable_if<traits::is_scalar<Scalar>::value, T>::type
+            operator()(Scalar s, T initial) const
+            {
+                return s;
+            }
+
+            template <typename Vector>
+            typename std::enable_if<!traits::is_scalar<Vector>::value, T>::type
+            operator()(Vector const& v, T initial) const
+            {
+                return blaze::sum(blaze::exp(v)) + initial;
+            }
+
+            static T finalize(T value, std::size_t size)
+            {
+                return blaze::log(value);
+            }
+        };
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const logsumexp_operation::match_data =
+    {
+        match_pattern_type{
+            "logsumexp",
+            std::vector<std::string>{
+                "logsumexp(_1)", "logsumexp(_1, _2)", "logsumexp(_1, _2, _3)"
+            },
+            &create_logsumexp_operation, &create_primitive<logsumexp_operation>,
+            R"(
+            a, axis, keepdims
+            Args:
+
+                a (array) : a scalar, a vector, a matrix or a tensor
+                axis (optional, integer): Axis over which the sum is taken.
+                    By default axis is None, and all elements are summed.
+                keepdims (optional, boolean): keep dimension of input
+
+            Returns:
+
+            The log of the sum of exponentials of input elements.)",
+            true
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    logsumexp_operation::logsumexp_operation(
+        primitive_arguments_type&& operands, std::string const& name,
+        std::string const& codename)
+      : base_type(std::move(operands), name, codename)
+    {
+    }
+}}}

--- a/src/plugins/statistics/max_operation.cpp
+++ b/src/plugins/statistics/max_operation.cpp
@@ -87,7 +87,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "amax(_1, _2, _3, _4)"
             },
             &create_amax_operation, &create_primitive<max_operation>, R"(
-            a, axis, keepdims
+            a, axis, keepdims, initial
             Args:
 
                 a (vector or matrix): a scalar, a vector or a matrix
@@ -96,6 +96,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 keepdims (optional, bool): If this is set to True, the axes which "
                    are reduced are left in the result as dimensions with size "
                    one. False by default
+                initial (optional, scalar): The minimum value of an output
+                   element.
 
             Returns:
 

--- a/src/plugins/statistics/min_operation.cpp
+++ b/src/plugins/statistics/min_operation.cpp
@@ -71,7 +71,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "amin(_1, _2, _3, _4)"
             },
             &create_amin_operation, &create_primitive<min_operation>, R"(
-            a, axis, keepdims
+            a, axis, keepdims, initial
             Args:
 
                 a (vector or matrix): a scalar, a vector or a matrix
@@ -80,7 +80,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 keepdims (optional, bool): If this is set to True, the axes which "
                    are reduced are left in the result as dimensions with size "
                    one. False by default
-
+                initial (optional, scalar): The maximum value of an output
+                   element.
             Returns:
 
             Returns the minimum of an array or minimum along an axis.)",

--- a/src/plugins/statistics/prod_operation.cpp
+++ b/src/plugins/statistics/prod_operation.cpp
@@ -71,12 +71,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "prod(_1, _2, _3, _4)"
             },
             &create_prod_operation, &create_primitive<prod_operation>, R"(
-            v, axis, keepdims
+            v, axis, keepdims, initial
             Args:
 
                 v (vector or matrix) : a vector or matrix
                 axis (optional, integer): a axis to sum along
                 keepdims (optional, boolean): keep dimension of input
+                initial (optional, scalar): The starting value for the product
 
             Returns:
 

--- a/src/plugins/statistics/statistics.cpp
+++ b/src/plugins/statistics/statistics.cpp
@@ -9,6 +9,8 @@
 
 PHYLANX_REGISTER_PLUGIN_MODULE();
 
+PHYLANX_REGISTER_PLUGIN_FACTORY(logsumexp_operation_plugin,
+    phylanx::execution_tree::primitives::logsumexp_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(max_operation_plugin,
     phylanx::execution_tree::primitives::max_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(mean_operation_plugin,

--- a/src/plugins/statistics/sum_operation.cpp
+++ b/src/plugins/statistics/sum_operation.cpp
@@ -70,12 +70,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "sum(_1, _2, _3, _4)"
             },
             &create_sum_operation, &create_primitive<sum_operation>, R"(
-            v, axis, keepdims
+            v, axis, keepdims, initial
             Args:
 
                 v (vector or matrix) : a vector or matrix
                 axis (optional, integer): a axis to sum along
                 keepdims (optional, boolean): keep dimension of input
+                initial (optional, scalar): The starting value for the sum
 
             Returns:
 

--- a/tests/unit/plugins/statistics/CMakeLists.txt
+++ b/tests/unit/plugins/statistics/CMakeLists.txt
@@ -4,6 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+	logsumexp_operation
     max_operation
     mean_operation
     min_operation

--- a/tests/unit/plugins/statistics/logsumexp_operation.cpp
+++ b/tests/unit/plugins/statistics/logsumexp_operation.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
+}
+
+void test_logsumexp_operation(std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(code), compile_and_run(expected_str));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    // scalars
+    test_logsumexp_operation("logsumexp(42.0)", "42.0");
+    test_logsumexp_operation("logsumexp(1)", "1");
+    test_logsumexp_operation("logsumexp__float(1)", "1.0");
+
+    // vectors
+    test_logsumexp_operation("logsumexp([42., 1., 2., 3.])", "42.0");
+    test_logsumexp_operation("logsumexp__float([42, 1, 2, 3])", "42.0");
+
+    test_logsumexp_operation("logsumexp([42., 1., 2., 3.], 0)", "42.0");
+    test_logsumexp_operation("logsumexp__float([42, 1, 2, 3], -1)", "42.0");
+
+    test_logsumexp_operation(
+        "logsumexp([42., 1., 2., 3.], nil, false)", "42.0");
+    test_logsumexp_operation(
+        "logsumexp([42., 1., 2., 3.], nil, true)", "[42.0]");
+    test_logsumexp_operation(
+        "logsumexp([42., 1., 2., 3.], 0, false)", "42.0");
+    test_logsumexp_operation(
+        "logsumexp([42., 1., 2., 3.], 0, true)", "[42.0]");
+    test_logsumexp_operation(
+        "logsumexp([42., 1., 2., 3.], -1, false)", "42.0");
+    test_logsumexp_operation(
+        "logsumexp([42., 1., 2., 3.], -1, true)", "[42.0]");
+
+    // matrices
+    test_logsumexp_operation("logsumexp([[42., 1.],[2., 3.]])", "42.0");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 3.]], nil, false)", "42.0");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 3.]], nil, true)", "[[42.0]]");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 33.]], 0)", "[42., 33.]");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 33.]], 1)", "[42., 33.]");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 33.]], 0, false)", "[42., 33.]");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 33.]], 1, false)", "[42., 33.]");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 33.]], 0, true)", "[[42., 33.]]");
+
+    test_logsumexp_operation(
+        "logsumexp([[42., 1.],[2., 33.]], 1, true)", "[[42.], [33.]]");
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    // tensors
+    test_logsumexp_operation(
+        "logsumexp([[[ 42.,  4.],[ 2.,  3.]],[[ 3.,  2.],[ 4.,  1.]]])",
+        "42.0");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2.,  3.]],[[ 3.,  2.]"
+                             ",[ 4.,  1.]]], nil, false)",
+                             "42.0");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2.,  3.]],[[ 3.,  2.]"
+                             ",[ 4.,  1.]]], nil, true)",
+                             "[[[42.0]]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 0)",
+                             "[[ 42.,  25.],[ 44.,  33.]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 1)",
+                             "[[ 42.,  33.],[ 44.,  25.]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 2)",
+                             "[[ 42.,  33.],[ 25.,  44.]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 0, false)",
+                             "[[ 42.,  25.],[ 44.,  33.]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 1, false)",
+                             "[[ 42.,  33.],[ 44.,  25.]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 2, false)",
+                             "[[ 42.,  33.],[ 25.,  44.]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 0, true)",
+                             "[[[ 42.,  25.],[ 44.,  33.]]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 1, true)",
+                             "[[[ 42.,  33.]],[[ 44.,  25.]]]");
+
+    test_logsumexp_operation("logsumexp([[[ 42.,  4.],[ 2., 33.]],[[ 3., 25.]"
+                             ",[ 44.,  1.]]], 2, true)",
+                             "[[[ 42.], [ 33.]],[[ 25.], [ 44.]]]");
+#endif
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
logsumexp primitive imitates the functionality of [SciPy logsumexp](https://docs.scipy.org/doc/scipy-0.19.1/reference/generated/scipy.misc.logsumexp.html)
There is also an explanation for the 4th argument of statistics `min`, `max`, `prod` and `sum` in their help.