### PR TITLE
Apply branch filter to docs_push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ anchors:
                 ignore:
                     - gh-pages
 
-    - &docs_push
+    - &docs_push_branch_filter
         filters:
             branches:
                 only:
@@ -447,6 +447,7 @@ workflows:
                 requires:
                     - configure
             - docs_push:
+                <<: *docs_push_branch_filter
                 requires:
                     - build
             - check.code_format:


### PR DESCRIPTION
In my previous pull request, I had missed applying docs push filter such that the docs were only built for the branch master. This resulted in docs being built for all the branches which is not what we wanted. This pull request fixes that issue. 