### PR TITLE
Updating tensordot in its usage of blaze::ravel

### DIFF
--- a/phylanx/plugins/matrixops/dot_operation_impl.hpp
+++ b/phylanx/plugins/matrixops/dot_operation_impl.hpp
@@ -42,9 +42,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return blaze::DynamicVector<T>(1, arr.scalar());
         case 1:
             return arr.vector();
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
         case 2:
             return blaze::trans(blaze::ravel(arr.matrix()));
-#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+
         case 3:
             return blaze::trans(blaze::ravel(arr.tensor()));
 #endif

--- a/tests/unit/plugins/matrixops/dot_operation.cpp
+++ b/tests/unit/plugins/matrixops/dot_operation.cpp
@@ -751,11 +751,13 @@ int main(int argc, char* argv[])
 {
     // outer product
     test_dot_operation("outer(6., 7.)", "[[42.]]");
-    test_dot_operation("outer(6., [1, 2, 7])", "[[6., 12., 42.]]");
-    test_dot_operation("outer(3., [[1, 2, 7]])", "[[3., 6., 21.]]");
     test_dot_operation("outer([0, 7, 1], 6)", "[[ 0], [42], [ 6]]");
     test_dot_operation("outer([1, 2, 3], [4, 5, 6, 7])",
         "[[ 4,  5,  6,  7],[ 8, 10, 12, 14],[12, 15, 18, 21]]");
+    test_dot_operation("outer(6., [1, 2, 7])", "[[6., 12., 42.]]");
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_dot_operation("outer(3., [[1, 2, 7]])", "[[3., 6., 21.]]");
     test_dot_operation("outer([1, 2, 3], [[42, 1, 1],[4, 5, 6]])",
         "[[ 42,   1,   1,   4,   5,   6],[ 84,   2,   2,   8,  10,  12],"
         "[126,   3,   3,  12,  15,  18]]");
@@ -765,7 +767,6 @@ int main(int argc, char* argv[])
     test_dot_operation("outer([[1, 1],[2, 3]], [[1, 4, 5]])",
         "[[ 1,  4,  5],[ 1,  4,  5],[ 2,  8, 10],[ 3, 12, 15]]");
 
-#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
     test_dot_operation("outer(3, [[[1,2],[2,3]]])", "[[3, 6, 6, 9]]");
     test_dot_operation("outer([1, 2, 3], [[[42, 1]],[[4, 5]]])",
         "[[ 42,   1,   4,   5], [ 84,   2,   8,  10], [126,   3,  12,  15]]");


### PR DESCRIPTION
This PR changes the tensordot in a way that blaze::ravel is used only when phylanx has blaze tensor. The reason is currently the blaze::ravel is only implemented in the blaze tensor.