### PR TITLE
Adding l2_normalize operation

### DIFF
--- a/phylanx/plugins/keras_support/keras_support.hpp
+++ b/phylanx/plugins/keras_support/keras_support.hpp
@@ -9,6 +9,7 @@
 #include <phylanx/plugins/keras_support/batch_dot_operation.hpp>
 #include <phylanx/plugins/keras_support/elu_operation.hpp>
 #include <phylanx/plugins/keras_support/hard_sigmoid_operation.hpp>
+#include <phylanx/plugins/keras_support/l2_normalize_operation.hpp>
 #include <phylanx/plugins/keras_support/one_hot_operation.hpp>
 #include <phylanx/plugins/keras_support/sigmoid_operation.hpp>
 #include <phylanx/plugins/keras_support/softmax_operation.hpp>

--- a/phylanx/plugins/keras_support/l2_normalize_operation.hpp
+++ b/phylanx/plugins/keras_support/l2_normalize_operation.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PLUGINS_KERAS_SUPPORT_L2_NORMALIZE_OPERATION)
+#define PHYLANX_PLUGINS_KERAS_SUPPORT_L2_NORMALIZE_OPERATION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx {  namespace execution_tree {  namespace primitives  {
+
+    class l2_normalize_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<l2_normalize_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+        using val_type = double;
+        using arg_type = ir::node_data<val_type>;
+
+    public:
+        static match_pattern_type const match_data;
+
+        l2_normalize_operation() = default;
+
+        l2_normalize_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    private:
+        primitive_argument_type l2_normalize0d() const;
+
+        primitive_argument_type l2_normalize1d(arg_type&& arg) const;
+
+        primitive_argument_type l2_normalize2d_axis0(arg_type&& arg) const;
+        primitive_argument_type l2_normalize2d_axis1(arg_type&& arg) const;
+        primitive_argument_type l2_normalize2d_flatten(arg_type&& arg) const;
+        primitive_argument_type l2_normalize2d(
+            arg_type&& arg, std::int64_t axis) const;
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+        primitive_argument_type l2_normalize3d_axis0(arg_type&& arg) const;
+        primitive_argument_type l2_normalize3d_axis1(arg_type&& arg) const;
+        primitive_argument_type l2_normalize3d_axis2(arg_type&& arg) const;
+        primitive_argument_type l2_normalize3d_flatten(arg_type&& arg) const;
+        primitive_argument_type l2_normalize3d(
+            arg_type&& arg, std::int64_t axis) const;
+#endif
+    };
+    inline primitive create_l2_normalize_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "l2_normalize", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/keras_support/l2_normalize_operation.hpp
+++ b/phylanx/plugins/keras_support/l2_normalize_operation.hpp
@@ -21,6 +21,13 @@
 #include <vector>
 
 namespace phylanx {  namespace execution_tree {  namespace primitives  {
+/// \brief Returns an array of the same shape which is l2 normalized
+///
+/// \param a      The scalar, vector, matrix, or tensor to perform l2
+///               normalization over
+/// \param axis   Optional. The default is None (normalizing over the whole
+///               array).
+/// Immitates the functionality of https://keras.io/backend/#l2_normalize
 
     class l2_normalize_operation
         : public primitive_component_base

--- a/src/plugins/keras_support/keras_support.cpp
+++ b/src/plugins/keras_support/keras_support.cpp
@@ -17,6 +17,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(elu_operation_plugin,
     phylanx::execution_tree::primitives::elu_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(hard_sigmoid_operation_plugin,
     phylanx::execution_tree::primitives::hard_sigmoid_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(l2_normalize_operation_plugin,
+    phylanx::execution_tree::primitives::l2_normalize_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(one_hot_operation_plugin,
     phylanx::execution_tree::primitives::one_hot_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(sigmoid_operation_plugin,

--- a/src/plugins/keras_support/l2_normalize_operation.cpp
+++ b/src/plugins/keras_support/l2_normalize_operation.cpp
@@ -1,0 +1,395 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/keras_support/l2_normalize_operation.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <blaze_tensor/Math.h>
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const l2_normalize_operation::match_data =
+    {
+        hpx::util::make_tuple("l2_normalize",
+        std::vector<std::string>{"l2_normalize(_1)","l2_normalize(_1,_2)"},
+        &create_l2_normalize_operation, &create_primitive<l2_normalize_operation>,
+        R"(a, axis
+        Args:
+
+            a (array_like) : input array
+            axis (optional, integer): axis along which to perform normalization
+                The default value is None.
+
+        Returns:
+
+        Normalizes an array with respect to the L2 norm alongside the specified
+        axis.)")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    l2_normalize_operation::l2_normalize_operation(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type l2_normalize_operation::l2_normalize0d() const
+    {
+        return primitive_argument_type{static_cast<double>(1.)};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type l2_normalize_operation::l2_normalize1d(
+        arg_type&& arg) const
+    {
+        auto v = arg.vector();
+        if (!arg.is_ref())
+        {
+            v = v/blaze::l2Norm(v);
+            return primitive_argument_type{std::move(arg)};
+        }
+
+        blaze::DynamicVector<val_type> result = v / blaze::l2Norm(v);
+        return primitive_argument_type{std::move(result)};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type l2_normalize_operation::l2_normalize2d_axis0(
+        arg_type&& arg) const
+    {
+        auto m = arg.matrix();
+        if (!arg.is_ref())
+        {
+            for (std::size_t i = 0; i != m.columns(); ++i)
+                blaze::column(m, i) =
+                    blaze::column(m, i) / blaze::l2Norm(blaze::column(m, i));
+
+            return primitive_argument_type{std::move(arg)};
+        }
+
+        blaze::DynamicMatrix<val_type> result(m.rows(), m.columns());
+        for (std::size_t i = 0; i != m.columns(); ++i)
+            blaze::column(result, i) =
+                blaze::column(m, i) / blaze::l2Norm(blaze::column(m, i));
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    primitive_argument_type l2_normalize_operation::l2_normalize2d_axis1(
+        arg_type&& arg) const
+    {
+        auto m = arg.matrix();
+        if (!arg.is_ref())
+        {
+            for (std::size_t i = 0; i != m.rows(); ++i)
+                blaze::row(m, i) =
+                    blaze::row(m, i) / blaze::l2Norm(blaze::row(m, i));
+
+            return primitive_argument_type{std::move(arg)};
+        }
+
+        blaze::DynamicMatrix<val_type> result(m.rows(), m.columns());
+        for (std::size_t i = 0; i != m.rows(); ++i)
+            blaze::row(result, i) =
+                blaze::row(m, i) / blaze::l2Norm(blaze::row(m, i));
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    primitive_argument_type l2_normalize_operation::l2_normalize2d_flatten(
+        arg_type&& arg) const
+    {
+        auto m = arg.matrix();
+        if (!arg.is_ref())
+        {
+            m = m / blaze::l2Norm(m);
+            return primitive_argument_type{std::move(arg)};
+        }
+
+        blaze::DynamicMatrix<val_type> result = m / blaze::l2Norm(m);
+        return primitive_argument_type{std::move(result)};
+    }
+
+    primitive_argument_type l2_normalize_operation::l2_normalize2d(
+        arg_type&& arg, std::int64_t axis) const
+    {
+        switch (axis)
+        {
+        case -2: HPX_FALLTHROUGH;
+        case 0:
+            return l2_normalize2d_axis0(std::move(arg));
+
+        case -1: HPX_FALLTHROUGH;
+        case 1:
+            return l2_normalize2d_axis1(std::move(arg));
+
+        default:
+            break;
+        }
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "l2_normalize_operation::l2_normalize2d",
+            generate_error_message(
+                "the l2_normalize_operation primitive requires operand axis "
+                "to be between -2 and 1 for matrices."));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    primitive_argument_type l2_normalize_operation::l2_normalize3d_axis0(
+        arg_type&& arg) const
+    {
+        auto t = arg.tensor();
+        if (!arg.is_ref())
+        {
+            for (std::size_t j = 0; j != t.rows(); ++j)
+            {
+                auto slice = blaze::rowslice(t, j);
+                for (std::size_t i = 0; i != t.rows(); ++i)
+                    blaze::row(slice, i) = blaze::row(slice, i) /
+                        blaze::l2Norm(blaze::row(slice, i));
+            }
+            return primitive_argument_type{std::move(arg)};
+        }
+
+        blaze::DynamicTensor<val_type> result(t.pages(), t.rows(), t.columns());
+        for (std::size_t j = 0; j != t.rows(); ++j)
+        {
+            auto slice = blaze::rowslice(result, j);
+            auto t_slice = blaze::rowslice(t, j);
+            for (std::size_t i = 0; i != t.rows(); ++i)
+                blaze::row(slice, i) = blaze::row(t_slice, i) /
+                    blaze::l2Norm(blaze::row(t_slice, i));
+        }
+        return primitive_argument_type{std::move(result)};
+    }
+
+//    primitive_argument_type l2_normalize_operation::l2_normalize3d_axis1(
+//        arg_type&& arg) const
+//    {
+//        auto t = arg.tensor();
+//        if (!arg.is_ref())
+//        {
+//            for (std::size_t i = 0; i != arg.tensor().columns(); ++i)
+//            {
+//                blaze::columnslice(t, i) =
+//                    blaze::l2_normalize<blaze::rowwise>(blaze::columnslice(t, i));
+//            }
+//            return primitive_argument_type{std::move(arg)};
+//        }
+//
+//        blaze::DynamicTensor<val_type> result(t.pages(), t.rows(), t.columns());
+//        for (std::size_t i = 0; i != t.columns(); ++i)
+//        {
+//            auto slice = blaze::columnslice(t, i);
+//            blaze::columnslice(result, i) = blaze::l2_normalize<blaze::rowwise>(slice);
+//        }
+//        return primitive_argument_type{std::move(result)};
+//    }
+
+    primitive_argument_type l2_normalize_operation::l2_normalize3d_axis2(
+        arg_type&& arg) const
+    {
+        auto t = arg.tensor();
+        if (!arg.is_ref())
+        {
+            for (std::size_t j = 0; j != t.rows(); ++j)
+            {
+                auto slice = blaze::rowslice(t, j);
+                for (std::size_t i = 0; i != t.columns(); ++i)
+                    blaze::column(slice, i) = blaze::column(slice, i) /
+                        blaze::l2Norm(blaze::column(slice, i));
+            }
+            return primitive_argument_type{std::move(arg)};
+        }
+
+        blaze::DynamicTensor<val_type> result(t.pages(), t.rows(), t.columns());
+        for (std::size_t j = 0; j != t.rows(); ++j)
+        {
+            auto slice = blaze::rowslice(result, j);
+            auto t_slice = blaze::rowslice(t, j);
+            for (std::size_t i = 0; i != t.columns(); ++i)
+                blaze::column(slice, i) = blaze::column(t_slice, i) /
+                    blaze::l2Norm(blaze::column(t_slice, i));
+        }
+        return primitive_argument_type{std::move(result)};
+    }
+
+    primitive_argument_type l2_normalize_operation::l2_normalize3d_flatten(
+        arg_type&& arg) const
+    {
+        auto t = arg.tensor();
+        if (!arg.is_ref())
+        {
+            t = t / blaze::l2Norm(t);
+
+            return primitive_argument_type{std::move(arg)};
+        }
+
+        blaze::DynamicTensor<val_type> result(t.pages(), t.rows(), t.columns());
+        for (std::size_t j = 0; j != t.rows(); ++j)
+        {
+            auto slice = blaze::rowslice(result, j);
+            auto t_slice = blaze::rowslice(t, j);
+            for (std::size_t i = 0; i != t.columns(); ++i)
+                blaze::column(slice, i) = blaze::column(t_slice, i) /
+                    blaze::l2Norm(blaze::column(t_slice, i));
+        }
+        return primitive_argument_type{std::move(result)};
+    }
+
+    primitive_argument_type l2_normalize_operation::l2_normalize3d(
+        arg_type&& arg, std::int64_t axis) const
+    {
+        switch (axis)
+        {
+        case -3: HPX_FALLTHROUGH;
+        case 0:
+            return l2_normalize3d_axis0(std::move(arg));
+
+        //case -2: HPX_FALLTHROUGH;
+        //case 1:
+        //    return l2_normalize3d_axis1(std::move(arg));
+
+        case -1: HPX_FALLTHROUGH;
+        case 2:
+            return l2_normalize3d_axis2(std::move(arg));
+
+        default:
+            break;
+        }
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "l2_normalize_operation::l2_normalize3d",
+            generate_error_message(
+                "the l2_normalize_operation primitive requires operand axis "
+                "to be between -3 and 2 for tensors."));
+    }
+#endif
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> l2_normalize_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args,
+        eval_context ctx) const
+    {
+        if (operands.empty() || operands.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "l2_normalize_operation::eval",
+                util::generate_error_message(
+                    "the l2_normalize_operation primitive requires one, or "
+                    "two operands",
+                    name_, codename_));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "l2_normalize_operation::eval",
+                util::generate_error_message(
+                    "the l2_normalize_operation primitive requires that the "
+                    "arguments given by the operands array are valid",
+                    name_, codename_));
+        }
+
+        auto this_ = this->shared_from_this();
+        if (operands.size() == 2 && valid(operands[1]))
+        {
+            return hpx::dataflow(hpx::launch::sync,
+                hpx::util::unwrapping([this_ = std::move(this_)](
+                    primitive_arguments_type&& args)
+                    ->primitive_argument_type {
+
+                    std::int64_t axis =
+                        execution_tree::extract_scalar_integer_value_strict(
+                            args[1], this_->name_, this_->codename_);
+
+                    // Extract the array, the result should always be double
+                    arg_type a = extract_numeric_value(
+                        std::move(args[0]), this_->name_, this_->codename_);
+
+                    std::size_t a_dims = a.num_dimensions();
+
+                    switch (a_dims)
+                    {
+                    case 0:
+                        return this_->l2_normalize0d();
+                    case 1:
+                        return this_->l2_normalize1d(std::move(a));
+                    case 2:
+                        return this_->l2_normalize2d(std::move(a), axis);
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+                    case 3:
+                        return this_->l2_normalize3d(std::move(a), axis);
+#endif
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "l2_normalize_operation::eval",
+                            util::generate_error_message(
+                                "operand a has an invalid "
+                                "number of dimensions",
+                                this_->name_, this_->codename_));
+                    }
+            }),
+                detail::map_operands(
+                    operands, functional::value_operand{}, args,
+                    name_, codename_, std::move(ctx)));
+        }
+        // No axis or axis=None
+        return hpx::dataflow(hpx::launch::sync,
+                hpx::util::unwrapping([this_ = std::move(this_)](
+                    primitive_argument_type&& arg)
+                    ->primitive_argument_type {
+
+                // Extract the array, the result should always be double
+                arg_type a = extract_numeric_value(
+                    std::move(arg), this_->name_, this_->codename_);
+
+                std::size_t a_dims = a.num_dimensions();
+
+                switch (a_dims)
+                {
+                case 0:
+                    return this_->l2_normalize0d();
+                case 1:
+                    return this_->l2_normalize1d(std::move(a));
+                case 2:
+                    return this_->l2_normalize2d_flatten(std::move(a));
+    //#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    //            case 3:
+    //                return this_->l2_normalize3d(std::move(a));
+    //#endif
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "l2_normalize_operation::eval",
+                        util::generate_error_message("operand a has an invalid "
+                            "number of dimensions ",
+                            this_->name_, this_->codename_));
+                }
+            }),
+                value_operand(operands[0], args, name_, codename_, ctx));
+    }
+
+}}}
+

--- a/tests/unit/plugins/keras_support/CMakeLists.txt
+++ b/tests/unit/plugins/keras_support/CMakeLists.txt
@@ -8,7 +8,7 @@ set(tests
     batch_dot_operation
     elu_operation
     hard_sigmoid_operation
-    l2+normalize_operation
+    l2_normalize_operation
     one_hot_operation
     sigmoid_operation
     softmax_operation

--- a/tests/unit/plugins/keras_support/CMakeLists.txt
+++ b/tests/unit/plugins/keras_support/CMakeLists.txt
@@ -8,8 +8,10 @@ set(tests
     batch_dot_operation
     elu_operation
     hard_sigmoid_operation
+    l2+normalize_operation
     one_hot_operation
-    sigmoid_operation    softmax_operation
+    sigmoid_operation
+    softmax_operation
     softplus_operation
    )
 

--- a/tests/unit/plugins/keras_support/l2_normalize_operation.cpp
+++ b/tests/unit/plugins/keras_support/l2_normalize_operation.cpp
@@ -1,0 +1,321 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+//////////////////////////////////////////////////////////////////////////
+void test_l2_normalize_operation_0d()
+{
+    phylanx::execution_tree::primitive arg =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(42));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    HPX_TEST_EQ(
+        1.0, phylanx::execution_tree::extract_numeric_value(f.get())[0]);
+}
+
+void test_l2_normalize_operation_1d()
+{
+    blaze::DynamicVector<double> subject{13., 42., 33.};
+    phylanx::execution_tree::primitive arg =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(subject));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicVector<double> expected{0.23648092, 0.7640153 , 0.60029775};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+void test_l2_normalize_operation_2d()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {4, 5, 6}};
+    phylanx::execution_tree::primitive arg =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicMatrix<double> expected{{0.10482848, 0.20965695, 0.31448543},
+                                          {0.4193139, 0.5241424, 0.62897086}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+void test_l2_normalize_operation_2d_nil()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {3, 4, 1}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicMatrix<double> expected{{0.15811388, 0.31622776, 0.47434163},
+                                          {0.47434163, 0.6324555 , 0.15811388}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+void test_l2_normalize_operation_2d_axis1()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {3, 4, 1}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicMatrix<double> expected{{0.26726124, 0.5345225, 0.8017837},
+                                          {0.5883484, 0.78446454, 0.19611613}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+void test_l2_normalize_operation_2d_axis0()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {3, 4, 1}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(0));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicMatrix<double> expected{{0.31622776, 0.4472136 , 0.94868326},
+                                          {0.94868326, 0.8944272 , 0.31622776}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+void test_l2_normalize_operation_3d()
+{
+    blaze::DynamicTensor<double> subject{
+        {{1.0, 2.0, 3.0}, {4.0, 1.0, 2.0}, {3.0, 4.0, 1.0}},
+        {{3.0, 6.0, 2.0}, {-2.0, 2.0, 0.0}, {1.0, 1.0, 3.0}}};
+
+    phylanx::execution_tree::primitive arg =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(arg)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicTensor<double> expected{
+        {{0.08804509, 0.17609018, 0.26413527},
+            {0.35218036, 0.08804509, 0.17609018},
+            {0.26413527, 0.35218036, 0.08804509}},
+        {{0.26413527, 0.52827054, 0.17609018},
+            {-0.17609018, 0.17609018, 0.},
+            {0.08804509, 0.08804509, 0.26413527}}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+void test_l2_normalize_operation_3d_axis0()
+{
+    blaze::DynamicTensor<double> subject{
+        {{1.0, 2.0, 3.0}, {4.0, 1.0, 2.0}, {3.0, 4.0, 1.0}},
+        {{3.0, 6.0, 2.0}, {-2.0, 2.0, 0.0}, {1.0, 1.0, 3.0}} };
+
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(-3));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1) });
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicTensor<double> expected {
+        {{0.31622776, 0.31622776, 0.8320502},
+            {0.89442718, 0.44721359, 0.99999994},
+            {0.94868326, 0.97014242, 0.31622776}},
+        {{0.94868326, 0.94868326, 0.55470014},
+            {-0.44721359, 0.89442718, 0.},
+            {0.31622776, 0.24253561, 0.94868326}}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+void test_l2_normalize_operation_3d_axis1()
+{
+    blaze::DynamicTensor<double> subject{
+        {{1.0, 2.0, 3.0}, {4.0, 1.0, 2.0}, {3.0, 4.0, 1.0}},
+        {{3.0, 6.0, 2.0}, {-2.0, 2.0, 0.0}, {1.0, 1.0, 3.0}}};
+
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(1));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicTensor<double> expected{
+        {{0.1961161, 0.43643573, 0.80178368},
+            {0.78446442, 0.21821786, 0.53452247},
+            {0.58834833, 0.87287146, 0.26726124}},
+        {{0.80178368, 0.93704259, 0.5547002},
+            {-0.53452247, 0.31234753, 0.},
+            {0.26726124, 0.15617377, 0.83205032}}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+
+void test_l2_normalize_operation_3d_axis2()
+{
+    blaze::DynamicTensor<double> subject{
+        {{1.0, 2.0, 3.0}, {4.0, 1.0, 2.0}, {3.0, 4.0, 1.0}},
+        {{3.0, 6.0, 2.0}, {-2.0, 2.0, 0.0}, {1.0, 1.0, 3.0}}};
+
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(-1));
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_l2_normalize_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicTensor<double> expected{
+        {{0.26726124, 0.53452247, 0.80178368},
+            {0.87287146, 0.21821786, 0.43643573},
+            {0.58834833, 0.78446442, 0.1961161}},
+        {{0.4285714, 0.85714281, 0.28571427},
+            {-0.70710677, 0.70710677, 0.},
+            {0.30151135, 0.30151135, 0.90453404}}};
+
+    HPX_TEST(allclose(phylanx::ir::node_data<double>(std::move(expected)),
+        phylanx::execution_tree::extract_numeric_value(f.get())));
+}
+#endif
+
+int main(int argc, char* argv[])
+{
+    test_l2_normalize_operation_0d();
+    test_l2_normalize_operation_1d();
+    test_l2_normalize_operation_2d();
+    test_l2_normalize_operation_2d_nil();
+    test_l2_normalize_operation_2d_axis1();
+    test_l2_normalize_operation_2d_axis0();
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    //test_l2_normalize_operation_3d();
+    test_l2_normalize_operation_3d_axis0();
+    test_l2_normalize_operation_3d_axis1();
+    test_l2_normalize_operation_3d_axis2();
+#endif
+
+    return hpx::util::report_errors();
+}

--- a/tests/unit/plugins/matrixops/transpose_operation.cpp
+++ b/tests/unit/plugins/matrixops/transpose_operation.cpp
@@ -180,6 +180,33 @@ void test_transpose_operation_2d()
         phylanx::execution_tree::extract_numeric_value(f.get()));
 }
 
+void test_transpose_operation_2d_nil()
+{
+    blaze::DynamicMatrix<std::int64_t> subject{{1, 2, 3},
+                                               {3, 4, 1}};
+    phylanx::execution_tree::primitive arg0 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(subject));
+
+    phylanx::execution_tree::primitive arg1 =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ast::nil{});
+
+    phylanx::execution_tree::primitive l2_normalize =
+        phylanx::execution_tree::primitives::create_transpose_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(arg0), std::move(arg1)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        l2_normalize.eval();
+
+    blaze::DynamicMatrix<std::int64_t> expected{{1, 3},{2, 4},{3, 1}};
+
+    HPX_TEST_EQ(phylanx::ir::node_data<std::int64_t>(std::move(expected)),
+        phylanx::execution_tree::extract_integer_value(f.get()));
+}
+
 void test_transpose_operation_2d_lit()
 {
     blaze::Rand<blaze::DynamicMatrix<double>> gen{};
@@ -297,6 +324,7 @@ int main(int argc, char* argv[])
     test_transpose_operation_1d_axes1d();
 
     test_transpose_operation_2d();
+    test_transpose_operation_2d_nil();
     test_transpose_operation_2d_lit();
     test_transpose_operation_2d_axes();
     test_transpose_operation_2d_axes_nochange();


### PR DESCRIPTION
This PR adds the functionality of Keras [l2_normalize](https://keras.io/backend/#l2_normalize) except for the case that the input is 3d and no axis is given (l2_normalize3d_flatten). It will be updated when `l2Norm` is added to the blaze_tensor.
It also modifies the transpose operation for the case of `axes=None`. The current version produces the correct response even if the nil value of `axes` is wrapped in a variable.
```py
import numpy as np
from phylanx import Phylanx, PhylanxSession, execution_tree

PhylanxSession.init(1)
	
def variable(value, dtype=None, name=None, constraint=None):
    return execution_tree.var(np.array(value, dtype))
	
@Phylanx
def permute_dimensions_eager(x, pattern):
	return np.transpose(x, pattern)

def permute_dimensions(x, pattern):
	return permute_dimensions_eager.lazy(x, pattern)

def eval(func):
    return func.eval()
	

def test_transpose_operation(axis):
	x_val = [[1,2,3],[4,5,6]]
	t1 = permute_dimensions(variable(x_val),axis)
	z1 = eval(t1)
	return z1
	
test_transpose_operation(None)
```
Working toward #857