### PR TITLE
Enable iterating over `zip`.

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -13,6 +13,19 @@ import phylanx.execution_tree
 from phylanx import PhylanxSession
 
 
+def physl_zip(loop):
+    targets = [it.id for it in loop.target.elts]
+    args = [arg.id for arg in loop.iter.args]
+    lambda_ = ['lambda', (*targets, ['list', (*targets, )])]
+    fmap = ['fmap', (lambda_, *args)]
+
+    def define(i, idx):
+        return ['define', (i, ['slice', ('__physl_iterator', str(idx))])]
+
+    indices = tuple(define(i, idx) for idx, i in enumerate(targets))
+    return (fmap, indices)
+
+
 mapped_methods = {
     "add": "__add",
     "array": "hstack",
@@ -877,6 +890,13 @@ class PhySL:
         # target_name = target.split('$', 1)[0]
         # self.defined.add(target_name)
         iteration_space = self.apply_rule(node.iter)
+        if isinstance(iteration_space, list) and iteration_space[0].startswith('zip'):
+            iter_space, indices = physl_zip(node)
+            symbol = get_symbol_info(node, 'for_each')
+            body = self.block(node.body)
+            body = ['block', (*indices, *body)]
+            op = get_symbol_info(node, 'lambda')
+            return [symbol, ([op, ('__physl_iterator', body)], iter_space)]
 
         # extract the type of the iteration space- used as the lookup key in
         # `mapping_function` dictionary above.

--- a/tests/regressions/python/912_zip.py
+++ b/tests/regressions/python/912_zip.py
@@ -1,0 +1,26 @@
+#  Copyright (c) 2019 R. Tohid
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+import numpy as np
+from phylanx import Phylanx
+
+
+@Phylanx
+def phy_fx(start, size):
+    indices = []
+    for i, j in zip(start, size):
+        indices = append(indices, [i, i + j])  # noqa: F821
+    return indices
+
+
+def np_fx(start, size):
+    indices = []
+    for i, j in zip(start, size):
+        indices.append([i, i + j])
+    return indices
+
+
+assert phy_fx([0, 1, 1], [1, 1, 3]) == np_fx([0, 1, 1], [1, 1, 3])

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -36,6 +36,7 @@ set(tests
     904_pass_decorator
     905_call_python_snippet
     911_list_comprehension
+    912_zip
     925_none_dtype
     array_len_494
     array_shape_486


### PR DESCRIPTION
Fix #912.
Only supports `zip` as the iteration space of a `for` loop.