### PR TITLE
Making sure 'None' can be used as a default argument

### DIFF
--- a/phylanx/util/repr_manip.hpp
+++ b/phylanx/util/repr_manip.hpp
@@ -15,6 +15,14 @@ namespace phylanx { namespace util
     PHYLANX_EXPORT std::ostream& repr(std::ostream& stream);
     PHYLANX_EXPORT std::ostream& norepr(std::ostream& stream);
     PHYLANX_EXPORT bool is_repr(std::ostream& stream);
+
+    struct PHYLANX_EXPORT repr_wrapper
+    {
+        repr_wrapper(std::ostream& strm);
+        ~repr_wrapper();
+
+        std::ostream& strm_;
+    };
 }}
 
 #endif

--- a/python/src/bindings/binding_helpers.cpp
+++ b/python/src/bindings/binding_helpers.cpp
@@ -7,6 +7,8 @@
 
 #include <phylanx/phylanx.hpp>
 
+#include <hpx/include/iostreams.hpp>
+
 #include <bindings/binding_helpers.hpp>
 #include <bindings/type_casters.hpp>
 #include <pybind11/pybind11.h>
@@ -57,6 +59,8 @@ namespace phylanx { namespace bindings
         return hpx::threads::run_as_hpx_thread(
             [&]() -> phylanx::execution_tree::primitive_argument_type
             {
+                phylanx::util::repr_wrapper wrap(hpx::consolestream);
+
                 auto const& code_x = phylanx::execution_tree::compile(
                     file_name, xexpr_str, c.eval_snippets, c.eval_env);
 

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -68,7 +68,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type target;
         if (argnum_ >= params.size())
         {
-            if (operands_.size() < 2 || !valid(operands_[1]))
+            if (operands_.size() < 2 ||
+                (!valid(operands_[1]) && !is_explicit_nil(operands_[1])))
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::primitives::access_argument::eval",
@@ -199,7 +200,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type target;
         if (argnum_ >= params.size())
         {
-            if (operands_.size() < 2 || !valid(operands_[1]))
+            if (operands_.size() < 2 ||
+                (!valid(operands_[1]) && !is_explicit_nil(operands_[1])))
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::primitives::access_argument::store",
@@ -305,7 +307,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type target;
         if (argnum_ >= params.size())
         {
-            if (operands_.size() < 2 || !valid(operands_[1]))
+            if (operands_.size() < 2 ||
+                (!valid(operands_[1]) && !is_explicit_nil(operands_[1])))
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::primitives::access_argument::store",

--- a/src/util/repr_manip.cpp
+++ b/src/util/repr_manip.cpp
@@ -36,5 +36,16 @@ namespace phylanx { namespace util
     {
         return stream.iword(detail::get_repr_manip_index()) != 0;
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    repr_wrapper::repr_wrapper(std::ostream& strm)
+        : strm_(strm)
+    {
+        strm_ << repr;
+    }
+    repr_wrapper::~repr_wrapper()
+    {
+        strm_ << norepr;
+    }
 }}
 

--- a/tests/regressions/python/837_none_default_argument.py
+++ b/tests/regressions/python/837_none_default_argument.py
@@ -1,0 +1,26 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #837: Using 'None' as default argument fails
+
+from phylanx import Phylanx
+from phylanx.util import debug_output
+
+
+def debug(s):   # silence flake
+    pass
+
+
+@Phylanx
+def fx(shape, minval=None):
+    debug(minval)
+    return 0
+
+
+fx(0)
+
+
+s = debug_output()
+assert s == "None\n", s

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -19,6 +19,8 @@ set(tests
     805_lazy_variable
     805_two_variables
     808_print_twice
+    826_default_args
+    837_none_default_argument
     array_len_494
     array_shape_486
     array_subscript_403


### PR DESCRIPTION
- flyby: `print(None)`/`debug(None)` in `@Phylanx` decorated function will actually print `None` and not `nil`

Fixes #837