### PR TITLE
Adding generic_primitive_bool with is_nan, isinf, isfinite, isneginf,and isposinf

### DIFF
--- a/phylanx/plugins/arithmetics/arithmetics.hpp
+++ b/phylanx/plugins/arithmetics/arithmetics.hpp
@@ -11,6 +11,7 @@
 #include <phylanx/plugins/arithmetics/cumsum.hpp>
 #include <phylanx/plugins/arithmetics/div_operation.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
 #include <phylanx/plugins/arithmetics/maximum.hpp>
 #include <phylanx/plugins/arithmetics/minimum.hpp>
 #include <phylanx/plugins/arithmetics/mul_operation.hpp>

--- a/phylanx/plugins/arithmetics/generic_operation_0d.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_0d.hpp
@@ -87,7 +87,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }},
             {"erf", [](T m) -> T { return blaze::erf(m); }},
             {"erfc", [](T m) -> T { return blaze::erfc(m); }},
-            {"square", [](T m) -> T { return m*m; }},
+            {"square", [](T m) -> T { return m * m; }},
             {"sign", [](T m) -> T { return blaze::sign(m); }},
             {"normalize",
                 [](T m) -> T {

--- a/phylanx/plugins/arithmetics/generic_operation_1d.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_1d.hpp
@@ -444,7 +444,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 [](arg_type<T>&& m) -> arg_type<T> {
                     if (m.is_ref())
                     {
-                        m = m.vector()*m.vector();
+                        m = m.vector() * m.vector();
                     }
                     else
                     {

--- a/phylanx/plugins/arithmetics/generic_operation_bool.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_bool.hpp
@@ -1,0 +1,124 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef PHYLANX_GENERIC_OPERATION_BOOL_HPP
+#define PHYLANX_GENERIC_OPERATION_BOOL_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    class generic_operation_bool
+      : public primitive_component_base
+      , public std::enable_shared_from_this<generic_operation_bool>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+        template <typename T>
+        using arg_type = ir::node_data<T>;
+
+    public:
+        static std::vector<match_pattern_type> const match_data;
+
+        generic_operation_bool() = default;
+
+        generic_operation_bool(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    public:
+        template <typename T>
+        using scalar_function = bool(T);
+        template <typename T>
+        using matrix_vector_function = arg_type<std::uint8_t>(arg_type<T>&&);
+
+        template <typename T>
+        using scalar_function_ptr = scalar_function<T>*;
+        template <typename T>
+        using matrix_vector_function_ptr = matrix_vector_function<T>*;
+
+    private:
+        template <typename T>
+        primitive_argument_type generic0d_bool(arg_type<T>&& op) const;
+        template <typename T>
+        primitive_argument_type generic1d_bool(arg_type<T>&& op) const;
+        template <typename T>
+        primitive_argument_type generic2d_bool(arg_type<T>&& op) const;
+
+        primitive_argument_type generic0d_bool(
+            primitive_argument_type&& op) const;
+        primitive_argument_type generic1d_bool(
+            primitive_argument_type&& op) const;
+        primitive_argument_type generic2d_bool(
+            primitive_argument_type&& op) const;
+
+        template <typename T>
+        static std::map<std::string, scalar_function_ptr<T>> const&
+            get_0d_map();
+        template <typename T>
+        static std::map<std::string, matrix_vector_function_ptr<T>> const&
+            get_1d_map();
+        template <typename T>
+        static std::map<std::string, matrix_vector_function_ptr<T>> const&
+            get_2d_map();
+
+        template <typename T>
+        static scalar_function_ptr<T> get_0d_function(
+            std::string const& funcname, std::string const& name,
+            std::string const& codename);
+        template <typename T>
+        static matrix_vector_function_ptr<T> get_1d_function(
+            std::string const& funcname, std::string const& name,
+            std::string const& codename);
+        template <typename T>
+        static matrix_vector_function_ptr<T> get_2d_function(
+            std::string const& funcname, std::string const& name,
+            std::string const& codename);
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        template <typename T>
+        primitive_argument_type generic3d_bool(arg_type<T>&& op) const;
+        primitive_argument_type generic3d_bool(
+            primitive_argument_type&& op) const;
+
+        template <typename T>
+        static std::map<std::string, matrix_vector_function_ptr<T>> const&
+            get_3d_map();
+        template <typename T>
+        static matrix_vector_function_ptr<T> get_3d_function(
+            std::string const& funcname, std::string const& name,
+            std::string const& codename);
+#endif
+    private:
+        std::string func_name_;
+        node_data_type dtype_;
+    };
+
+    inline primitive create_generic_operation_bool(hpx::id_type const& locality,
+        primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "__gen_bool", std::move(operands), name, codename);
+    }
+}}}
+
+#endif    //PHYLANX_GENERIC_OPERATION_HPP

--- a/phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef PHYLANX_GENERIC_OPERATION_BOOL_ND_HPP
+#define PHYLANX_GENERIC_OPERATION_BOOL_ND_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/assert.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Math.h>
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    generic_operation_bool::scalar_function_ptr<T>
+    generic_operation_bool::get_0d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename)
+    {
+        auto func_map = get_0d_map<T>();
+        auto it = func_map.find(funcname);
+        if (it == func_map.end())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "generic_operation_bool::get_0d_function",
+                util::generate_error_message(
+                    "unknown function requested: " + funcname, name, codename));
+        }
+        return it->second;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    generic_operation_bool::matrix_vector_function_ptr<T>
+    generic_operation_bool::get_1d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename)
+    {
+        auto func_map = get_1d_map<T>();
+        auto it = func_map.find(funcname);
+        if (it == func_map.end())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "generic_operation_bool::get_1d_function",
+                util::generate_error_message(
+                    "unknown function requested: " + funcname, name, codename));
+        }
+        return it->second;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    generic_operation_bool::matrix_vector_function_ptr<T>
+    generic_operation_bool::get_2d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename)
+    {
+        auto func_map = get_2d_map<T>();
+        auto it = func_map.find(funcname);
+        if (it == func_map.end())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "generic_operation_bool::get_2d_function",
+                util::generate_error_message(
+                    "unknown function requested: " + funcname, name, codename));
+        }
+        return it->second;
+    }
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    generic_operation_bool::matrix_vector_function_ptr<T>
+    generic_operation_bool::get_3d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename)
+    {
+        auto func_map = get_3d_map<T>();
+        auto it = func_map.find(funcname);
+        if (it == func_map.end())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "generic_operation_bool::get_3d_function",
+                util::generate_error_message(
+                    "unknown function requested: " + funcname, name, codename));
+        }
+        return it->second;
+    }
+#endif
+}}}
+
+#endif

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -2377,13 +2377,12 @@ namespace phylanx { namespace ir
             {
             case node_data<std::int64_t>::storage0d:          HPX_FALLTHROUGH;
             case node_data<std::int64_t>::custom_storage0d:
-                    out << nd.scalar();
-                    break;
+                out << nd.scalar();
+                break;
 
             case node_data<std::int64_t>::storage1d:          HPX_FALLTHROUGH;
             case node_data<std::int64_t>::custom_storage1d:
-                detail::print_array<std::int64_t>(
-                    out, nd.vector(), nd.size());
+                detail::print_array<std::int64_t>(out, nd.vector(), nd.size());
                 break;
 
             case node_data<std::int64_t>::storage2d:          HPX_FALLTHROUGH;
@@ -2450,6 +2449,7 @@ namespace phylanx { namespace ir
                     out << std::boolalpha;
                     detail::print_matrix<bool>(out, m, m.rows(), m.columns());
                 }
+                break;
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
             case node_data<std::uint8_t>::storage3d:          HPX_FALLTHROUGH;

--- a/src/plugins/arithmetics/arithmetics.cpp
+++ b/src/plugins/arithmetics/arithmetics.cpp
@@ -47,8 +47,30 @@ namespace phylanx { namespace plugin
             }
         }
     };
+
+    struct generic_operation_bool_plugin : plugin_base
+    {
+        void register_known_primitives(std::string const& fullpath) override
+        {
+            namespace pet = phylanx::execution_tree;
+
+            std::string generic_operation_bool_name("__gen_bool");
+            for (auto const& pattern :
+                pet::primitives::generic_operation_bool::match_data)
+            {
+                pet::register_pattern(
+                    generic_operation_bool_name, pattern, fullpath);
+            }
+        }
+    };
 }}
 
 PHYLANX_REGISTER_PLUGIN_FACTORY(phylanx::plugin::generic_operation_plugin,
     generic_operation_plugin,
-    phylanx::execution_tree::primitives::make_list::match_data, "__gen");
+    phylanx::execution_tree::primitives::generic_operation::match_data,
+    "__gen");
+
+PHYLANX_REGISTER_PLUGIN_FACTORY(phylanx::plugin::generic_operation_bool_plugin,
+    generic_operation_bool_plugin,
+    phylanx::execution_tree::primitives::generic_operation_bool::match_data,
+    "__gen_bool");

--- a/src/plugins/arithmetics/generic_operation_bool.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool.cpp
@@ -1,0 +1,273 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/assert.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+///////////////////////////////////////////////////////////////////////////////
+#define PHYLANX_GEN_MATCH_DATA(name)                                           \
+    match_pattern_type                                                         \
+    {                                                                          \
+        name, std::vector<std::string>{name "(_1)"},                           \
+            &create_generic_operation_bool,                                    \
+            &create_primitive<generic_operation_bool>,                         \
+            "arg\n"                                                            \
+            "Args:\n"                                                          \
+            "\n"                                                               \
+            "    arg (float) : a floating point number\n"                      \
+            "\n"                                                               \
+            "Returns:\n"                                                       \
+            "\n"                                                               \
+            "This function implements function `" name "` from Python's "      \
+            "math library.",                                                   \
+            true                                                               \
+    }                                                                          \
+    /**/
+
+    std::vector<match_pattern_type> const
+        generic_operation_bool::match_data = {
+            PHYLANX_GEN_MATCH_DATA("isnan"),
+            PHYLANX_GEN_MATCH_DATA("isinf"),
+            PHYLANX_GEN_MATCH_DATA("isneginf"),
+            PHYLANX_GEN_MATCH_DATA("isposinf"),
+            PHYLANX_GEN_MATCH_DATA("isfinite")
+        };
+
+#undef PHYLANX_GEN_MATCH_DATA
+
+    ///////////////////////////////////////////////////////////////////////////
+    generic_operation_bool::generic_operation_bool(
+        primitive_arguments_type && operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+      , func_name_(extract_function_name(name))
+      , dtype_(extract_dtype(name_))
+    {
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    primitive_argument_type generic_operation_bool::generic0d_bool(
+        arg_type<T>&& op) const
+    {
+        return primitive_argument_type{
+            get_0d_function<T>(func_name_, name_, codename_)(op.scalar())};
+    }
+
+    template <typename T>
+    primitive_argument_type generic_operation_bool::generic1d_bool(
+        arg_type<T>&& op) const
+    {
+        return primitive_argument_type{
+            get_1d_function<T>(func_name_, name_, codename_)(std::move(op))};
+    }
+
+    template <typename T>
+    primitive_argument_type generic_operation_bool::generic2d_bool(
+        arg_type<T>&& op) const
+    {
+        return primitive_argument_type{
+            get_2d_function<T>(func_name_, name_, codename_)(std::move(op))};
+    }
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    template <typename T>
+    primitive_argument_type generic_operation_bool::generic3d_bool(
+        arg_type<T>&& op) const
+    {
+        return primitive_argument_type{
+            get_3d_function<T>(func_name_, name_, codename_)(std::move(op))};
+    }
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type generic_operation_bool::generic0d_bool(
+        primitive_argument_type&& op) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = node_data_type_double;  // use double by default
+        }
+
+        switch (t)
+        {
+        case node_data_type_int64:
+            return generic0d_bool(
+                extract_integer_value(std::move(op), name_, codename_));
+
+        case node_data_type_double:
+        case node_data_type_bool:
+        case node_data_type_unknown:
+            return generic0d_bool(
+                extract_numeric_value(std::move(op), name_, codename_));
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "generic_operation_bool::generic0d_bool",
+            generate_error_message("operand has unsupported type"));
+    }
+
+    primitive_argument_type generic_operation_bool::generic1d_bool(
+        primitive_argument_type&& op) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = node_data_type_double;  // use double by default
+        }
+
+        switch (t)
+        {
+        case node_data_type_int64:
+            return generic1d_bool(
+                extract_integer_value(std::move(op), name_, codename_));
+
+        case node_data_type_double:
+        case node_data_type_bool:
+        case node_data_type_unknown:
+            return generic1d_bool(
+                extract_numeric_value(std::move(op), name_, codename_));
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "generic_operation_bool::generic1d_bool",
+            generate_error_message("operand has unsupported type"));
+    }
+
+    primitive_argument_type generic_operation_bool::generic2d_bool(
+        primitive_argument_type&& op) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = node_data_type_double;  // use double by default
+        }
+
+        switch (t)
+        {
+        case node_data_type_int64:
+            return generic2d_bool(
+                extract_integer_value(std::move(op), name_, codename_));
+
+        case node_data_type_double:
+        case node_data_type_bool:
+        case node_data_type_unknown:
+            return generic2d_bool(
+                extract_numeric_value(std::move(op), name_, codename_));
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "generic_operation_bool::generic2d_bool",
+            generate_error_message("operand has unsupported type"));
+    }
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    primitive_argument_type generic_operation_bool::generic3d_bool(
+        primitive_argument_type&& op) const
+    {
+        node_data_type t = dtype_;
+        if (t == node_data_type_unknown)
+        {
+            t = node_data_type_double;  // use double by default
+        }
+
+        switch (t)
+        {
+        case node_data_type_int64:
+            return generic3d_bool(
+                extract_integer_value(std::move(op), name_, codename_));
+
+        case node_data_type_double:
+        case node_data_type_bool:
+        case node_data_type_unknown:
+            return generic3d_bool(
+                extract_numeric_value(std::move(op), name_, codename_));
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "generic_operation_bool::generic3d_bool",
+            generate_error_message("operand has unsupported type"));
+    }
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> generic_operation_bool::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "generic_operation_bool::eval",
+                generate_error_message(
+                    "the generic_operation_bool primitive requires"
+                    "exactly one operand"));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "generic_operation_bool::eval",
+                generate_error_message(
+                    "the generic_operation_bool primitive requires "
+                    "that the arguments given by the operands "
+                    "array is valid"));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping(
+                [this_ = std::move(this_)](primitive_argument_type&& op)
+                -> primitive_argument_type
+                {
+                    std::size_t dims = extract_numeric_value_dimension(
+                        op, this_->name_, this_->codename_);
+                    switch (dims)
+                    {
+                    case 0:
+                        return this_->generic0d_bool(std::move(op));
+
+                    case 1:
+                        return this_->generic1d_bool(std::move(op));
+
+                    case 2:
+                        return this_->generic2d_bool(std::move(op));
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+                    case 3:
+                        return this_->generic3d_bool(std::move(op));
+#endif
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "generic_operation_bool::eval",
+                            this_->generate_error_message(
+                                "left hand side operand has unsupported "
+                                "number of dimensions"));
+                    }
+                }),
+            value_operand(operands[0], args, name_, codename_, std::move(ctx)));
+    }
+}}}

--- a/src/plugins/arithmetics/generic_operation_bool_0d_float.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_0d_float.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <map>
+#include <string>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::scalar_function_ptr<double>> const&
+    generic_operation_bool::get_0d_map()
+    {
+        static std::map<std::string, scalar_function_ptr<double>> map0d = {
+            {"isnan", [](double val) -> bool { return std::isnan(val); }},
+            {"isinf", [](double val) -> bool { return std::isinf(val); }},
+            {"isfinite", [](double val) -> bool { return std::isfinite(val); }},
+            {"isneginf",
+                [](double val) -> bool {
+                    return std::isinf(val) && std::signbit(val);
+                }},
+            {"isposinf", [](double val) -> bool {
+                 return std::isinf(val) && !std::signbit(val);
+             }}};
+        return map0d;
+    }
+
+    template generic_operation_bool::scalar_function_ptr<double>
+    generic_operation_bool::get_0d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}

--- a/src/plugins/arithmetics/generic_operation_bool_0d_int64.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_0d_int64.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2018 Tianyi Zhang
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::scalar_function_ptr<std::int64_t>> const&
+    generic_operation_bool::get_0d_map()
+    {
+        static std::map<std::string, scalar_function_ptr<std::int64_t>> map0d =
+            {};
+        return map0d;
+    }
+
+    template generic_operation_bool::scalar_function_ptr<std::int64_t>
+    generic_operation_bool::get_0d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}

--- a/src/plugins/arithmetics/generic_operation_bool_1d_float.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_1d_float.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::matrix_vector_function_ptr<double>> const&
+    generic_operation_bool::get_1d_map()
+    {
+        static std::map<std::string, matrix_vector_function_ptr<double>> map1d =
+        {
+            {"isnan",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.vector(), [](double val) -> std::uint8_t {
+                            return std::isnan(val);
+                        })};
+                }},
+            {"isinf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.vector(), [](double val) -> std::uint8_t {
+                            return std::isinf(val);
+                        })};
+                }},
+            {"isfinite",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.vector(), [](double val) -> std::uint8_t {
+                            return std::isfinite(val);
+                        })};
+                }},
+            {"isneginf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.vector(), [](double val) -> std::uint8_t {
+                            return std::isinf(val) && std::signbit(val);
+                        })};
+                }},
+            {"isposinf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.vector(), [](double val) -> std::uint8_t {
+                            return std::isinf(val) && !std::signbit(val);
+                        })};
+                }},
+        };
+        return map1d;
+    }
+
+    template generic_operation_bool::matrix_vector_function_ptr<double>
+    generic_operation_bool::get_1d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}

--- a/src/plugins/arithmetics/generic_operation_bool_1d_int64.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_1d_int64.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::matrix_vector_function_ptr<std::int64_t>> const&
+    generic_operation_bool::get_1d_map()
+    {
+        static std::map<std::string, matrix_vector_function_ptr<std::int64_t>>
+            map1d = {};
+        return map1d;
+    }
+
+    template generic_operation_bool::matrix_vector_function_ptr<std::int64_t>
+    generic_operation_bool::get_1d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}

--- a/src/plugins/arithmetics/generic_operation_bool_2d_float.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_2d_float.cpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::matrix_vector_function_ptr<double>> const&
+    generic_operation_bool::get_2d_map()
+    {
+        static std::map<std::string, matrix_vector_function_ptr<double>> map1d =
+        {
+            {"isnan",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.matrix(), [](double val) -> std::uint8_t {
+                            return std::isnan(val);
+                        })};
+                }},
+            {"isinf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.matrix(), [](double val) -> std::uint8_t {
+                            return std::isinf(val);
+                        })};
+                }},
+            {"isfinite",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.matrix(), [](double val) -> std::uint8_t {
+                            return std::isfinite(val);
+                        })};
+                }},
+            {"isneginf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.matrix(), [](double val) -> std::uint8_t {
+                            return std::isinf(val) && std::signbit(val);
+                        })};
+                }},
+            {"isposinf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.matrix(), [](double val) -> std::uint8_t {
+                            return std::isinf(val) && !std::signbit(val);
+                        })};
+                }},
+        };
+        return map1d;
+    }
+
+    template generic_operation_bool::matrix_vector_function_ptr<double>
+    generic_operation_bool::get_2d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}

--- a/src/plugins/arithmetics/generic_operation_bool_2d_int64.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_2d_int64.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::matrix_vector_function_ptr<std::int64_t>> const&
+    generic_operation_bool::get_2d_map()
+    {
+        static std::map<std::string, matrix_vector_function_ptr<std::int64_t>>
+            map1d = {};
+        return map1d;
+    }
+
+    template generic_operation_bool::matrix_vector_function_ptr<std::int64_t>
+    generic_operation_bool::get_2d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}

--- a/src/plugins/arithmetics/generic_operation_bool_3d_float.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_3d_float.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::matrix_vector_function_ptr<double>> const&
+    generic_operation_bool::get_3d_map()
+    {
+        static std::map<std::string, matrix_vector_function_ptr<double>> map1d =
+        {
+            {"isnan",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.tensor(), [](double val) -> std::uint8_t {
+                            return std::isnan(val);
+                        })};
+                }},
+            {"isinf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.tensor(), [](double val) -> std::uint8_t {
+                            return std::isinf(val);
+                        })};
+                }},
+            {"isfinite",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.tensor(), [](double val) -> std::uint8_t {
+                            return std::isfinite(val);
+                        })};
+                }},
+            {"isneginf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.tensor(), [](double val) -> std::uint8_t {
+                            return std::isinf(val) && std::signbit(val);
+                        })};
+                }},
+            {"isposinf",
+                [](arg_type<double>&& m) -> arg_type<std::uint8_t> {
+                    return arg_type<std::uint8_t>{blaze::map(
+                        m.tensor(), [](double val) -> std::uint8_t {
+                            return std::isinf(val) && !std::signbit(val);
+                        })};
+                }},
+        };
+        return map1d;
+    }
+
+    template generic_operation_bool::matrix_vector_function_ptr<double>
+    generic_operation_bool::get_3d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}
+
+#endif

--- a/src/plugins/arithmetics/generic_operation_bool_3d_int64.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool_3d_int64.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
+#include <phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp>
+
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <string>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+     ///////////////////////////////////////////////////////////////////////////
+    template <>
+    std::map<std::string,
+        generic_operation_bool::matrix_vector_function_ptr<std::int64_t>> const&
+    generic_operation_bool::get_3d_map()
+    {
+        static std::map<std::string, matrix_vector_function_ptr<std::int64_t>>
+            map1d = {};
+        return map1d;
+    }
+
+   template generic_operation_bool::matrix_vector_function_ptr<std::int64_t>
+    generic_operation_bool::get_3d_function(std::string const& funcname,
+        std::string const& name, std::string const& codename);
+}}}
+
+#endif

--- a/src/plugins/listops/listops.cpp
+++ b/src/plugins/listops/listops.cpp
@@ -22,7 +22,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(len_operation_plugin,
 PHYLANX_REGISTER_PLUGIN_FACTORY(append_operation_plugin,
     phylanx::execution_tree::primitives::append_operation::match_data);
 
-namespace phylanx { namespace plugin {
+namespace phylanx { namespace plugin
+{
     struct car_cdr_plugin : plugin_base
     {
         void register_known_primitives(std::string const& fullpath) override
@@ -40,5 +41,5 @@ namespace phylanx { namespace plugin {
 }}
 
 PHYLANX_REGISTER_PLUGIN_FACTORY(phylanx::plugin::car_cdr_plugin, car_cdr_plugin,
-    phylanx::execution_tree::primitives::make_list::match_data,
+    phylanx::execution_tree::primitives::car_cdr_operation::match_data,
     "car_cdr_plugin");

--- a/tests/unit/plugins/arithmetics/CMakeLists.txt
+++ b/tests/unit/plugins/arithmetics/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
     cumsum
     div_operation
     generic_operation
+    generic_operation_bool
     maximum
     minimum
     mul_operation

--- a/tests/unit/plugins/arithmetics/generic_operation_bool.cpp
+++ b/tests/unit/plugins/arithmetics/generic_operation_bool.cpp
@@ -1,0 +1,231 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Blaze.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Blaze.h>
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+using custom_vector_type = blaze::CustomVector<double, true, true>;
+using custom_matrix_type = blaze::CustomMatrix<double, true, true>;
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+using custom_tensor_type = blaze::CustomTensor<double, true, true>;
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+void test_generic_operation_0d(std::string const& func_name,
+    bool func(double))
+{
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(0.5));
+
+    phylanx::execution_tree::primitive generic =
+        phylanx::execution_tree::primitives::create_generic_operation_bool(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(lhs)},
+            func_name);
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        generic.eval();
+    HPX_TEST_EQ(func(0.5),
+        phylanx::execution_tree::extract_scalar_boolean_value(f.get()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_generic_operation_1d(std::string const& func_name,
+    blaze::DynamicVector<std::uint8_t> func(custom_vector_type))
+{
+    blaze::Rand<blaze::DynamicVector<double>> gen{};
+    blaze::DynamicVector<double> n = gen.generate(22UL);
+    custom_vector_type m(n.data(), n.size(), n.spacing());
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive generic =
+        phylanx::execution_tree::primitives::create_generic_operation_bool(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(lhs)},
+            func_name);
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        generic.eval();
+    blaze::DynamicVector<std::uint8_t> expected = func(m);
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_generic_operation_2d(std::string const& func_name,
+    blaze::DynamicMatrix<std::uint8_t> func(custom_matrix_type))
+{
+    blaze::Rand<blaze::DynamicMatrix<double>> gen{};
+    blaze::DynamicMatrix<double> n = gen.generate(22UL, 22UL);
+    custom_matrix_type m(n.data(), n.rows(), n.columns(), n.spacing());
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive generic =
+        phylanx::execution_tree::primitives::create_generic_operation_bool(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(lhs)},
+            func_name);
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        generic.eval();
+    blaze::DynamicMatrix<std::uint8_t> expected = func(m);
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
+}
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_generic_operation_3d(std::string const& func_name,
+    blaze::DynamicTensor<std::uint8_t> func(custom_tensor_type))
+{
+    blaze::Rand<blaze::DynamicTensor<double>> gen{};
+    blaze::DynamicTensor<double> n = gen.generate(22UL, 22UL, 22UL);
+    custom_tensor_type m(
+        n.data(), n.pages(), n.rows(), n.columns(), n.spacing());
+
+    phylanx::execution_tree::primitive lhs =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive generic =
+        phylanx::execution_tree::primitives::create_generic_operation_bool(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(lhs)},
+            func_name);
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        generic.eval();
+    blaze::DynamicTensor<std::uint8_t> expected = func(m);
+    HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
+}
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+void test_0d_operations()
+{
+    test_generic_operation_0d("isnan", std::isnan);
+    test_generic_operation_0d("isinf", std::isinf);
+    test_generic_operation_0d("isfinite", std::isfinite);
+    test_generic_operation_0d("isneginf",
+        [](double m) -> bool { return std::isinf(m) && std::signbit(m); });
+    test_generic_operation_0d("isposinf",
+        [](double m) -> bool { return std::isinf(m) && !std::signbit(m); });
+}
+
+void test_1d_operations()
+{
+    test_generic_operation_1d("isnan",
+        [](custom_vector_type m) -> blaze::DynamicVector<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isnan(m); });
+        });
+    test_generic_operation_1d("isinf",
+        [](custom_vector_type m) -> blaze::DynamicVector<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isinf(m); });
+        });
+    test_generic_operation_1d("isfinite",
+        [](custom_vector_type m) -> blaze::DynamicVector<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isfinite(m); });
+        });
+    test_generic_operation_1d("isneginf",
+        [](custom_vector_type m) -> blaze::DynamicVector<std::uint8_t> {
+            return blaze::map(
+                m, [](double m) { return std::isinf(m) && std::signbit(m); });
+        });
+    test_generic_operation_1d("isposinf",
+        [](custom_vector_type m) -> blaze::DynamicVector<std::uint8_t> {
+            return blaze::map(
+                m, [](double m) { return std::isinf(m) && !std::signbit(m); });
+        });
+}
+
+void test_2d_operations()
+{
+    test_generic_operation_2d("isnan",
+        [](custom_matrix_type m) -> blaze::DynamicMatrix<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isnan(m); });
+        });
+    test_generic_operation_2d("isinf",
+        [](custom_matrix_type m) -> blaze::DynamicMatrix<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isinf(m); });
+        });
+    test_generic_operation_2d("isfinite",
+        [](custom_matrix_type m) -> blaze::DynamicMatrix<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isfinite(m); });
+        });
+    test_generic_operation_2d("isneginf",
+        [](custom_matrix_type m) -> blaze::DynamicMatrix<std::uint8_t> {
+            return blaze::map(
+                m, [](double m) { return std::isinf(m) && std::signbit(m); });
+        });
+    test_generic_operation_2d("isposinf",
+        [](custom_matrix_type m) -> blaze::DynamicMatrix<std::uint8_t> {
+            return blaze::map(
+                m, [](double m) { return std::isinf(m) && !std::signbit(m); });
+        });
+}
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_3d_operations()
+{
+    test_generic_operation_3d("isnan",
+        [](custom_tensor_type m) -> blaze::DynamicTensor<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isnan(m); });
+        });
+    test_generic_operation_3d("isinf",
+        [](custom_tensor_type m) -> blaze::DynamicTensor<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isinf(m); });
+        });
+    test_generic_operation_3d("isfinite",
+        [](custom_tensor_type m) -> blaze::DynamicTensor<std::uint8_t> {
+            return blaze::map(m, [](double m) { return std::isfinite(m); });
+        });
+    test_generic_operation_3d("isneginf",
+        [](custom_tensor_type m) -> blaze::DynamicTensor<std::uint8_t> {
+            return blaze::map(
+                m, [](double m) { return std::isinf(m) && std::signbit(m); });
+        });
+    test_generic_operation_3d("isposinf",
+        [](custom_tensor_type m) -> blaze::DynamicTensor<std::uint8_t> {
+            return blaze::map(
+                m, [](double m) { return std::isinf(m) && !std::signbit(m); });
+        });
+}
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_0d_operations();
+    test_1d_operations();
+    test_2d_operations();
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_3d_operations();
+#endif
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #842

- flyby: fixing primitive registration for various primitives
- flyby: adding missing break statement in node_data.cpp