### PR TITLE
Automatically Populate Documentation from Helpstring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,10 +175,6 @@ if(PHYLANX_WITH_EXAMPLES)
   add_subdirectory(examples)
 endif()
 
-if(PHYLANX_WITH_DOCUMENTATION)
-  add_subdirectory(docs)
-endif()
-
 ################################################################################
 # Targets related to Python (must come before tests)
 add_subdirectory(python)
@@ -188,6 +184,12 @@ phylanx_export_targets(${phylanx_targets})
 foreach(target ${phylanx_targets})
   add_phylanx_pseudo_dependencies(core ${target})
 endforeach()
+
+###############################################################################
+# Must come after Python
+if(PHYLANX_WITH_DOCUMENTATION)
+  add_subdirectory(docs)
+endif()
 
 ###############################################################################
 # Tests

--- a/cmake/templates/generate_rst.py.in
+++ b/cmake/templates/generate_rst.py.in
@@ -4,18 +4,21 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-from phylanx import PhylanxSession
 import subprocess as sub
-import re, os
-from phylanx.util import phyhelpex
+import sys, re, os
+sys.path.append('@PHYLANX_PYTHON_EXTENSION_LOCATION@')
 
+from phylanx import PhylanxSession
 PhylanxSession.init(1)
+from phylanx.util import phyhelpex
 
 os.environ["PAGER"] = "cat"
 
-f= open("sphinx/reference/phyhelp.rst","w")
+file_name = sys.argv[1]
+f= open(file_name,"w")
+print("\nPrimitives ", file=f)
 
-p = sub.Popen(["../bin/physl","--docs"],stdout=sub.PIPE)
+p = sub.Popen(["@CMAKE_BINARY_DIR@/bin/physl","--docs"],stdout=sub.PIPE)
 for bline in p.stdout.readlines():
     line = str(bline,'ASCII').strip()
     g = re.match(r'pattern:\s*(\w+)',line)

--- a/cmake/templates/generate_rst.py.in
+++ b/cmake/templates/generate_rst.py.in
@@ -4,6 +4,8 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+# flake8: noqa
+
 import subprocess as sub
 import sys, re, os
 sys.path.append('@PHYLANX_PYTHON_EXTENSION_LOCATION@')
@@ -12,8 +14,6 @@ from phylanx import PhylanxSession
 PhylanxSession.init(1)
 
 from phylanx.util import phyhelpex
-
-os.environ["PAGER"] = "cat"
 
 file_name = sys.argv[1]
 f= open(file_name,"w")

--- a/cmake/templates/generate_rst.py.in
+++ b/cmake/templates/generate_rst.py.in
@@ -10,13 +10,16 @@ sys.path.append('@PHYLANX_PYTHON_EXTENSION_LOCATION@')
 
 from phylanx import PhylanxSession
 PhylanxSession.init(1)
+
 from phylanx.util import phyhelpex
 
 os.environ["PAGER"] = "cat"
 
 file_name = sys.argv[1]
 f= open(file_name,"w")
-print("\nPrimitives ", file=f)
+print("=========================",file=f)
+print("Primitives ", file=f)
+print("=========================",file=f)
 
 p = sub.Popen(["@CMAKE_BINARY_DIR@/bin/physl","--docs"],stdout=sub.PIPE)
 for bline in p.stdout.readlines():
@@ -25,9 +28,9 @@ for bline in p.stdout.readlines():
     if g:
         pat = g.group(1)
         try:
-            print("\nPrimitive:",pat,end='', file=f)
-            print("\n==========================================================", file=f)
-            print(re.sub(r'^(.*)',r'(\1)',re.sub('^\s*','',phyhelpex(pat))), file=f)
+            print(pat, file=f)
+            print("^^^^^^^^^^^^^^^^^^^^^^^^^^^^", file=f)
+            print(pat,re.sub(r'^(.*)',r'(\1)',re.sub('^\s*','',phyhelpex(pat))), file=f)
             print('\n', file=f)
         except:
             print("")

--- a/cmake/templates/generate_rst.py.in
+++ b/cmake/templates/generate_rst.py.in
@@ -1,0 +1,30 @@
+# Copyright (c) 2019 Steven R. Brandt
+# Copyright (c) 2019 Bibek Wagle
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+from phylanx import PhylanxSession
+import subprocess as sub
+import re, os
+from phylanx.util import phyhelpex
+
+PhylanxSession.init(1)
+
+os.environ["PAGER"] = "cat"
+
+f= open("sphinx/reference/phyhelp.rst","w")
+
+p = sub.Popen(["../bin/physl","--docs"],stdout=sub.PIPE)
+for bline in p.stdout.readlines():
+    line = str(bline,'ASCII').strip()
+    g = re.match(r'pattern:\s*(\w+)',line)
+    if g:
+        pat = g.group(1)
+        try:
+            print("\nPrimitive:",pat,end='', file=f)
+            print("\n==========================================================", file=f)
+            print(re.sub(r'^(.*)',r'(\1)',re.sub('^\s*','',phyhelpex(pat))), file=f)
+            print('\n', file=f)
+        except:
+            print("")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -101,16 +101,18 @@ set(SPHINX_DOCS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/share/phylanx/docs/html")
 add_custom_target(docs
   ALL
   DEPENDS ${SPHINX_DOCS_OUTPUT_DIR})
-add_dependencies(docs core examples)
+add_dependencies(docs core examples python_setup)
 
 #generate rst from helpstring
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/generate_rst.py.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/generate_rst.py")
+        "${CMAKE_BINARY_DIR}/bin/generate_rst.py")
+
+set(GENERATED_RST_FILE "${CMAKE_CURRENT_BINARY_DIR}/sphinx/reference/phyhelp.rst")
 
 add_custom_command(
-  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/sphinx/reference/phyhelp.rst"
-  COMMAND ${PYTHON_EXECUTABLE} generate_rst.py
-  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/generate_rst.py"
+  OUTPUT "${GENERATED_RST_FILE}"
+  COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_BINARY_DIR}/bin/generate_rst.py ${GENERATED_RST_FILE}
+  DEPENDS "${CMAKE_BINARY_DIR}/bin/generate_rst.py"
     )
 
 #create sphinx documentation
@@ -118,7 +120,7 @@ add_custom_command(
   OUTPUT "${SPHINX_DOCS_OUTPUT_DIR}"
   DEPENDS "${sphinx_source_files_build}"
     "${CMAKE_CURRENT_BINARY_DIR}/phylanx_autodoc/index.xml"
-    "${CMAKE_CURRENT_BINARY_DIR}/sphinx/reference/phyhelp.rst"
+    "${GENERATED_RST_FILE}"
   COMMAND ${SPHINX_EXECUTABLE} -b html -n -d
     "${CMAKE_CURRENT_BINARY_DIR}/doctree"
     "${CMAKE_CURRENT_BINARY_DIR}/sphinx"

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -98,18 +98,32 @@ phylanx_source_to_doxygen(phylanx_autodoc
 
 set(SPHINX_DOCS_OUTPUT_DIR "${CMAKE_BINARY_DIR}/share/phylanx/docs/html")
 
+add_custom_target(docs
+  ALL
+  DEPENDS ${SPHINX_DOCS_OUTPUT_DIR})
+add_dependencies(docs core examples)
+
+#generate rst from helpstring
+configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/generate_rst.py.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/generate_rst.py")
+
+add_custom_command(
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/sphinx/reference/phyhelp.rst"
+  COMMAND ${PYTHON_EXECUTABLE} generate_rst.py
+  DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/generate_rst.py"
+    )
+
+#create sphinx documentation
 add_custom_command(
   OUTPUT "${SPHINX_DOCS_OUTPUT_DIR}"
   DEPENDS "${sphinx_source_files_build}"
     "${CMAKE_CURRENT_BINARY_DIR}/phylanx_autodoc/index.xml"
+    "${CMAKE_CURRENT_BINARY_DIR}/sphinx/reference/phyhelp.rst"
   COMMAND ${SPHINX_EXECUTABLE} -b html -n -d
     "${CMAKE_CURRENT_BINARY_DIR}/doctree"
     "${CMAKE_CURRENT_BINARY_DIR}/sphinx"
     "${SPHINX_DOCS_OUTPUT_DIR}")
 
-add_custom_target(docs
-  ALL
-  DEPENDS ${SPHINX_DOCS_OUTPUT_DIR})
 
 add_custom_target(git_docs
   COMMAND "${CMAKE_COMMAND}"

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -5,9 +5,9 @@
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-===================================
+=========================================
 Welcome to the |phylanx| documentation!
-===================================
+=========================================
 
 If you can't find what you're looking for in the documentation, please contact us on `IRC <stellar_irc_>`_.
 
@@ -16,12 +16,7 @@ If you can't find what you're looking for in the documentation, please contact u
    :maxdepth: 2
 
    manual
-
-.. toctree::
-   :caption: Reference
-   :maxdepth: 2
-
-   api
+   reference
 
 .. toctree::
    :caption: Miscellaneous

--- a/docs/sphinx/reference.rst
+++ b/docs/sphinx/reference.rst
@@ -1,15 +1,14 @@
 ..
-    Copyright (C) 2018 Mikael Simberg
     Copyright (C) 2018 Bibek Wagle
 
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-.. _manual:
+.. _reference:
 
-=======
-Manual
-=======
+===========
+References
+===========
 
 The manual is your comprehensive guide to |phylanx|. It contains detailed
 information on how to build and use |phylanx| in different scenarios.
@@ -17,4 +16,5 @@ information on how to build and use |phylanx| in different scenarios.
 .. toctree::
    :maxdepth: 2
 
-   manual/about
+   reference/api
+   reference/phyhelp

--- a/docs/sphinx/reference/api.rst
+++ b/docs/sphinx/reference/api.rst
@@ -5,8 +5,8 @@
     Distributed under the Boost Software License, Version 1.0. (See accompanying
     file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-=============
+===============
 API reference
-=============
+===============
 
 .. doxygenindex::


### PR DESCRIPTION
This pull request adds the ability to automatically populate the Phylanx documentation from the helpstring.
Demo: https://stellar-group.github.io/phylanx/docs/sphinx/branches/auto_docs_from_helptext/html/index.html

The following page was automatically populated from the text in the helpstring. 
https://stellar-group.github.io/phylanx/docs/sphinx/branches/auto_docs_from_helptext/html/reference/phyhelp.html