### PR TITLE
Add test for range::size(), handle empty int ranges

### DIFF
--- a/phylanx/ir/ranges.hpp
+++ b/phylanx/ir/ranges.hpp
@@ -325,6 +325,12 @@ namespace phylanx { namespace ir
         range(std::int64_t start, std::int64_t stop, std::int64_t step = 1)
             : data_(int_range_type{start, stop, step})
         {
+            if (step == 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::invalid_status,
+                    "phylanx::ir::range::range",
+                    "range step must not be zero");
+            }
         }
 
         range(std::int64_t stop)

--- a/src/ir/ranges.cpp
+++ b/src/ir/ranges.cpp
@@ -352,6 +352,12 @@ namespace phylanx { namespace ir
                 std::int64_t const step = int_range.step();
 
                 std::int64_t const distance_to_start = stop - start;
+
+                // Adding step to start must get closer to stop
+                if ((distance_to_start > 0) != (step > 0))
+                {
+                    return 0;
+                }
                 std::int64_t const n_steps = distance_to_start / step;
                 std::int64_t const remaining_step =
                     distance_to_start % step > 0 ? 1 : 0;

--- a/src/ir/ranges.cpp
+++ b/src/ir/ranges.cpp
@@ -360,7 +360,7 @@ namespace phylanx { namespace ir
                 }
                 std::int64_t const n_steps = distance_to_start / step;
                 std::int64_t const remaining_step =
-                    distance_to_start % step > 0 ? 1 : 0;
+                    (distance_to_start % step > 0) ? 1 : 0;
 
                 return n_steps + remaining_step;
             }

--- a/tests/unit/ir/ranges.cpp
+++ b/tests/unit/ir/ranges.cpp
@@ -69,16 +69,39 @@ void test_int_range_all_args()
     HPX_TEST_EQ(std::distance(r.begin(), r.end()), 5);
 }
 
+void test_int_range_zero_step()
+{
+    bool caught_exception = false;
+    try
+    {
+        phylanx::ir::range r(1, 10, 0);
+    }
+    catch (hpx::exception const&)
+    {
+        caught_exception = true;
+    }
+    HPX_TEST(caught_exception);
+}
+
 void test_int_range_size()
 {
-    phylanx::ir::range r(-1, static_cast<std::int64_t>(0));
+    phylanx::ir::range r(
+        static_cast<std::int64_t>(-1), static_cast<std::int64_t>(0));
 
     HPX_TEST_EQ(r.size(), 1);
 }
 
-void test_int_empty_range_size()
+void test_int_empty_range_size_1()
 {
     phylanx::ir::range r(-6);
+
+    HPX_TEST_EQ(r.size(), 0);
+}
+
+void test_int_empty_range_size_2()
+{
+    phylanx::ir::range r(
+        static_cast<std::int64_t>(1), static_cast<std::int64_t>(1));
 
     HPX_TEST_EQ(r.size(), 0);
 }
@@ -204,9 +227,11 @@ int main(int argc, char* argv[])
 
     test_int_range_stop_arg();
     test_int_range_all_args();
+    test_int_range_zero_step();
 
     test_int_range_size();
-    test_int_empty_range_size();
+    test_int_empty_range_size_1();
+    test_int_empty_range_size_2();
 
     test_arg_type_range();
     test_arg_pair_range();

--- a/tests/unit/ir/ranges.cpp
+++ b/tests/unit/ir/ranges.cpp
@@ -69,6 +69,20 @@ void test_int_range_all_args()
     HPX_TEST_EQ(std::distance(r.begin(), r.end()), 5);
 }
 
+void test_int_range_size()
+{
+    phylanx::ir::range r(-1, static_cast<std::int64_t>(0));
+
+    HPX_TEST_EQ(r.size(), 1);
+}
+
+void test_int_empty_range_size()
+{
+    phylanx::ir::range r(-6);
+
+    HPX_TEST_EQ(r.size(), 0);
+}
+
 void test_arg_type_range()
 {
     using arg_t = phylanx::execution_tree::primitive_argument_type;
@@ -190,6 +204,9 @@ int main(int argc, char* argv[])
 
     test_int_range_stop_arg();
     test_int_range_all_args();
+
+    test_int_range_size();
+    test_int_empty_range_size();
 
     test_arg_type_range();
     test_arg_pair_range();


### PR DESCRIPTION
This PR fixes a bug in `phylanx::ir::range::size` that causes this example to print an unexpected value:
```cpp
phylanx::ir::range r(-1);
std::printf("r.size(): %d \n", r.size())
// Actual output:
// r.size(): -1
// Expected output:
// r.size(): 0
```