### PR TITLE
Removing extract_boolean_data from the base primitive

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -256,15 +256,6 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     // Extract a ir::node_data<std::uint8_t> type from a given primitive_argument_type,
     // throw if it doesn't hold one.
-    PHYLANX_EXPORT ir::node_data<std::uint8_t> extract_boolean_data(
-        primitive_argument_type const& val,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
-    PHYLANX_EXPORT ir::node_data<std::uint8_t>&& extract_boolean_data(
-        primitive_argument_type&& val,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
-
     PHYLANX_EXPORT bool is_boolean_data_operand(
         primitive_argument_type const& val);
 

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -1381,66 +1381,6 @@ namespace phylanx { namespace execution_tree
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    ir::node_data<std::uint8_t>
-    extract_boolean_data(primitive_argument_type const& val,
-        std::string const& name, std::string const& codename)
-    {
-        switch (val.index())
-        {
-        case 1:                     // phylanx::ir::node_data<std::uint8_t>
-            return util::get<1>(val).ref();
-
-        case 0: HPX_FALLTHROUGH;    // nil
-        case 2: HPX_FALLTHROUGH;    // ir::node_data<std::int64_t>
-        case 3: HPX_FALLTHROUGH;    // string
-        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
-        case 5: HPX_FALLTHROUGH;    // primitive
-        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
-        case 7: HPX_FALLTHROUGH;    // phylanx::ir::range
-        case 8: HPX_FALLTHROUGH;    // phylanx::ir::dictionary
-        default:
-            break;
-        }
-
-        std::string type(detail::get_primitive_argument_type_name(val.index()));
-        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "phylanx::execution_tree::extract_boolean_data",
-            util::generate_error_message(
-                "primitive_argument_type does not hold a boolean "
-                    "value type (type held: '" + type + "')",
-                name, codename));
-    }
-
-    ir::node_data<std::uint8_t>&& extract_boolean_data(
-        primitive_argument_type&& val, std::string const& name,
-        std::string const& codename)
-    {
-        switch (val.index())
-        {
-        case 1:                     // phylanx::ir::node_data<std::uint8_t>
-            return util::get<1>(std::move(val));
-
-        case 0: HPX_FALLTHROUGH;    // nil
-        case 2: HPX_FALLTHROUGH;    // ir::node_data<std::int64_t>
-        case 3: HPX_FALLTHROUGH;    // string
-        case 4: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
-        case 5: HPX_FALLTHROUGH;    // primitive
-        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
-        case 7: HPX_FALLTHROUGH;    // phylanx::ir::range
-        case 8: HPX_FALLTHROUGH;    // phylanx::ir::dictionary
-        default:
-            break;
-        }
-
-        std::string type(detail::get_primitive_argument_type_name(val.index()));
-        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "phylanx::execution_tree::extract_boolean_data",
-            util::generate_error_message(
-                "primitive_argument_type does not hold a boolean "
-                    "value type (type held: '" + type + "')",
-                name, codename));
-    }
-
     bool is_boolean_data_operand(primitive_argument_type const& val)
     {
         switch (val.index())

--- a/tests/unit/plugins/booleans/and_operation.cpp
+++ b/tests/unit/plugins/booleans/and_operation.cpp
@@ -36,7 +36,7 @@ void test_and_operation_0d_false()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d_double_false()
@@ -59,7 +59,7 @@ void test_and_operation_0d_double_false()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d_true()
@@ -82,7 +82,7 @@ void test_and_operation_0d_true()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d_double_true()
@@ -105,7 +105,7 @@ void test_and_operation_0d_double_true()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d_lit_false()
@@ -126,7 +126,7 @@ void test_and_operation_0d_lit_false()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d_double_lit_false()
@@ -147,7 +147,7 @@ void test_and_operation_0d_double_lit_false()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d_lit_true()
@@ -168,7 +168,7 @@ void test_and_operation_0d_lit_true()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d_double_lit_true()
@@ -189,7 +189,7 @@ void test_and_operation_0d_double_lit_true()
         and_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_false()
@@ -218,7 +218,7 @@ void test_and_operation_0d1d_false()
         blaze::map(v, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_lit_false()
@@ -245,7 +245,7 @@ void test_and_operation_0d1d_lit_false()
         blaze::map(v, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_double_false()
@@ -273,7 +273,7 @@ void test_and_operation_0d1d_double_false()
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_double_lit_false()
@@ -299,7 +299,7 @@ void test_and_operation_0d1d_double_lit_false()
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_true()
@@ -328,7 +328,7 @@ void test_and_operation_0d1d_true()
         blaze::map(v, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_lit_true()
@@ -355,7 +355,7 @@ void test_and_operation_0d1d_lit_true()
         blaze::map(v, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_double_true()
@@ -384,7 +384,7 @@ void test_and_operation_0d1d_double_true()
         blaze::map(v, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d1d_double_lit_true()
@@ -411,7 +411,7 @@ void test_and_operation_0d1d_double_lit_true()
         blaze::map(v, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_false()
@@ -440,7 +440,7 @@ void test_and_operation_0d2d_false()
         blaze::map(m, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_lit_false()
@@ -467,7 +467,7 @@ void test_and_operation_0d2d_lit_false()
         blaze::map(m, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_double_false()
@@ -495,7 +495,7 @@ void test_and_operation_0d2d_double_false()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_double_lit_false()
@@ -521,7 +521,7 @@ void test_and_operation_0d2d_double_lit_false()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_true()
@@ -550,7 +550,7 @@ void test_and_operation_0d2d_true()
         blaze::map(m, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_lit_true()
@@ -577,7 +577,7 @@ void test_and_operation_0d2d_lit_true()
         blaze::map(m, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_double_true()
@@ -606,7 +606,7 @@ void test_and_operation_0d2d_double_true()
         blaze::map(m, [](double x) { return (x != 0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_0d2d_double_lit_true()
@@ -633,7 +633,7 @@ void test_and_operation_0d2d_double_lit_true()
         blaze::map(m, [](double x) { return (x != 0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d()
@@ -663,7 +663,7 @@ void test_and_operation_1d()
         blaze::map(v1, v2, [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d_lit()
@@ -691,7 +691,7 @@ void test_and_operation_1d_lit()
         blaze::map(v1, v2, [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d_double()
@@ -721,7 +721,7 @@ void test_and_operation_1d_double()
         blaze::map(v1, v2, [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d_double_lit()
@@ -749,7 +749,7 @@ void test_and_operation_1d_double_lit()
         blaze::map(v1, v2, [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_false()
@@ -778,7 +778,7 @@ void test_and_operation_1d0d_false()
         blaze::map(v, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_lit_false()
@@ -805,7 +805,7 @@ void test_and_operation_1d0d_lit_false()
         blaze::map(v, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_double_false()
@@ -833,7 +833,7 @@ void test_and_operation_1d0d_double_false()
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_double_lit_false()
@@ -859,7 +859,7 @@ void test_and_operation_1d0d_double_lit_false()
     blaze::DynamicVector<double> expected(v.size(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_true()
@@ -888,7 +888,7 @@ void test_and_operation_1d0d_true()
         blaze::map(v, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_lit_true()
@@ -915,7 +915,7 @@ void test_and_operation_1d0d_lit_true()
         blaze::map(v, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_double_true()
@@ -944,7 +944,7 @@ void test_and_operation_1d0d_double_true()
         blaze::map(v, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d0d_double_lit_true()
@@ -971,7 +971,7 @@ void test_and_operation_1d0d_double_lit_true()
         blaze::map(v, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d2d()
@@ -1007,7 +1007,7 @@ void test_and_operation_1d2d()
             [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d2d_lit()
@@ -1041,7 +1041,7 @@ void test_and_operation_1d2d_lit()
             [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d2d_double()
@@ -1077,7 +1077,7 @@ void test_and_operation_1d2d_double()
             [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_1d2d_double_lit()
@@ -1111,7 +1111,7 @@ void test_and_operation_1d2d_double_lit()
             [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d()
@@ -1141,7 +1141,7 @@ void test_and_operation_2d()
         blaze::map(m1, m2, [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d_lit()
@@ -1169,7 +1169,7 @@ void test_and_operation_2d_lit()
         blaze::map(m1, m2, [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d_double()
@@ -1199,7 +1199,7 @@ void test_and_operation_2d_double()
         blaze::map(m1, m2, [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d_double_lit()
@@ -1227,7 +1227,7 @@ void test_and_operation_2d_double_lit()
         blaze::map(m1, m2, [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_true()
@@ -1256,7 +1256,7 @@ void test_and_operation_2d0d_true()
         blaze::map(m, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_lit_true()
@@ -1283,7 +1283,7 @@ void test_and_operation_2d0d_lit_true()
         blaze::map(m, [](bool x) { return (x && true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_false()
@@ -1312,7 +1312,7 @@ void test_and_operation_2d0d_false()
         blaze::map(m, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_lit_false()
@@ -1339,7 +1339,7 @@ void test_and_operation_2d0d_lit_false()
         blaze::map(m, [](bool x) { return (x && false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_double_true()
@@ -1368,7 +1368,7 @@ void test_and_operation_2d0d_double_true()
         blaze::map(m, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_double_lit_true()
@@ -1395,7 +1395,7 @@ void test_and_operation_2d0d_double_lit_true()
         blaze::map(m, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_double_false()
@@ -1423,7 +1423,7 @@ void test_and_operation_2d0d_double_false()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d0d_double_lit_false()
@@ -1449,7 +1449,7 @@ void test_and_operation_2d0d_double_lit_false()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 0.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d1d()
@@ -1484,7 +1484,7 @@ void test_and_operation_2d1d()
             [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d1d_lit()
@@ -1517,7 +1517,7 @@ void test_and_operation_2d1d_lit()
             [](bool x, bool y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d1d_double()
@@ -1552,7 +1552,7 @@ void test_and_operation_2d1d_double()
             [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_and_operation_2d1d_double_lit()
@@ -1585,7 +1585,7 @@ void test_and_operation_2d1d_double_lit()
             [](double x, double y) { return x && y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/plugins/booleans/equal_operation.cpp
+++ b/tests/unit/plugins/booleans/equal_operation.cpp
@@ -36,7 +36,7 @@ void test_equal_operation_0d_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d_bool_false()
@@ -58,7 +58,7 @@ void test_equal_operation_0d_bool_false()
     phylanx::execution_tree::primitive_argument_type f = equal.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d_bool_false_return_bool()
@@ -81,7 +81,7 @@ void test_equal_operation_0d_bool_false_return_bool()
 
     HPX_TEST_EQ(f.index(), 1);    //node_data<std::uint8_t>
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d_true()
@@ -104,7 +104,7 @@ void test_equal_operation_0d_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d_true_return_double()
@@ -148,7 +148,7 @@ void test_equal_operation_0d_lit_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d_lit_true()
@@ -169,7 +169,7 @@ void test_equal_operation_0d_lit_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(true)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d1d()
@@ -198,7 +198,7 @@ void test_equal_operation_0d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d1d_lit()
@@ -225,7 +225,7 @@ void test_equal_operation_0d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d1d_bool()
@@ -252,7 +252,7 @@ void test_equal_operation_0d1d_bool()
         blaze::map(v, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d1d_bool_lit()
@@ -277,7 +277,7 @@ void test_equal_operation_0d1d_bool_lit()
         blaze::map(v, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d1d_return_double()
@@ -364,7 +364,7 @@ void test_equal_operation_0d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d2d_lit()
@@ -391,7 +391,7 @@ void test_equal_operation_0d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d2d_return_double()
@@ -447,7 +447,7 @@ void test_equal_operation_0d2d_bool()
         blaze::map(m, [](bool x) { return (x == true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_0d2d_bool_lit()
@@ -472,7 +472,7 @@ void test_equal_operation_0d2d_bool_lit()
         blaze::map(m, [](bool x) { return (x == true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d()
@@ -502,7 +502,7 @@ void test_equal_operation_1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d_return_double()
@@ -560,7 +560,7 @@ void test_equal_operation_1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d0d()
@@ -589,7 +589,7 @@ void test_equal_operation_1d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d0d_return_double()
@@ -645,7 +645,7 @@ void test_equal_operation_1d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d0d_bool()
@@ -674,7 +674,7 @@ void test_equal_operation_1d0d_bool()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d0d_bool_lit()
@@ -701,7 +701,7 @@ void test_equal_operation_1d0d_bool_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d2d()
@@ -737,7 +737,7 @@ void test_equal_operation_1d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d2d_lit()
@@ -771,7 +771,7 @@ void test_equal_operation_1d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_1d2d_return_double()
@@ -873,7 +873,7 @@ void test_equal_operation_2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d_return_double()
@@ -931,7 +931,7 @@ void test_equal_operation_2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d_bool()
@@ -961,7 +961,7 @@ void test_equal_operation_2d_bool()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d_bool_lit()
@@ -989,7 +989,7 @@ void test_equal_operation_2d_bool_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d0d()
@@ -1018,7 +1018,7 @@ void test_equal_operation_2d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d0d_return_double()
@@ -1074,7 +1074,7 @@ void test_equal_operation_2d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d0d_bool()
@@ -1103,7 +1103,7 @@ void test_equal_operation_2d0d_bool()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d0d_bool_lit()
@@ -1128,7 +1128,7 @@ void test_equal_operation_2d0d_bool_lit()
         blaze::map(m, [](bool x) { return (x == true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d1d()
@@ -1163,7 +1163,7 @@ void test_equal_operation_2d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d1d_return_double()
@@ -1231,7 +1231,7 @@ void test_equal_operation_2d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d1d_bool()
@@ -1264,7 +1264,7 @@ void test_equal_operation_2d1d_bool()
             [](bool x, bool y) { return x == y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_equal_operation_2d1d_bool_lit()
@@ -1295,7 +1295,7 @@ void test_equal_operation_2d1d_bool_lit()
             [](bool x, bool y) { return x == y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/plugins/booleans/greater_equal_operation.cpp
+++ b/tests/unit/plugins/booleans/greater_equal_operation.cpp
@@ -37,7 +37,7 @@ void test_greater_equal_operation_0d_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d_false()
@@ -62,7 +62,7 @@ void test_greater_equal_operation_0d_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d_lit_true()
@@ -85,7 +85,7 @@ void test_greater_equal_operation_0d_lit_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d_lit_false()
@@ -108,7 +108,7 @@ void test_greater_equal_operation_0d_lit_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d1d()
@@ -139,7 +139,7 @@ void test_greater_equal_operation_0d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d1d_lit()
@@ -168,7 +168,7 @@ void test_greater_equal_operation_0d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d2d()
@@ -199,7 +199,7 @@ void test_greater_equal_operation_0d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d2d_lit()
@@ -228,7 +228,7 @@ void test_greater_equal_operation_0d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_1d()
@@ -260,7 +260,7 @@ void test_greater_equal_operation_1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_1d_lit()
@@ -290,7 +290,7 @@ void test_greater_equal_operation_1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_1d0d()
@@ -321,7 +321,7 @@ void test_greater_equal_operation_1d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_1d0d_lit()
@@ -350,7 +350,7 @@ void test_greater_equal_operation_1d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_1d2d()
@@ -388,7 +388,7 @@ void test_greater_equal_operation_1d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_1d2d_lit()
@@ -424,7 +424,7 @@ void test_greater_equal_operation_1d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_2d()
@@ -456,7 +456,7 @@ void test_greater_equal_operation_2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_2d_lit()
@@ -486,7 +486,7 @@ void test_greater_equal_operation_2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_2d0d()
@@ -517,7 +517,7 @@ void test_greater_equal_operation_2d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_2d0d_lit()
@@ -546,7 +546,7 @@ void test_greater_equal_operation_2d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_2d1d()
@@ -583,7 +583,7 @@ void test_greater_equal_operation_2d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_2d1d_lit()
@@ -618,7 +618,7 @@ void test_greater_equal_operation_2d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_equal_operation_0d_true_return_double()
@@ -699,7 +699,7 @@ void test_greater_equal_operation_0d1d_return_bool()
         blaze::map(v, [](double x) { return (x >= 1.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(expected),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
     HPX_TEST_EQ(f.index(), 1);    //node_data<std::uint8_t>
 }
 

--- a/tests/unit/plugins/booleans/greater_operation.cpp
+++ b/tests/unit/plugins/booleans/greater_operation.cpp
@@ -35,7 +35,7 @@ void test_greater_operation_0d_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d_true_return_double()
@@ -83,7 +83,7 @@ void test_greater_operation_0d_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d_lit_true()
@@ -105,7 +105,7 @@ void test_greater_operation_0d_lit_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d_lit_false()
@@ -127,7 +127,7 @@ void test_greater_operation_0d_lit_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d1d()
@@ -157,7 +157,7 @@ void test_greater_operation_0d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d1d_lit()
@@ -185,7 +185,7 @@ void test_greater_operation_0d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d1d_return_double()
@@ -242,7 +242,7 @@ void test_greater_operation_0d1d_return_bool()
         blaze::map(v, [](double x) { return (x > 1.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(expected),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
     HPX_TEST_EQ(f.index(), 1);    //node_data<std::uint8_t>
 }
 
@@ -273,7 +273,7 @@ void test_greater_operation_0d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d2d_lit()
@@ -301,7 +301,7 @@ void test_greater_operation_0d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_0d2d_return_double()
@@ -361,7 +361,7 @@ void test_greater_operation_1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_1d_lit()
@@ -390,7 +390,7 @@ void test_greater_operation_1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_1d_return_double()
@@ -450,7 +450,7 @@ void test_greater_operation_1d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_1d0d_lit()
@@ -478,7 +478,7 @@ void test_greater_operation_1d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_1d0d_return_double()
@@ -544,7 +544,7 @@ void test_greater_operation_1d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_1d2d_lit()
@@ -579,7 +579,7 @@ void test_greater_operation_1d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_1d2d_return_double()
@@ -646,7 +646,7 @@ void test_greater_operation_2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_2d_lit()
@@ -675,7 +675,7 @@ void test_greater_operation_2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_2d_return_double()
@@ -735,7 +735,7 @@ void test_greater_operation_2d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_2d0d_lit()
@@ -763,7 +763,7 @@ void test_greater_operation_2d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_2d0d_return_double()
@@ -828,7 +828,7 @@ void test_greater_operation_2d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_2d1d_lit()
@@ -862,7 +862,7 @@ void test_greater_operation_2d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_greater_operation_2d1d_return_double()

--- a/tests/unit/plugins/booleans/less_equal_operation.cpp
+++ b/tests/unit/plugins/booleans/less_equal_operation.cpp
@@ -36,7 +36,7 @@ void test_less_equal_operation_0d_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d_false()
@@ -61,7 +61,7 @@ void test_less_equal_operation_0d_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d_lit_true()
@@ -84,7 +84,7 @@ void test_less_equal_operation_0d_lit_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d_lit_false()
@@ -107,7 +107,7 @@ void test_less_equal_operation_0d_lit_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d1d()
@@ -138,7 +138,7 @@ void test_less_equal_operation_0d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d1d_lit()
@@ -167,7 +167,7 @@ void test_less_equal_operation_0d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d2d()
@@ -198,7 +198,7 @@ void test_less_equal_operation_0d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d2d_lit()
@@ -227,7 +227,7 @@ void test_less_equal_operation_0d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_1d()
@@ -259,7 +259,7 @@ void test_less_equal_operation_1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_1d_lit()
@@ -289,7 +289,7 @@ void test_less_equal_operation_1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_1d0d()
@@ -320,7 +320,7 @@ void test_less_equal_operation_1d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_1d0d_lit()
@@ -349,7 +349,7 @@ void test_less_equal_operation_1d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_1d2d()
@@ -387,7 +387,7 @@ void test_less_equal_operation_1d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_1d2d_lit()
@@ -423,7 +423,7 @@ void test_less_equal_operation_1d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_2d()
@@ -455,7 +455,7 @@ void test_less_equal_operation_2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_2d_lit()
@@ -485,7 +485,7 @@ void test_less_equal_operation_2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_2d0d()
@@ -516,7 +516,7 @@ void test_less_equal_operation_2d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_2d0d_lit()
@@ -545,7 +545,7 @@ void test_less_equal_operation_2d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_2d1d()
@@ -582,7 +582,7 @@ void test_less_equal_operation_2d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_2d1d_lit()
@@ -617,7 +617,7 @@ void test_less_equal_operation_2d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_equal_operation_0d_true_return_double()
@@ -700,7 +700,7 @@ void test_less_equal_operation_0d1d_return_bool()
         blaze::map(v, [](double x) { return (x <= 1.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(expected),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
     HPX_TEST_EQ(f.index(), 1);    //node_data<std::uint8_t>
 }
 

--- a/tests/unit/plugins/booleans/less_operation.cpp
+++ b/tests/unit/plugins/booleans/less_operation.cpp
@@ -35,7 +35,7 @@ void test_less_operation_0d_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d_false()
@@ -58,7 +58,7 @@ void test_less_operation_0d_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d_lit_true()
@@ -79,7 +79,7 @@ void test_less_operation_0d_lit_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d_lit_false()
@@ -100,7 +100,7 @@ void test_less_operation_0d_lit_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d1d()
@@ -129,7 +129,7 @@ void test_less_operation_0d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d1d_lit()
@@ -156,7 +156,7 @@ void test_less_operation_0d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d2d()
@@ -185,7 +185,7 @@ void test_less_operation_0d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d2d_lit()
@@ -212,7 +212,7 @@ void test_less_operation_0d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_1d()
@@ -242,7 +242,7 @@ void test_less_operation_1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_1d_lit()
@@ -270,7 +270,7 @@ void test_less_operation_1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_1d0d()
@@ -299,7 +299,7 @@ void test_less_operation_1d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_1d0d_lit()
@@ -326,7 +326,7 @@ void test_less_operation_1d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_1d2d()
@@ -362,7 +362,7 @@ void test_less_operation_1d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_1d2d_lit()
@@ -396,7 +396,7 @@ void test_less_operation_1d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_2d()
@@ -426,7 +426,7 @@ void test_less_operation_2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_2d_lit()
@@ -454,7 +454,7 @@ void test_less_operation_2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_2d0d()
@@ -483,7 +483,7 @@ void test_less_operation_2d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_2d0d_lit()
@@ -510,7 +510,7 @@ void test_less_operation_2d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_2d1d()
@@ -545,7 +545,7 @@ void test_less_operation_2d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_2d1d_lit()
@@ -578,7 +578,7 @@ void test_less_operation_2d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_2d0d_int()
@@ -605,7 +605,7 @@ void test_less_operation_2d0d_int()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_less_operation_0d_true_return_double()
@@ -685,7 +685,7 @@ void test_less_operation_0d1d_return_bool()
         blaze::map(v, [](double x) { return (x < 1.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(expected),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
     HPX_TEST_EQ(f.index(), 1);    //node_data<std::uint8_t>
 }
 

--- a/tests/unit/plugins/booleans/not_equal_operation.cpp
+++ b/tests/unit/plugins/booleans/not_equal_operation.cpp
@@ -36,7 +36,7 @@ void test_not_equal_operation_0d_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d_true_return_double()
@@ -82,7 +82,7 @@ void test_not_equal_operation_0d_bool_true()
     phylanx::execution_tree::primitive_argument_type f = not_equal.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d_bool_true_return_bool()
@@ -106,7 +106,7 @@ void test_not_equal_operation_0d_bool_true_return_bool()
 
     HPX_TEST_EQ(f.index(), 1);    //node_data<std::uint8_t>
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d_false()
@@ -130,7 +130,7 @@ void test_not_equal_operation_0d_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d_lit_true()
@@ -152,7 +152,7 @@ void test_not_equal_operation_0d_lit_true()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(1.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d_lit_false()
@@ -174,7 +174,7 @@ void test_not_equal_operation_0d_lit_false()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(0.0),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(false)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d1d()
@@ -204,7 +204,7 @@ void test_not_equal_operation_0d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d1d_lit()
@@ -232,7 +232,7 @@ void test_not_equal_operation_0d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d1d_bool()
@@ -260,7 +260,7 @@ void test_not_equal_operation_0d1d_bool()
         blaze::map(v, [](bool x) { return (x != false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d1d_bool_lit()
@@ -286,7 +286,7 @@ void test_not_equal_operation_0d1d_bool_lit()
         blaze::map(v, [](bool x) { return (x != false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d1d_return_double()
@@ -344,7 +344,7 @@ void test_not_equal_operation_0d1d_return_bool()
 
     HPX_TEST_EQ(f.index(), 1);
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(expected),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d2d()
@@ -374,7 +374,7 @@ void test_not_equal_operation_0d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d2d_return_double()
@@ -431,7 +431,7 @@ void test_not_equal_operation_0d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d2d_bool()
@@ -459,7 +459,7 @@ void test_not_equal_operation_0d2d_bool()
         blaze::map(m, [](bool x) { return (x != true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_0d2d_bool_lit()
@@ -485,7 +485,7 @@ void test_not_equal_operation_0d2d_bool_lit()
         blaze::map(m, [](bool x) { return (x != true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d()
@@ -516,7 +516,7 @@ void test_not_equal_operation_1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>((expected)),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d_return_double()
@@ -575,7 +575,7 @@ void test_not_equal_operation_1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d0d()
@@ -605,7 +605,7 @@ void test_not_equal_operation_1d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d0d_return_double()
@@ -662,7 +662,7 @@ void test_not_equal_operation_1d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d0d_bool()
@@ -692,7 +692,7 @@ void test_not_equal_operation_1d0d_bool()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d0d_bool_lit()
@@ -720,7 +720,7 @@ void test_not_equal_operation_1d0d_bool_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d2d()
@@ -757,7 +757,7 @@ void test_not_equal_operation_1d2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d2d_lit()
@@ -792,7 +792,7 @@ void test_not_equal_operation_1d2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_1d2d_return_double()
@@ -895,7 +895,7 @@ void test_not_equal_operation_2d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d_return_double()
@@ -954,7 +954,7 @@ void test_not_equal_operation_2d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d_bool()
@@ -985,7 +985,7 @@ void test_not_equal_operation_2d_bool()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d_bool_lit()
@@ -1014,7 +1014,7 @@ void test_not_equal_operation_2d_bool_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d0d()
@@ -1044,7 +1044,7 @@ void test_not_equal_operation_2d0d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d0d_return_double()
@@ -1101,7 +1101,7 @@ void test_not_equal_operation_2d0d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d0d_bool()
@@ -1131,7 +1131,7 @@ void test_not_equal_operation_2d0d_bool()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d0d_bool_lit()
@@ -1157,7 +1157,7 @@ void test_not_equal_operation_2d0d_bool_lit()
         blaze::map(m, [](bool x) { return (x != true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d1d()
@@ -1193,7 +1193,7 @@ void test_not_equal_operation_2d1d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d1d_return_double()
@@ -1262,7 +1262,7 @@ void test_not_equal_operation_2d1d_lit()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(expected),
         phylanx::execution_tree::extract_numeric_value(f));
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d1d_bool()
@@ -1296,7 +1296,7 @@ void test_not_equal_operation_2d1d_bool()
             [](bool x, bool y) { return x != y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_not_equal_operation_2d1d_bool_lit()
@@ -1328,7 +1328,7 @@ void test_not_equal_operation_2d1d_bool_lit()
             [](bool x, bool y) { return x != y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/plugins/booleans/or_operation.cpp
+++ b/tests/unit/plugins/booleans/or_operation.cpp
@@ -36,7 +36,7 @@ void test_or_operation_0d_false()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d_double_false()
@@ -59,7 +59,7 @@ void test_or_operation_0d_double_false()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d_true()
@@ -82,7 +82,7 @@ void test_or_operation_0d_true()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d_double_true()
@@ -105,7 +105,7 @@ void test_or_operation_0d_double_true()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d_lit_false()
@@ -126,7 +126,7 @@ void test_or_operation_0d_lit_false()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d_double_lit_false()
@@ -147,7 +147,7 @@ void test_or_operation_0d_double_lit_false()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d_lit_true()
@@ -168,7 +168,7 @@ void test_or_operation_0d_lit_true()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d_double_lit_true()
@@ -189,7 +189,7 @@ void test_or_operation_0d_double_lit_true()
         or_operation.eval().get();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_false()
@@ -218,7 +218,7 @@ void test_or_operation_0d1d_false()
         blaze::map(v, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_lit_false()
@@ -245,7 +245,7 @@ void test_or_operation_0d1d_lit_false()
         blaze::map(v, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_double_false()
@@ -274,7 +274,7 @@ void test_or_operation_0d1d_double_false()
         blaze::map(v, [](double x) { return (x || 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_double_lit_false()
@@ -301,7 +301,7 @@ void test_or_operation_0d1d_double_lit_false()
         blaze::map(v, [](double x) { return (x || 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_true()
@@ -330,7 +330,7 @@ void test_or_operation_0d1d_true()
         blaze::map(v, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_lit_true()
@@ -357,7 +357,7 @@ void test_or_operation_0d1d_lit_true()
         blaze::map(v, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_double_true()
@@ -385,7 +385,7 @@ void test_or_operation_0d1d_double_true()
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d1d_double_lit_true()
@@ -411,7 +411,7 @@ void test_or_operation_0d1d_double_lit_true()
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_false()
@@ -440,7 +440,7 @@ void test_or_operation_0d2d_false()
         blaze::map(m, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_lit_false()
@@ -467,7 +467,7 @@ void test_or_operation_0d2d_lit_false()
         blaze::map(m, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_double_false()
@@ -496,7 +496,7 @@ void test_or_operation_0d2d_double_false()
         blaze::map(m, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_double_lit_false()
@@ -523,7 +523,7 @@ void test_or_operation_0d2d_double_lit_false()
         blaze::map(m, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_true()
@@ -552,7 +552,7 @@ void test_or_operation_0d2d_true()
         blaze::map(m, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_lit_true()
@@ -579,7 +579,7 @@ void test_or_operation_0d2d_lit_true()
         blaze::map(m, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_double_true()
@@ -607,7 +607,7 @@ void test_or_operation_0d2d_double_true()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_0d2d_double_lit_true()
@@ -633,7 +633,7 @@ void test_or_operation_0d2d_double_lit_true()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d()
@@ -663,7 +663,7 @@ void test_or_operation_1d()
         blaze::map(v1, v2, [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d_lit()
@@ -691,7 +691,7 @@ void test_or_operation_1d_lit()
         blaze::map(v1, v2, [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d_double()
@@ -721,7 +721,7 @@ void test_or_operation_1d_double()
         blaze::map(v1, v2, [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d_double_lit()
@@ -749,7 +749,7 @@ void test_or_operation_1d_double_lit()
         blaze::map(v1, v2, [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_false()
@@ -778,7 +778,7 @@ void test_or_operation_1d0d_false()
         blaze::map(v, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_lit_false()
@@ -805,7 +805,7 @@ void test_or_operation_1d0d_lit_false()
         blaze::map(v, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_double_false()
@@ -834,7 +834,7 @@ void test_or_operation_1d0d_double_false()
         blaze::map(v, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_double_lit_false()
@@ -861,7 +861,7 @@ void test_or_operation_1d0d_double_lit_false()
         blaze::map(v, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_true()
@@ -890,7 +890,7 @@ void test_or_operation_1d0d_true()
         blaze::map(v, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_lit_true()
@@ -917,7 +917,7 @@ void test_or_operation_1d0d_lit_true()
         blaze::map(v, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_double_true()
@@ -945,7 +945,7 @@ void test_or_operation_1d0d_double_true()
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d0d_double_lit_true()
@@ -971,7 +971,7 @@ void test_or_operation_1d0d_double_lit_true()
     blaze::DynamicVector<double> expected(v.size(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d2d()
@@ -1007,7 +1007,7 @@ void test_or_operation_1d2d()
             [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d2d_lit()
@@ -1041,7 +1041,7 @@ void test_or_operation_1d2d_lit()
             [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d2d_double()
@@ -1077,7 +1077,7 @@ void test_or_operation_1d2d_double()
             [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_1d2d_double_lit()
@@ -1111,7 +1111,7 @@ void test_or_operation_1d2d_double_lit()
             [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d()
@@ -1141,7 +1141,7 @@ void test_or_operation_2d()
         blaze::map(m1, m2, [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d_lit()
@@ -1169,7 +1169,7 @@ void test_or_operation_2d_lit()
         blaze::map(m1, m2, [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d_double()
@@ -1199,7 +1199,7 @@ void test_or_operation_2d_double()
         blaze::map(m1, m2, [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d_double_lit()
@@ -1227,7 +1227,7 @@ void test_or_operation_2d_double_lit()
         blaze::map(m1, m2, [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_true()
@@ -1256,7 +1256,7 @@ void test_or_operation_2d0d_true()
         blaze::map(m, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_lit_true()
@@ -1283,7 +1283,7 @@ void test_or_operation_2d0d_lit_true()
         blaze::map(m, [](bool x) { return (x || true); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_false()
@@ -1312,7 +1312,7 @@ void test_or_operation_2d0d_false()
         blaze::map(m, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_lit_false()
@@ -1339,7 +1339,7 @@ void test_or_operation_2d0d_lit_false()
         blaze::map(m, [](bool x) { return (x || false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_double_true()
@@ -1367,7 +1367,7 @@ void test_or_operation_2d0d_double_true()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_double_lit_true()
@@ -1393,7 +1393,7 @@ void test_or_operation_2d0d_double_lit_true()
     blaze::DynamicMatrix<double> expected(m.rows(), m.columns(), 1.0);
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_double_false()
@@ -1422,7 +1422,7 @@ void test_or_operation_2d0d_double_false()
         blaze::map(m, [](double x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d0d_double_lit_false()
@@ -1449,7 +1449,7 @@ void test_or_operation_2d0d_double_lit_false()
         blaze::map(m, [](bool x) { return (x != 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d1d()
@@ -1484,7 +1484,7 @@ void test_or_operation_2d1d()
             [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d1d_lit()
@@ -1517,7 +1517,7 @@ void test_or_operation_2d1d_lit()
             [](bool x, bool y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d1d_double()
@@ -1552,7 +1552,7 @@ void test_or_operation_2d1d_double()
             [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 void test_or_operation_2d1d_double_lit()
@@ -1585,7 +1585,7 @@ void test_or_operation_2d1d_double_lit()
             [](double x, double y) { return x || y; });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f));
+        phylanx::execution_tree::extract_boolean_value_strict(f));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/tests/unit/plugins/booleans/unary_not_operation.cpp
+++ b/tests/unit/plugins/booleans/unary_not_operation.cpp
@@ -30,7 +30,7 @@ void test_unary_not_operation_0d_false()
         unary_not.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_0d_true()
@@ -49,7 +49,7 @@ void test_unary_not_operation_0d_true()
         unary_not.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_0d_false_lit()
@@ -64,7 +64,7 @@ void test_unary_not_operation_0d_false_lit()
         unary_not.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(true),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_0d_true_lit()
@@ -79,7 +79,7 @@ void test_unary_not_operation_0d_true_lit()
         unary_not.eval();
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(false),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_1d()
@@ -104,7 +104,7 @@ void test_unary_not_operation_1d()
         blaze::map(v, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_1d_lit()
@@ -127,7 +127,7 @@ void test_unary_not_operation_1d_lit()
         blaze::map(v, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_1d_double()
@@ -152,7 +152,7 @@ void test_unary_not_operation_1d_double()
         blaze::map(v, [](double x) { return (x == 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_1d_double_lit()
@@ -175,7 +175,7 @@ void test_unary_not_operation_1d_double_lit()
         blaze::map(v, [](double x) { return (x == 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_2d()
@@ -200,7 +200,7 @@ void test_unary_not_operation_2d()
         blaze::map(m, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_2d_lit()
@@ -223,7 +223,7 @@ void test_unary_not_operation_2d_lit()
         blaze::map(m, [](bool x) { return (x == false); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_2d_double()
@@ -248,7 +248,7 @@ void test_unary_not_operation_2d_double()
         blaze::map(m, [](double x) { return (x == 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 void test_unary_not_operation_2d_double_lit()
@@ -271,7 +271,7 @@ void test_unary_not_operation_2d_double_lit()
         blaze::map(m, [](double x) { return (x == 0.0); });
 
     HPX_TEST_EQ(phylanx::ir::node_data<std::uint8_t>(std::move(expected)),
-        phylanx::execution_tree::extract_boolean_data(f.get()));
+        phylanx::execution_tree::extract_boolean_value_strict(f.get()));
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This PR replaces the instances of `extract_boolean_data` with `extract_boolean_value_strict` and removes it from the base primitive as it is a duplicate, please refer to [this](https://github.com/STEllAR-GROUP/phylanx/blob/6b32848f6c01cc25383b5cfd786f5610118fd747/src/execution_tree/primitives/base_primitive.cpp#L1383) and [this](https://github.com/STEllAR-GROUP/phylanx/blob/6b32848f6c01cc25383b5cfd786f5610118fd747/src/execution_tree/primitives/base_primitive.cpp#L1912).