### PR TITLE
Adding flipud and fliplr to the flip operation

### DIFF
--- a/phylanx/plugins/matrixops/flip_operation.hpp
+++ b/phylanx/plugins/matrixops/flip_operation.hpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2018 Bita Hasheminezhad
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2019 Bita Hasheminezhad
+// Copyright (c) 2018-2019 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -30,6 +30,14 @@ namespace phylanx { namespace execution_tree { namespace primitives {
       : public primitive_component_base
       , public std::enable_shared_from_this<flip_operation>
     {
+    public:
+        enum flip_mode
+        {
+            flip_mode_up_down,       // flipud
+            flip_mode_left_right,    // fliplr
+            flip_mode_axes
+        };
+
     protected:
         using val_type = std::int64_t;
         hpx::future<primitive_argument_type> eval(
@@ -38,7 +46,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
             eval_context ctx) const override;
 
     public:
-        static match_pattern_type const match_data;
+        static std::vector<match_pattern_type> const match_data;
 
         flip_operation() = default;
 
@@ -86,7 +94,38 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         template <typename T>
         primitive_argument_type flipnd(ir::node_data<T>&& arg,
             ir::range&& axes) const;
+        primitive_argument_type flipnd_helper(
+            primitive_argument_type&& arg) const;
+
+        template <typename T>
+        primitive_argument_type flipud(ir::node_data<T>&& arg) const;
+        primitive_argument_type flipud_helper(
+            primitive_argument_type&& arg) const;
+
+        template <typename T>
+        primitive_argument_type fliplr(ir::node_data<T>&& arg) const;
+        primitive_argument_type fliplr_helper(
+            primitive_argument_type&& arg) const;
+
+    private:
+        flip_mode mode_;
     };
+
+    inline primitive create_flipud_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "flipud", std::move(operands), name, codename);
+    }
+
+    inline primitive create_fliplr_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "fliplr", std::move(operands), name, codename);
+    }
 
     inline primitive create_flip_operation(hpx::id_type const& locality,
         primitive_arguments_type&& operands, std::string const& name = "",

--- a/src/plugins/matrixops/flip_operation.cpp
+++ b/src/plugins/matrixops/flip_operation.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2018 Bita Hasheminezhad
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2019 Bita Hasheminezhad
+// Copyright (c) 2018-2019 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -34,9 +34,33 @@
 namespace phylanx { namespace execution_tree { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-    match_pattern_type const flip_operation::match_data =
+    std::vector<match_pattern_type> const flip_operation::match_data =
     {
-        hpx::util::make_tuple("flip",
+        match_pattern_type{"flipud",
+        std::vector<std::string>{"flipud(_1)"},
+        &create_flip_operation, &create_primitive<flip_operation>,
+        "a\n"
+        "Args:\n"
+        "\n"
+        "    a (array) : a vector a matrix or a tensor\n"
+        "\n"
+        "Returns:\n"
+        "\n"
+        "Flip array in the up/down direction"},
+
+        match_pattern_type{"fliplr",
+        std::vector<std::string>{"fliplr(_1)"},
+        &create_flip_operation, &create_primitive<flip_operation>,
+        "a\n"
+        "Args:\n"
+        "\n"
+        "    a (array) : a matrix or a tensor\n"
+        "\n"
+        "Returns:\n"
+        "\n"
+        "Flip array in the left/right direction"},
+
+        match_pattern_type{"flip",
         std::vector<std::string>{"flip(_1,_2)","flip(_1)"},
         &create_flip_operation, &create_primitive<flip_operation>,
         "a, axes\n"
@@ -49,15 +73,32 @@ namespace phylanx { namespace execution_tree { namespace primitives
         "\n"
         "Returns:\n"
         "\n"
-        "Reverses the order of elements in an array along the given axis")
+        "Reverses the order of elements in an array along the given axes"},
     };
 
     ///////////////////////////////////////////////////////////////////////////
+    flip_operation::flip_mode extract_flip_mode(std::string const& name)
+    {
+        flip_operation::flip_mode result = flip_operation::flip_mode_axes;
+
+        if (name.find("flipud") != std::string::npos)
+        {
+            result = flip_operation::flip_mode_up_down;
+        }
+        else if (name.find("fliplr") != std::string::npos)
+        {
+            result = flip_operation::flip_mode_left_right;
+        }
+        return result;
+    }
+
     flip_operation::flip_operation(primitive_arguments_type&& operands,
         std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
+        , mode_(extract_flip_mode(name_))
     {}
 
+    ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     primitive_argument_type flip_operation::flip1d(ir::node_data<T>&& arg) const
     {
@@ -745,6 +786,140 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
     }
 
+    primitive_argument_type flip_operation::flipnd_helper(
+        primitive_argument_type&& arg) const
+    {
+        switch (extract_common_type(arg))
+        {
+        case node_data_type_bool:
+            return flipnd(
+                extract_boolean_value(std::move(arg), name_, codename_));
+        case node_data_type_int64:
+            return flipnd(
+                extract_integer_value(std::move(arg), name_, codename_));
+        case node_data_type_double:
+            return flipnd(
+                extract_numeric_value(std::move(arg), name_, codename_));
+        default:
+            break;
+        }
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "flip::flipnd_helper",
+            generate_error_message(
+                "the flip primitive requires for all arguments "
+                "to be numeric data types"));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    primitive_argument_type flip_operation::flipud(ir::node_data<T>&& arg) const
+    {
+        switch (arg.num_dimensions())
+        {
+        case 0:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "flip_operation::flipud",
+                generate_error_message("input array should be >= 1d"));
+
+        case 1:
+            return flip1d(std::move(arg));
+
+        case 2:
+            return flip2d_axis0(std::move(arg));
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        case 3:
+            return flip3d_axis0(std::move(arg));
+#endif
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "flip_operation::flipud",
+                generate_error_message(
+                    "operand a has an invalid number of dimensions"));
+        }
+    }
+
+    primitive_argument_type flip_operation::flipud_helper(
+        primitive_argument_type&& arg) const
+    {
+        switch (extract_common_type(arg))
+        {
+        case node_data_type_bool:
+            return flipud(
+                extract_boolean_value(std::move(arg), name_, codename_));
+        case node_data_type_int64:
+            return flipud(
+                extract_integer_value(std::move(arg), name_, codename_));
+        case node_data_type_double:
+            return flipud(
+                extract_numeric_value(std::move(arg), name_, codename_));
+        default:
+            break;
+        }
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "flip::flipud_helper",
+            generate_error_message(
+                "the flip primitive requires for all arguments "
+                "to be numeric data types"));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    primitive_argument_type flip_operation::fliplr(ir::node_data<T>&& arg) const
+    {
+        switch (arg.num_dimensions())
+        {
+        case 0:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "flip_operation::fliplr",
+                generate_error_message("input array should be >= 2d"));
+
+        case 1:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "flip_operation::fliplr",
+                generate_error_message("input array should be >= 2d"));
+
+        case 2:
+            return flip2d_axis1(std::move(arg));
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        case 3:
+            return flip3d_axis1(std::move(arg));
+#endif
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "flip_operation::fliplr",
+                generate_error_message(
+                    "operand a has an invalid number of dimensions"));
+        }
+    }
+
+    primitive_argument_type flip_operation::fliplr_helper(
+        primitive_argument_type&& arg) const
+    {
+        switch (extract_common_type(arg))
+        {
+        case node_data_type_bool:
+            return fliplr(
+                extract_boolean_value(std::move(arg), name_, codename_));
+        case node_data_type_int64:
+            return fliplr(
+                extract_integer_value(std::move(arg), name_, codename_));
+        case node_data_type_double:
+            return fliplr(
+                extract_numeric_value(std::move(arg), name_, codename_));
+        default:
+            break;
+        }
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "flip::fliplr_helper",
+            generate_error_message(
+                "the flip primitive requires for all arguments "
+                "to be numeric data types"));
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> flip_operation::eval(
         primitive_arguments_type const& operands,
@@ -771,6 +946,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         auto this_ = this->shared_from_this();
         if (operands.size() == 2 && valid(operands[1]))
         {
+            if (this_->mode_ == flip_mode_up_down ||
+                this_->mode_ == flip_mode_left_right)
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "flip::eval",
+                    this_->generate_error_message(
+                        "the flip operation in up/down and left/right mode "
+                        "requires exactly one operand"));
+
             return hpx::dataflow(hpx::launch::sync,
                 hpx::util::unwrapping(
                     [this_ = std::move(this_)](primitive_argument_type&& arg,
@@ -806,31 +989,37 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 value_operand(operands[0], args, name_, codename_, ctx),
                 list_operand(operands[1], args, name_, codename_, ctx));
         }
-        return hpx::dataflow(hpx::launch::sync,
-            hpx::util::unwrapping(
-                [this_ = std::move(this_)](
-                    primitive_argument_type&& arg) -> primitive_argument_type {
-                    switch (extract_common_type(arg))
-                    {
-                    case node_data_type_bool:
-                        return this_->flipnd(extract_boolean_value(
-                            std::move(arg), this_->name_, this_->codename_));
-                    case node_data_type_int64:
-                        return this_->flipnd(extract_integer_value(
-                            std::move(arg), this_->name_, this_->codename_));
-                    case node_data_type_double:
-                        return this_->flipnd(extract_numeric_value(
-                            std::move(arg), this_->name_, this_->codename_));
-                    default:
-                        break;
-                    }
+        if (operands.size() == 1 || mode_ == flip_mode_axes)
+        {
+            return hpx::dataflow(hpx::launch::sync,
+                hpx::util::unwrapping(
+                    [this_ = std::move(this_)](primitive_argument_type&& arg)
+                        -> primitive_argument_type {
+                        switch (this_->mode_)
+                        {
+                        case flip_mode_up_down:
+                            return this_->flipud_helper(std::move(arg));
 
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "flip::eval",
-                        this_->generate_error_message(
-                            "the flip primitive requires for all arguments "
-                            "to be numeric data types"));
-                }),
-            value_operand(operands[0], args, name_, codename_, ctx));
+                        case flip_mode_left_right:
+                            return this_->fliplr_helper(std::move(arg));
+
+                        case flip_mode_axes:
+                            return this_->flipnd_helper(std::move(arg));
+
+                        default:
+                            break;
+                        }
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "flip_operation::eval",
+                            this_->generate_error_message(
+                                "unsupported flip mode requested"));
+                    }),
+                value_operand(operands[0], args, name_, codename_, ctx));
+        }
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "flip::eval",
+            this_->generate_error_message(
+                "the flip operation in up/down and left/right mode "
+                "requires exactly one operand"));
     }
 }}}

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -47,8 +47,12 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(eye_operation_plugin,
     phylanx::execution_tree::primitives::eye_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(flatten_plugin,
     phylanx::execution_tree::primitives::flatten::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(flipud_operation_plugin,
+    phylanx::execution_tree::primitives::flip_operation::match_data[0]);
+PHYLANX_REGISTER_PLUGIN_FACTORY(fliplr_operation_plugin,
+    phylanx::execution_tree::primitives::flip_operation::match_data[1]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(flip_operation_plugin,
-    phylanx::execution_tree::primitives::flip_operation::match_data);
+    phylanx::execution_tree::primitives::flip_operation::match_data[2]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(gradient_operation_plugin,
     phylanx::execution_tree::primitives::gradient_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(hsplit_operation_plugin,

--- a/tests/unit/plugins/matrixops/flip_operation.cpp
+++ b/tests/unit/plugins/matrixops/flip_operation.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2018 Bita Hasheminezhad
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2019 Bita Hasheminezhad
+// Copyright (c) 2018-2019 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -43,6 +43,7 @@ int main(int argc, char* argv[])
     test_flip_operation("flip([13., 42., 33.], 0)", "hstack(33., 42., 13.)");
     test_flip_operation("flip([13., 42., 33.]+0, 0)", "hstack(33., 42., 13.)");
     test_flip_operation("flip([13., 42., 33.], -1)", "hstack(33., 42., 13.)");
+    test_flip_operation("flipud([13, 42, 33])", "[33, 42, 13]");
 
     test_flip_operation("flip([[13, 42, 33],[101, 12, 65]])",
         "[[ 65,  12, 101], [ 33,  42,  13]]");
@@ -60,6 +61,10 @@ int main(int argc, char* argv[])
         "[[ 65,  12, 101], [ 33,  42,  13]]");
     test_flip_operation("flip([[13, 42, 33],[101, 12, 65]]+0, make_list(1,0))",
         "[[ 65,  12, 101], [ 33,  42,  13]]");
+    test_flip_operation("flipud([[13, 42, 33],[101, 12, 65]])",
+        "[[101,  12,  65],[ 13,  42,  33]]");
+    test_flip_operation("fliplr([[13, 42, 33],[101, 12, 65]])",
+        "[[ 33,  42,  13],[ 65,  12, 101]]");
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
     test_flip_operation(
@@ -101,6 +106,12 @@ int main(int argc, char* argv[])
     test_flip_operation(
         "flip([[[13., 42., 33.],[101., 12., 65.]]], make_list(-3,-2,-1))",
         "[[[ 65.,  12., 101.], [ 33.,  42.,  13.]]]");
+    test_flip_operation(
+        "flipud([[[13, 42, 33],[101, 12, 65]],[[3, 4, 31],[10, 2, 5]]])",
+        "[[[ 3,  4,  31],[ 10,  2,  5]],[[ 13,  42,  33],[101,  12,  65]]]");
+    test_flip_operation(
+        "fliplr([[[13, 42, 33],[101, 12, 65]],[[3, 4, 31],[10, 2, 5]]])",
+        "[[[101,  12,  65],[ 13,  42,  33]],[[ 10,  2,  5],[ 3,  4,  31]]]");
 #endif
 
     return hpx::util::report_errors();


### PR DESCRIPTION
This PR adds the functionality of  NumPy [flipud](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.flipud.html) and [fliplr](https://docs.scipy.org/doc/numpy-1.15.1/reference/generated/numpy.fliplr.html) to the flip operation. (#684)