### PR TITLE
Fixing how statistics primitives handle negative axis when axes are passed as a list 

### DIFF
--- a/phylanx/plugins/statistics/statistics_base_impl.hpp
+++ b/phylanx/plugins/statistics/statistics_base_impl.hpp
@@ -610,6 +610,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         {
             std::int64_t axis =
                 extract_scalar_integer_value(std::move(elem), name_, codename_);
+
+            if (axis < 0)
+                axis = axis + dims;
             if (seen_axes.find(axis) != seen_axes.end())
             {
                 // axes must be unique

--- a/tests/unit/plugins/statistics/all_operation.cpp
+++ b/tests/unit/plugins/statistics/all_operation.cpp
@@ -397,6 +397,162 @@ void test_all_operation_2d_numpy_false()
     HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_all_operation_3d()
+{
+    blaze::Rand<blaze::DynamicTensor<int>> gen{};
+    blaze::DynamicTensor<std::uint8_t> m =
+        gen.generate(10UL, 101UL, 101UL, 0, 1);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(m.nonZeros() == m.rows() * m.columns(),
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_all_operation_3d_true()
+{
+    blaze::Rand<blaze::DynamicTensor<int>> gen{};
+    blaze::DynamicTensor<std::uint8_t> m =
+        gen.generate(10UL, 101UL, 101UL, 1, 2);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_all_operation_3d_double()
+{
+    blaze::Rand<blaze::DynamicTensor<int>> gen{};
+    blaze::DynamicTensor<double> m = gen.generate(10UL, 101UL, 101UL, 0, 1);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(m.nonZeros() == m.rows() * m.columns(),
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_all_operation_3d_double_true()
+{
+    blaze::Rand<blaze::DynamicTensor<int>> gen{};
+    blaze::DynamicTensor<double> m = gen.generate(10UL, 101UL, 101UL, 1, 2);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_all_operation_3d_double_numpy_false()
+{
+    blaze::DynamicTensor<double> m{{{1.0, 2.0, 3.0}, {0.0, 1.0, 0.0}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_all_operation_3d_double_numpy_true()
+{
+    blaze::DynamicTensor<double> m{{{1.0, 2.0, 3.0}, {4.0, 1.0, 6.0}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_all_operation_3d_numpy_true()
+{
+    blaze::DynamicTensor<std::uint8_t> m{
+        {{true, true, true}, {true, true, true}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_all_operation_3d_numpy_false()
+{
+    blaze::DynamicTensor<std::uint8_t> m{
+        {{true, true, true}, {false, true, false}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive all =
+        phylanx::execution_tree::primitives::create_all_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = all.eval().get();
+
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+#endif
+
 int main(int argc, char* argv[])
 {
     test_all_operation_0d_true();
@@ -422,5 +578,15 @@ int main(int argc, char* argv[])
     test_all_operation_2d_numpy_true();
     test_all_operation_2d_numpy_false();
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_all_operation_3d();
+    test_all_operation_3d_true();
+    test_all_operation_3d_double();
+    test_all_operation_3d_double_true();
+    test_all_operation_3d_double_numpy_false();
+    test_all_operation_3d_double_numpy_true();
+    test_all_operation_3d_numpy_true();
+    test_all_operation_3d_numpy_false();
+#endif
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/statistics/any_operation.cpp
+++ b/tests/unit/plugins/statistics/any_operation.cpp
@@ -392,6 +392,158 @@ void test_any_operation_2d_double_numpy_true()
     HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
 }
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_any_operation_3d()
+{
+    blaze::Rand<blaze::DynamicTensor<int>> gen{};
+    blaze::DynamicTensor<std::uint8_t> m =
+        gen.generate(10UL, 101UL, 101UL, 0, 1);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(m.nonZeros() != 0,
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_any_operation_3d_false()
+{
+    blaze::DynamicTensor<std::uint8_t> m(10UL, 101UL, 101UL, 0);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_any_operation_3d_double()
+{
+    blaze::Rand<blaze::DynamicTensor<int>> gen{};
+    blaze::DynamicTensor<double> m = gen.generate(10UL, 101UL, 101UL, 0, 1);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(m.nonZeros() != 0,
+        phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_any_operation_3d_double_false()
+{
+    blaze::DynamicTensor<double> m(10UL, 101UL, 101UL, 0.0);
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_any_operation_3d_numpy_false()
+{
+    blaze::DynamicTensor<double> m{
+        {{false, false, false}, {false, false, false}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_any_operation_3d_numpy_true()
+{
+    blaze::DynamicTensor<double> m{{{true, false, true}, {false, true, true}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_any_operation_3d_double_numpy_false()
+{
+    blaze::DynamicTensor<double> m{{{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(0, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+
+void test_any_operation_3d_double_numpy_true()
+{
+    blaze::DynamicTensor<double> m{{{1.0, 0.0, 3.0}, {0.0, 1.0, 6.0}}};
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(m));
+
+    phylanx::execution_tree::primitive any =
+        phylanx::execution_tree::primitives::create_any_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg1)});
+
+    phylanx::execution_tree::primitive_argument_type f = any.eval().get();
+
+    HPX_TEST_EQ(1, phylanx::execution_tree::extract_scalar_boolean_value(f));
+}
+#endif
+
 int main(int argc, char* argv[])
 {
     test_any_operation_0d_true();
@@ -417,5 +569,15 @@ int main(int argc, char* argv[])
     test_any_operation_2d_double_numpy_false();
     test_any_operation_2d_double_numpy_true();
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_any_operation_3d();
+    test_any_operation_3d_false();
+    test_any_operation_3d_double();
+    test_any_operation_3d_double_false();
+    test_any_operation_3d_numpy_false();
+    test_any_operation_3d_numpy_true();
+    test_any_operation_3d_double_numpy_false();
+    test_any_operation_3d_double_numpy_true();
+#endif
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/statistics/max_operation.cpp
+++ b/tests/unit/plugins/statistics/max_operation.cpp
@@ -76,11 +76,53 @@ int main(int argc, char* argv[])
         "amax([[13., 42., 33.],[101, 12, 65]],  1)", "hstack(42., 101.)");
     test_max_operation(
         "amax([[13., 42., 33.],[101, 12, 65]], -1)", "hstack(42., 101.)");
+    test_max_operation("amax([[13., 42., 33.],[101, 12, 65]],  make_list(-1, 0))",
+                       "101.");
     test_max_operation("amax([[13., 42., 33.],[101, 12, 65]],  0, true)",
         "vstack(hstack(101. ,42., 65.))");
     test_max_operation("amax([[13., 42., 33.],[101, 12, 65]],  1, true)",
         "vstack(hstack(42.), hstack(101.))");
+    test_max_operation(
+        "amax([[13., 42., 33.],[101., 12., 65.]],  make_list(0), true)",
+        "vstack(hstack(101. ,42., 65.))");
+    test_max_operation(
+        "amax([[13., 42., 33.],[101., 12., 65.]],  make_list(-1, 0), true)",
+        "vstack(hstack(101.))");
     test_2d_keep_dims_true();
-
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]])", "101.");
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]], 0)",
+        "vstack(hstack(13., 42., 33.), hstack(101., 12., 65.))");
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]], 1)",
+        "vstack(hstack(101., 42., 65.))");
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]], 2)",
+        "vstack(hstack(42., 101.))");
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]], -1)",
+        "vstack(hstack(42., 101.))");
+    test_max_operation(
+        "amax([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1))",
+        "hstack(42., 101.)");
+    test_max_operation(
+        "amax([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1, 1))",
+        "101.");
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]], 0, true)",
+        "[[[13., 42., 33.], [101., 12., 65.]]]");
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]], 1, true)",
+        "[[[101., 42., 65.]]]");
+    test_max_operation("amax([[[13., 42., 33.],[101., 12., 65.]]], -1, true)",
+        "[[[42.], [101.]]]");
+    test_max_operation(
+        "amax([[[13., 42., 33.],[101., 12., 65.]]], make_list(1, -1), true)",
+        "[[[101.]]]");
+    test_max_operation(
+        "amax([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1), true)",
+        "[[[42.], [101.]]]");
+    test_max_operation(
+        "amax([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, 1), true)",
+        "[[[101., 42., 65.]]]");
+    test_max_operation(
+        "amax([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1, 1), true)",
+        "[[[101.]]]");
+#endif
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/statistics/mean_operation.cpp
+++ b/tests/unit/plugins/statistics/mean_operation.cpp
@@ -135,6 +135,122 @@ void test_mean_operation_2d_y_axis()
     HPX_TEST_EQ(expected, actual);
 }
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_mean_operation_3d_flat()
+{
+    blaze::DynamicTensor<double> tensor_1{{{1.0, 5.0, 6.0}, {4.0, 5.0, 6.0}},
+        {{-2.0, 3.0, 8.0}, {2.0, -3.0, 4.0}}};
+
+    double expected = 3.25;
+
+    phylanx::execution_tree::primitive first =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(tensor_1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_mean_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(first)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_mean_operation_3d_x_axis()
+{
+    using arg_type = phylanx::execution_tree::primitive_argument_type;
+
+    blaze::DynamicTensor<double> tensor_1{{{1.0, 5.0, 6.0}, {4.0, 5.0, 6.0}},
+        {{-2.0, 3.0, 8.0}, {2.0, -3.0, 4.0}}};
+
+    phylanx::ir::node_data<double> expected(
+        blaze::DynamicMatrix<double>{{-0.5, 4.0, 7.0}, {3.0, 1.0, 5.0}});
+
+    phylanx::execution_tree::primitive first =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(tensor_1));
+
+    phylanx::execution_tree::primitive second =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(0));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_mean_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(first), std::move(second)});
+
+    hpx::future<arg_type> f = p.eval();
+
+    auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
+
+    HPX_TEST_EQ(expected, actual);
+}
+
+void test_mean_operation_3d_y_axis()
+{
+    using arg_type = phylanx::execution_tree::primitive_argument_type;
+    blaze::DynamicTensor<double> tensor_1{{{1.0, 5.0, 6.0}, {4.0, 5.0, 6.0}},
+        {{-2.0, 3.0, 8.0}, {2.0, -3.0, 4.0}}};
+
+    phylanx::ir::node_data<double> expected(
+        blaze::DynamicMatrix<double>{{2.5, 5., 6.}, {0., 0., 6.}});
+
+    phylanx::execution_tree::primitive first =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(tensor_1));
+
+    phylanx::execution_tree::primitive second =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(1));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_mean_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(first), std::move(second)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
+
+    auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
+
+    HPX_TEST_EQ(expected, actual);
+}
+
+void test_mean_operation_3d_z_axis()
+{
+    using arg_type = phylanx::execution_tree::primitive_argument_type;
+    blaze::DynamicTensor<double> tensor_1{{{1.0, 5.0, 6.0}, {4.0, 5.0, 6.0}},
+        {{-2.0, 3.0, 8.0}, {2.0, -3.0, 4.0}}};
+
+    phylanx::ir::node_data<double> expected(
+        blaze::DynamicMatrix<double>{{4., 5.}, {3., 1.}});
+
+    phylanx::execution_tree::primitive first =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(tensor_1));
+
+    phylanx::execution_tree::primitive second =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(2));
+
+    phylanx::execution_tree::primitive p =
+        phylanx::execution_tree::primitives::create_mean_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(first), std::move(second)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f = p.eval();
+
+    auto actual = phylanx::execution_tree::extract_numeric_value(f.get());
+
+    HPX_TEST_EQ(expected, actual);
+}
+#endif
+
 int main(int argc, char* argv[])
 {
     test_mean_operation_0d();
@@ -142,6 +258,11 @@ int main(int argc, char* argv[])
     test_mean_operation_2d_flat();
     test_mean_operation_2d_x_axis();
     test_mean_operation_2d_y_axis();
-
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_mean_operation_3d_flat();
+    test_mean_operation_3d_x_axis();
+    test_mean_operation_3d_y_axis();
+    test_mean_operation_3d_z_axis();
+#endif
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/statistics/min_operation.cpp
+++ b/tests/unit/plugins/statistics/min_operation.cpp
@@ -81,6 +81,48 @@ int main(int argc, char* argv[])
     test_min_operation("amin([[13., 42., 33.],[101., 12., 65.]],  1, true)",
         "vstack(hstack(13.), hstack(12.))");
     test_2d_keep_dims_true();
-
+    test_min_operation(
+        "amin([[13., 42., 33.],[101., 12., 65.]],  make_list(0), true)",
+        "vstack(hstack(13. ,12., 33.))");
+    test_min_operation(
+        "amin([[13., 42., 33.],[101., 12., 65.]],  make_list(-1, 0), true)",
+        "vstack(hstack(12.))");
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]])", "12.");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], 0)",
+        "vstack(hstack(13., 42., 33.), hstack(101., 12., 65.))");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], 1)",
+        "vstack(hstack(13., 12., 33.))");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], -2)",
+        "vstack(hstack(13., 12., 33.))");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], 2)",
+        "vstack(hstack(13., 12.))");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], -1)",
+        "vstack(hstack(13., 12.))");
+    test_min_operation(
+        "amin([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1))",
+        "hstack(13., 12.)");
+    test_min_operation(
+        "amin([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1, 1))",
+        "12.");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], 0, true)",
+        "[[[13., 42., 33.], [101., 12., 65.]]]");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], 1, true)",
+        "[[[13., 12., 33.]]]");
+    test_min_operation("amin([[[13., 42., 33.],[101., 12., 65.]]], -1, true)",
+        "[[[13.], [12.]]]");
+    test_min_operation(
+        "amin([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1), true)",
+        "[[[13.], [12.]]]");
+    test_min_operation(
+        "amin([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, 1), true)",
+        "[[[13., 12., 33.]]]");
+    test_min_operation(
+        "amin([[[13., 42., 33.],[101., 12., 65.]]], make_list(1, -1), true)",
+        "[[[12.]]]");
+    test_min_operation(
+        "amin([[[13., 42., 33.],[101., 12., 65.]]], make_list(0, -1, 1), true)",
+        "[[[12.]]]");
+#endif
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/statistics/sum_operation.cpp
+++ b/tests/unit/plugins/statistics/sum_operation.cpp
@@ -297,6 +297,166 @@ void test_2d_keep_dims_false()
         phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_3d()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}}, {{13., 42.}}, {{54., 54.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg0)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    double expected = 178.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis0()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}}, {{13., 42.}}, {{54., 54.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(0));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicMatrix<double> expected{{73., 105.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis1()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}}, {{13., 42.}}, {{54., 54.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicMatrix<double> expected{{6., 9.}, {13., 42.}, {54., 54.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_axis2()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}}, {{13., 42.}}, {{54., 54.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(2));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicMatrix<double> expected{{15.}, {55.}, {108.}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_keep_dims_true()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}}, {{13., 42.}}, {{54., 54.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(true));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    blaze::DynamicTensor<double> expected{{{178.}}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+
+void test_3d_keep_dims_false()
+{
+    blaze::DynamicTensor<double> subject{
+        {{6., 9.}}, {{13., 42.}}, {{54., 54.}}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+    phylanx::execution_tree::primitive arg2 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(false));
+
+    phylanx::execution_tree::primitive sum =
+        phylanx::execution_tree::primitives::create_sum_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1), std::move(arg2)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        sum.eval();
+
+    double expected = 178.;
+
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get()));
+}
+#endif
+
 int main(int argc, char* argv[])
 {
     test_0d();
@@ -308,6 +468,13 @@ int main(int argc, char* argv[])
     test_2d_axis1();
     test_2d_keep_dims_true();
     test_2d_keep_dims_false();
-
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_3d();
+    test_3d_axis0();
+    test_3d_axis1();
+    test_3d_axis2();
+    test_3d_keep_dims_true();
+    test_3d_keep_dims_false();
+#endif
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
This PR addresses issue #835. 