### PR TITLE
Adding ctc_decode primitive

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -814,6 +814,12 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
+    PHYLANX_EXPORT hpx::future<std::uint8_t> scalar_boolean_operand(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>",
+        eval_context ctx = eval_context{});
 
     // Extract a std::string from a primitive_argument_type (that
     // could be a primitive or a string value).

--- a/phylanx/plugins/keras_support/ctc_decode_operation.hpp
+++ b/phylanx/plugins/keras_support/ctc_decode_operation.hpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 Shahrzad Shirzad
+// Copyright (c) 2018-2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PLUGINS_KERAS_SUPPORT_CTC_DECODE_OPERATION)
+#define PHYLANX_PLUGINS_KERAS_SUPPORT_CTC_DECODE_OPERATION
+
+#include <phylanx/config.hpp>
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/ir/node_data.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    /// \brief Returns the result of Connectionist temporal classification applied to a
+    ///  squence.
+    /// \param y_pred The scalar, vector, matrix, or tensor to perform ctc_decode over
+    /// \param input_length
+    /// \param greedy boolean, if True performs best-path search otherwise beam-search
+    /// \param beam_width Integer, if greedy is False specifies the width of the beam.
+    /// \param top_paths Integer, if greedy is False specifies the number of top paths
+    ///  desired.
+    class ctc_decode_operation
+      : public primitive_component_base
+      , public std::enable_shared_from_this<ctc_decode_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+    public:
+        static match_pattern_type const match_data;
+
+        ctc_decode_operation() = default;
+
+        ctc_decode_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+    };
+
+    inline primitive create_ctc_decode_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "ctc_decode", std::move(operands), name, codename);
+    }
+}}}
+
+#endif
+#endif

--- a/phylanx/plugins/keras_support/keras_support.hpp
+++ b/phylanx/plugins/keras_support/keras_support.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_PLUGINS_KERAS_SUPPORT_MAR_11_2019_0441PM
 
 #include <phylanx/plugins/keras_support/batch_dot_operation.hpp>
+#include <phylanx/plugins/keras_support/ctc_decode_operation.hpp>
 #include <phylanx/plugins/keras_support/elu_operation.hpp>
 #include <phylanx/plugins/keras_support/hard_sigmoid_operation.hpp>
 #include <phylanx/plugins/keras_support/l2_normalize_operation.hpp>

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -3821,6 +3821,34 @@ namespace phylanx { namespace execution_tree
         return extract_scalar_boolean_value(val, name, codename);
     }
 
+    hpx::future<std::uint8_t> scalar_boolean_operand(
+        primitive_argument_type const& val,
+        primitive_arguments_type const& args, std::string const& name,
+        std::string const& codename, eval_context ctx)
+    {
+        primitive const* p = util::get_if<primitive>(&val);
+        if (p != nullptr)
+        {
+            hpx::future<primitive_argument_type> f =
+                p->eval(args, std::move(ctx));
+            if (f.is_ready())
+            {
+                return hpx::make_ready_future(
+                    extract_scalar_boolean_value(f.get(), name, codename));
+            }
+
+            return f.then(hpx::launch::sync,
+                [&](hpx::future<primitive_argument_type>&& f) {
+                    return extract_scalar_boolean_value(
+                        f.get(), name, codename);
+                });
+        }
+
+        HPX_ASSERT(valid(val));
+        return hpx::make_ready_future(
+            extract_scalar_boolean_value(val, name, codename));
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<std::string> string_operand(primitive_argument_type const& val,
         primitive_arguments_type const& args, std::string const& name,

--- a/src/plugins/keras_support/ctc_decode_operation.cpp
+++ b/src/plugins/keras_support/ctc_decode_operation.cpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2019 Shahrzad Shirzad
+// Copyright (c) 2018-2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/keras_support/ctc_decode_operation.hpp>
+#include <phylanx/util/matrix_iterators.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const ctc_decode_operation::match_data = {
+        hpx::util::make_tuple("ctc_decode",
+            std::vector<std::string>{
+                "ctc_decode(_1, _2, __arg(_3_greedy, 1), __arg(_4_beam_width, "
+                "100), __arg(_5_top_paths, 1))"},
+            &create_ctc_decode_operation,
+            &create_primitive<ctc_decode_operation>,
+            R"(y_pred, input_length, greedy, beam_width, top_paths
+            Args:
+
+                y_pred : The scalar, vector, matrix, or tensor to perform ctc_decode over
+                input_length
+                greedy : boolean, if True performs best-path search otherwise beam-search
+                beam_width : Integer, if greedy is False specifies the width of the beam.
+                top_paths : Integer, if greedy is False specifies the number of top paths
+                            desired.
+            Returns:
+
+            Returns the result of Connectionist temporal classification applied to a
+            squence.)")};
+
+    ///////////////////////////////////////////////////////////////////////////
+    ctc_decode_operation::ctc_decode_operation(
+        primitive_arguments_type&& operands, std::string const& name,
+        std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> ctc_decode_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args,
+        eval_context ctx) const
+    {
+        if (operands.size() < 2 || operands.size() > 5)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "ctc_decode_operation::eval",
+                generate_error_message("the ctc_decode_operation primitive "
+                                       "requires at least two and at "
+                                       "most five operands"));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "ctc_decode_operation::eval",
+                generate_error_message(
+                    "the ctc_decode_operation primitive requires that the "
+                    "argument given by the operands array is valid"));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping(
+                [this_ = std::move(this_)](ir::node_data<double>&& arg1,
+                    ir::node_data<std::int64_t>&& arg2, std::uint8_t greedy,
+                    std::int64_t beam_width,
+                    std::int64_t top_paths) -> primitive_argument_type {
+                    if (arg1.num_dimensions() != 3)
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "ctc_decode_operation::eval",
+                            this_->generate_error_message(
+                                "y_pred should be a tensor"));
+
+                    auto y_pred = arg1.tensor();
+                    std::size_t num_samples = y_pred.pages();
+                    std::size_t seq_length = y_pred.rows();
+                    std::size_t num_classes = y_pred.columns();
+
+                    if (arg2.num_dimensions() != 1)
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "ctc_decode_operation::eval",
+                            this_->generate_error_message(
+                                "input_length should be a vector"));
+                    auto input_length = arg2.vector();
+                    blaze::DynamicMatrix<double> log_prob(num_samples, 1, 0.);
+                    blaze::DynamicMatrix<double> decoded_dense(
+                        num_samples, seq_length, -1.);
+
+                    blaze::DynamicVector<std::int64_t> decoded_length(
+                        num_samples, 0.);
+
+                    if (!greedy)
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "ctc_decode_operation::eval",
+                            this_->generate_error_message(
+                                "has not been implemented yet"));
+                    using phylanx::util::matrix_row_iterator;
+
+                    for (std::size_t i = 0; i < num_samples; ++i)
+                    {
+                        std::int64_t length = input_length[i];
+                        auto prob = blaze::pageslice(y_pred, i);
+                        auto tmp =
+                            blaze::submatrix(prob, 0, 0, length, num_classes);
+                        matrix_row_iterator<decltype(prob)> tmp_begin(prob);
+                        matrix_row_iterator<decltype(prob)> tmp_end(
+                            prob, length);
+
+                        blaze::DynamicVector<double> decoded(length);
+                        auto decoded_it = decoded.begin();
+                        double sum = 0.;
+
+                        for (auto it = tmp_begin; it != tmp_end;
+                             ++it, ++decoded_it)
+                        {
+                            auto local_max =
+                                std::max_element(it->begin(), it->end());
+                            sum += blaze::log(*local_max);
+                            *decoded_it = std::distance(it->begin(), local_max);
+                        }
+                        log_prob(i, 0) = -sum;
+                        std::size_t k = 0;
+                        for (std::size_t j = 0; j < decoded.size() - 1; ++j)
+                        {
+                            if ((decoded[j] != decoded[j + 1]) &&
+                                (decoded[j] < num_classes - 1))
+                                decoded[k++] = decoded[j];
+                        }
+                        decoded[k++] = decoded[decoded.size() - 1];
+                        decoded.resize(k);
+
+                        decoded_length[i] = k;
+                        auto decoded_row = blaze::row(decoded_dense, i);
+                        auto decoded_row_length =
+                            blaze::subvector(decoded_row, 0, k);
+                        decoded_row_length = blaze::trans(decoded);
+                    }
+                    blaze::DynamicMatrix<double> decoded_dense_final =
+                        blaze::submatrix(decoded_dense, 0, 0, num_samples,
+                            (blaze::max)(decoded_length));
+
+                    primitive_arguments_type result;
+                    result.reserve(2);
+
+                    result.push_back(primitive_argument_type{
+                        std::move(decoded_dense_final)});
+                    result.push_back(
+                        primitive_argument_type{std::move(log_prob)});
+
+                    return primitive_argument_type{std::move(result)};
+                }),
+            numeric_operand(operands[0], args, name_, codename_, ctx),
+            integer_operand_strict(operands[1], args, name_, codename_, ctx),
+            scalar_boolean_operand(operands[2], args, name_, codename_, ctx),
+            scalar_integer_operand_strict(
+                operands[3], args, name_, codename_, ctx),
+            scalar_integer_operand_strict(
+                operands[4], args, name_, codename_, ctx));
+    }
+}}}
+#endif

--- a/src/plugins/keras_support/keras_support.cpp
+++ b/src/plugins/keras_support/keras_support.cpp
@@ -15,6 +15,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(avg_pool_operation_plugin,
     phylanx::execution_tree::primitives::pool_operation::match_data[1]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(batch_dot_operation_plugin,
     phylanx::execution_tree::primitives::batch_dot_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(ctc_decode_operation_plugin,
+    phylanx::execution_tree::primitives::ctc_decode_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(elu_operation_plugin,
     phylanx::execution_tree::primitives::elu_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(hard_sigmoid_operation_plugin,

--- a/tests/unit/plugins/keras_support/CMakeLists.txt
+++ b/tests/unit/plugins/keras_support/CMakeLists.txt
@@ -6,6 +6,7 @@
 set(tests
 
     batch_dot_operation
+    ctc_decode_operation
     elu_operation
     hard_sigmoid_operation
     l2_normalize_operation

--- a/tests/unit/plugins/keras_support/ctc_decode_operation.cpp
+++ b/tests/unit/plugins/keras_support/ctc_decode_operation.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2019 Shahrzad Shirzad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#if defined(PHYLANX_HAVE_BLAZE_TENSOR)
+///////////////////////////////////////////////////////////////////////////////
+void test_ctc_decode_operation_1()
+{
+    blaze::DynamicTensor<double> arg1{
+        {{0.2, 0.2, 0.6}, {0.4, 0.3, 0.3}}, {{0.7, 0.15, 0.15}, {0., 0., 0.}}};
+    blaze::DynamicVector<std::int64_t> arg2{2, 1};
+
+    phylanx::execution_tree::primitive y_pred =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(arg1));
+    phylanx::execution_tree::primitive input_length =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(arg2));
+    phylanx::execution_tree::primitive greedy =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(1));
+    phylanx::execution_tree::primitive beam_width =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(10));
+    phylanx::execution_tree::primitive top_paths =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(10));
+
+    phylanx::execution_tree::primitive ctc_decode =
+        phylanx::execution_tree::primitives::create_ctc_decode_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(y_pred),
+                std::move(input_length), std::move(greedy),
+                std::move(beam_width), std::move(top_paths)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        ctc_decode.eval();
+    auto result = phylanx::execution_tree::extract_list_value(f.get());
+
+    auto it = result.begin();
+
+    blaze::DynamicMatrix<double> expected_decoded_dense{{0.}, {0.}};
+    blaze::DynamicMatrix<double> expected_log_prob{{1.42711636}, {0.35667494}};
+
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected_decoded_dense)),
+        phylanx::execution_tree::extract_numeric_value(*it));
+    HPX_TEST(
+        allclose(phylanx::ir::node_data<double>(std::move(expected_log_prob)),
+            phylanx::execution_tree::extract_numeric_value(*++it)));
+}
+
+void test_ctc_decode_operation_2()
+{
+    blaze::DynamicTensor<double> arg1{
+        {{1., 0., 0., 0.}, {0., 0., 0.4, 0.6}, {0., 0., 0.4, 0.6},
+            {0., 0.9, 0.1, 0.}, {0., 0., 0., 0.}, {0., 0., 0., 0.}},
+        {{0.1, 0.9, 0., 0.}, {0., 0.9, 0.1, 0.}, {0., 0., 0.1, 0.9},
+            {0., 0.9, 0.1, 0.1}, {0.9, 0.1, 0., 0.}, {0., 0., 0., 0.}}};
+    blaze::DynamicVector<std::int64_t> arg2{4, 5};
+
+    phylanx::execution_tree::primitive y_pred =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(arg1));
+    phylanx::execution_tree::primitive input_length =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(arg2));
+    phylanx::execution_tree::primitive greedy =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::uint8_t>(1));
+    phylanx::execution_tree::primitive beam_width =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(10));
+    phylanx::execution_tree::primitive top_paths =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<std::int64_t>(10));
+
+    phylanx::execution_tree::primitive ctc_decode =
+        phylanx::execution_tree::primitives::create_ctc_decode_operation(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{std::move(y_pred),
+                std::move(input_length), std::move(greedy),
+                std::move(beam_width), std::move(top_paths)});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        ctc_decode.eval();
+    auto result = phylanx::execution_tree::extract_list_value(f.get());
+
+    auto it = result.begin();
+
+    blaze::DynamicMatrix<double> expected_decoded_dense{
+        {0., 1., -1.}, {1., 1., 0.}};
+    blaze::DynamicMatrix<double> expected_log_prob{{1.12701166}, {0.52680272}};
+
+    HPX_TEST_EQ(
+        phylanx::ir::node_data<double>(std::move(expected_decoded_dense)),
+        phylanx::execution_tree::extract_numeric_value(*it));
+    HPX_TEST(
+        allclose(phylanx::ir::node_data<double>(std::move(expected_log_prob)),
+            phylanx::execution_tree::extract_numeric_value(*++it)));
+}
+
+int main(int argc, char* argv[])
+{
+    test_ctc_decode_operation_1();
+    test_ctc_decode_operation_2();
+
+    return hpx::util::report_errors();
+}
+#endif


### PR DESCRIPTION
Based on the implementation of [ctc_decode](https://github.com/keras-team/keras/blob/b2771d13b0f9146cde43af00f5a5156f56614436/keras/backend/numpy_backend.py#L720) in numpy backend of keras.