### PR TITLE
Allow to pass decorated Phylanx functions as arguments to another Phylanx function

### DIFF
--- a/examples/algorithms/lra/lra_csv_instrumented.cpp
+++ b/examples/algorithms/lra/lra_csv_instrumented.cpp
@@ -306,10 +306,10 @@ int hpx_main(boost::program_options::variables_map& vm)
     // Compile the given code
     phylanx::execution_tree::compiler::function_list snippets;
     auto const& code_read_x = phylanx::execution_tree::compile(
-        "read_x", phylanx::ast::generate_ast(read_x_code), snippets);
+        "read_x", read_x_code, snippets);
 
     auto const& code_read_y = phylanx::execution_tree::compile(
-        "read_y", phylanx::ast::generate_ast(read_y_code), snippets);
+        "read_y", read_y_code, snippets);
 
     auto const& code_lra = phylanx::execution_tree::compile(
         vm.count("direct") != 0 ? "lra_direct" : "lra",

--- a/phylanx/execution_tree/compile.hpp
+++ b/phylanx/execution_tree/compile.hpp
@@ -58,66 +58,62 @@ namespace phylanx { namespace execution_tree
         compiler::expression_pattern_list const& patterns,
         hpx::id_type const& default_locality = hpx::find_here());
 
-    /// Compile a given expression into a function.
-    PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::vector<ast::expression> const& exprs,
-        compiler::function_list& snippets,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    /// Compile a given expression into a function.
-    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& expr,
-        compiler::function_list& snippets,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    /// Compile a given expression into a function. Reuse the given compilation
-    /// environment.
-    PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::vector<ast::expression> const& exprs,
-        compiler::function_list& snippets, compiler::environment& env,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    /// Compile a given expression into a function. Reuse the given compilation
-    /// environment.
-    PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::string const& expr, compiler::function_list& snippets,
-        compiler::environment& env,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// Compile a given expression into a function.
-    PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::string const& name, std::string const& func_name,
-        std::vector<ast::expression> const& exprs,
-        compiler::function_list& snippets,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::string const& name, std::string const& expr,
-        compiler::function_list& snippets,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
-        std::string const& func_name, std::string const& expr,
-        compiler::function_list& snippets,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    /// Compile a given expression into a function. Reuse the given compilation
-    /// environment.
     PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
         std::string const& func_name, std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets, compiler::environment& env,
         hpx::id_type const& default_locality = hpx::find_here());
 
-    /// Compile a given expression into a function. Reuse the given compilation
-    /// environment.
-    PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::string const& name, std::string const& expr,
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::string const& expr,
         compiler::function_list& snippets, compiler::environment& env,
         hpx::id_type const& default_locality = hpx::find_here());
 
     PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
-        std::string const& func_name, std::string const& expr,
+        std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets, compiler::environment& env,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& expr, compiler::function_list& snippets,
+        compiler::environment& env,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(
+        std::vector<ast::expression> const& exprs,
+        compiler::function_list& snippets, compiler::environment& env,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& expr,
+        compiler::function_list& snippets, compiler::environment& env,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    ///////////////////////////////////////////////////////////////////////////
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::vector<ast::expression> const& exprs,
+        compiler::function_list& snippets,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::string const& expr,
+        compiler::function_list& snippets,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& expr, compiler::function_list& snippets,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::vector<ast::expression> const& exprs,
+        compiler::function_list& snippets,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(
+        std::vector<ast::expression> const& exprs,
+        compiler::function_list& snippets,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& expr,
+        compiler::function_list& snippets,
         hpx::id_type const& default_locality = hpx::find_here());
 
     ///////////////////////////////////////////////////////////////////////////

--- a/phylanx/execution_tree/compile.hpp
+++ b/phylanx/execution_tree/compile.hpp
@@ -50,18 +50,18 @@ namespace phylanx { namespace execution_tree
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    /// Compile a given expression into a function. Reuse the given compilation
+    /// environment.
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::vector<ast::expression> const& exprs,
+        compiler::function_list& snippets, compiler::environment& env,
+        compiler::expression_pattern_list const& patterns,
+        hpx::id_type const& default_locality = hpx::find_here());
+
     /// Compile a given expression into a function.
     PHYLANX_EXPORT compiler::entry_point const& compile(
         std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets,
-        hpx::id_type const& default_locality = hpx::find_here());
-
-    /// Compile a given expression into a function. Reuse the given compilation
-    /// environment.
-    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
-        std::vector<ast::expression> const& exprs,
-        compiler::function_list& snippets, compiler::environment& env,
-        compiler::expression_pattern_list const& patterns,
         hpx::id_type const& default_locality = hpx::find_here());
 
     /// Compile a given expression into a function.
@@ -86,7 +86,7 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     /// Compile a given expression into a function.
     PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::string const& name,
+        std::string const& name, std::string const& func_name,
         std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets,
         hpx::id_type const& default_locality = hpx::find_here());
@@ -96,10 +96,15 @@ namespace phylanx { namespace execution_tree
         compiler::function_list& snippets,
         hpx::id_type const& default_locality = hpx::find_here());
 
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::string const& expr,
+        compiler::function_list& snippets,
+        hpx::id_type const& default_locality = hpx::find_here());
+
     /// Compile a given expression into a function. Reuse the given compilation
     /// environment.
-    PHYLANX_EXPORT compiler::entry_point const& compile(
-        std::string const& name, std::vector<ast::expression> const& exprs,
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets, compiler::environment& env,
         hpx::id_type const& default_locality = hpx::find_here());
 
@@ -107,6 +112,11 @@ namespace phylanx { namespace execution_tree
     /// environment.
     PHYLANX_EXPORT compiler::entry_point const& compile(
         std::string const& name, std::string const& expr,
+        compiler::function_list& snippets, compiler::environment& env,
+        hpx::id_type const& default_locality = hpx::find_here());
+
+    PHYLANX_EXPORT compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::string const& expr,
         compiler::function_list& snippets, compiler::environment& env,
         hpx::id_type const& default_locality = hpx::find_here());
 

--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -356,8 +356,9 @@ namespace phylanx { namespace execution_tree { namespace compiler
     {
         entry_point() = default;        // needed for serialization
 
-        entry_point(std::string const& name)
-          : name_(name)
+        entry_point(std::string const& func_name, std::string const& name)
+          : func_name_(func_name)
+          , name_(name)
         {
         }
 
@@ -410,7 +411,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
         void serialize(hpx::serialization::input_archive& ar, unsigned);
         void serialize(hpx::serialization::output_archive& ar, unsigned);
 
-        std::string name_;      // the name of this entry point
+        std::string name_;          // the name of this entry point
+        std::string func_name_;     // the function name this was compiled from
         std::list<function> code_;  // the functions representing this
     };
 
@@ -434,7 +436,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                 if (it == last)
                 {
                     return it->run(ctx);
-        }
+                }
                 it->run(ctx);
             }
             return primitive_argument_type{};

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -382,7 +382,8 @@ class PhySL:
                 PhySL.compiler_state = phylanx.execution_tree.compiler_state()
 
             phylanx.execution_tree.compile(
-                self.file_name, self.__src__, PhySL.compiler_state)
+                self.file_name, self.wrapped_function.__name__, self.__src__,
+                PhySL.compiler_state)
             self.is_compiled = True
 
     def generate_physl(self, ir):

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -17,7 +17,7 @@ from phylanx.exceptions import InvalidDecoratorArgumentError
 
 
 def Phylanx(__phylanx_arg=None, **kwargs):
-    class __PhylanxDecorator(object):
+    class _PhylanxDecorator(object):
         def __init__(self, f):
             """
             :function:f the decorated funtion.
@@ -80,18 +80,35 @@ def Phylanx(__phylanx_arg=None, **kwargs):
             return tree
 
         def lazy(self, *args):
+            """Compile this decorator, return wrapper binding the function to
+                arguments"""
+
             if self.backend == 'OpenSCoP':
                 raise NotImplementedError(
                     "OpenSCoP kernels are not yet callable.")
 
-            return self.backend.lazy(args)
+            # If a PhylanxDecorator is passed as an argument to an
+            # invocation of a Phylanx function we need to extract the
+            # compiled execution tree and pass along that instead
+            f = lambda val : val.backend.lazy() \
+                    if type(val).__name__ == _PhylanxDecorator.__name__ else val
+
+            return self.backend.lazy(tuple(map(f, args)))
 
         def __call__(self, *args):
+            """Invoke this decorator using the given arguments"""
+
             if self.backend == 'OpenSCoP':
                 raise NotImplementedError(
                     "OpenSCoP kernels are not yet callable.")
 
-            result = self.backend.call(args)
+            # If a PhylanxDecorator is passed as an argument to an
+            # invocation of a Phylanx function we need to extract the
+            # compiled execution tree and pass along that instead
+            f = lambda val : val.backend.lazy() \
+                    if type(val).__name__ == _PhylanxDecorator.__name__ else val
+
+            result = self.backend.call(tuple(map(f, args)))
 
             self.__perfdata__ = self.backend.__perfdata__
 
@@ -101,8 +118,8 @@ def Phylanx(__phylanx_arg=None, **kwargs):
             return generate_phylanx_ast(self.__src__)
 
     if callable(__phylanx_arg):
-        return __PhylanxDecorator(__phylanx_arg)
+        return _PhylanxDecorator(__phylanx_arg)
     elif __phylanx_arg is not None:
         raise InvalidDecoratorArgumentError
     else:
-        return __PhylanxDecorator
+        return _PhylanxDecorator

--- a/python/src/bindings/ast.cpp
+++ b/python/src/bindings/ast.cpp
@@ -284,9 +284,4 @@ void phylanx::bindings::bind_ast(pybind11::module m)
     ast.def("traverse", &phylanx::bindings::traverse<phylanx::ast::function_call>,
         "traverse the given AST expression and call the provided function "
         "on each part of it");
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Compiler State
-    pybind11::class_<phylanx::bindings::compiler_state>(m, "compiler_state")
-        .def(pybind11::init<>());
 }

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -180,7 +180,8 @@ namespace phylanx { namespace bindings
     ///////////////////////////////////////////////////////////////////////////
     // compile expression
     std::string expression_compiler(std::string const& file_name,
-        std::string const& xexpr_str, compiler_state& c);
+        std::string const& func_name, std::string const& xexpr_str,
+        compiler_state& c);
 
     // evaluate compiled expression
     phylanx::execution_tree::primitive_argument_type expression_evaluator(

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -56,7 +56,7 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
 
     // Compiler State
     pybind11::class_<phylanx::bindings::compiler_state>(
-        execution_tree, "compiler_state")
+            execution_tree, "compiler_state")
         .def(pybind11::init<>())
         .def("code_for",
             [](phylanx::bindings::compiler_state const& state,
@@ -94,50 +94,7 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
                 });
             });
 
-    execution_tree.def("var",
-        [](phylanx::execution_tree::primitive_argument_type const& arg) {
-            pybind11::gil_scoped_release release;       // release GIL
-            return hpx::threads::run_as_hpx_thread(
-                [&]()
-                {
-                    using namespace phylanx::execution_tree;
-                    return create_primitive_component(hpx::find_here(),
-                        "variable", arg);
-                });
-        },
-        "create a new variable from a primitive_argument_type");
-
-    execution_tree.def("var",
-        [](std::string const& d) {
-            pybind11::gil_scoped_release release;       // release GIL
-            return hpx::threads::run_as_hpx_thread(
-                [&]()
-                {
-                    using namespace phylanx::execution_tree;
-                    return create_primitive_component(hpx::find_here(),
-                        "variable", primitive_argument_type{d});
-                });
-        },
-        "create a new variable from a string");
-
-    bind_variable<double>(execution_tree);
-    bind_variable<std::int64_t>(execution_tree);
-    bind_variable<std::uint8_t>(execution_tree);
-
-    execution_tree.def("var",
-        [](pybind11::none) {
-            pybind11::gil_scoped_release release;       // release GIL
-            return hpx::threads::run_as_hpx_thread(
-                [&]()
-                {
-                    using namespace phylanx::execution_tree;
-                    return create_primitive_component(
-                        hpx::find_here(), "variable",
-                        primitive_argument_type{phylanx::ast::nil{true}});
-                });
-        },
-        "create a new variable from 'None'");
-
+    ///////////////////////////////////////////////////////////////////////////
     execution_tree.def("compile", phylanx::bindings::expression_compiler,
         "compile a numerical expression in PhySL");
 
@@ -211,39 +168,39 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
                 "eval",
                 [](phylanx::execution_tree::variable const& var,
                     pybind11::args args)
-            {
-                pybind11::gil_scoped_release release;       // release GIL
-                return hpx::threads::run_as_hpx_thread(
-                        [&]() { return var.eval(std::move(args)); });
-            },
-            "evaluate execution tree")
+                {
+                    pybind11::gil_scoped_release release;       // release GIL
+                    return hpx::threads::run_as_hpx_thread(
+                            [&]() { return var.eval(std::move(args)); });
+                },
+                "evaluate execution tree")
             .def(
                 "__call__",
                 [](phylanx::execution_tree::variable const& var,
                     pybind11::args args)
-            {
-                pybind11::gil_scoped_release release;       // release GIL
-                    return hpx::threads::run_as_hpx_thread(
-                        [&]() { return var.eval(std::move(args)); });
-            },
+                {
+                    pybind11::gil_scoped_release release;       // release GIL
+                        return hpx::threads::run_as_hpx_thread(
+                            [&]() { return var.eval(std::move(args)); });
+                },
                 "evaluate execution tree")
             .def_property_readonly(
                 "dtype",
                 [](phylanx::execution_tree::variable const& var) {
                     return var.dtype();
                 },
-            "return the dtype of the value stored by the variable")
+                "return the dtype of the value stored by the variable")
             .def_property_readonly(
                 "name",
                 [](phylanx::execution_tree::variable const& var) {
                     return var.name();
                 },
                 "return the name of the variable")
-        .def("__str__",
+            .def("__str__",
                 [](phylanx::execution_tree::variable const& var) {
                     return var.name();
                 })
-        .def("__repr__",
+            .def("__repr__",
                 [](phylanx::execution_tree::variable const& var) {
                     return bindings::repr<phylanx::execution_tree::primitive>(
                         var.value());
@@ -284,5 +241,5 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
         .def("__str__",
             &phylanx::bindings::as_string<phylanx::execution_tree::primitive>)
         .def("__repr__",
-            &phylanx::bindings::repr<phylanx::execution_tree::primitive);
+            &phylanx::bindings::repr<phylanx::execution_tree::primitive>);
 }

--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -59,12 +59,12 @@ namespace phylanx { namespace execution_tree
 
     ///////////////////////////////////////////////////////////////////////////
     compiler::entry_point const& compile(std::string const& name,
-        std::vector<ast::expression> const& exprs,
+        std::string const& func_name, std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets, compiler::environment& env,
         compiler::expression_pattern_list const& patterns,
         hpx::id_type const& default_locality)
     {
-        compiler::entry_point entry_point(name);
+        compiler::entry_point entry_point(func_name, name);
 
         for (auto const& expr : exprs)
         {
@@ -78,11 +78,11 @@ namespace phylanx { namespace execution_tree
     }
 
     compiler::entry_point const& compile(std::string const& name,
-        std::vector<ast::expression> const& exprs,
+        std::string const& func_name, std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets, compiler::environment& env,
         hpx::id_type const& default_locality)
     {
-        compiler::entry_point entry_point(name);
+        compiler::entry_point entry_point(func_name, name);
 
         for (auto const& expr : exprs)
         {
@@ -99,18 +99,27 @@ namespace phylanx { namespace execution_tree
         std::string const& expr, compiler::function_list& snippets,
         compiler::environment& env, hpx::id_type const& default_locality)
     {
-        return compile(
-            name, ast::generate_ast(expr), snippets, env, default_locality);
+        return compile(name, "<unknown>", ast::generate_ast(expr), snippets,
+            env, default_locality);
     }
 
     compiler::entry_point const& compile(std::string const& name,
-        std::vector<ast::expression> const& exprs,
+        std::string const& func_name, std::string const& expr,
+        compiler::function_list& snippets, compiler::environment& env,
+        hpx::id_type const& default_locality)
+    {
+        return compile(name, func_name, ast::generate_ast(expr), snippets, env,
+            default_locality);
+    }
+
+    compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets, hpx::id_type const& default_locality)
     {
         compiler::environment env =
             compiler::default_environment(default_locality);
 
-        compiler::entry_point entry_point(name);
+        compiler::entry_point entry_point(func_name, name);
 
         for (auto const& expr : exprs)
         {
@@ -127,8 +136,16 @@ namespace phylanx { namespace execution_tree
         std::string const& expr, compiler::function_list& snippets,
         hpx::id_type const& default_locality)
     {
-        return compile(
-            name, ast::generate_ast(expr), snippets, default_locality);
+        return compile(name, "<unknown>", ast::generate_ast(expr), snippets,
+            default_locality);
+    }
+
+    compiler::entry_point const& compile(std::string const& name,
+        std::string const& func_name, std::string const& expr,
+        compiler::function_list& snippets, hpx::id_type const& default_locality)
+    {
+        return compile(name, func_name, ast::generate_ast(expr), snippets,
+            default_locality);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -137,29 +154,31 @@ namespace phylanx { namespace execution_tree
         compiler::function_list& snippets, compiler::environment& env,
         hpx::id_type const& default_locality)
     {
-        return compile("<unknown>", exprs, snippets, env, default_locality);
+        return compile(
+            "<unknown>", "<unknown>", exprs, snippets, env, default_locality);
     }
 
     compiler::entry_point const& compile(std::string const& expr,
         compiler::function_list& snippets, compiler::environment& env,
         hpx::id_type const& default_locality)
     {
-        return compile("<unknown>", ast::generate_ast(expr), snippets, env,
-            default_locality);
+        return compile("<unknown>", "<unknown>", ast::generate_ast(expr),
+            snippets, env, default_locality);
     }
 
     compiler::entry_point const& compile(
         std::vector<ast::expression> const& exprs,
         compiler::function_list& snippets, hpx::id_type const& default_locality)
     {
-        return compile("<unknown>", exprs, snippets, default_locality);
+        return compile(
+            "<unknown>", "<unknown>", exprs, snippets, default_locality);
     }
 
     compiler::entry_point const& compile(std::string const& expr,
         compiler::function_list& snippets, hpx::id_type const& default_locality)
     {
-        return compile(
-            "<unknown>", ast::generate_ast(expr), snippets, default_locality);
+        return compile("<unknown>", "<unknown>", ast::generate_ast(expr),
+            snippets, default_locality);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -96,6 +96,15 @@ namespace phylanx { namespace execution_tree
     }
 
     compiler::entry_point const& compile(std::string const& name,
+        std::vector<ast::expression> const& exprs,
+        compiler::function_list& snippets, compiler::environment& env,
+        hpx::id_type const& default_locality)
+    {
+        return compile(
+            name, "<unknown>", exprs, snippets, env, default_locality);
+    }
+
+    compiler::entry_point const& compile(std::string const& name,
         std::string const& expr, compiler::function_list& snippets,
         compiler::environment& env, hpx::id_type const& default_locality)
     {
@@ -138,6 +147,13 @@ namespace phylanx { namespace execution_tree
     {
         return compile(name, "<unknown>", ast::generate_ast(expr), snippets,
             default_locality);
+    }
+
+    compiler::entry_point const& compile(std::string const& name,
+        std::vector<ast::expression> const& exprs,
+        compiler::function_list& snippets, hpx::id_type const& default_locality)
+    {
+        return compile(name, "<unknown>", exprs, snippets, default_locality);
     }
 
     compiler::entry_point const& compile(std::string const& name,

--- a/src/execution_tree/compiler_component.cpp
+++ b/src/execution_tree/compiler_component.cpp
@@ -48,7 +48,8 @@ namespace phylanx { namespace execution_tree
     compiler::entry_point compiler_component::compile(
         std::string const& name, std::vector<ast::expression> exprs)
     {
-        return execution_tree::compile(name, exprs, snippets_, env_, patterns_);
+        return execution_tree::compile(
+            name, "<unknown>", exprs, snippets_, env_, patterns_);
     }
 
     compiler::function compiler_component::define_variable(

--- a/src/plugins/controls/fold_left_operation.cpp
+++ b/src/plugins/controls/fold_left_operation.cpp
@@ -123,13 +123,28 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 for (auto&& elem : list)
                 {
                     primitive_arguments_type args(2);
-                    args[0] = std::move(initial);
+                    if (is_primitive_operand(initial))
+                    {
+                        args[0] = value_operand_sync(std::move(initial),
+                            primitive_arguments_type{}, this_->name_,
+                            this_->codename_, ctx);
+                    }
+                    else
+                    {
+                        args[0] = std::move(initial);
+                    }
                     args[1] = std::move(elem);
 
                     initial = value_operand_sync(bound_func, std::move(args),
                         this_->name_, this_->codename_, ctx);
                 }
 
+                if (is_primitive_operand(initial))
+                {
+                    return primitive_argument_type{value_operand_sync(
+                        std::move(initial), primitive_arguments_type{},
+                        this_->name_, this_->codename_, ctx)};
+                }
                 return primitive_argument_type{std::move(initial)};
             }),
             value_operand(operands_[0], args, name_, codename_,

--- a/src/plugins/controls/fold_right_operation.cpp
+++ b/src/plugins/controls/fold_right_operation.cpp
@@ -125,12 +125,27 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     primitive_arguments_type args(2);
 
                     args[0] = std::move(*i);
-                    args[1] = std::move(initial);
+                    if (is_primitive_operand(initial))
+                    {
+                        args[1] = value_operand_sync(std::move(initial),
+                            primitive_arguments_type{}, this_->name_,
+                            this_->codename_, ctx);
+                    }
+                    else
+                    {
+                        args[1] = std::move(initial);
+                    }
 
                     initial = value_operand_sync(bound_func, std::move(args),
                         this_->name_, this_->codename_, ctx);
                 }
 
+                if (is_primitive_operand(initial))
+                {
+                    return primitive_argument_type{value_operand_sync(
+                        std::move(initial), primitive_arguments_type{},
+                        this_->name_, this_->codename_, ctx)};
+                }
                 return primitive_argument_type{std::move(initial)};
             }),
             value_operand(operands_[0], args, name_, codename_,

--- a/tests/regressions/python/904_pass_decorator.py
+++ b/tests/regressions/python/904_pass_decorator.py
@@ -9,9 +9,14 @@ import numpy as np
 from phylanx import Phylanx, PhylanxSession, execution_tree
 
 
+# appease flake
+def fold_left(x, y, z):
+    pass
+
+
 @Phylanx
 def fn():
-    return lambda a, b : 2 * a - b
+    return lambda a, b: 2 * a - b
 
 
 @Phylanx

--- a/tests/regressions/python/904_pass_decorator.py
+++ b/tests/regressions/python/904_pass_decorator.py
@@ -1,0 +1,22 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #904: Cannot pass function as an argument
+
+import numpy as np
+from phylanx import Phylanx, PhylanxSession, execution_tree
+
+
+@Phylanx
+def fn():
+    return lambda a, b : 2 * a - b
+
+
+@Phylanx
+def foldl_eager(fn, elems, initializer):
+    return fold_left(fn, initializer, elems)
+
+
+assert foldl_eager(fn, [1, 2, 3], 3) == 13

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -33,6 +33,7 @@ set(tests
     896_return_none
     903_variable_conversion
     903_variable_dtype
+    904_pass_decorator
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tests/regressions/python/passing_compiler_state_453.py
+++ b/tests/regressions/python/passing_compiler_state_453.py
@@ -11,7 +11,7 @@ from phylanx import Phylanx, PhylanxSession
 
 PhylanxSession.init(1)
 
-cs = phylanx.compiler_state()
+cs = et.compiler_state()
 
 src_mul2 = """
 define(mul2, n,

--- a/tests/regressions/python/passing_compiler_state_453.py
+++ b/tests/regressions/python/passing_compiler_state_453.py
@@ -22,7 +22,7 @@ define(mul2, n,
     )
 )
 """
-et.compile('passing_compiler_state_453.py', src_mul2, cs)
+et.compile('passing_compiler_state_453.py', 'mul2', src_mul2, cs)
 
 
 @Phylanx(compiler_state=cs)

--- a/tests/unit/execution_tree/function_call_arguments.cpp
+++ b/tests/unit/execution_tree/function_call_arguments.cpp
@@ -25,8 +25,9 @@ phylanx::execution_tree::compiler::function compile_and_run(
         phylanx::execution_tree::compiler::default_environment(
             patterns, hpx::find_here());
 
-    auto const& code = phylanx::execution_tree::compile("<unknown>",
-        phylanx::ast::generate_ast(codestr), snippets, env, patterns);
+    auto const& code =
+        phylanx::execution_tree::compile("<unknown>", "<unknown>",
+            phylanx::ast::generate_ast(codestr), snippets, env, patterns);
     return code.run();
 }
 

--- a/tests/unit/python/execution_tree/eval.py
+++ b/tests/unit/python/execution_tree/eval.py
@@ -12,7 +12,7 @@ import numpy as np
 PhylanxSession.init(1)
 
 et = phylanx.execution_tree
-cs = phylanx.compiler_state()
+cs = et.compiler_state()
 
 fib10 = et.eval("""
 block(


### PR DESCRIPTION
- moved compiler_state object into module phylanx.execution_tree
- flyby: change bindings such that the expression returned from lazy() is
  properly usable as an argument to other lazy calls
- flyby: fixing fold_left/fold_right to evaluate intermediate results, if needed

Fixes #904