### PR TITLE
Modifying hard_sigmoid

### DIFF
--- a/src/plugins/keras_support/hard_sigmoid_operation.cpp
+++ b/src/plugins/keras_support/hard_sigmoid_operation.cpp
@@ -117,8 +117,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto ones = detail::make_uniform(1.0, v);
         auto zeros = detail::make_uniform(0.0, v);
-        auto fifth = detail::make_uniform(0.5, v);
-        auto halfs = detail::make_uniform(0.2, v);
+        auto fifth = detail::make_uniform(0.2, v);
+        auto halfs = detail::make_uniform(0.5, v);
 
         if (!arg.is_ref())
         {
@@ -139,8 +139,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto ones = detail::make_uniform(1.0, m);
         auto zeros = detail::make_uniform(0.0, m);
-        auto fifth = detail::make_uniform(0.5, m);
-        auto halfs = detail::make_uniform(0.2, m);
+        auto fifth = detail::make_uniform(0.2, m);
+        auto halfs = detail::make_uniform(0.5, m);
 
         if (!arg.is_ref())
         {
@@ -162,8 +162,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         auto ones = detail::make_uniform(1.0, t);
         auto zeros = detail::make_uniform(0.0, t);
-        auto fifth = detail::make_uniform(0.5, t);
-        auto halfs = detail::make_uniform(0.2, t);
+        auto fifth = detail::make_uniform(0.2, t);
+        auto halfs = detail::make_uniform(0.5, t);
 
         if (!arg.is_ref())
         {

--- a/tests/unit/plugins/keras_support/hard_sigmoid_operation.cpp
+++ b/tests/unit/plugins/keras_support/hard_sigmoid_operation.cpp
@@ -52,7 +52,7 @@ void test_hard_sigmoid_operation_1d()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         hard_sigmoid.eval();
 
-    blaze::DynamicVector<double> expected{0.7, 1., 1.};
+    blaze::DynamicVector<double> expected{0.7, 0.9, 1.};
 
     auto result = phylanx::execution_tree::extract_numeric_value(f.get());
     HPX_TEST(
@@ -76,7 +76,7 @@ void test_hard_sigmoid_operation_2d()
         hard_sigmoid.eval();
 
     blaze::DynamicMatrix<double> expected{
-        {0.7, 1., 1.}, {1., 0.7, 1.}, {1., 1., 0.7}};
+        {0.7, 0.9, 1.}, {1., 0.7, 0.9}, {1., 1., 0.7}};
 
     auto result = phylanx::execution_tree::extract_numeric_value(f.get());
     HPX_TEST(
@@ -103,8 +103,8 @@ void test_hard_sigmoid_operation_3d()
         hard_sigmoid.eval();
 
     blaze::DynamicTensor<double> expected{
-        {{0.7, 1., 1.}, {1., 0.7, 1.}, {1., 1., 0.7}},
-        {{1., 1., 1.}, {0., 1., 0.2}, {0.7, 0.7, 1.}}};
+        {{0.7, .9, 1.}, {1., 0.7, 0.9}, {1., 1., 0.7}},
+        {{1., 1., 0.9}, {0.1, 0.9, 0.5}, {0.7, 0.7, 1.}}};
 
     auto result = phylanx::execution_tree::extract_numeric_value(f.get());
     HPX_TEST(


### PR DESCRIPTION
I modified the values of fifths and halves. Tests are also modified according to 
```py
def hard_sigmoid(x):
    y = 0.2 * x + 0.5
    return np.clip(y, 0, 1)
```