### PR TITLE
Adding support to execution_tree.var() to expose the numpy dtype of the value it holds

### DIFF
--- a/phylanx/execution_tree/primitives/primitive_argument_type.hpp
+++ b/phylanx/execution_tree/primitives/primitive_argument_type.hpp
@@ -356,6 +356,19 @@ namespace phylanx { namespace execution_tree
 
     struct primitive_argument_type : argument_value_type
     {
+        enum variant_index
+        {
+            nil_index = 0,
+            bool_index = 1,
+            int64_index = 2,
+            string_index = 3,
+            float64_index = 4,
+            primitive_index = 5,
+            expression_index = 6,
+            list_index = 7,
+            dictionary_index = 8
+        };
+
         primitive_argument_type() = default;
 
         primitive_argument_type(ast::nil val)

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -23,7 +23,7 @@ mapped_methods = {
     "multiply": "__mul",
     "negative": "__minus",
     "print": "cout",
-    "subtract": "__sub",
+    "subtract": "__sub"
 }
 
 numpy_constants = {

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017 Hartmut Kaiser
+//  Copyright (c) 2017-2019 Hartmut Kaiser
 //  Copyright (c) 2018 R. Tohid
 //  Copyright (c) 2018 Steven R. Brandt
 //
@@ -10,6 +10,7 @@
 
 #include <phylanx/phylanx.hpp>
 
+#include <pybind11/numpy.h>
 #include <pybind11/pybind11.h>
 
 #include <hpx/runtime/threads/run_as_hpx_thread.hpp>
@@ -206,6 +207,9 @@ namespace phylanx { namespace bindings
     // retrieve tree topology in Newick format for given expression
     std::string retrieve_newick_tree_topology(std::string const& file_name,
         std::string const& xexpr_str, compiler_state& c);
+
+    // extract the dtype of the given variable/expression
+    pybind11::dtype extract_dtype(phylanx::execution_tree::primitive const& p);
 }}
 
 #endif

--- a/tests/unit/python/execution_tree/eval.py
+++ b/tests/unit/python/execution_tree/eval.py
@@ -6,7 +6,7 @@
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 import phylanx
-from phylanx import Phylanx, PhylanxSession
+from phylanx import Phylanx, PhylanxSession, execution_tree
 import numpy as np
 
 PhylanxSession.init(1)
@@ -236,50 +236,31 @@ assert np.all(np.sign(v) == do_sign(v))
 assert np.all(np.square(v) == do_square(v))
 
 
-def phytype():
-    pass
+def phytype(x):
+    return execution_tree.var(x).dtype
 
 
-def phyname():
-    pass
-
-
-@Phylanx
 def get_types():
     return [
         phytype(None),
         phytype(0),
         phytype(1.0),
         phytype("x"),
+        phytype(np.array([True, False])),
         phytype(np.array([1, 2])),
         phytype(np.array([1.0, 2.0])),
         phytype([1.0, "x"]),
         phytype({"x": 1})]
 
 
-assert get_types() == [0, 2, 4, 3, 2, 4, 7, 8]
-
-
-@Phylanx
-def get_names():
-    return [
-        phyname(None),
-        phyname(0),
-        phyname(1.0),
-        phyname("x"),
-        phyname(np.array([1, 2])),
-        phyname(np.array([1.0, 2.0])),
-        phyname([1.0, "x"]),
-        phyname({"x": 1})]
-
-
-assert get_names() == [
-    'phylanx::ast::nil',
-    'phylanx::ir::node_data<std::int64_t>',
-    'phylanx::ir::node_data<double>',
-    'std::string',
-    'phylanx::ir::node_data<std::int64_t>',
-    'phylanx::ir::node_data<double>',
-    'phylanx::ir::range',
-    'phylanx::ir::dictionary'
-]
+types = get_types()
+assert types == [
+    np.dtype('O'),
+    np.dtype('int64'),
+    np.dtype('float64'),
+    np.dtype('S'),
+    np.dtype('int8'),
+    np.dtype('int64'),
+    np.dtype('float64'),
+    np.dtype('O'),
+    np.dtype('O')], types


### PR DESCRIPTION
- flyby: streamline (internal) __type() and __name() primitives

Working towards #684