### PR TITLE
Fixing constant/constant_like to properly support dtype

### DIFF
--- a/phylanx/execution_tree/primitives/primitive_argument_type.hpp
+++ b/phylanx/execution_tree/primitives/primitive_argument_type.hpp
@@ -458,6 +458,9 @@ namespace phylanx { namespace execution_tree
         {
         }
 
+        primitive_argument_type(char const* val)
+          : argument_value_type{std::string(val)}
+        {}
         primitive_argument_type(std::string const& val)
           : argument_value_type{val}
         {}

--- a/phylanx/plugins/matrixops/constant.hpp
+++ b/phylanx/plugins/matrixops/constant.hpp
@@ -53,22 +53,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
         ir::node_data<T> constant2d_helper(primitive_argument_type&& op,
             operand_type::dimensions_type const& dim) const;
 
-        primitive_argument_type constant0d(primitive_argument_type&& op) const;
-        primitive_argument_type constant1d(
-            primitive_argument_type&& op, std::size_t dim) const;
+        primitive_argument_type constant0d(
+            primitive_argument_type&& op, node_data_type dtype) const;
+        primitive_argument_type constant1d(primitive_argument_type&& op,
+            std::size_t dim, node_data_type dtype) const;
         primitive_argument_type constant2d(primitive_argument_type&& op,
-            operand_type::dimensions_type const& dim) const;
+            operand_type::dimensions_type const& dim,
+            node_data_type dtype) const;
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
         template <typename T>
         ir::node_data<T> constant3d_helper(primitive_argument_type&& op,
             operand_type::dimensions_type const& dim) const;
         primitive_argument_type constant3d(primitive_argument_type&& op,
-            operand_type::dimensions_type const& dim) const;
+            operand_type::dimensions_type const& dim,
+            node_data_type dtype) const;
 #endif
 
     private:
-        node_data_type dtype_;
         bool implements_like_operations_;
     };
 

--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -587,6 +587,8 @@ namespace pybind11 { namespace detail
         template <typename Type>
         static handle cast_impl_automatic(Type* src)
         {
+            using T_ = typename casted_type<T>::type;
+
             switch (src->index())
             {
             // blaze::DynamicVector<T>
@@ -600,12 +602,12 @@ namespace pybind11 { namespace detail
             // custom types require a copy (done by vector_copy/matrix_copy)
             // blaze::CustomVector<T>
             case phylanx::ir::node_data<T>::custom_storage1d:
-                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                return blaze_encapsulate(new blaze::DynamicVector<T_>(
                     src->vector_copy()));
 
             // blaze::CustomMatrix<T>
             case phylanx::ir::node_data<T>::custom_storage2d:
-                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                return blaze_encapsulate(new blaze::DynamicMatrix<T_>(
                     src->matrix_copy()));
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
@@ -615,7 +617,7 @@ namespace pybind11 { namespace detail
 
             // blaze::CustomTensor<T>
             case phylanx::ir::node_data<T>::custom_storage3d:
-                return blaze_encapsulate(new blaze::DynamicTensor<T>(
+                return blaze_encapsulate(new blaze::DynamicTensor<T_>(
                     src->tensor_copy()));
 #endif
             default:
@@ -628,38 +630,40 @@ namespace pybind11 { namespace detail
         template <typename Type>
         static handle cast_impl_move(Type* src)
         {
+            using T_ = typename casted_type<T>::type;
+
             switch (src->index())
             {
             // blaze::DynamicVector<T>
             case phylanx::ir::node_data<T>::storage1d:
-                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                return blaze_encapsulate(new blaze::DynamicVector<T_>(
                     std::move(src->vector_non_ref())));
 
             // blaze::DynamicMatrix<T>
             case phylanx::ir::node_data<T>::storage2d:
-                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                return blaze_encapsulate(new blaze::DynamicMatrix<T_>(
                     std::move(src->matrix_non_ref())));
 
             // custom types require a copy (done by vector_copy/matrix_copy)
             // blaze::CustomVector<T>
             case phylanx::ir::node_data<T>::custom_storage1d:
-                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                return blaze_encapsulate(new blaze::DynamicVector<T_>(
                     src->vector_copy()));
 
             // blaze::CustomMatrix<T>
             case phylanx::ir::node_data<T>::custom_storage2d:
-                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                return blaze_encapsulate(new blaze::DynamicMatrix<T_>(
                     src->matrix_copy()));
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
             // blaze::DynamicTensor<T>
             case phylanx::ir::node_data<T>::storage3d:
-                return blaze_encapsulate(new blaze::DynamicTensor<T>(
+                return blaze_encapsulate(new blaze::DynamicTensor<T_>(
                     std::move(src->tensor_non_ref())));
 
             // blaze::CustomTensor<T>
             case phylanx::ir::node_data<T>::custom_storage3d:
-                return blaze_encapsulate(new blaze::DynamicTensor<T>(
+                return blaze_encapsulate(new blaze::DynamicTensor<T_>(
                     src->tensor_copy()));
 #endif
             default:
@@ -672,6 +676,8 @@ namespace pybind11 { namespace detail
         template <typename Type>
         static handle cast_impl_copy(Type* src)
         {
+            using T_ = typename casted_type<T>::type;
+
             switch (src->index())
             {
             // blaze::DynamicVector<T>
@@ -684,12 +690,12 @@ namespace pybind11 { namespace detail
 
             // blaze::CustomVector<T>
             case phylanx::ir::node_data<T>::custom_storage1d:
-                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                return blaze_encapsulate(new blaze::DynamicVector<T_>(
                     src->vector_copy()));
 
             // blaze::CustomMatrix<T>
             case phylanx::ir::node_data<T>::custom_storage2d:
-                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                return blaze_encapsulate(new blaze::DynamicMatrix<T_>(
                     src->matrix_copy()));
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
@@ -699,7 +705,7 @@ namespace pybind11 { namespace detail
 
             // blaze::CustomTensor<T>
             case phylanx::ir::node_data<T>::custom_storage3d:
-                return blaze_encapsulate(new blaze::DynamicTensor<T>(
+                return blaze_encapsulate(new blaze::DynamicTensor<T_>(
                     src->tensor_copy()));
 #endif
             default:
@@ -712,6 +718,8 @@ namespace pybind11 { namespace detail
         template <typename Type>
         static handle cast_impl_automatic_reference(Type* src)
         {
+            using T_ = typename casted_type<T>::type;
+
             switch (src->index())
             {
             // blaze::DynamicVector<T>
@@ -725,12 +733,12 @@ namespace pybind11 { namespace detail
             // custom types require a copy (done by vector_copy/matrix_copy)
             // blaze::CustomVector<T>
             case phylanx::ir::node_data<T>::custom_storage1d:
-                return blaze_encapsulate(new blaze::DynamicVector<T>(
+                return blaze_encapsulate(new blaze::DynamicVector<T_>(
                     src->vector_copy()));
 
             // blaze::CustomMatrix<T>
             case phylanx::ir::node_data<T>::custom_storage2d:
-                return blaze_encapsulate(new blaze::DynamicMatrix<T>(
+                return blaze_encapsulate(new blaze::DynamicMatrix<T_>(
                     src->matrix_copy()));
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
@@ -740,7 +748,7 @@ namespace pybind11 { namespace detail
 
             // blaze::CustomTensor<T>
             case phylanx::ir::node_data<T>::custom_storage3d:
-                return blaze_encapsulate(new blaze::DynamicTensor<T>(
+                return blaze_encapsulate(new blaze::DynamicTensor<T_>(
                     src->tensor_copy()));
 #endif
             default:

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -1489,9 +1489,11 @@ namespace phylanx { namespace execution_tree { namespace compiler
         {
             std::map<std::string, primitive_argument_type> constants =
             {
+                // generally useful constants
                 {"nil", primitive_argument_type{ast::nil{true}}},
                 {"false", primitive_argument_type{false}},
                 {"true", primitive_argument_type{true}},
+                // number extrema
                 {"inf",
                     primitive_argument_type{
                         std::numeric_limits<double>::infinity()}},
@@ -1503,6 +1505,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                         std::numeric_limits<double>::quiet_NaN()}},
                 {"NZERO", primitive_argument_type{-0.0}},
                 {"PZERO", primitive_argument_type{+0.0}},
+                // useful math constants
                 {"euler",
                     primitive_argument_type{
                         2.7182818284590452353602874713526624977572}},
@@ -1511,7 +1514,11 @@ namespace phylanx { namespace execution_tree { namespace compiler
                         0.5772156649015328606065120900824024310421}},
                 {"pi",
                     primitive_argument_type{
-                        3.1415926535897932384626433832795028841971}}
+                        3.1415926535897932384626433832795028841971}},
+                // numpy dtype type constants
+                {"int", primitive_argument_type{"int64"}},
+                {"float", primitive_argument_type{"float64"}},
+                {"bool", primitive_argument_type{"bool"}}
             };
             return constants;
         }

--- a/src/execution_tree/primitives/node_data_helpers0d.cpp
+++ b/src/execution_tree/primitives/node_data_helpers0d.cpp
@@ -31,11 +31,11 @@ namespace phylanx { namespace execution_tree
         {
             result = node_data_type_bool;
         }
-        else if (spec == "int")
+        else if (spec.find("int") == 0)
         {
             result = node_data_type_int64;
         }
-        else if (spec == "float")
+        else if (spec.find("float") == 0)
         {
             result = node_data_type_double;
         }

--- a/src/plugins/matrixops/eye_operation.cpp
+++ b/src/plugins/matrixops/eye_operation.cpp
@@ -224,7 +224,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
                 return this_->eye_nmk(n, m, k, dtype);
             }),
-            detail::map_operands(ops, functional::value_operand{},
+            detail::map_operands(std::move(ops), functional::value_operand{},
                 args, name_, codename_, std::move(ctx)));
     }
 }}}

--- a/tests/regressions/python/635_arange_args.py
+++ b/tests/regressions/python/635_arange_args.py
@@ -13,25 +13,31 @@ def test_arange_float():
     return arange_float
 
 
-assert (test_arange_float() == np.arange(3, dtype='int')).all
+r = test_arange_float()
+assert r.dtype.name == 'float64', r.dtype.name
+assert (r == np.arange(3, dtype='float64')).all()
 
 
 @Phylanx
 def test_arange_int():
-    arange_int = np.arange(1, 3, dtype='int')
+    arange_int = np.arange(1, 3, dtype='int64')
     return arange_int
 
 
-assert (test_arange_int() == np.arange(1, 3, dtype='int')).all
+r = test_arange_int()
+assert r.dtype.name == 'int64', r.dtype.name
+assert (r == np.arange(1, 3, dtype='int64')).all()
 
 
 @Phylanx
 def test_cumsum_float(a):
-    return np.cumsum(a, dtype='float')
+    return np.cumsum(a, dtype=float)
 
 
 a = np.array([[1.5, 2, 3], [4, 5, 6]])
-assert (test_cumsum_float(a) == np.cumsum(a, dtype='float')).all
+r = test_cumsum_float(a)
+assert r.dtype.name == 'float64', r.dtype.name
+assert (r == np.cumsum(a, dtype=float)).all()
 
 
 @Phylanx
@@ -40,45 +46,56 @@ def test_cumsum_int(a):
 
 
 a = np.array([[1, 2, 3], [4, 5, 6]])
-assert (test_cumsum_float(a) == np.cumsum(a, dtype='int')).all
+r = test_cumsum_int(a)
+assert r.dtype.name == 'int64', r.dtype.name
+assert (r == np.cumsum(a, dtype=int)).all()
 
 
 @Phylanx
 def test_stack_bool():
-    return np.array([[True], [False], [True]], dtype='bool')
+    return np.array([[True], [False], [True]], dtype=bool)
 
 
-assert (test_stack_bool() == np.array([[True], [False], [True]],
-                                      dtype='bool')).all
+r = test_stack_bool()
+assert r.dtype.name == 'bool', r.dtype.name
+assert (r == np.array([[True], [False], [True]], dtype=bool)).all()
 
 
 @Phylanx
 def test_stack_float():
-    return np.array([[1], [2], [3]], dtype='float')
+    return np.array([[1], [2], [3]], dtype=float)
 
 
-assert (test_stack_float() == np.array([[1], [2], [3]], dtype='float')).all
+r = test_stack_float()
+assert r.dtype.name == 'float64', r.dtype.name
+assert (r == np.array([[1], [2], [3]], dtype=float)).all()
 
 
 @Phylanx
 def test_stack_int():
-    return np.array([[1], [2], [3]], dtype='int')
+    return np.array([[1], [2], [3]], dtype='int64')
 
 
-assert (test_stack_int() == np.array([[1], [2], [3]], dtype='int')).all
+r = test_stack_int()
+assert r.dtype.name == 'int64', r.dtype.name
+assert (r == np.array([[1], [2], [3]], dtype='int64')).all()
 
 
 @Phylanx
 def test_zeros():
-    return np.zeros((3, 3), dtype='int')
+    return np.zeros((3, 3), dtype='int64')
 
 
-assert (test_zeros() == np.zeros((3, 3), dtype='int')).all
+r = test_zeros()
+assert r.dtype.name == 'int64', r.dtype.name
+assert (r == np.zeros((3, 3), dtype='int64')).all()
 
 
 @Phylanx
 def test_ones():
-    return np.ones((3, 3), dtype='float')
+    return np.ones((3, 3), dtype=float)
 
 
-assert (test_ones() == np.ones((3, 3), dtype='float')).all
+r = test_ones()
+assert r.dtype.name == 'float64', r.dtype.name
+assert (r == np.ones((3, 3), dtype=float)).all()

--- a/tests/regressions/python/805_lazy_variable.py
+++ b/tests/regressions/python/805_lazy_variable.py
@@ -14,13 +14,13 @@ def variable(value, dtype=None):
     return execution_tree.variable(np.array(value, dtype), dtype)
 
 
-@Phylanx
-def ones_like_eager(x):
-    return np.ones_like(x)
+@Phylanx(debug=True)
+def ones_like_eager(x, dtype=None):
+    return np.ones_like(x, dtype=dtype)
 
 
-def ones_like(x):
-    return ones_like_eager.lazy(x)
+def ones_like(x, dtype=None):
+    return ones_like_eager.lazy(x, dtype)
 
 
 def eval(func):
@@ -28,4 +28,4 @@ def eval(func):
 
 
 x = variable(np.array([1, 2, 3]))
-print(eval(ones_like(x)))
+assert (eval(ones_like(x, 'float64')) == [1.0, 1.0, 1.0]).all()

--- a/tests/unit/plugins/matrixops/constant.cpp
+++ b/tests/unit/plugins/matrixops/constant.cpp
@@ -183,17 +183,33 @@ int main(int argc, char* argv[])
     test_constant_3d();
 #endif
 
-    // zeros, ones, full
-    test_constant_operation("constant(42, list())", "42");
-    test_constant_operation("constant(42, list(4))", "[42, 42, 42, 42]");
+    // zeros, ones, full, default dtype is 'float64'
     test_constant_operation(
-        "constant(42, list(2, 2))", "[[42, 42], [42, 42]]");
+        "constant(42, list())", "42.0");
+    test_constant_operation(
+        "constant(42, list(4))", "[42.0, 42.0, 42.0, 42.0]");
+    test_constant_operation(
+        "constant(42, list(2, 2))", "[[42.0, 42.0], [42.0, 42.0]]");
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
     test_constant_operation("constant(42, list(2, 2, 2))",
+        "[[[42.0, 42.0], [42.0, 42.0]], [[42.0, 42.0], [42.0, 42.0]]]");
+#endif
+
+    test_constant_operation(
+        R"(constant(42, list(), __arg(dtype, "int")))", "42");
+    test_constant_operation(
+        R"(constant(42, list(4), __arg(dtype, "int")))",
+        "[42, 42, 42, 42]");
+    test_constant_operation(
+        R"(constant(42, list(2, 2), __arg(dtype, "int")))",
+        "[[42, 42], [42, 42]]");
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_constant_operation(
+        R"(constant(42, list(2, 2, 2), __arg(dtype, "int")))",
         "[[[42, 42], [42, 42]], [[42, 42], [42, 42]]]");
 #endif
 
-    // ...like operations
+    // ...like operations, default dtype is derived from argument
     test_constant_operation("constant_like(42, 1)", "42");
     test_constant_operation("constant_like(42, [1, 2, 3, 4])",
         "[42, 42, 42, 42]");
@@ -206,30 +222,53 @@ int main(int argc, char* argv[])
         "[[[42, 42], [42, 42]], [[42, 42], [42, 42]]]");
 #endif
 
+    test_constant_operation(
+        "constant_like(42.0, 1)", "42.0");
+    test_constant_operation(
+        "constant_like(42.0, [1, 2, 3, 4])",
+        "[42.0, 42.0, 42.0, 42.0]");
+    test_constant_operation(
+        "constant_like(42.0, [[1, 2], [3, 4]])",
+        "[[42.0, 42.0], [42.0, 42.0]]");
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+    test_constant_operation(
+        "constant_like(42.0, [[[1, 2], [3, 4]], [[1, 2], [3, 4]]])",
+        "[[[42.0, 42.0], [42.0, 42.0]], [[42.0, 42.0], [42.0, 42.0]]]");
+#endif
+
     // empty
     test_empty_operation(
-        "constant__int(list())", std::array<int, PHYLANX_MAX_DIMENSIONS>{});
+        R"(constant(nil, list(), __arg(dtype, "int")))",
+        std::array<int, PHYLANX_MAX_DIMENSIONS>{});
     test_empty_operation(
-        "constant__int(list(4))", std::array<int, PHYLANX_MAX_DIMENSIONS>{4});
-    test_empty_operation("constant__int(list(2, 2))",
+        R"(constant(nil, list(4), __arg(dtype, "int")))",
+        std::array<int, PHYLANX_MAX_DIMENSIONS>{4});
+    test_empty_operation(
+        R"(constant(nil, list(2, 2), __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2});
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
-    test_empty_operation("constant__int(list(2, 2, 2))",
+    test_empty_operation(
+        R"(constant(nil, list(2, 2, 2), __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2, 2});
 #endif
 
     // empty_like
-    test_empty_operation("constant_like__int(1)",
+    test_empty_operation(
+        R"(constant_like(nil, 1, __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{});
-    test_empty_operation("constant_like__int([1, 2, 3, 4])",
+    test_empty_operation(
+        R"(constant_like(nil, [1, 2, 3, 4], __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{4});
     test_empty_operation(
-        "constant_like__int([[1, 2], [3, 4]])",
+        R"(constant_like(nil, [[1, 2], [3, 4]], __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2});
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
     test_empty_operation(
-        "constant_like__int("
-        "   dstack(list([[1, 2], [3, 4]], [[1, 2], [3, 4]])))",
+        R"(constant_like(
+                nil,
+                [[[1, 2], [3, 4]], [[1, 2], [3, 4]]],
+                __arg(dtype, "int"))
+        )",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2, 2});
 #endif
 

--- a/tests/unit/python/execution_tree/primitives/numpy_dtype.py
+++ b/tests/unit/python/execution_tree/primitives/numpy_dtype.py
@@ -13,7 +13,7 @@ def test_arange_float():
     return arange_float
 
 
-assert (test_arange_float() == np.arange(3, dtype='int')).all
+assert (test_arange_float() == np.arange(3, dtype='int')).all()
 
 
 @Phylanx
@@ -22,7 +22,7 @@ def test_arange_int():
     return arange_int
 
 
-assert (test_arange_int() == np.arange(1, 3, dtype='int')).all
+assert (test_arange_int() == np.arange(1, 3, dtype='int')).all()
 
 
 @Phylanx
@@ -31,7 +31,7 @@ def test_cumsum_float(a):
 
 
 a = np.array([[1.5, 2, 3], [4, 5, 6]])
-assert (test_cumsum_float(a) == np.cumsum(a, dtype=float)).all
+assert (test_cumsum_float(a) == np.cumsum(a, dtype=float)).all()
 
 
 @Phylanx
@@ -40,7 +40,7 @@ def test_cumsum_int(a):
 
 
 a = np.array([[1, 2, 3], [4, 5, 6]])
-assert (test_cumsum_float(a) == np.cumsum(a, dtype='int')).all
+assert (test_cumsum_float(a) == np.cumsum(a, dtype='int')).all()
 
 
 @Phylanx
@@ -49,7 +49,7 @@ def test_stack_bool():
 
 
 assert (test_stack_bool() == np.array([[True], [False], [True]],
-                                      dtype='bool')).all
+                                      dtype='bool')).all()
 
 
 @Phylanx
@@ -57,7 +57,7 @@ def test_stack_float():
     return np.array([[1], [2], [3]], dtype='float')
 
 
-assert (test_stack_float() == np.array([[1], [2], [3]], dtype='float')).all
+assert (test_stack_float() == np.array([[1], [2], [3]], dtype='float')).all()
 
 
 @Phylanx
@@ -65,7 +65,7 @@ def test_stack_int():
     return np.array([[1], [2], [3]], dtype='int')
 
 
-assert (test_stack_int() == np.array([[1], [2], [3]], dtype=int)).all
+assert (test_stack_int() == np.array([[1], [2], [3]], dtype=int)).all()
 
 
 @Phylanx
@@ -73,7 +73,7 @@ def test_zeros():
     return np.zeros((3, 3), dtype='int')
 
 
-assert (test_zeros() == np.zeros((3, 3), dtype=int)).all
+assert (test_zeros() == np.zeros((3, 3), dtype=int)).all()
 
 
 @Phylanx
@@ -81,7 +81,7 @@ def test_ones():
     return np.ones((3, 3), dtype='float')
 
 
-assert (test_ones() == np.ones((3, 3), dtype=float)).all
+assert (test_ones() == np.ones((3, 3), dtype=float)).all()
 
 
 @Phylanx
@@ -91,7 +91,7 @@ def test_ones_like():
 
 
 a = np.zeros((3, 3), dtype=int)
-assert (test_ones_like() == np.ones_like(a, dtype=int)).all
+assert (test_ones_like() == np.ones_like(a, dtype=int)).all()
 
 
 @Phylanx
@@ -101,7 +101,7 @@ def test_zeros_like():
 
 
 a = np.ones((3, 3), dtype=int)
-assert (test_zeros_like() == np.zeros_like(a, dtype=int)).all
+assert (test_zeros_like() == np.zeros_like(a, dtype=int)).all()
 
 
 @Phylanx
@@ -109,7 +109,7 @@ def test_full():
     return np.full((3, 3), 2, dtype='int')
 
 
-assert (test_full() == np.full((3, 3), 2, dtype=int)).all
+assert (test_full() == np.full((3, 3), 2, dtype=int)).all()
 
 
 @Phylanx
@@ -119,4 +119,4 @@ def test_full_like():
 
 
 a = np.zeros((3, 3), dtype=int)
-assert (test_full_like() == np.full_like(a, 42, dtype=int)).all
+assert (test_full_like() == np.full_like(a, 42, dtype=int)).all()


### PR DESCRIPTION
- added more tests
- flyby: added `float`, `int`, and `bool` as keyword constants to compiler
- flyby: added missing constructor for primitive_argument_type from char const*
- flyby: fixed type of numpy.array(..., dtype=bool) when returned from PhySL
- flyby: Fixes #918

Working towards #866 
