### PR TITLE
Adding execution_tree.variable to the Python bindings

### DIFF
--- a/examples/InitMatrix.py
+++ b/examples/InitMatrix.py
@@ -4,6 +4,7 @@
 #
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 import phylanx
 from phylanx.util import *
 import numpy as np
@@ -11,15 +12,15 @@ import numpy as np
 et = phylanx.execution_tree
 
 # Create a vector of zeros
-vz = et.var(np.zeros(10))
+vz = et.variable(np.zeros(10))
 
 print(vz)
 
-mz = et.var(np.zeros((3, 4)))
+mz = et.variable(np.zeros((3, 4)))
 
 print(mz)
 
-v = et.var(np.linspace(2.0, 3.4, 5))
+v = et.variable(np.linspace(2.0, 3.4, 5))
 
 print(v)
 
@@ -29,7 +30,8 @@ m = et.eval("file_read_csv(\"./breast_cancer.csv\")")
 print(m)
 
 print(m)
-print(et.eval("slice", m, et.var(0), et.var(3), et.var(0), et.var(3)))
+print(et.eval("slice", m,
+    et.variable(0), et.variable(3), et.variable(0), et.variable(3)))    # noqa
 
 three = et.eval("3")
 four = et.eval("4")

--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -576,6 +576,18 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT bool is_string_operand(primitive_argument_type const& val);
 
+    PHYLANX_EXPORT std::string extract_string_value_strict(
+        primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT std::string extract_string_value_strict(
+        primitive_argument_type && val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    PHYLANX_EXPORT bool is_string_operand_strict(
+        primitive_argument_type const& val);
+
     // Extract an AST type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT std::vector<ast::expression> extract_ast_value(

--- a/python/src/bindings/binding_helpers.cpp
+++ b/python/src/bindings/binding_helpers.cpp
@@ -327,7 +327,8 @@ namespace phylanx { namespace bindings
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    pybind11::dtype extract_dtype(phylanx::execution_tree::primitive const& p)
+    pybind11::dtype extract_dtype(
+        phylanx::execution_tree::primitive_argument_type const& p)
     {
         pybind11::gil_scoped_release release;       // release GIL
 
@@ -336,15 +337,19 @@ namespace phylanx { namespace bindings
             {
                 using namespace phylanx::execution_tree;
 
-                primitive_arguments_type args;
-                args.push_back(p);
+                std::int64_t type_id = p.index();
+                if (type_id == primitive_argument_type::primitive_index)
+                {
+                    primitive_arguments_type args;
+                    args.emplace_back(p);
 
-                primitive type = primitives::create_phytype(
-                    hpx::find_here(), std::move(args), "dtype", "<unknown>");
+                    primitive type = primitives::create_phytype(
+                        hpx::find_here(), std::move(args), "dtype", "<unknown>");
 
-                primitive_argument_type id = type.eval(hpx::launch::sync);
-                std::int64_t type_id = extract_scalar_integer_value_strict(
-                    id, "dtype", "<unknown>");
+                    primitive_argument_type id = type.eval(hpx::launch::sync);
+                    std::int64_t type_id = extract_scalar_integer_value_strict(
+                        id, "dtype", "<unknown>");
+                }
 
                 pybind11::gil_scoped_acquire acquire;
 

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -209,7 +209,8 @@ namespace phylanx { namespace bindings
         std::string const& xexpr_str, compiler_state& c);
 
     // extract the dtype of the given variable/expression
-    pybind11::dtype extract_dtype(phylanx::execution_tree::primitive const& p);
+    pybind11::dtype extract_dtype(
+        phylanx::execution_tree::primitive_argument_type const& p);
 }}
 
 #endif

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -94,6 +94,9 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
     auto var =
         pybind11::class_<phylanx::execution_tree::variable>(execution_tree,
             "variable", "type representing an arbitrary execution tree")
+            // copy-constructor must go before constructor that takes
+            // primitive_argument_type to avoid implicit conversion
+            .def(pybind11::init<phylanx::execution_tree::variable const&>())
             .def(pybind11::init<phylanx::execution_tree::primitive,
                      pybind11::object, pybind11::object, pybind11::object>(),
                 pybind11::arg("value"),
@@ -119,7 +122,6 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
                 pybind11::arg("dtype") = pybind11::none(),
                 pybind11::arg("name") = pybind11::none(),
                 pybind11::arg("constraint") = pybind11::none())
-            .def(pybind11::init<phylanx::execution_tree::variable const&>())
             .def(
                 "eval",
                 [](phylanx::execution_tree::variable const& var,

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -123,7 +123,8 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
             .def(
                 "eval",
                 [](phylanx::execution_tree::variable const& var,
-                    pybind11::args args) {
+                    pybind11::args args)
+                {
                     pybind11::gil_scoped_release release;    // release GIL
                     return hpx::threads::run_as_hpx_thread(
                         [&]() { return var.eval(std::move(args)); });
@@ -132,7 +133,8 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
             .def(
                 "__call__",
                 [](phylanx::execution_tree::variable const& var,
-                    pybind11::args args) {
+                    pybind11::args args)
+                {
                     pybind11::gil_scoped_release release;    // release GIL
                     return hpx::threads::run_as_hpx_thread(
                         [&]() { return var.eval(std::move(args)); });

--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -395,6 +395,9 @@ namespace pybind11 { namespace detail
             return isinstance<array_t<std::int64_t>>(src) ||
                    isinstance<array_t<std::int32_t>>(src) ||
                    isinstance<array_t<std::int16_t>>(src);
+                   isinstance<array_t<std::uint64_t>>(src) ||
+                   isinstance<array_t<std::uint32_t>>(src) ||
+                   isinstance<array_t<std::uint16_t>>(src);
         }
     };
 

--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -18,6 +18,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+#include <bindings/variable.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -394,7 +396,7 @@ namespace pybind11 { namespace detail
         {
             return isinstance<array_t<std::int64_t>>(src) ||
                    isinstance<array_t<std::int32_t>>(src) ||
-                   isinstance<array_t<std::int16_t>>(src);
+                   isinstance<array_t<std::int16_t>>(src) ||
                    isinstance<array_t<std::uint64_t>>(src) ||
                    isinstance<array_t<std::uint32_t>>(src) ||
                    isinstance<array_t<std::uint16_t>>(src);
@@ -1202,6 +1204,16 @@ namespace pybind11 { namespace detail
     bool variant_caster_helper<Derived, V<Ts...>>::load(
         handle src, bool convert)
     {
+        // Handle conversion from variable right away
+        if (pybind11::isinstance<phylanx::execution_tree::variable>(src))
+        {
+            phylanx::execution_tree::variable var =
+                src.cast<phylanx::execution_tree::variable>();
+            value =
+                phylanx::execution_tree::primitive_argument_type{var.value()};
+            return true;
+        }
+
         // Do a first pass without conversions to improve constructor resolution.
         // E.g. `py::int_(1).cast<variant<double, int>>()` needs to fill the `int`
         // slot of the variant. Without two-pass loading `double` would be filled

--- a/python/src/bindings/variable.cpp
+++ b/python/src/bindings/variable.cpp
@@ -1,0 +1,226 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+#include <bindings/binding_helpers.hpp>
+#include <bindings/type_casters.hpp>
+#include <bindings/variable.hpp>
+
+#include <hpx/util/assert.hpp>
+#include <hpx/util/format.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace phylanx { namespace execution_tree
+{
+    ///////////////////////////////////////////////////////////////////////////
+    variable::variable(primitive value, pybind11::object dtype,
+            pybind11::object name, pybind11::object constraint)
+      : dtype_(dtype.is_none() ?
+                bindings::extract_dtype(value) : std::move(dtype))
+      , value_(std::move(value))
+      , name_(name.is_none() ?
+              hpx::util::format("variable_{}", ++variable_count) :
+              name.cast<std::string>())
+      , constraint_(std::move(constraint))
+    {
+    }
+
+    variable::variable(pybind11::array value, pybind11::object dtype,
+            pybind11::object name, pybind11::object constraint)
+      : dtype_(dtype.is_none() ? value.dtype() : std::move(dtype))
+      , value_(create_variable(
+          pybind11::cast<primitive_argument_type>(std::move(value))))
+      , name_(name.is_none() ?
+              hpx::util::format("variable_{}", ++variable_count) :
+              name.cast<std::string>())
+      , constraint_(std::move(constraint))
+  {}
+
+    variable::variable(std::string value, pybind11::object dtype,
+            pybind11::object name, pybind11::object constraint)
+      : dtype_(dtype.is_none() ? pybind11::dtype("S") : std::move(dtype))
+      , value_(create_variable(primitive_argument_type(std::move(value))))
+      , name_(name.is_none() ?
+              hpx::util::format("variable_{}", ++variable_count) :
+              name.cast<std::string>())
+      , constraint_(std::move(constraint))
+    {}
+
+    variable::variable(primitive_argument_type value, pybind11::object dtype,
+            pybind11::object name, pybind11::object constraint)
+      : dtype_(dtype.is_none() ?
+          bindings::extract_dtype(value) : std::move(dtype))
+      , value_(is_primitive_operand(value) ?
+              primitive_operand(std::move(value)) :
+              create_variable(std::move(value)))
+      , name_(name.is_none() ?
+              hpx::util::format("variable_{}", ++variable_count) :
+              name.cast<std::string>())
+      , constraint_(std::move(constraint))
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive variable::create_variable(primitive_argument_type&& value)
+    {
+        return create_primitive_component(
+            hpx::find_here(), "variable", std::move(value));
+    }
+
+    std::size_t variable::variable_count = 0;
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        template <typename T>
+        pybind11::handle convert_array(primitive_argument_type&& result)
+        {
+            pybind11::array_t<T> arr = pybind11::cast(std::move(result));
+            return arr.release();
+        }
+    }
+
+    pybind11::handle variable::handle_return_f(
+        primitive_argument_type&& result) const
+    {
+        if (dtype_.itemsize() == 4)
+        {
+            return detail::convert_array<float>(std::move(result));
+        }
+
+        HPX_ASSERT(dtype_.itemsize() == 8);
+        return detail::convert_array<double>(std::move(result));
+    }
+
+    pybind11::handle variable::handle_return_i(
+        primitive_argument_type&& result) const
+    {
+        if (dtype_.itemsize() == 2)
+        {
+            return detail::convert_array<std::int16_t>(std::move(result));
+        }
+        else if (dtype_.itemsize() == 4)
+        {
+            return detail::convert_array<std::int32_t>(std::move(result));
+        }
+
+        HPX_ASSERT(dtype_.itemsize() == 8);
+        return detail::convert_array<std::int64_t>(std::move(result));
+    }
+
+    pybind11::handle variable::handle_return_u(
+        primitive_argument_type&& result) const
+    {
+        if (dtype_.itemsize() == 2)
+        {
+            return detail::convert_array<std::uint16_t>(std::move(result));
+        }
+        else if (dtype_.itemsize() == 4)
+        {
+            return detail::convert_array<std::uint32_t>(std::move(result));
+        }
+
+        HPX_ASSERT(dtype_.itemsize() == 8);
+        return detail::convert_array<std::uint64_t>(std::move(result));
+    }
+
+    pybind11::handle variable::handle_return_b(
+        primitive_argument_type&& result) const
+    {
+        return pybind11::cast(std::move(result));
+    }
+
+    pybind11::handle variable::handle_return_S(
+        primitive_argument_type&& result) const
+    {
+        pybind11::str s = pybind11::cast(std::move(result));
+        return s.release();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    pybind11::handle variable::eval(pybind11::args args) const
+    {
+        phylanx::execution_tree::primitive_arguments_type keep_alive;
+        keep_alive.reserve(args.size());
+        phylanx::execution_tree::primitive_arguments_type fargs;
+        fargs.reserve(args.size());
+
+        {
+            pybind11::gil_scoped_acquire acquire;
+            for (auto const& item : args)
+            {
+                using phylanx::execution_tree::primitive_argument_type;
+
+                primitive_argument_type value =
+                    item.cast<primitive_argument_type>();
+
+                keep_alive.emplace_back(std::move(value));
+                fargs.emplace_back(extract_ref_value(keep_alive.back()));
+            }
+        }
+
+        primitive_argument_type result =
+            value_operand_sync(value_, std::move(fargs));
+
+        switch (dtype_.kind())
+        {
+        case 'b':   // boolean
+            if (!is_boolean_operand_strict(result))
+            {
+                return handle_return_b(std::move(result));
+            }
+            break;
+
+        case 'i':   // signed integer
+            if (!is_integer_operand_strict(result) || dtype_.itemsize() != 8)
+            {
+                return handle_return_i(std::move(result));
+            }
+            break;
+
+        case 'u':   // unsigned integer
+            return handle_return_u(std::move(result));
+
+        case 'f':   // floating-point
+            if (!is_numeric_operand_strict(result) || dtype_.itemsize() != 8)
+            {
+                return handle_return_f(std::move(result));
+            }
+            break;
+
+        case 'O':   // object
+            break;
+
+        case 'S':   // (byte-)string
+            if (!is_string_operand_strict(result))
+            {
+                return handle_return_S(std::move(result));
+            }
+            break;
+
+        case 'c': HPX_FALLTHROUGH;  // complex floating-point
+        case 'm': HPX_FALLTHROUGH;  // timedelta
+        case 'M': HPX_FALLTHROUGH;  // datetime
+        case 'U': HPX_FALLTHROUGH;  // Unicode
+        case 'V':                   // void
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "variable::eval",
+                    hpx::util::format("unsupported dtype: {}", dtype_.kind()));
+            }
+            break;
+        }
+
+        return pybind11::cast(std::move(result));
+    }
+}}

--- a/python/src/bindings/variable.hpp
+++ b/python/src/bindings/variable.hpp
@@ -93,13 +93,13 @@ namespace phylanx { namespace execution_tree
 
     protected:
         pybind11::handle handle_return_f(
-            primitive_argument_type&& result) const;
+            primitive_argument_type&& result, pybind11::ssize_t itemsize) const;
 
         pybind11::handle handle_return_i(
-            primitive_argument_type&& result) const;
+            primitive_argument_type&& result, pybind11::ssize_t itemsize) const;
 
         pybind11::handle handle_return_u(
-            primitive_argument_type&& result) const;
+            primitive_argument_type&& result, pybind11::ssize_t itemsize) const;
 
         pybind11::handle handle_return_b(
             primitive_argument_type&& result) const;

--- a/python/src/bindings/variable.hpp
+++ b/python/src/bindings/variable.hpp
@@ -76,10 +76,7 @@ namespace phylanx { namespace execution_tree
 
         pybind11::handle eval(pybind11::args args) const;
 
-        pybind11::dtype dtype() const
-        {
-            return dtype_;
-        };
+        pybind11::dtype dtype() const;
 
         std::string name() const
         {

--- a/python/src/bindings/variable.hpp
+++ b/python/src/bindings/variable.hpp
@@ -1,0 +1,118 @@
+//  Copyright (c) 2019 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PYBIND11_EXECUTION_TREE_HPP)
+#define PHYLANX_PYBIND11_EXECUTION_TREE_HPP
+
+#include <phylanx/phylanx.hpp>
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <utility>
+
+namespace phylanx { namespace execution_tree
+{
+    struct variable
+    {
+    private:
+        static primitive create_variable(primitive_argument_type&& value);
+        static std::size_t variable_count;
+
+    public:
+        variable(primitive value, pybind11::object dtype, pybind11::object name,
+            pybind11::object constraint);
+
+        variable(pybind11::array value, pybind11::object dtype,
+            pybind11::object name, pybind11::object constraint);
+
+        variable(std::string value, pybind11::object dtype,
+            pybind11::object name, pybind11::object constraint);
+
+        variable(primitive_argument_type value, pybind11::object dtype,
+            pybind11::object name, pybind11::object constraint);
+
+//         template <typename T>
+//         variable(std::vector<T> value, pybind11::dtype dtype,
+//                 pybind11::object name, pybind11::object constraint)
+//           : value_(ir::node_data<T>{std::move(value)})
+//           , dtype_(pybind11::dtype(std::move(dtype)))
+//           , name_(name.is_none() ? "" : name.cast<std::string>())
+//           , constraint_(std::move(constraint))
+//         {}
+//         template <typename T>
+//         variable(std::vector<std::vector<T>> value,
+//                 pybind11::object dtype, pybind11::object name,
+//                 pybind11::object constraint)
+//           : value_(ir::node_data<T>{std::move(value)})
+//           , dtype_(pybind11::dtype(std::move(dtype)))
+//           , name_(name.is_none() ? "" : name.cast<std::string>())
+//           , constraint_(std::move(constraint))
+//         {}
+// #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+//         template <typename T>
+//         variable(std::vector<std::vector<std::vector<T>>> value,
+//                 pybind11::object dtype, pybind11::object name,
+//                 pybind11::object constraint)
+//           : value_(ir::node_data<T>{std::move(value)})
+//           , dtype_(pybind11::dtype(std::move(dtype)))
+//           , name_(name.is_none() ? "" : name.cast<std::string>())
+//           , constraint_(std::move(constraint))
+//         {}
+// #endif
+
+        ~variable()
+        {
+            pybind11::gil_scoped_acquire acquire;
+            dtype_.release();
+            constraint_.release();
+        }
+
+        pybind11::handle eval(pybind11::args args) const;
+
+        pybind11::dtype dtype() const
+        {
+            return dtype_;
+        };
+
+        std::string name() const
+        {
+            return name_;
+        }
+
+        primitive value() const
+        {
+            return value_;
+        }
+
+    protected:
+        pybind11::handle handle_return_f(
+            primitive_argument_type&& result) const;
+
+        pybind11::handle handle_return_i(
+            primitive_argument_type&& result) const;
+
+        pybind11::handle handle_return_u(
+            primitive_argument_type&& result) const;
+
+        pybind11::handle handle_return_b(
+            primitive_argument_type&& result) const;
+
+        pybind11::handle handle_return_S(
+            primitive_argument_type&& result) const;
+
+    private:
+        pybind11::dtype dtype_;
+        primitive value_;
+        std::string name_;
+        pybind11::object constraint_;
+    };
+}}
+
+#endif

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -2271,6 +2271,86 @@ namespace phylanx { namespace execution_tree
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    std::string extract_string_value_strict(primitive_argument_type const& val,
+        std::string const& name, std::string const& codename)
+    {
+        switch (val.index())
+        {
+        case 3:     // string
+            return util::get<3>(val);
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
+        case 2: HPX_FALLTHROUGH;    // ir::node_data<std::int64_t>
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7: HPX_FALLTHROUGH;    // phylanx::ir::range
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 8: HPX_FALLTHROUGH;    // phylanx::ir::dictionary
+        default:
+            break;
+        }
+
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_string_value_strict",
+            util::generate_error_message(
+                "primitive_argument_type does not hold a string "
+                    "value type (type held: '" + type + "')",
+                name, codename));
+    }
+
+    std::string extract_string_value_strict(primitive_argument_type && val,
+        std::string const& name, std::string const& codename)
+    {
+        switch (val.index())
+        {
+        case 3:     // string
+            return util::get<3>(std::move(val));
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
+        case 2: HPX_FALLTHROUGH;    // ir::node_data<std::int64_t>
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7: HPX_FALLTHROUGH;    // phylanx::ir::range
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 8: HPX_FALLTHROUGH;    // phylanx::ir::dictionary
+        default:
+            break;
+        }
+
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "phylanx::execution_tree::extract_string_value_strict",
+            util::generate_error_message(
+                "primitive_argument_type does not hold a string "
+                    "value type (type held: '" + type + "')",
+                name, codename));
+    }
+
+    bool is_string_operand_strict(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case 3:     // string
+            return true;
+
+        case 0: HPX_FALLTHROUGH;    // nil
+        case 1: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
+        case 2: HPX_FALLTHROUGH;    // ir::node_data<std::int64_t>
+        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
+        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case 7: HPX_FALLTHROUGH;    // phylanx::ir::range
+        case 5: HPX_FALLTHROUGH;    // primitive
+        case 8: HPX_FALLTHROUGH;    // phylanx::ir::dictionary
+        default:
+            break;
+        }
+        return false;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     std::vector<ast::expression> extract_ast_value(
         primitive_argument_type const& val,
         std::string const& name, std::string const& codename)
@@ -2692,10 +2772,12 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
             return *p;
 
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::extract_primitive",
             util::generate_error_message(
-                "primitive_value_type does not hold a primitive",
+                "primitive_value_type does not hold a primitive "
+                "value type (type held: '" + type + "')",
                 name, codename));
     }
 
@@ -2707,10 +2789,12 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
             return *p;
 
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::extract_primitive",
             util::generate_error_message(
-                "primitive_value_type does not hold a primitive",
+                "primitive_value_type does not hold a primitive "
+                "value type (type held: '" + type + "')",
                 parts, codename));
     }
 
@@ -2721,10 +2805,12 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
             return std::move(*p);
 
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::extract_primitive",
             util::generate_error_message(
-                "primitive_value_type does not hold a primitive",
+                "primitive_value_type does not hold a primitive "
+                "value type (type held: '" + type + "')",
                 name, codename));
     }
 
@@ -2736,10 +2822,12 @@ namespace phylanx { namespace execution_tree
         if (p != nullptr)
             return std::move(*p);
 
+        std::string type(detail::get_primitive_argument_type_name(val.index()));
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::extract_primitive",
             util::generate_error_message(
-                "primitive_value_type does not hold a primitive",
+                "primitive_value_type does not hold a primitive "
+                "value type (type held: '" + type + "')",
                 parts, codename));
     }
 

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -14,7 +14,6 @@
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/runtime/threads/run_as_os_thread.hpp>
-#include <hpx/runtime/threads/run_as_os_thread.hpp>
 #include <hpx/util/register_locks.hpp>
 
 #include <atomic>

--- a/tests/regressions/python/805_lazy_variable.py
+++ b/tests/regressions/python/805_lazy_variable.py
@@ -11,7 +11,7 @@ PhylanxSession.init()
 
 
 def variable(value, dtype=None):
-    return execution_tree.var(np.array(value, dtype))
+    return execution_tree.variable(np.array(value, dtype), dtype)
 
 
 @Phylanx

--- a/tests/regressions/python/805_two_variables.py
+++ b/tests/regressions/python/805_two_variables.py
@@ -11,7 +11,7 @@ PhylanxSession.init()
 
 
 def variable(value, dtype=None):
-    return execution_tree.var(np.array(value, dtype))
+    return execution_tree.variable(np.array(value, dtype), dtype)
 
 
 @Phylanx

--- a/tests/regressions/python/852_concatenate_list.py
+++ b/tests/regressions/python/852_concatenate_list.py
@@ -14,7 +14,7 @@ def variable(value, dtype=None, name=None, constraint=None):
     if constraint is not None:
         raise TypeError("Constraint is the projection function to be "
                         "applied to the variable after an optimizer update")
-    return execution_tree.var(np.array(value, dtype))
+    return execution_tree.variable(np.array(value, dtype), dtype)
 
 
 def eval(func):

--- a/tests/regressions/python/874_0d_shape.py
+++ b/tests/regressions/python/874_0d_shape.py
@@ -13,7 +13,7 @@ PhylanxSession.init(1)
 
 
 def variable(value):
-    return execution_tree.var(np.float64(value))
+    return execution_tree.variable(np.float64(value))
 
 
 val = variable(42.0).eval()

--- a/tests/regressions/python/903_variable_conversion.py
+++ b/tests/regressions/python/903_variable_conversion.py
@@ -1,0 +1,43 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx import Phylanx, PhylanxSession, execution_tree
+
+
+PhylanxSession.init(1)
+
+
+def variable(value, dtype=None, name=None, constraint=None):
+    if constraint is not None:
+        raise TypeError("Constraint is the projection function to be "
+                        "applied to the variable after an optimizer update")
+    return execution_tree.variable(np.array(value, dtype=dtype), dtype=dtype, name=name)
+
+
+def eval(func):
+    return func.eval()
+
+
+@Phylanx
+def hard_sigmoid_eager(x):
+    return hard_sigmoid(x)
+
+
+def hard_sigmoid(x):
+    return hard_sigmoid_eager.lazy(x)
+
+
+def parse_shape_or_val(shape_or_val):
+    return shape_or_val, np.random.random(shape_or_val).astype(np.float32) - 0.5
+
+
+def test_hard_sigmoid_operation(x_shape_or_val):
+    x_val = np.random.random(x_shape_or_val).astype(np.float32) - 0.5
+    t = hard_sigmoid(variable(x_val))
+    return eval(t)
+
+
+print(test_hard_sigmoid_operation((4,2)))

--- a/tests/regressions/python/903_variable_conversion.py
+++ b/tests/regressions/python/903_variable_conversion.py
@@ -14,7 +14,8 @@ def variable(value, dtype=None, name=None, constraint=None):
     if constraint is not None:
         raise TypeError("Constraint is the projection function to be "
                         "applied to the variable after an optimizer update")
-    return execution_tree.variable(np.array(value, dtype=dtype), dtype=dtype, name=name)
+    return execution_tree.variable(
+        np.array(value, dtype=dtype), dtype=dtype, name=name)
 
 
 def eval(func):
@@ -40,4 +41,4 @@ def test_hard_sigmoid_operation(x_shape_or_val):
     return eval(t)
 
 
-print(test_hard_sigmoid_operation((4,2)))
+print(test_hard_sigmoid_operation((4, 2)))

--- a/tests/regressions/python/903_variable_dtype.py
+++ b/tests/regressions/python/903_variable_dtype.py
@@ -1,0 +1,34 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# 903: The dtype of a variable is `object`
+
+import numpy as np
+from phylanx import Phylanx, PhylanxSession, execution_tree
+
+
+PhylanxSession.init(1)
+
+
+def variable(value, dtype=None, name=None):
+    return execution_tree.variable(
+        np.array(value, dtype=dtype), dtype=dtype, name=name)
+
+
+def dtype_(x):
+    return execution_tree.variable(x).dtype
+
+
+def test_dtype():
+    # 'float16' is not supported (yet)
+#    assert dtype_(variable(1, dtype='float16')) == 'float16'
+    assert dtype_(variable(1, dtype='float64')) == 'float64'
+    assert dtype_(variable(1, dtype='float32')) == 'float32'
+    assert dtype_(variable(1, dtype='int32')) == 'int32'
+    assert dtype_(variable(1, dtype='int64')) == 'int64'
+
+
+test_dtype()
+

--- a/tests/regressions/python/903_variable_dtype.py
+++ b/tests/regressions/python/903_variable_dtype.py
@@ -23,7 +23,7 @@ def dtype_(x):
 
 def test_dtype():
     # 'float16' is not supported (yet)
-#    assert dtype_(variable(1, dtype='float16')) == 'float16'
+    # assert dtype_(variable(1, dtype='float16')) == 'float16'
     assert dtype_(variable(1, dtype='float64')) == 'float64'
     assert dtype_(variable(1, dtype='float32')) == 'float32'
     assert dtype_(variable(1, dtype='int32')) == 'int32'
@@ -31,4 +31,3 @@ def test_dtype():
 
 
 test_dtype()
-

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -31,6 +31,7 @@ set(tests
     874_0d_shape
     886_notnone
     896_return_none
+    903_variable_dtype
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -31,6 +31,7 @@ set(tests
     874_0d_shape
     886_notnone
     896_return_none
+    903_variable_conversion
     903_variable_dtype
     array_len_494
     array_shape_486

--- a/tests/unit/python/execution_tree/eval.py
+++ b/tests/unit/python/execution_tree/eval.py
@@ -237,7 +237,7 @@ assert np.all(np.square(v) == do_square(v))
 
 
 def phytype(x):
-    return execution_tree.var(x).dtype
+    return execution_tree.variable(x).dtype
 
 
 def get_types():
@@ -247,7 +247,10 @@ def get_types():
         phytype(1.0),
         phytype("x"),
         phytype(np.array([True, False])),
-        phytype(np.array([1, 2])),
+        phytype(np.array([1, 2], dtype='int16')),
+        phytype(np.array([1, 2], dtype='int32')),
+        phytype(np.array([1, 2], dtype='int64')),
+        phytype(np.array([1.0, 2.0], dtype='float32')),
         phytype(np.array([1.0, 2.0])),
         phytype([1.0, "x"]),
         phytype({"x": 1})]
@@ -259,8 +262,11 @@ assert types == [
     np.dtype('int64'),
     np.dtype('float64'),
     np.dtype('S'),
-    np.dtype('int8'),
+    np.dtype('bool'),
+    np.dtype('int16'),
+    np.dtype('int32'),
     np.dtype('int64'),
+    np.dtype('float32'),
     np.dtype('float64'),
     np.dtype('O'),
     np.dtype('O')], types

--- a/tests/unit/python/execution_tree/make_array.py
+++ b/tests/unit/python/execution_tree/make_array.py
@@ -17,32 +17,32 @@ x0 = 0
 nx = 11
 dx = 1.0
 et = phylanx.execution_tree
-var = et.var(np.linspace(x0, (nx - 1) * dx, nx))
+var = et.variable(np.linspace(x0, (nx - 1) * dx, nx))
 r = var.eval()
 assert isinstance(r, np.ndarray)
 assert len(r) == nx
 sum2 = 0
-for i in range(11):
+for i in range(nx):
     sum2 += i * i
-    assert x0 + dx * i == r[i]
+    assert x0 + dx * i == r[i], r[i]
 
 # Test creation from a python array
 va = [1, 2, 3, 4, 5]
-vx = et.var(va).eval()
+vx = et.variable(va).eval()
 for i in range(len(va)):
     assert vx[i] == va[i]
 
 # Create a vector that's all zeros
-r = et.var(np.zeros(nx)).eval()
+r = et.variable(np.zeros(nx)).eval()
 assert isinstance(r, np.ndarray)
 assert len(r) == nx
-for i in range(11):
+for i in range(nx):
     assert 0 == r[i]
 
 # Create a matrix that's all zeros
 nx = 5
 ny = 4
-m = et.var(np.zeros((nx, ny))).eval()
+m = et.variable(np.zeros((nx, ny))).eval()
 assert isinstance(m, np.ndarray)
 assert len(m) == nx
 assert len(m[1]) == ny
@@ -51,7 +51,7 @@ for i in range(nx):
         assert m[i][j] == 0
 
 m2 = [[1.0, 2.0, 3.0], [1.1, 2, 2, 3.2], [1.5, 2.6, 3.7]]
-m3 = et.var(m2).eval()
+m3 = et.variable(m2).eval()
 for i in range(len(m2)):
     for j in range(len(m2[0])):
         assert m3[i][j] == m2[i][j]


### PR DESCRIPTION
- remove execution_tree.primitive
- remove execution_tree.var
- flyby: add extract_string_value_strict/is_string_operand_strict

Fixes #903