### PR TITLE
Add support to eval method.

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -350,7 +350,6 @@ class PhySL:
         self.ir = self.apply_rule(tree.body[0])
         check_return(self.ir)
         self.__src__ = self.generate_physl(self.ir)
-        self.lazy = kwargs.get('lazy')
 
         if self.kwargs.get("debug"):
             print_physl_src(self.__src__)
@@ -423,7 +422,7 @@ class PhySL:
 
         return result
 
-    def call(self, args):
+    def lazy(self, args):
         self.__perfdata__ = (None, None, None)
         self.performance_primitives = None
 
@@ -446,11 +445,11 @@ class PhySL:
             self.is_compiled = True
 
         self.args = args
-        if self.lazy:
-            return self
+        return self
 
-        result = self.eval()
-        return result
+    def call(self, args):
+        self.lazy(args)
+        return self.eval()
 
 # #############################################################################
 # Transducer rules

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -632,35 +632,32 @@ class PhySL:
         if 'hstack' in symbol:
             return create_array(args, dtype)
         elif 'zeros_like' in symbol:
-            symbol = symbol.replace('zeros_like', 'constant' + dtype)
-            op = get_symbol_info(node.func, 'shape')
-            return [symbol, ('0', [op, args])]
+            symbol = symbol.replace('zeros_like', 'constant_like' + dtype)
+            return [symbol, ('0', args)]
         elif 'ones_like' in symbol:
-            symbol = symbol.replace('ones_like', 'constant' + dtype)
-            op = get_symbol_info(node.func, 'shape')
-            return [symbol, ('1', [op, args])]
+            symbol = symbol.replace('ones_like', 'constant_like' + dtype)
+            return [symbol, ('1', args)]
         elif 'full_like' in symbol:
-            symbol = symbol.replace('full_like', 'constant' + dtype)
-            op = get_symbol_info(node.func, 'shape')
-            return [symbol, (args[1], [op, (args[0], )])]
+            symbol = symbol.replace('full_like', 'constant_like' + dtype)
+            return [symbol, (args[1], (args[0], ))]
         elif 'zeros' in symbol:
             symbol = symbol.replace('zeros', 'constant' + dtype)
-            op = get_symbol_info(node.func, 'list')
             if isinstance(args[0], tuple):
+                op = get_symbol_info(node.func, 'list')
                 return [symbol, ('0', [op, args])]
             else:
                 return [symbol, ('0', args)]
         elif 'ones' in symbol:
             symbol = symbol.replace('ones', 'constant' + dtype)
-            op = get_symbol_info(node.func, 'list')
             if isinstance(args[0], tuple):
+                op = get_symbol_info(node.func, 'list')
                 return [symbol, ('1', [op, args])]
             else:
                 return [symbol, ('1', args)]
         elif 'full' in symbol:
             symbol = symbol.replace('full', 'constant' + dtype)
-            op = get_symbol_info(node.func, 'list')
             if isinstance(args[0], tuple):
+                op = get_symbol_info(node.func, 'list')
                 return [symbol, (args[1], [op, args[0]])]
             else:
                 return [symbol, (args[1], args[0])]

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -27,8 +27,7 @@ def Phylanx(__phylanx_arg=None, **kwargs):
                 'target',
                 'compiler_state',
                 'performance',
-                'localities',
-                'lazy'
+                'localities'
             ]
 
             self.backends_map = {'PhySL': PhySL, 'OpenSCoP': OpenSCoP}
@@ -79,6 +78,13 @@ def Phylanx(__phylanx_arg=None, **kwargs):
             ast.increment_lineno(tree, actual_lineno)
             assert len(tree.body) == 1
             return tree
+
+        def lazy(self, *args):
+            if self.backend == 'OpenSCoP':
+                raise NotImplementedError(
+                    "OpenSCoP kernels are not yet callable.")
+
+            return self.backend.lazy(args)
 
         def __call__(self, *args):
             if self.backend == 'OpenSCoP':

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -27,7 +27,8 @@ def Phylanx(__phylanx_arg=None, **kwargs):
                 'target',
                 'compiler_state',
                 'performance',
-                'localities'
+                'localities',
+                'lazy'
             ]
 
             self.backends_map = {'PhySL': PhySL, 'OpenSCoP': OpenSCoP}

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -94,10 +94,6 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
         },
         "create a new variable from a string");
 
-    bind_variable<double>(execution_tree);
-    bind_variable<std::int64_t>(execution_tree);
-    bind_variable<std::uint8_t>(execution_tree);
-
     execution_tree.def("var",
         [](phylanx::execution_tree::primitive_argument_type const& arg) {
             pybind11::gil_scoped_release release;       // release GIL
@@ -110,6 +106,10 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
                 });
         },
         "create a new variable from a primitive_argument_type");
+
+    bind_variable<double>(execution_tree);
+    bind_variable<std::int64_t>(execution_tree);
+    bind_variable<std::uint8_t>(execution_tree);
 
     execution_tree.def("compile", phylanx::bindings::expression_compiler,
         "compile a numerical expression in PhySL");

--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -378,6 +378,16 @@ namespace pybind11 { namespace detail
     };
 
     template <>
+    struct is_array_instance<double>
+    {
+        static bool call(handle src)
+        {
+            return isinstance<array_t<double>>(src) ||
+                   isinstance<array_t<float>>(src);
+        }
+    };
+
+    template <>
     struct is_array_instance<std::int64_t>
     {
         static bool call(handle src)

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -163,8 +163,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
             break;
         }
 
-        return hpx::make_ready_future(
-            extract_value(params[argnum_], name_, codename_));
+        // evaluate the argument
+        return value_operand(
+            params[argnum_], this->noargs, name_, codename_, std::move(ctx));
     }
 
     void access_argument::store(primitive_arguments_type&& data,

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -164,6 +164,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         // evaluate the argument
+        ctx.add_mode(eval_dont_evaluate_partials);
         return value_operand(
             params[argnum_], this->noargs, name_, codename_, std::move(ctx));
     }

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -113,7 +113,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         eval_context ctx) const
     {
         if ((ctx.mode_ & eval_dont_evaluate_partials) &&
-            primitive_->operands_.empty() && !params.empty())
+            primitive_->operands_.empty())
         {
             // return a client referring to this component as the evaluation
             // result

--- a/tests/regressions/python/805_lazy_variable.py
+++ b/tests/regressions/python/805_lazy_variable.py
@@ -7,7 +7,6 @@ import numpy as np
 from phylanx import Phylanx, PhylanxSession, execution_tree
 
 
-PhylanxSession.cfg.append('--hpx:ini=phylanx.sync_execution!=1"')
 PhylanxSession.init()
 
 

--- a/tests/regressions/python/805_lazy_variable.py
+++ b/tests/regressions/python/805_lazy_variable.py
@@ -1,0 +1,32 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx import Phylanx, PhylanxSession, execution_tree
+
+
+PhylanxSession.cfg.append('--hpx:ini=phylanx.sync_execution!=1"')
+PhylanxSession.init()
+
+
+def variable(value, dtype=None):
+    return execution_tree.var(np.array(value, dtype))
+
+
+@Phylanx
+def ones_like_eager(x):
+    return np.ones_like(x)
+
+
+def ones_like(x):
+    return ones_like_eager.lazy(x)
+
+
+def eval(func):
+    return func.eval()
+
+
+x = variable(np.array([1, 2, 3]))
+print(eval(ones_like(x)))

--- a/tests/regressions/python/805_two_variables.py
+++ b/tests/regressions/python/805_two_variables.py
@@ -41,4 +41,3 @@ def test_dot_operation(x_shape_or_val, y_shape_or_val):
 
 result, expected = test_dot_operation((4, 2), (2, 4))
 assert np.allclose(result, expected), (result, expected)
-

--- a/tests/regressions/python/805_two_variables.py
+++ b/tests/regressions/python/805_two_variables.py
@@ -1,0 +1,44 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx import Phylanx, PhylanxSession, execution_tree
+
+
+PhylanxSession.init()
+
+
+def variable(value, dtype=None):
+    return execution_tree.var(np.array(value, dtype))
+
+
+@Phylanx
+def dot_eager(x, y):
+    return np.dot(x, y)
+
+
+def dot(x, y):
+    return dot_eager.lazy(x, y)
+
+
+def eval(func):
+    return func.eval()
+
+
+def parse_shape_or_val(shape_or_val):
+    return shape_or_val, np.random.random(shape_or_val).astype(np.float32) - 0.5
+
+
+def test_dot_operation(x_shape_or_val, y_shape_or_val):
+    x_shape, x_val = parse_shape_or_val(x_shape_or_val)
+    y_shape, y_val = parse_shape_or_val(y_shape_or_val)
+    t = dot(variable(x_val), variable(y_val))
+    z = eval(t)
+    return z, np.dot(x_val, y_val)
+
+
+result, expected = test_dot_operation((4, 2), (2, 4))
+assert np.allclose(result, expected), (result, expected)
+

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
     640_function_argument
     651_vstack_dtype
     794_3d_array
+    805_lazy_variable
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Hartmut Kaiser
+# Copyright (c) 2017-2019 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,6 +17,7 @@ set(tests
     651_vstack_dtype
     794_3d_array
     805_lazy_variable
+    805_two_variables
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tests/unit/python/execution_tree/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
     dynamic_init
     for
     eval
+    lazy_eval
     make_array
     map_numpy
     map_numpy_constants

--- a/tests/unit/python/execution_tree/lazy_eval.py
+++ b/tests/unit/python/execution_tree/lazy_eval.py
@@ -9,13 +9,13 @@ from phylanx import Phylanx
 expected = np.array([[1, 2], [3, 4]])
 
 
-@Phylanx(lazy=True)
+@Phylanx
 def foo(m):
     a = np.array([[m, 2], [3, 4]])
     return a
 
 
-lazy_foo = foo(1)
+lazy_foo = foo.lazy(1)
 evaluated_foo = lazy_foo.eval()
 assert (evaluated_foo == expected).all()
 
@@ -28,3 +28,16 @@ def foo(m):
 
 evaluated_foo = foo(1)
 assert (evaluated_foo == expected).all()
+
+
+@Phylanx
+def eye_eager(size):
+    return np.eye(size)
+
+
+def eye(size):
+    return eye_eager.lazy(3)
+
+
+assert (eye_eager(3) == np.eye(3)).all()
+assert (eye(3).eval() == np.eye(3)).all()

--- a/tests/unit/python/execution_tree/lazy_eval.py
+++ b/tests/unit/python/execution_tree/lazy_eval.py
@@ -36,7 +36,7 @@ def eye_eager(size):
 
 
 def eye(size):
-    return eye_eager.lazy(3)
+    return eye_eager.lazy(size)
 
 
 assert (eye_eager(3) == np.eye(3)).all()

--- a/tests/unit/python/execution_tree/lazy_eval.py
+++ b/tests/unit/python/execution_tree/lazy_eval.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2019 R. Tohid
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx import Phylanx
+
+expected = np.array([[1, 2], [3, 4]])
+
+
+@Phylanx(lazy=True)
+def foo(m):
+    a = np.array([[m, 2], [3, 4]])
+    return a
+
+
+lazy_foo = foo(1)
+evaluated_foo = lazy_foo.eval()
+assert (evaluated_foo == expected).all()
+
+
+@Phylanx
+def foo(m):
+    a = np.array([[m, 2], [3, 4]])
+    return a
+
+
+evaluated_foo = foo(1)
+assert (evaluated_foo == expected).all()


### PR DESCRIPTION
Adds a new configuration option, 'lazy', to the Phylanx decorator. If set, the evaluation of the function is postponed untill the 'eval' method is invoked.