### PR TITLE
Adding arithmetic operations to execution_tree.variable

### DIFF
--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -113,28 +113,29 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
             .def(
                 "eval",
                 [](phylanx::execution_tree::variable const& var,
-                    pybind11::args args)
-                {
+                    pybind11::args args) {
                     pybind11::gil_scoped_release release;       // release GIL
                     return hpx::threads::run_as_hpx_thread(
                             [&]() { return var.eval(std::move(args)); });
                 },
                 "evaluate execution tree")
-            .def("__call__",
+            .def(
+                "__call__",
                 [](phylanx::execution_tree::variable const& var,
-                    pybind11::args args)
-                {
+                    pybind11::args args) {
                     pybind11::gil_scoped_release release;       // release GIL
                     return hpx::threads::run_as_hpx_thread(
                         [&]() { return var.eval(std::move(args)); });
                 },
                 "evaluate execution tree")
-            .def_property_readonly("dtype",
+            .def_property_readonly(
+                "dtype",
                 [](phylanx::execution_tree::variable const& var) {
                     return var.dtype();
                 },
                 "return the dtype of the value stored by the variable")
-            .def_property_readonly("name",
+            .def_property_readonly(
+                "name",
                 [](phylanx::execution_tree::variable const& var) {
                     return var.name();
                 },
@@ -163,8 +164,16 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
             .def("__neg__", &phylanx::execution_tree::unary_minus_variables)
             .def("__iadd__", &phylanx::execution_tree::iadd_variables)
             .def("__iadd__", &phylanx::execution_tree::iadd_variables_gen)
+            .def("update_add", &phylanx::execution_tree::iadd_variables)
+            .def("update_add", &phylanx::execution_tree::iadd_variables_gen)
             .def("__isub__", &phylanx::execution_tree::isub_variables)
-            .def("__isub__", &phylanx::execution_tree::isub_variables_gen);
+            .def("__isub__", &phylanx::execution_tree::isub_variables_gen)
+            .def("update_sub", &phylanx::execution_tree::isub_variables)
+            .def("update_sub", &phylanx::execution_tree::isub_variables_gen)
+            .def("update_moving_average",
+                &phylanx::execution_tree::moving_average_variables)
+            .def("update_moving_average",
+                &phylanx::execution_tree::moving_average_variables_gen);
 
     // phylanx.execution_tree.primitive
     pybind11::class_<phylanx::execution_tree::primitive>(execution_tree,

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+//  Copyright (c) 2017-2019 Hartmut Kaiser
 //  Copyright (c) 2018 R. Tohid
 //  Copyright (c) 2018 Steven R. Brandt
 //
@@ -147,7 +147,24 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
                 [](phylanx::execution_tree::variable const& var) {
                     return bindings::repr<phylanx::execution_tree::primitive>(
                         var.value());
-                });
+                })
+            .def("__add__", &phylanx::execution_tree::add_variables)
+            .def("__add__", &phylanx::execution_tree::add_variables_gen)
+            .def("__radd__", &phylanx::execution_tree::radd_variables_gen)
+            .def("__sub__", &phylanx::execution_tree::sub_variables)
+            .def("__sub__", &phylanx::execution_tree::sub_variables_gen)
+            .def("__rsub__", &phylanx::execution_tree::rsub_variables_gen)
+            .def("__mul__", &phylanx::execution_tree::mul_variables)
+            .def("__mul__", &phylanx::execution_tree::mul_variables_gen)
+            .def("__rmul__", &phylanx::execution_tree::rmul_variables_gen)
+            .def("__div__", &phylanx::execution_tree::div_variables)
+            .def("__div__", &phylanx::execution_tree::div_variables_gen)
+            .def("__rdiv__", &phylanx::execution_tree::rdiv_variables_gen)
+            .def("__neg__", &phylanx::execution_tree::unary_minus_variables)
+            .def("__iadd__", &phylanx::execution_tree::iadd_variables)
+            .def("__iadd__", &phylanx::execution_tree::iadd_variables_gen)
+            .def("__isub__", &phylanx::execution_tree::isub_variables)
+            .def("__isub__", &phylanx::execution_tree::isub_variables_gen);
 
     // phylanx.execution_tree.primitive
     pybind11::class_<phylanx::execution_tree::primitive>(execution_tree,

--- a/python/src/bindings/variable.cpp
+++ b/python/src/bindings/variable.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace execution_tree
             pybind11::object name, pybind11::object constraint)
       : dtype_(std::move(dtype))
       , name_(name.is_none() ?
-              hpx::util::format("variable_{}", ++variable_count) :
+              hpx::util::format("Variable_{}", ++variable_count) :
               name.cast<std::string>())
       , value_(std::move(value))
       , constraint_(std::move(constraint))
@@ -39,7 +39,7 @@ namespace phylanx { namespace execution_tree
         pybind11::object name, pybind11::object constraint)
       : dtype_(dtype.is_none() ? value.dtype() : std::move(dtype))
       , name_(name.is_none() ?
-                hpx::util::format("variable_{}", ++variable_count) :
+                hpx::util::format("Variable_{}", ++variable_count) :
                 name.cast<std::string>())
       , value_(create_variable(
             pybind11::cast<primitive_argument_type>(std::move(value)), name_))
@@ -50,7 +50,7 @@ namespace phylanx { namespace execution_tree
         pybind11::object name, pybind11::object constraint)
       : dtype_(dtype.is_none() ? pybind11::dtype("S") : std::move(dtype))
       , name_(name.is_none() ?
-                hpx::util::format("variable_{}", ++variable_count) :
+                hpx::util::format("Variable_{}", ++variable_count) :
                 name.cast<std::string>())
       , value_(
             create_variable(primitive_argument_type(std::move(value)), name_))
@@ -61,8 +61,28 @@ namespace phylanx { namespace execution_tree
             pybind11::object name, pybind11::object constraint)
       : dtype_(std::move(dtype))
       , name_(name.is_none() ?
-              hpx::util::format("variable_{}", ++variable_count) :
+              hpx::util::format("Variable_{}", ++variable_count) :
               name.cast<std::string>())
+      , value_(is_primitive_operand(value) ?
+              primitive_operand(std::move(value)) :
+              create_variable(std::move(value), name_))
+      , constraint_(std::move(constraint))
+    {}
+
+    variable::variable(primitive value, pybind11::object dtype,
+            char const* name, pybind11::object constraint)
+      : dtype_(std::move(dtype))
+      , name_(hpx::util::format("{}_{}", name, ++variable_count))
+      , value_(is_primitive_operand(value) ?
+              primitive_operand(std::move(value)) :
+              create_variable(std::move(value), name_))
+      , constraint_(std::move(constraint))
+    {}
+
+    variable::variable(primitive_argument_type value, pybind11::object dtype,
+            char const* name, pybind11::object constraint)
+      : dtype_(std::move(dtype))
+      , name_(hpx::util::format("{}_{}", name, ++variable_count))
       , value_(is_primitive_operand(value) ?
               primitive_operand(std::move(value)) :
               create_variable(std::move(value), name_))
@@ -246,4 +266,116 @@ namespace phylanx { namespace execution_tree
             pybind11::return_value_policy::move);
         return h.release();
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+#define PHYLANX_VARIABLE_OPERATION(op, name)                                   \
+    /* forward operation */                                                    \
+    phylanx::execution_tree::variable op##_variables_gen(                      \
+        phylanx::execution_tree::variable const& lhs,                          \
+        phylanx::execution_tree::primitive_argument_type const& rhs)           \
+    {                                                                          \
+        using namespace phylanx::execution_tree;                               \
+        primitive_arguments_type args;                                         \
+        args.reserve(2);                                                       \
+        args.emplace_back(lhs.value());                                        \
+        args.emplace_back(rhs);                                                \
+        return phylanx::execution_tree::variable{                              \
+            primitives::create_##op##_operation(                               \
+                hpx::find_here(), std::move(args)),                            \
+            lhs.dtype(), name};                                                \
+    }                                                                          \
+                                                                               \
+    phylanx::execution_tree::variable op##_variables(                          \
+        phylanx::execution_tree::variable const& lhs,                          \
+        phylanx::execution_tree::variable const& rhs)                          \
+    {                                                                          \
+        return op##_variables_gen(lhs, rhs.value());                           \
+    }                                                                          \
+                                                                               \
+    /* reverse operation */                                                    \
+    phylanx::execution_tree::variable r##op##_variables_gen(                   \
+        phylanx::execution_tree::variable const& rhs,                          \
+        phylanx::execution_tree::primitive_argument_type const& lhs)           \
+    {                                                                          \
+        using namespace phylanx::execution_tree;                               \
+        primitive_arguments_type args;                                         \
+        args.reserve(2);                                                       \
+        args.emplace_back(lhs);                                                \
+        args.emplace_back(rhs.value());                                        \
+        return phylanx::execution_tree::variable{                              \
+            primitives::create_##op##_operation(                               \
+                hpx::find_here(), std::move(args)),                            \
+            rhs.dtype(), name};                                                \
+    }                                                                          \
+    /**/
+
+    // this generates the equivalent for 'block(store(lhs, op(lhs, rhs)), lhs)'
+#define PHYLANX_VARIABLE_INPLACE_OPERATION(op, __name)                         \
+    /* in-place operation */                                                   \
+    phylanx::execution_tree::variable i##op##_variables_gen(                   \
+        phylanx::execution_tree::variable& lhs,                                \
+        phylanx::execution_tree::primitive_argument_type const& rhs)           \
+    {                                                                          \
+        using namespace phylanx::execution_tree;                               \
+                                                                               \
+        /* create operation */                                                 \
+        primitive_arguments_type args;                                         \
+        args.reserve(2);                                                       \
+        args.emplace_back(lhs.value());                                        \
+        args.emplace_back(rhs);                                                \
+        primitive op = primitives::create_##op##_operation(                    \
+            hpx::find_here(), std::move(args));                                \
+                                                                               \
+        /* store the result back in the lhs argument */                        \
+        args.reserve(2);                                                       \
+        args.emplace_back(lhs.value());                                        \
+        args.emplace_back(primitive_argument_type{std::move(op)});             \
+        primitive storeop = primitives::create_store_operation(                \
+            hpx::find_here(), std::move(args));                                \
+                                                                               \
+        /* create block that executes operation and returns result lhs */      \
+        args.reserve(2);                                                       \
+        args.emplace_back(primitive_argument_type{std::move(storeop)});        \
+        args.emplace_back(lhs.value());                                        \
+        primitive block = primitives::create_block_operation(                  \
+            hpx::find_here(), std::move(args));                                \
+                                                                               \
+        /* return */                                                           \
+        return phylanx::execution_tree::variable{                              \
+            std::move(block), lhs.dtype(), __name};                            \
+    }                                                                          \
+                                                                               \
+    phylanx::execution_tree::variable i##op##_variables(                       \
+        phylanx::execution_tree::variable& lhs,                                \
+        phylanx::execution_tree::variable const& rhs)                          \
+    {                                                                          \
+        return i##op##_variables_gen(lhs, rhs.value());                        \
+    }                                                                          \
+    /**/
+
+    ///////////////////////////////////////////////////////////////////////////
+    // implement arithmetic operations
+    PHYLANX_VARIABLE_OPERATION(add, "Add")                      // __add__
+    PHYLANX_VARIABLE_OPERATION(sub, "Sub")                      // __sub__
+    PHYLANX_VARIABLE_OPERATION(mul, "Mul")                      // __mul__
+    PHYLANX_VARIABLE_OPERATION(div, "Mul")                      // __div__
+
+    phylanx::execution_tree::variable unary_minus_variables(    // __neg__
+        phylanx::execution_tree::variable const& target)
+    {
+        using namespace phylanx::execution_tree;
+        primitive_arguments_type args;
+        args.reserve(1);
+        args.emplace_back(target.value());
+        return phylanx::execution_tree::variable{
+            primitives::create_unary_minus_operation(
+                hpx::find_here(), std::move(args)),
+            target.dtype(), "Neg"};
+    }
+
+    PHYLANX_VARIABLE_INPLACE_OPERATION(add, "AssignAdd")        // __iadd__
+    PHYLANX_VARIABLE_INPLACE_OPERATION(sub, "AssignSub")        // __isub__
+
+#undef PHYLANX_VARIABLE_OPERATION
+#undef PHYLANX_VARIABLE_INPLACE_OPERATION
 }}

--- a/python/src/bindings/variable.hpp
+++ b/python/src/bindings/variable.hpp
@@ -71,7 +71,7 @@ namespace phylanx { namespace execution_tree
         {
             return value_;
         }
-        void value(primitive&& new_value)
+        void value(primitive new_value)
         {
             value_ = std::move(new_value);
         }
@@ -133,14 +133,25 @@ namespace phylanx { namespace execution_tree
     PHYLANX_VARIABLE_OPERATION_DECLARATION(mul)                 // __mul__
     PHYLANX_VARIABLE_OPERATION_DECLARATION(div)                 // __div__
 
-    phylanx::execution_tree::variable unary_minus_variables(    // __neg__
-        phylanx::execution_tree::variable const& lhs);
-
     PHYLANX_VARIABLE_INPLACE_OPERATION_DECLARATION(add)         // __iadd__
     PHYLANX_VARIABLE_INPLACE_OPERATION_DECLARATION(sub)         // __isub__
 
 #undef PHYLANX_VARIABLE_OPERATION_DECLARATION
 #undef PHYLANX_VARIABLE_INPLACE_OPERATION_DECLARATION
+
+    ///////////////////////////////////////////////////////////////////////////
+    phylanx::execution_tree::variable unary_minus_variables(    // __neg__
+        phylanx::execution_tree::variable const& lhs);
+
+    phylanx::execution_tree::variable moving_average_variables(
+        phylanx::execution_tree::variable& var,
+        phylanx::execution_tree::variable const& value,
+        phylanx::execution_tree::primitive_argument_type const& momentum);
+
+    phylanx::execution_tree::variable moving_average_variables_gen(
+        phylanx::execution_tree::variable& var,
+        phylanx::execution_tree::primitive_argument_type const& value,
+        phylanx::execution_tree::primitive_argument_type const& momentum);
 }}
 
 #endif

--- a/python/src/bindings/variable.hpp
+++ b/python/src/bindings/variable.hpp
@@ -31,14 +31,25 @@ namespace phylanx { namespace execution_tree
             pybind11::object name = pybind11::none(),
             pybind11::object constraint = pybind11::none());
 
+        variable(primitive value, pybind11::object dtype,
+            char const* name = "Variable",
+            pybind11::object constraint = pybind11::none());
+
         variable(pybind11::array value, pybind11::object dtype,
-            pybind11::object name, pybind11::object constraint);
+            pybind11::object name,
+            pybind11::object constraint = pybind11::none());
 
         variable(std::string value, pybind11::object dtype,
-            pybind11::object name, pybind11::object constraint);
+            pybind11::object name,
+            pybind11::object constraint = pybind11::none());
 
         variable(primitive_argument_type value, pybind11::object dtype,
-            pybind11::object name, pybind11::object constraint);
+            pybind11::object name,
+            pybind11::object constraint = pybind11::none());
+
+        variable(primitive_argument_type value, pybind11::object dtype,
+            char const* name = "Variable",
+            pybind11::object constraint = pybind11::none());
 
         ~variable()
         {
@@ -59,6 +70,10 @@ namespace phylanx { namespace execution_tree
         primitive value() const
         {
             return value_;
+        }
+        void value(primitive&& new_value)
+        {
+            value_ = std::move(new_value);
         }
 
     protected:
@@ -83,6 +98,49 @@ namespace phylanx { namespace execution_tree
         primitive value_;
         pybind11::object constraint_;
     };
+
+#define PHYLANX_VARIABLE_OPERATION_DECLARATION(op)                             \
+    /* forward operation */                                                    \
+    phylanx::execution_tree::variable op##_variables(                          \
+        phylanx::execution_tree::variable const& lhs,                          \
+        phylanx::execution_tree::variable const& rhs);                         \
+                                                                               \
+    phylanx::execution_tree::variable op##_variables_gen(                      \
+        phylanx::execution_tree::variable const& lhs,                          \
+        phylanx::execution_tree::primitive_argument_type const& rhs);          \
+                                                                               \
+    /* reverse operation */                                                    \
+    phylanx::execution_tree::variable r##op##_variables_gen(                   \
+        phylanx::execution_tree::variable const& rhs,                          \
+        phylanx::execution_tree::primitive_argument_type const& lhs);          \
+    /**/
+
+#define PHYLANX_VARIABLE_INPLACE_OPERATION_DECLARATION(op)                     \
+    /* in-place operation */                                                   \
+    phylanx::execution_tree::variable i##op##_variables(                       \
+        phylanx::execution_tree::variable& lhs,                                \
+        phylanx::execution_tree::variable const& rhs);                         \
+                                                                               \
+    phylanx::execution_tree::variable i##op##_variables_gen(                   \
+        phylanx::execution_tree::variable& lhs,                                \
+        phylanx::execution_tree::primitive_argument_type const& rhs);          \
+        /**/
+
+    ///////////////////////////////////////////////////////////////////////////
+    // declare arithmetic operations
+    PHYLANX_VARIABLE_OPERATION_DECLARATION(add)                 // __add__
+    PHYLANX_VARIABLE_OPERATION_DECLARATION(sub)                 // __sub__
+    PHYLANX_VARIABLE_OPERATION_DECLARATION(mul)                 // __mul__
+    PHYLANX_VARIABLE_OPERATION_DECLARATION(div)                 // __div__
+
+    phylanx::execution_tree::variable unary_minus_variables(    // __neg__
+        phylanx::execution_tree::variable const& lhs);
+
+    PHYLANX_VARIABLE_INPLACE_OPERATION_DECLARATION(add)         // __iadd__
+    PHYLANX_VARIABLE_INPLACE_OPERATION_DECLARATION(sub)         // __isub__
+
+#undef PHYLANX_VARIABLE_OPERATION_DECLARATION
+#undef PHYLANX_VARIABLE_INPLACE_OPERATION_DECLARATION
 }}
 
 #endif

--- a/tests/regressions/python/936_arithmetic_operations.py
+++ b/tests/regressions/python/936_arithmetic_operations.py
@@ -1,3 +1,10 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #936: Add support for aggregation function to execution_tree.variable
+
 
 import numpy as np
 from phylanx import Phylanx, PhylanxSession, execution_tree
@@ -46,12 +53,13 @@ def where(condition, then_expression, else_expression):
     return where_eager.lazy(condition, then_expression, else_expression)
 
 
-def test_switch():
-    val = np.random.random()
+def test_switch(val):
     x = variable(val)
     x = variable(where(greater_equal(x, 0.5), x * 0.1, x * 0.2))
-#    x += 42.0
     return eval(-x)
 
 
-print(test_switch())
+v = np.random.random()
+expected = v * 0.1 if v >= 0.5 else v * 0.2
+r = test_switch(v)
+assert r == -expected, (r, -expected)

--- a/tests/regressions/python/936_arithmetic_operations.py
+++ b/tests/regressions/python/936_arithmetic_operations.py
@@ -1,0 +1,57 @@
+
+import numpy as np
+from phylanx import Phylanx, PhylanxSession, execution_tree
+
+
+PhylanxSession.init(1)
+
+
+_FLOATX = "float64"
+
+
+def floatx():
+    return _FLOATX
+
+
+def variable(value, dtype=None, name=None, constraint=None):
+    if dtype is None:
+        dtype = floatx()
+    from phylanx.ast.physl import PhySL
+    if isinstance(value, PhySL.eval_wrapper):
+        return execution_tree.variable(value.code(), dtype)
+    if isinstance(value, execution_tree.variable):
+        return value
+    return execution_tree.variable(value, dtype=dtype, name=name)
+
+
+def eval(x):
+    return x.eval()
+
+
+@Phylanx
+def greater_equal_eager(x, y):
+    return x >= y
+
+
+def greater_equal(x, y):
+    return greater_equal_eager.lazy(x, y)
+
+
+@Phylanx
+def where_eager(condition, then_expression, else_expression):
+    return where(condition, then_expression, else_expression)
+
+
+def where(condition, then_expression, else_expression):
+    return where_eager.lazy(condition, then_expression, else_expression)
+
+
+def test_switch():
+    val = np.random.random()
+    x = variable(val)
+    x = variable(where(greater_equal(x, 0.5), x * 0.1, x * 0.2))
+#    x += 42.0
+    return eval(-x)
+
+
+print(test_switch())

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -40,6 +40,7 @@ set(tests
     925_none_dtype
     933_arange
     933_eval_wrapper
+    936_arithmetic_operations
     array_len_494
     array_shape_486
     array_subscript_403


### PR DESCRIPTION
 This add the basic arithmetic operations to `variable` (add, sub, mul, div, neg, assign-add, assign-sub)