### PR TITLE
Allow for explicit None to be passed as a dtype to eye()

### DIFF
--- a/src/plugins/matrixops/eye_operation.cpp
+++ b/src/plugins/matrixops/eye_operation.cpp
@@ -215,8 +215,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         std::move(args[2]), this_->name_, this_->codename_) :
                     0;
 
-                node_data_type dtype = map_dtype(extract_string_value(
-                    std::move(args[3]), this_->name_, this_->codename_));
+                node_data_type dtype = valid(args[3]) ?
+                    map_dtype(extract_string_value(
+                        std::move(args[3]), this_->name_, this_->codename_)) :
+                    node_data_type_double;
 
                 if (n == m && k == 0)
                 {

--- a/tests/regressions/python/925_none_dtype.py
+++ b/tests/regressions/python/925_none_dtype.py
@@ -13,6 +13,7 @@ from phylanx import Phylanx
 def eye_eager(n, dtype, name):
     return np.eye(n, dtype=dtype)
 
+
 def eye(n, dtype=None, name=None):
     return eye_eager.lazy(n, dtype, name)
 

--- a/tests/regressions/python/925_none_dtype.py
+++ b/tests/regressions/python/925_none_dtype.py
@@ -1,0 +1,23 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# 925: Cannot pass a None dtype
+
+import numpy as np
+from phylanx import Phylanx
+
+
+@Phylanx
+def eye_eager(n, dtype, name):
+    return np.eye(n, dtype=dtype)
+
+def eye(n, dtype=None, name=None):
+    return eye_eager.lazy(n, dtype, name)
+
+
+result = eye(3).eval()
+expected = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+assert result.dtype.name == 'float64'
+assert (result == expected).all()

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -35,6 +35,7 @@ set(tests
     903_variable_dtype
     904_pass_decorator
     911_list_comprehension
+    925_none_dtype
     array_len_494
     array_shape_486
     array_subscript_403


### PR DESCRIPTION
Fixes: #925