### PR TITLE
Fixing internal type the statistics primitives operate on

### DIFF
--- a/phylanx/plugins/statistics/statistics_base.hpp
+++ b/phylanx/plugins/statistics/statistics_base.hpp
@@ -60,28 +60,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& codename);
 
     private:
-        template <typename T>
+        template <typename T, typename Init>
         primitive_argument_type statistics0d(arg_type<T>&& arg,
             hpx::util::optional<std::int64_t> const& axis,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
-        template <typename T>
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
+        template <typename T, typename Init>
         primitive_argument_type statistics1d(arg_type<T>&& arg,
             hpx::util::optional<std::int64_t> const& axis,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
-        template <typename T>
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
+        template <typename T, typename Init>
         primitive_argument_type statistics2d(arg_type<T>&& arg,
             hpx::util::optional<std::int64_t> const& axis,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
 
-        template <typename T>
+        template <typename T, typename Init>
         primitive_argument_type statistics2d_flat(arg_type<T>&& arg,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
-        template <typename T>
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
+        template <typename T, typename Init>
         primitive_argument_type statistics2d_axis0(arg_type<T>&& arg,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
-        template <typename T>
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
+        template <typename T, typename Init>
         primitive_argument_type statistics2d_axis1(arg_type<T>&& arg,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
 
         template <typename T>
         primitive_argument_type statisticsnd(arg_type<T>&& arg,
@@ -89,23 +89,23 @@ namespace phylanx { namespace execution_tree { namespace primitives
             bool keepdims, primitive_argument_type&& initial) const;
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
-        template <typename T>
+        template <typename T, typename Init>
         primitive_argument_type statistics3d(arg_type<T>&& arg,
             hpx::util::optional<std::int64_t> const& axis,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
 
-        template <typename T>
+        template <typename T, typename Init>
         primitive_argument_type statistics3d_flat(arg_type<T>&& arg,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
-        template <typename T>
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
+        template <typename T, typename Init>
         primitive_argument_type statistics3d_axis0(arg_type<T>&& arg,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
-        template <typename T>
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
+        template <typename T, typename Init>
         primitive_argument_type statistics3d_axis1(arg_type<T>&& arg,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
-        template <typename T>
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
+        template <typename T, typename Init>
         primitive_argument_type statistics3d_axis2(arg_type<T>&& arg,
-            bool keepdims, hpx::util::optional<T> const& initial) const;
+            bool keepdims, hpx::util::optional<Init> const& initial) const;
 #endif
 
         primitive_argument_type statisticsnd(primitive_argument_type&& arg,

--- a/phylanx/plugins/statistics/statistics_base_impl.hpp
+++ b/phylanx/plugins/statistics/statistics_base_impl.hpp
@@ -46,10 +46,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics0d(
         arg_type<T>&& arg, hpx::util::optional<std::int64_t> const& axis,
-        bool keepdims, hpx::util::optional<T> const& initial) const
+        bool keepdims, hpx::util::optional<Init> const& initial) const
     {
         if (axis && axis.value() != 0 && axis.value() != -1)
         {
@@ -62,7 +62,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         Op<T> op{name_, codename_};
 
-        T initial_value = Op<T>::initial();
+        Init initial_value = Op<T>::initial();
         if (initial)
         {
             initial_value = *initial;
@@ -74,10 +74,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics1d(
         arg_type<T>&& arg, hpx::util::optional<std::int64_t> const& axis,
-        bool keepdims, hpx::util::optional<T> const& initial) const
+        bool keepdims, hpx::util::optional<Init> const& initial) const
     {
         if (axis && axis.value() != 0 && axis.value() != -1)
         {
@@ -91,7 +91,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         Op<T> op{name_, codename_};
 
-        T initial_value = Op<T>::initial();
+        Init initial_value = Op<T>::initial();
         if (initial)
         {
             initial_value = *initial;
@@ -111,17 +111,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     ///////////////////////////////////////////////////////////////////////////
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics2d_flat(
         arg_type<T>&& arg, bool keepdims,
-        hpx::util::optional<T> const& initial) const
+        hpx::util::optional<Init> const& initial) const
     {
         auto m = arg.matrix();
 
         Op<T> op{name_, codename_};
         std::size_t size = 0;
 
-        T result = Op<T>::initial();
+        Init result = Op<T>::initial();
         if (initial)
         {
             result = *initial;
@@ -144,14 +144,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics2d_axis0(
         arg_type<T>&& arg, bool keepdims,
-        hpx::util::optional<T> const& initial) const
+        hpx::util::optional<Init> const& initial) const
     {
         auto m = arg.matrix();
 
-        T initial_value = Op<T>::initial();
+        Init initial_value = Op<T>::initial();
         if (initial)
         {
             initial_value = *initial;
@@ -182,14 +182,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics2d_axis1(
         arg_type<T>&& arg, bool keepdims,
-        hpx::util::optional<T> const& initial) const
+        hpx::util::optional<Init> const& initial) const
     {
         auto m = arg.matrix();
 
-        T initial_value = Op<T>::initial();
+        Init initial_value = Op<T>::initial();
         if (initial)
         {
             initial_value = *initial;
@@ -220,10 +220,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics2d(
         arg_type<T>&& arg, hpx::util::optional<std::int64_t> const& axis,
-        bool keepdims, hpx::util::optional<T> const& initial) const
+        bool keepdims, hpx::util::optional<Init> const& initial) const
     {
         if (axis)
         {
@@ -251,10 +251,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics3d_flat(
         arg_type<T>&& arg, bool keepdims,
-        hpx::util::optional<T> const& initial) const
+        hpx::util::optional<Init> const& initial) const
     {
         auto t = arg.tensor();
 
@@ -262,7 +262,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         std::size_t size = 0;
 
-        T result = Op<T>::initial();
+        Init result = Op<T>::initial();
         if (initial)
         {
             result = *initial;
@@ -289,14 +289,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics3d_axis0(
         arg_type<T>&& arg, bool keepdims,
-        hpx::util::optional<T> const& initial) const
+        hpx::util::optional<Init> const& initial) const
     {
         auto t = arg.tensor();
 
-        T initial_value = Op<T>::initial();
+        Init initial_value = Op<T>::initial();
         if (initial)
         {
             initial_value = *initial;
@@ -336,14 +336,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics3d_axis1(
         arg_type<T>&& arg, bool keepdims,
-        hpx::util::optional<T> const& initial) const
+        hpx::util::optional<Init> const& initial) const
     {
         auto t = arg.tensor();
 
-        T initial_value = Op<T>::initial();
+        Init initial_value = Op<T>::initial();
         if (initial)
         {
             initial_value = *initial;
@@ -383,14 +383,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics3d_axis2(
         arg_type<T>&& arg, bool keepdims,
-        hpx::util::optional<T> const& initial) const
+        hpx::util::optional<Init> const& initial) const
     {
         auto t = arg.tensor();
 
-        T initial_value = Op<T>::initial();
+        Init initial_value = Op<T>::initial();
         if (initial)
         {
             initial_value = *initial;
@@ -430,10 +430,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     template <template <class T> class Op, typename Derived>
-    template <typename T>
+    template <typename T, typename Init>
     primitive_argument_type statistics<Op, Derived>::statistics3d(
         arg_type<T>&& arg, hpx::util::optional<std::int64_t> const& axis,
-        bool keepdims, hpx::util::optional<T> const& initial) const
+        bool keepdims, hpx::util::optional<Init> const& initial) const
     {
         if (axis)
         {
@@ -470,7 +470,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         arg_type<T>&& arg, hpx::util::optional<std::int64_t> const& axis,
         bool keepdims, primitive_argument_type&& initial) const
     {
-        hpx::util::optional<T> initial_value;
+        using initial_type = typename Op<T>::result_type;
+
+        hpx::util::optional<initial_type> initial_value;
         if (valid(initial))
         {
             initial_value =

--- a/src/plugins/statistics/all_operation.cpp
+++ b/src/plugins/statistics/all_operation.cpp
@@ -31,6 +31,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_all_op
         {
+            using result_type = bool;
+
             statistics_all_op(std::string const& name,
                 std::string const& codename)
             {}

--- a/src/plugins/statistics/any_operation.cpp
+++ b/src/plugins/statistics/any_operation.cpp
@@ -31,6 +31,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_any_op
         {
+            using result_type = bool;
+
             statistics_any_op(std::string const& name,
                 std::string const& codename)
             {}

--- a/src/plugins/statistics/logsumexp_operation.cpp
+++ b/src/plugins/statistics/logsumexp_operation.cpp
@@ -32,30 +32,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_logsumexp_op
         {
+            using result_type = double;
+
             statistics_logsumexp_op(std::string const& name,
                 std::string const& codename)
             {}
 
-            static constexpr T initial()
+            static constexpr double initial()
             {
-                return T(0);
+                return 0.0;
             }
 
             template <typename Scalar>
-            typename std::enable_if<traits::is_scalar<Scalar>::value, T>::type
-            operator()(Scalar s, T initial) const
+            typename std::enable_if<traits::is_scalar<Scalar>::value,
+                double>::type
+            operator()(Scalar s, double initial) const
             {
                 return s;
             }
 
             template <typename Vector>
-            typename std::enable_if<!traits::is_scalar<Vector>::value, T>::type
-            operator()(Vector const& v, T initial) const
+            typename std::enable_if<!traits::is_scalar<Vector>::value,
+                double>::type
+            operator()(Vector const& v, double initial) const
             {
                 return blaze::sum(blaze::exp(v)) + initial;
             }
 
-            static T finalize(T value, std::size_t size)
+            static double finalize(double value, std::size_t size)
             {
                 return blaze::log(value);
             }

--- a/src/plugins/statistics/max_operation.cpp
+++ b/src/plugins/statistics/max_operation.cpp
@@ -33,6 +33,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_max_op
         {
+            using result_type = T;
+
             statistics_max_op(std::string const& name,
                 std::string const& codename)
             {}

--- a/src/plugins/statistics/mean_operation.cpp
+++ b/src/plugins/statistics/mean_operation.cpp
@@ -29,32 +29,34 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_mean_op
         {
+            using result_type = double;
+
             statistics_mean_op(std::string const& name,
                     std::string const& codename)
               : name_(name), codename_(codename)
             {
             }
 
-            static constexpr T initial()
+            static constexpr double initial()
             {
-                return T(0);
+                return 0.0;
             }
 
             template <typename Scalar>
             typename std::enable_if<traits::is_scalar<Scalar>::value, T>::type
-            operator()(Scalar s, T initial) const
+            operator()(Scalar s, double initial) const
             {
                 return s + initial;
             }
 
             template <typename Vector>
             typename std::enable_if<!traits::is_scalar<Vector>::value, T>::type
-            operator()(Vector const& v, T initial) const
+            operator()(Vector const& v, double initial) const
             {
                 return blaze::sum(v) + initial;
             }
 
-            T finalize(T value, std::size_t size) const
+            double finalize(double value, std::size_t size) const
             {
                 if (size == 0)
                 {

--- a/src/plugins/statistics/min_operation.cpp
+++ b/src/plugins/statistics/min_operation.cpp
@@ -31,6 +31,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_min_op
         {
+            using result_type = T;
+
             statistics_min_op(std::string const& name,
                 std::string const& codename)
             {}

--- a/src/plugins/statistics/prod_operation.cpp
+++ b/src/plugins/statistics/prod_operation.cpp
@@ -31,6 +31,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_prod_op
         {
+            using result_type = T;
+
             statistics_prod_op(std::string const& name,
                 std::string const& codename)
             {}

--- a/src/plugins/statistics/std_operation.cpp
+++ b/src/plugins/statistics/std_operation.cpp
@@ -33,39 +33,43 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_std_op
         {
+            using result_type = double;
+
             statistics_std_op(std::string const& name,
                     std::string const& codename)
               : name_(name), codename_(codename)
               , count_(0), mean_(0), m2_(0)
             {}
 
-            static constexpr T initial()
+            static constexpr double initial()
             {
-                return T(0);
+                return 0.0;
             }
 
             // Use Welford's online algorithm, see
             // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-            void process_value(T val)
+            void process_value(double val)
             {
                 ++count_;
-                T delta = val - mean_;
+                double delta = val - mean_;
                 mean_ += delta / count_;
-                T delta2 = val - mean_;
+                double delta2 = val - mean_;
                 m2_ += delta * delta2;
             }
 
             template <typename Scalar>
-            typename std::enable_if<traits::is_scalar<Scalar>::value, T>::type
-            operator()(Scalar s, T initial)
+            typename std::enable_if<traits::is_scalar<Scalar>::value,
+                double>::type
+            operator()(Scalar s, double initial)
             {
                 process_value(s);
                 return initial;
             }
 
             template <typename Vector>
-            typename std::enable_if<!traits::is_scalar<Vector>::value, T>::type
-            operator()(Vector const& v, T initial)
+            typename std::enable_if<!traits::is_scalar<Vector>::value,
+                double>::type
+            operator()(Vector const& v, double initial)
             {
                 for (auto && elem : v)
                 {
@@ -74,7 +78,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 return initial;
             }
 
-            T finalize(T value, std::size_t size) const
+            double finalize(double value, std::size_t size) const
             {
                 HPX_ASSERT(count_ == size);
                 if (size == 0)
@@ -87,7 +91,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
                 if (size == 1)
                 {
-                    return T(0);
+                    return 0.0;
                 }
 
                 return std::sqrt(m2_ / size);
@@ -97,8 +101,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& codename_;
 
             std::size_t count_;
-            T mean_;
-            T m2_;
+            double mean_;
+            double m2_;
         };
     }
 

--- a/src/plugins/statistics/sum_operation.cpp
+++ b/src/plugins/statistics/sum_operation.cpp
@@ -30,6 +30,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_sum_op
         {
+            using result_type = T;
+
             statistics_sum_op(std::string const& name,
                 std::string const& codename)
             {}

--- a/src/plugins/statistics/var_operation.cpp
+++ b/src/plugins/statistics/var_operation.cpp
@@ -32,39 +32,43 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         struct statistics_var_op
         {
+            using result_type = double;
+
             statistics_var_op(std::string const& name,
                     std::string const& codename)
               : name_(name), codename_(codename)
               , count_(0), mean_(0), m2_(0)
             {}
 
-            static constexpr T initial()
+            static constexpr double initial()
             {
-                return T(0);
+                return 0.0;
             }
 
             // Use Welford's online algorithm, see
             // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
-            void process_value(T val)
+            void process_value(double val)
             {
                 ++count_;
-                T delta = val - mean_;
+                double delta = val - mean_;
                 mean_ += delta / count_;
-                T delta2 = val - mean_;
+                double delta2 = val - mean_;
                 m2_ += delta * delta2;
             }
 
             template <typename Scalar>
-            typename std::enable_if<traits::is_scalar<Scalar>::value, T>::type
-            operator()(Scalar s, T initial)
+            typename std::enable_if<traits::is_scalar<Scalar>::value,
+                double>::type
+            operator()(Scalar s, double initial)
             {
                 process_value(s);
                 return initial;
             }
 
             template <typename Vector>
-            typename std::enable_if<!traits::is_scalar<Vector>::value, T>::type
-            operator()(Vector const& v, T initial)
+            typename std::enable_if<!traits::is_scalar<Vector>::value,
+                double>::type
+            operator()(Vector const& v, double initial)
             {
                 for (auto && elem : v)
                 {
@@ -73,7 +77,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 return initial;
             }
 
-            T finalize(T value, std::size_t size) const
+            double finalize(double value, std::size_t size) const
             {
                 HPX_ASSERT(count_ == size);
                 if (size == 0)
@@ -86,7 +90,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
                 if (size == 1)
                 {
-                    return T(0);
+                    return 0.0;
                 }
 
                 return m2_ / size;
@@ -96,8 +100,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& codename_;
 
             std::size_t count_;
-            T mean_;
-            T m2_;
+            double mean_;
+            double m2_;
         };
     }
 

--- a/tests/unit/plugins/statistics/logsumexp_operation.cpp
+++ b/tests/unit/plugins/statistics/logsumexp_operation.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
 {
     // scalars
     test_logsumexp_operation("logsumexp(42.0)", "42.0");
-    test_logsumexp_operation("logsumexp(1)", "1");
+    test_logsumexp_operation("logsumexp(1)", "1.0");
     test_logsumexp_operation("logsumexp__float(1)", "1.0");
 
     // vectors

--- a/tests/unit/plugins/statistics/std_operation.cpp
+++ b/tests/unit/plugins/statistics/std_operation.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[])
 {
     // scalars
     test_count_std_operation("std(1.0)", "0.0");
-    test_count_std_operation("std(1)", "0");
+    test_count_std_operation("std(1)", "0.0");
     test_count_std_operation("std__float(1)", "0.0");
 
     // vectors

--- a/tests/unit/plugins/statistics/var_operation.cpp
+++ b/tests/unit/plugins/statistics/var_operation.cpp
@@ -37,7 +37,7 @@ int main(int argc, char* argv[])
 {
     // scalars
     test_count_var_operation("var(1.0)", "0.0");
-    test_count_var_operation("var(1)", "0");
+    test_count_var_operation("var(1)", "0.0");
     test_count_var_operation("var__float(1)", "0.0");
 
     // vectors


### PR DESCRIPTION
- `mean`, `var`, `std`, and `logsumexp` now operate on doubles,
  `all` and `any` operate on bool; for all others the type is derived
  from the type of the input data

Fixes #859