### PR TITLE
Adding truncated_normal random number distribution

### DIFF
--- a/phylanx/include/util.hpp
+++ b/phylanx/include/util.hpp
@@ -10,10 +10,12 @@
 #include <phylanx/util/hashed_string.hpp>
 #include <phylanx/util/none_manip.hpp>
 #include <phylanx/util/performance_data.hpp>
+#include <phylanx/util/random.hpp>
 #include <phylanx/util/repr_manip.hpp>
 #include <phylanx/util/serialization/ast.hpp>
 #include <phylanx/util/serialization/blaze.hpp>
 #include <phylanx/util/serialization/variant.hpp>
+#include <phylanx/util/truncated_normal_distribution.hpp>
 #include <phylanx/util/variant.hpp>
 
 #endif

--- a/phylanx/plugins/matrixops/random.hpp
+++ b/phylanx/plugins/matrixops/random.hpp
@@ -104,6 +104,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ///     list("normal", mean, stddev): Generates random numbers
         ///             according to the Normal (or Gaussian) random number
         ///             distribution (mean: mean, stddev: standard deviation)\n
+        ///     list("truncated_normal", mean, stddev): Generates random numbers
+        ///             according to the Normal (or Gaussian) random number
+        ///             distribution. Values whose magnitude is more than
+        ///             two standard deviations from the mean are dropped and
+        ///             re-picked (mean: mean, stddev: standard deviation)\n
         ///     list("lognormal", m, s): Produces random numbers according
         ///             to a log-normal distribution (m: log-scale, s: shape)\n
         ///     list("chi_squared", n): Produces random positive

--- a/phylanx/util/truncated_normal_distribution.hpp
+++ b/phylanx/util/truncated_normal_distribution.hpp
@@ -1,0 +1,227 @@
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_TRUNCATED_NORMAL_DISTRIBUTION_MAR_11_2019_0621PM)
+#define PHYLANX_UTIL_TRUNCATED_NORMAL_DISTRIBUTION_MAR_11_2019_0621PM
+
+#include <phylanx/config.hpp>
+
+#include <hpx/util/assert.hpp>
+
+#include <cstddef>
+#include <type_traits>
+
+namespace phylanx { namespace util
+{
+    // A truncated normal has values generated follow a normal distribution with
+    // specified mean and standard deviation, except that values whose magnitude
+    // is more than two standard deviations from the mean are dropped and re-picked.
+    template <typename T = double>
+    class truncated_normal_distribution
+    {
+    public:
+        static_assert(std::is_same<T, float>::value ||
+                std::is_same<T, double>::value ||
+                std::is_same<T, long double>::value,
+            "invalid template argument for truncated_normal_distribution, "
+            "requires one of: float, double, or long double");
+
+        typedef T result_type;
+
+        struct param_type
+        {
+            typedef truncated_normal_distribution distribution_type;
+
+            explicit param_type(T mean = 0.0, T sigma = 1.0)
+              : mean_(mean), sigma_(sigma)
+            {
+                HPX_ASSERT(0.0 < sigma_);
+            }
+
+            // test for equality
+            bool operator==(param_type const& right) const
+            {
+                return mean_ == right.mean_ && sigma_ == right.sigma_;
+            }
+
+            // test for inequality
+            bool operator!=(param_type const& right) const
+            {
+                return !(*this == right);
+            }
+
+            // return mean value
+            T mean() const
+            {
+                return mean_;
+            }
+
+            // return sigma value
+            T sigma() const
+            {
+                return sigma_;
+            }
+
+            // return sigma value
+            T stddev() const
+            {
+                return sigma_;
+            }
+
+            T mean_;
+            T sigma_;
+        };
+
+        explicit truncated_normal_distribution(T mean = 0.0, T sigma = 1.0)
+          : params_(mean, sigma)
+          , value2_(0.0)
+          , value2_valid_(false)
+        {
+        }
+
+        explicit truncated_normal_distribution(param_type const& params)
+          : params_(params)
+          , value2_(0.0)
+          , value2_valid_(false)
+        {
+        }
+
+        // return mean value
+        T mean() const
+        {
+            return params_.mean();
+        }
+
+        // return sigma value
+        T sigma() const
+        {
+            return params_.sigma();
+        }
+
+        // return sigma value
+        T stddev() const
+        {
+            return params_.sigma();
+        }
+
+        // return parameter package
+        param_type param() const
+        {
+            return params_;
+        }
+
+        // set parameter package
+        void param(param_type const& params)
+        {
+            params_ = params;
+            reset();
+        }
+
+        // get smallest possible result
+        result_type (min)() const
+        {
+            return params_.mean_ - 2 * params_.sigma_;
+        }
+
+        // get largest possible result
+        result_type (max)() const
+        {
+            return params_.mean_ + 2 * params_.sigma_;
+        }
+
+        // clear internal state
+        void reset()
+        {
+            value2_valid_ = false;
+        }
+
+        // return next value
+        template <typename Engine>
+        result_type operator()(Engine& eng)
+        {
+            return generate(eng, params_);
+        }
+
+        // return next value, given parameter package
+        template <typename Engine>
+        result_type operator()(Engine& eng, param_type const& params)
+        {
+            reset();
+            return generate(eng, params, true);
+        }
+
+    private:
+        // compute next value, see Knuth, vol. 2, p. 122, algorithm P
+        template <typename Engine>
+        result_type generate(Engine& eng, param_type const& params,
+            bool force = false)
+        {
+            T result;
+            while (true)
+            {
+                if (!force && value2_valid_)
+                {
+                    result = value2_;
+                    value2_valid_ = false;
+                }
+                else
+                {
+                    constexpr std::size_t neg1 = static_cast<std::size_t>(-1);
+
+                    // generate two values, store one, return one
+                    T val1, val2, s;
+                    while (true)
+                    {
+                        // reject bad values
+                        val1 = 2 * std::generate_canonical<T, neg1>(eng) - 1;
+                        val2 = 2 * std::generate_canonical<T, neg1>(eng) - 1;
+                        s = val1 * val1 + val2 * val2;
+                        if (s < 1)
+                            break;
+                    }
+
+                    T const x =
+                        static_cast<T>(std::sqrt(-2.0 * std::log(s) / s));
+
+                    result = x * val1;
+
+                    if (!force)
+                    {    // save second value for next call
+                        value2_ = x * val2;
+                        value2_valid_ = true;
+                    }
+                }
+
+                // exit if number is in valid range
+                if (result >= static_cast<T>(-2) && result <= static_cast<T>(2))
+                    break;
+            }
+
+            return result * params.sigma_ + params.mean_;
+        }
+
+        param_type params_;
+        T value2_;
+        bool value2_valid_;
+    };
+
+    // test for equality
+    template <typename T>
+    bool operator==(truncated_normal_distribution<T> const& lhs,
+        truncated_normal_distribution<T> const& rhs)
+    {
+        return lhs.param() == rhs.param();
+    }
+
+    // test for inequality
+    template <typename T>
+    bool operator!=(truncated_normal_distribution<T> const& lhs,
+        truncated_normal_distribution<T> const& rhs)
+    {
+        return !(lhs == rhs);
+    }
+}}
+
+#endif

--- a/src/plugins/matrixops/random.cpp
+++ b/src/plugins/matrixops/random.cpp
@@ -8,6 +8,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/matrixops/random.hpp>
 #include <phylanx/util/random.hpp>
+#include <phylanx/util/truncated_normal_distribution.hpp>
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
@@ -521,6 +522,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         PHYLANX_RANDOM_DISTRIBUTION_2(
             normal, std::normal_distribution<double>, double, double);
         PHYLANX_RANDOM_DISTRIBUTION_2(
+            truncated_normal, util::truncated_normal_distribution<double>,
+            double, double);
+        PHYLANX_RANDOM_DISTRIBUTION_2(
             lognormal, std::lognormal_distribution<double>, double, double);
         PHYLANX_RANDOM_DISTRIBUTION_1(
             chi_squared, std::chi_squared_distribution<double>, double, double);
@@ -550,6 +554,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             { "weibull", create_weibull },
             { "extreme_value", create_extreme_value },
             { "normal", create_normal },
+            { "truncated_normal", create_truncated_normal },
             { "lognormal", create_lognormal },
             { "chi_squared", create_chi_squared },
             { "cauchy", create_cauchy },

--- a/tests/unit/plugins/matrixops/random_distributions.cpp
+++ b/tests/unit/plugins/matrixops/random_distributions.cpp
@@ -890,6 +890,69 @@ void test_normal_distribution_params(std::mt19937& gen)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+void test_truncated_normal_distribution(std::mt19937& gen)
+{
+    std::string const code = R"(block(
+            define(call, size, random(size, "truncated_normal")),
+            call
+        ))";
+
+    auto call = compile(code);
+
+    {
+        phylanx::util::truncated_normal_distribution<double> dist;
+        generate_0d<double>(call, gen, dist);
+    }
+    {
+        phylanx::util::truncated_normal_distribution<double> dist;
+        generate_1d<double>(call, gen, dist);
+    }
+    {
+        phylanx::util::truncated_normal_distribution<double> dist;
+        generate_2d<double>(call, gen, dist);
+    }
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    {
+        phylanx::util::truncated_normal_distribution<double> dist;
+        generate_3d<double>(call, gen, dist);
+    }
+#endif
+}
+
+void test_truncated_normal_distribution_params(std::mt19937& gen)
+{
+    using namespace phylanx::execution_tree::primitives;
+
+    std::string const code = R"(block(
+            define(call, size,
+                random(size, list("truncated_normal", 0.8, 1.2))
+            ),
+            call
+        ))";
+
+    auto call = compile(code);
+
+    {
+        phylanx::util::truncated_normal_distribution<double> dist{0.8, 1.2};
+        generate_0d<double>(call, gen, dist);
+    }
+    {
+        phylanx::util::truncated_normal_distribution<double> dist{0.8, 1.2};
+        generate_1d<double>(call, gen, dist);
+    }
+    {
+        phylanx::util::truncated_normal_distribution<double> dist{0.8, 1.2};
+        generate_2d<double>(call, gen, dist);
+    }
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    {
+        phylanx::util::truncated_normal_distribution<double> dist{0.8, 1.2};
+        generate_3d<double>(call, gen, dist);
+    }
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////////////
 void test_lognormal_distribution(std::mt19937& gen)
 {
     std::string const code = R"(block(
@@ -1231,6 +1294,9 @@ int main(int argc, char* argv[])
 
     test_normal_distribution(gen);
     test_normal_distribution_params(gen);
+
+    test_truncated_normal_distribution(gen);
+    test_truncated_normal_distribution_params(gen);
 
     test_lognormal_distribution(gen);
     test_lognormal_distribution_params(gen);


### PR DESCRIPTION
Fixes #864

This enables to write:
```
@Phylanx
def truncated_normal(shape, mean=0.0, stddev=1.0, dtype=None, seed=None):
    if not seed is None:
        set_seed(seed)
    return random(shape, ["truncated_normal", mean, stddev])
```
The `dtype` is currently not supported by the `random` primitive. We should add that once we have found a way to support named arguments.
