### PR TITLE
Changing the output of ctc_decode_operation to be compatible with tensorflow

### DIFF
--- a/src/plugins/keras_support/ctc_decode_operation.cpp
+++ b/src/plugins/keras_support/ctc_decode_operation.cpp
@@ -168,9 +168,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                     primitive_arguments_type result;
                     result.reserve(2);
-
-                    result.push_back(primitive_argument_type{
+                    primitive_arguments_type first;
+                    first.reserve(1);
+                    first.push_back(primitive_argument_type{
                         std::move(decoded_dense_final)});
+                    result.push_back(primitive_argument_type{std::move(first)});
                     result.push_back(
                         primitive_argument_type{std::move(log_prob)});
 

--- a/tests/unit/plugins/keras_support/ctc_decode_operation.cpp
+++ b/tests/unit/plugins/keras_support/ctc_decode_operation.cpp
@@ -47,15 +47,15 @@ void test_ctc_decode_operation_1()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         ctc_decode.eval();
     auto result = phylanx::execution_tree::extract_list_value(f.get());
-
     auto it = result.begin();
+    auto first = phylanx::execution_tree::extract_list_value(*it);
 
     blaze::DynamicMatrix<double> expected_decoded_dense{{0.}, {0.}};
     blaze::DynamicMatrix<double> expected_log_prob{{1.42711636}, {0.35667494}};
 
     HPX_TEST_EQ(
         phylanx::ir::node_data<double>(std::move(expected_decoded_dense)),
-        phylanx::execution_tree::extract_numeric_value(*it));
+        phylanx::execution_tree::extract_numeric_value(*first.begin()));
     HPX_TEST(
         allclose(phylanx::ir::node_data<double>(std::move(expected_log_prob)),
             phylanx::execution_tree::extract_numeric_value(*++it)));
@@ -96,8 +96,8 @@ void test_ctc_decode_operation_2()
     hpx::future<phylanx::execution_tree::primitive_argument_type> f =
         ctc_decode.eval();
     auto result = phylanx::execution_tree::extract_list_value(f.get());
-
     auto it = result.begin();
+    auto first = phylanx::execution_tree::extract_list_value(*it);
 
     blaze::DynamicMatrix<double> expected_decoded_dense{
         {0., 1., -1.}, {1., 1., 0.}};
@@ -105,7 +105,7 @@ void test_ctc_decode_operation_2()
 
     HPX_TEST_EQ(
         phylanx::ir::node_data<double>(std::move(expected_decoded_dense)),
-        phylanx::execution_tree::extract_numeric_value(*it));
+        phylanx::execution_tree::extract_numeric_value(*first.begin()));
     HPX_TEST(
         allclose(phylanx::ir::node_data<double>(std::move(expected_log_prob)),
             phylanx::execution_tree::extract_numeric_value(*++it)));


### PR DESCRIPTION
The tensorflow backend of keras returns a tuple where the first element is a list of size one.