### PR TITLE
Adding conv2d operation

### DIFF
--- a/phylanx/plugins/keras_support/conv2d_operation.hpp
+++ b/phylanx/plugins/keras_support/conv2d_operation.hpp
@@ -50,39 +50,40 @@ namespace phylanx { namespace execution_tree { namespace primitives {
     private:
         template <typename Matrix1, typename Matrix2>
         double convolve_step(const Matrix1& m1, const Matrix2& m2) const;
-        //template <typename Vector1, typename Vector2>
-        //double convolve_step(const Vector1& v1, const Vector2& v2,
-        //    std::int64_t dilation_rate, std::size_t kernel_size) const;
-        //template <typename Vector1, typename Vector2>
-        //double convolve_step(const Vector1& v1, const Vector2& v2,
-        //    std::int64_t dilation_rate, std::size_t kernel_size,
-        //    std::size_t r) const;
+        template <typename Matrix1, typename Matrix2>
+        double convolve_step(const Matrix1& m1, const Matrix2& m2,
+            std::size_t dilation_rate_r, std::size_t dilation_rate_c,
+            std::size_t kernel_rows, std::size_t kernel_columns) const;
+        template <typename Vector1, typename Vector2>
+        double convolve_step(const Vector1& v1, const Vector2& v2,
+            std::int64_t dilation_rate, std::size_t kernel_size,
+            std::size_t r) const;
 
         primitive_argument_type conv2d_valid(ir::node_data<double>&& arg,
             ir::node_data<double>&& kernel) const;
-        //primitive_argument_type conv2d_valid(ir::node_data<double>&& arg,
-        //    ir::node_data<double>&& kernel, std::int64_t strides) const;
-        //primitive_argument_type conv2d_valid_dilation(
-        //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-        //    std::int64_t dilation_rate) const;
+        primitive_argument_type conv2d_valid(ir::node_data<double>&& arg,
+            ir::node_data<double>&& kernel, ir::range&& strides) const;
+        primitive_argument_type conv2d_valid_dilation(
+            ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+            ir::range&& dilation_rate) const;
 
         primitive_argument_type conv2d_same(ir::node_data<double>&& arg,
             ir::node_data<double>&& kernel) const;
-        //primitive_argument_type conv2d_same(ir::node_data<double>&& arg,
-        //    ir::node_data<double>&& kernel, std::int64_t strides) const;
-        //primitive_argument_type conv2d_same_dilation(
-        //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-        //    std::int64_t dilation_rate) const;
+        primitive_argument_type conv2d_same(ir::node_data<double>&& arg,
+            ir::node_data<double>&& kernel, ir::range&& strides) const;
+        primitive_argument_type conv2d_same_dilation(
+            ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+            ir::range&& dilation_rate) const;
 
 
         primitive_argument_type conv2d_any_pad(ir::node_data<double>&& arg,
             ir::node_data<double>&& kernel, std::string&& padding) const;
-        //primitive_argument_type conv2d_any_pad(ir::node_data<double>&& arg,
-        //    ir::node_data<double>&& kernel, std::string&& padding,
-        //    std::int64_t strides) const;
-        //primitive_argument_type conv2d_any_pad_dilation(
-        //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-        //    std::string&& padding, std::int64_t dilation_rate) const;
+        primitive_argument_type conv2d_any_pad(ir::node_data<double>&& arg,
+            ir::node_data<double>&& kernel, std::string&& padding,
+            ir::range&& strides) const;
+        primitive_argument_type conv2d_any_pad_dilation(
+            ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+            std::string&& padding, ir::range&& dilation_rate) const;
     };
 
     inline primitive create_conv2d_operation(hpx::id_type const& locality,

--- a/phylanx/plugins/keras_support/conv2d_operation.hpp
+++ b/phylanx/plugins/keras_support/conv2d_operation.hpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_KERAS_SUPPORT_CONV2D_OPERATION)
+#define PHYLANX_KERAS_SUPPORT_CONV2D_OPERATION
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives {
+/// \brief returns 2D convoltion
+/// \param x              a matrix
+/// \param kernel         a matrix, the filter
+/// \param padding        Padding mode, either `valid` or `same`
+/// \param strides        The step to apply convolution on each dimension
+/// \param dilation_rate  The rate to sample x in each step
+
+    class conv2d_operation
+      : public primitive_component_base
+      , public std::enable_shared_from_this<conv2d_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+    public:
+        static match_pattern_type const match_data;
+
+        conv2d_operation() = default;
+
+        conv2d_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    private:
+        template <typename Matrix1, typename Matrix2>
+        double convolve_step(const Matrix1& m1, const Matrix2& m2) const;
+        //template <typename Vector1, typename Vector2>
+        //double convolve_step(const Vector1& v1, const Vector2& v2,
+        //    std::int64_t dilation_rate, std::size_t kernel_size) const;
+        //template <typename Vector1, typename Vector2>
+        //double convolve_step(const Vector1& v1, const Vector2& v2,
+        //    std::int64_t dilation_rate, std::size_t kernel_size,
+        //    std::size_t r) const;
+
+        primitive_argument_type conv2d_valid(ir::node_data<double>&& arg,
+            ir::node_data<double>&& kernel) const;
+        //primitive_argument_type conv2d_valid(ir::node_data<double>&& arg,
+        //    ir::node_data<double>&& kernel, std::int64_t strides) const;
+        //primitive_argument_type conv2d_valid_dilation(
+        //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        //    std::int64_t dilation_rate) const;
+
+        primitive_argument_type conv2d_same(ir::node_data<double>&& arg,
+            ir::node_data<double>&& kernel) const;
+        //primitive_argument_type conv2d_same(ir::node_data<double>&& arg,
+        //    ir::node_data<double>&& kernel, std::int64_t strides) const;
+        //primitive_argument_type conv2d_same_dilation(
+        //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        //    std::int64_t dilation_rate) const;
+
+
+        primitive_argument_type conv2d_any_pad(ir::node_data<double>&& arg,
+            ir::node_data<double>&& kernel, std::string&& padding) const;
+        //primitive_argument_type conv2d_any_pad(ir::node_data<double>&& arg,
+        //    ir::node_data<double>&& kernel, std::string&& padding,
+        //    std::int64_t strides) const;
+        //primitive_argument_type conv2d_any_pad_dilation(
+        //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        //    std::string&& padding, std::int64_t dilation_rate) const;
+    };
+
+    inline primitive create_conv2d_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "conv2d", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/keras_support/conv2d_operation.hpp
+++ b/phylanx/plugins/keras_support/conv2d_operation.hpp
@@ -54,10 +54,11 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         double convolve_step(const Matrix1& m1, const Matrix2& m2,
             std::size_t dilation_rate_r, std::size_t dilation_rate_c,
             std::size_t kernel_rows, std::size_t kernel_columns) const;
-        template <typename Vector1, typename Vector2>
-        double convolve_step(const Vector1& v1, const Vector2& v2,
-            std::int64_t dilation_rate, std::size_t kernel_size,
-            std::size_t r) const;
+        template <typename Matrix1, typename Matrix2>
+        double convolve_step(const Matrix1& m1, const Matrix2& m2,
+            std::size_t dilation_height, std::size_t dilation_width,
+            std::size_t kernel_rows, std::size_t kernel_columns,
+            std::size_t r_remainder, std::size_t c_remainder) const;
 
         primitive_argument_type conv2d_valid(ir::node_data<double>&& arg,
             ir::node_data<double>&& kernel) const;

--- a/phylanx/plugins/keras_support/keras_support.hpp
+++ b/phylanx/plugins/keras_support/keras_support.hpp
@@ -8,6 +8,7 @@
 
 #include <phylanx/plugins/keras_support/batch_dot_operation.hpp>
 #include <phylanx/plugins/keras_support/conv1d_operation.hpp>
+#include <phylanx/plugins/keras_support/conv2d_operation.hpp>
 #include <phylanx/plugins/keras_support/ctc_decode_operation.hpp>
 #include <phylanx/plugins/keras_support/elu_operation.hpp>
 #include <phylanx/plugins/keras_support/hard_sigmoid_operation.hpp>

--- a/src/plugins/keras_support/conv1d_operation.cpp
+++ b/src/plugins/keras_support/conv1d_operation.cpp
@@ -289,16 +289,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     (blaze::min)(v_size, dilated_k_size + i_rel);
 
                 if (remainder == 0)
+                {
                     result[i] =
                         convolve_step(blaze::subvector(v, 0, vector_size),
-                        blaze::subvector(k,
-                            blaze::ceil(static_cast<float>(-i_rel) /
-                                static_cast<float>(dilation_rate)),
-                            kernel_size),
-                        dilation_rate, kernel_size);
+                            blaze::subvector(k,
+                                blaze::ceil(static_cast<float>(-i_rel) /
+                                    static_cast<float>(dilation_rate)),
+                                kernel_size),
+                            dilation_rate, kernel_size);
+                }
                 else if (dilation_rate - remainder >= v_size)
+                {
                     result[i] = 0;
+                }
                 else
+                {
                     result[i] = convolve_step(
                         blaze::subvector(v, 0, vector_size),
                         blaze::subvector(k,
@@ -306,6 +311,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 static_cast<float>(dilation_rate)),
                             kernel_size),
                         dilation_rate, kernel_size, dilation_rate - remainder);
+                }
             }
             else if (i_rel > static_cast<std::int64_t>(v_size) -
                     static_cast<std::int64_t>(dilated_k_size))

--- a/src/plugins/keras_support/conv2d_operation.cpp
+++ b/src/plugins/keras_support/conv2d_operation.cpp
@@ -1,0 +1,620 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/keras_support/conv2d_operation.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/optional.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const conv2d_operation::match_data =
+    {
+        hpx::util::make_tuple("conv2d",
+        std::vector<std::string>{R"(
+            conv2d(_1, _2_kernel,
+            __arg(_3_padding, "valid"),
+            __arg(_4_strides, 1),
+            __arg(_5_dilation_rate, 1))
+        )"},
+        &create_conv2d_operation, &create_primitive<conv2d_operation>,
+        R"(x, kernel, padding, strides, dilation_rate
+        Args:
+
+            x (array) : a matrix
+            kernel (array) : a matrix
+            padding (optional, string) : padding mode, `valid` by default. It
+                can be either `valid` or `same`. `vaild` means no
+                padding. `same` results the output with the same shape as
+                original array in case of unit strides.
+            strides (optional, a tuple of integers) : the step to apply
+                convolution over array. It sets to (1,1) by default.
+            dilation_rate (optional, a tuple of integers) : indicates the
+                dilation rate, the rate to sample the array in each step of
+                convolution, (1,1) by default.
+
+        Returns:
+
+        2D convolution (or 2D mathematical cross-correlation))")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    conv2d_operation::conv2d_operation(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename Matrix1, typename Matrix2>
+    double conv2d_operation::convolve_step(
+        const Matrix1& m1, const Matrix2& m2) const
+    {
+        return blaze::sum(m1 % m2);
+    }
+
+    //template <typename Vector1, typename Vector2>
+    //double conv2d_operation::convolve_step(const Vector1& v1, const Vector2& v2,
+    //    std::int64_t dilation_rate, std::size_t kernel_size) const
+    //{
+    //    return blaze::sum(blaze::elements(
+    //                          v1,
+    //                          [dilation_rate, kernel_size](
+    //                              std::size_t i) { return i * dilation_rate; },
+    //                          kernel_size) *
+    //        v2);
+    //}
+
+    //template <typename Vector1, typename Vector2>
+    //double conv2d_operation::convolve_step(const Vector1& v1, const Vector2& v2,
+    //    std::int64_t dilation_rate, std::size_t kernel_size,
+    //    std::size_t r) const
+    //{
+    //    return blaze::sum(blaze::elements(
+    //                          v1,
+    //                          [dilation_rate, kernel_size, r](std::size_t i) {
+    //                              return i * dilation_rate + r;
+    //                          },
+    //                          kernel_size) *
+    //        v2);
+    //}
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type conv2d_operation::conv2d_valid(
+        ir::node_data<double>&& arg,
+        ir::node_data<double>&& kernel) const
+    {
+        auto m = arg.matrix();
+        auto k = kernel.matrix();
+        std::size_t krows = k.rows();
+        std::size_t kcolumns = k.columns();
+        std::size_t result_rows = m.rows() - krows + 1;
+        std::size_t result_columns = m.columns() - kcolumns + 1;
+
+        blaze::DynamicMatrix<double> result(result_rows, result_columns);
+
+        for (std::size_t i = 0; i != result_rows; ++i)
+            for (std::size_t j = 0; j != result_columns; ++j)
+                result(i, j) = convolve_step(
+                    blaze::submatrix(m, i, j, krows, kcolumns), k);
+
+        return primitive_argument_type{std::move(result)};
+    }
+
+    //primitive_argument_type conv2d_operation::conv2d_valid(
+    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+    //    std::int64_t strides) const
+    //{
+    //    auto v = arg.vector();
+    //    auto k = kernel.vector();
+    //    std::size_t k_size = kernel.size();
+    //    std::size_t result_size =
+    //        blaze::ceil(static_cast<float>(arg.size() - k_size + 1) /
+    //            static_cast<float>(strides));
+
+    //    blaze::DynamicVector<double> result(result_size);
+
+    //    for (std::size_t i = 0; i != result_size; ++i)
+    //        result[i] =
+    //            convolve_step(blaze::subvector(v, i * strides, k_size), k);
+
+    //    return primitive_argument_type{std::move(result)};
+    //}
+
+    //primitive_argument_type conv2d_operation::conv2d_valid_dilation(
+    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+    //    std::int64_t dilation_rate) const
+    //{
+    //    auto v = arg.vector();
+    //    auto k = kernel.vector();
+    //    std::size_t k_size = kernel.size();
+    //    std::size_t dilated_k_size = dilation_rate * (k_size - 1) + 1;
+    //    std::size_t result_size = arg.size() - dilated_k_size + 1;
+
+    //    blaze::DynamicVector<double> result(result_size);
+
+    //    for (std::size_t i = 0; i != result_size; ++i)
+    //        result[i] = convolve_step(blaze::subvector(v, i, dilated_k_size), k,
+    //            dilation_rate, k_size);
+
+    //    return primitive_argument_type{std::move(result)};
+    //}
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type conv2d_operation::conv2d_same(
+        ir::node_data<double>&& arg,
+        ir::node_data<double>&& kernel) const
+    {
+        auto m = arg.matrix();
+        auto k = kernel.matrix();
+        std::size_t filter_height = k.rows();
+        std::size_t filter_width = k.columns();
+        std::size_t nrows = m.rows();
+        std::size_t ncolumns = m.columns();
+        std::size_t pad_top = (filter_height - 1) / 2;
+        std::size_t pad_left = (filter_width - 1) / 2;
+        std::int64_t r_rel;    //relative row
+        std::int64_t c_rel;    //relative column
+
+        blaze::DynamicMatrix<double> result(nrows, ncolumns);
+
+        for (std::size_t r = 0; r != nrows; ++r)
+        {
+            r_rel = r - pad_top;
+            for (std::size_t c = 0; c != ncolumns; ++c)
+            {
+                c_rel = c - pad_left;
+                if (r_rel < 0)
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, 0, filter_height + r_rel,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, -r_rel, -c_rel,
+                                filter_height + r_rel, filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, c_rel, filter_height + r_rel,
+                                ncolumns - c_rel),
+                            blaze::submatrix(k, -r_rel, 0,
+                                filter_height + r_rel, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, c_rel, filter_height + r_rel,
+                                filter_width),
+                            blaze::submatrix(k, -r_rel, 0,
+                                filter_height + r_rel, filter_width));
+                    }
+                }
+                else if (r_rel > static_cast<std::int64_t>(nrows) -
+                        static_cast<std::int64_t>(filter_height))
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, r_rel, 0, nrows - r_rel,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, 0, -c_rel, nrows - r_rel,
+                                filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              nrows - r_rel, ncolumns - c_rel),
+                                blaze::submatrix(
+                                    k, 0, 0, nrows - r_rel, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              nrows - r_rel, filter_width),
+                                blaze::submatrix(
+                                    k, 0, 0, nrows - r_rel, filter_width));
+                    }
+                }
+                else
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, r_rel, 0, filter_height,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, 0, -c_rel, filter_height,
+                                filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              filter_height, ncolumns - c_rel),
+                                blaze::submatrix(
+                                    k, 0, 0, filter_height, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              filter_height, filter_width),
+                                k);
+                    }
+                }
+            }
+        }
+        return primitive_argument_type{std::move(result)};
+    }
+
+    //primitive_argument_type conv2d_operation::conv2d_same(
+    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+    //    std::int64_t strides) const
+    //{
+    //    auto v = arg.vector();
+    //    auto k = kernel.vector();
+    //    std::size_t k_size = kernel.size();
+    //    std::size_t v_size = arg.size();
+    //    std::size_t pad_width;
+    //    std::int64_t i_rel;
+
+    //    if (v_size % strides == 0)
+    //        pad_width =
+    //            (blaze::max)(k_size - strides, static_cast<std::size_t>(0));
+
+    //    else
+    //        pad_width = (blaze::max)(
+    //            k_size - (v_size % strides), static_cast<std::size_t>(0));
+
+    //    std::size_t result_size = blaze::ceil(
+    //        static_cast<float>(v_size + pad_width - k_size + 1) /
+    //        static_cast<float>(strides));
+
+    //    blaze::DynamicVector<double> result(result_size);
+
+    //    std::size_t pad_left = pad_width / 2;
+
+    //    for (std::size_t i = 0; i != result_size; ++i)
+    //    {
+    //        i_rel = i * strides - pad_left;
+    //        if (i_rel < 0)
+    //        {
+    //            result[i] =
+    //                convolve_step(blaze::subvector(v, 0, k_size + i_rel),
+    //                    blaze::subvector(k, -i_rel, k_size + i_rel));
+    //        }
+    //        else if (i_rel > static_cast<std::int64_t>(v_size) -
+    //                static_cast<std::int64_t>(k_size))
+    //        {
+    //            result[i] =
+    //                convolve_step(blaze::subvector(v, i_rel, v_size - i_rel),
+    //                    blaze::subvector(k, 0, v_size - i_rel));
+    //        }
+    //        else
+    //        {
+    //            result[i] =
+    //                convolve_step(blaze::subvector(v, i_rel, k_size), k);
+    //        }
+    //    }
+    //    return primitive_argument_type{std::move(result)};
+    //}
+
+    //primitive_argument_type conv2d_operation::conv2d_same_dilation(
+    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+    //    std::int64_t dilation_rate) const
+    //{
+    //    auto v = arg.vector();
+    //    auto k = kernel.vector();
+    //    std::size_t k_size = kernel.size();
+    //    std::size_t dilated_k_size = dilation_rate * (k_size - 1) + 1;
+    //    std::size_t v_size = arg.size();
+    //    std::size_t pad_left = (dilated_k_size - 1) / 2;
+    //    std::int64_t i_rel;
+
+    //    blaze::DynamicVector<double> result(v_size);
+
+    //    for (std::size_t i = 0; i != v_size; ++i)
+    //    {
+    //        i_rel = i - pad_left;
+    //        if (i_rel < 0)
+    //        {
+    //            std::size_t kernel_size;
+    //            std::size_t remainder = -i_rel % dilation_rate;
+    //            if (dilated_k_size + i_rel > v_size)
+    //            {
+    //                kernel_size =
+    //                    blaze::ceil(static_cast<float>(v_size - remainder) /
+    //                        static_cast<float>(dilation_rate));
+    //                if (remainder == 0)
+    //                    result[i] = convolve_step(v,
+    //                        blaze::subvector(k,
+    //                            blaze::ceil(static_cast<float>(-i_rel) /
+    //                                static_cast<float>(dilation_rate)),
+    //                            kernel_size),
+    //                        dilation_rate, kernel_size);
+    //                else
+    //                    result[i] = convolve_step(v,
+    //                        blaze::subvector(k,
+    //                            blaze::ceil(static_cast<float>(-i_rel) /
+    //                                static_cast<float>(dilation_rate)),
+    //                            kernel_size),
+    //                        dilation_rate, kernel_size,
+    //                        dilation_rate - remainder);
+    //            }
+    //            else
+    //            {
+    //                kernel_size =
+    //                blaze::ceil(static_cast<float>(dilated_k_size + i_rel) /
+    //                    static_cast<float>(dilation_rate));
+    //                if (remainder == 0)
+    //                    result[i] = convolve_step(
+    //                        blaze::subvector(v, 0, dilated_k_size + i_rel),
+    //                        blaze::subvector(k,
+    //                            blaze::ceil(static_cast<float>(-i_rel) /
+    //                                static_cast<float>(dilation_rate)),
+    //                            kernel_size),
+    //                        dilation_rate, kernel_size);
+    //                else
+    //                    result[i] = convolve_step(
+    //                        blaze::subvector(v, 0, dilated_k_size + i_rel),
+    //                        blaze::subvector(k,
+    //                            blaze::ceil(static_cast<float>(-i_rel) /
+    //                                static_cast<float>(dilation_rate)),
+    //                            kernel_size),
+    //                        dilation_rate, kernel_size,
+    //                        dilation_rate - remainder);
+    //            }
+    //        }
+    //        else if (i_rel > static_cast<std::int64_t>(v_size) -
+    //                static_cast<std::int64_t>(dilated_k_size))
+    //        {
+    //            std::size_t kernel_size =
+    //                blaze::ceil(static_cast<float>(v_size - i_rel) /
+    //                    static_cast<float>(dilation_rate));
+    //            result[i] = convolve_step(
+    //                blaze::subvector(v, i_rel, v_size - i_rel),
+    //                blaze::subvector(k, 0, kernel_size),
+    //                dilation_rate, kernel_size);
+    //        }
+    //        else
+    //        {
+    //            result[i] =
+    //                convolve_step(blaze::subvector(v, i_rel, dilated_k_size), k,
+    //                    dilation_rate, k_size);
+    //        }
+    //    }
+    //    return primitive_argument_type{std::move(result)};
+    //}
+
+    /////////////////////////////////////////////////////////////////////////////
+    primitive_argument_type conv2d_operation::conv2d_any_pad(
+        ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        std::string&& padding) const
+    {
+        if (padding == "valid")
+            return conv2d_valid(std::move(arg), std::move(kernel));
+
+        // padding == "same"
+        return conv2d_same(std::move(arg), std::move(kernel));
+    }
+
+    //primitive_argument_type conv2d_operation::conv2d_any_pad(
+    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+    //    std::string&& padding, std::int64_t strides) const
+    //{
+    //    if (padding == "valid")
+    //        return conv2d_valid(std::move(arg), std::move(kernel), strides);
+
+    //    else if (padding == "same")
+    //        return conv2d_same(std::move(arg), std::move(kernel), strides);
+
+    //    // padding == causal
+    //    return conv2d_causal(std::move(arg), std::move(kernel), strides);
+    //}
+
+    //primitive_argument_type conv2d_operation::conv2d_any_pad_dilation(
+    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+    //    std::string&& padding, std::int64_t dilation_rate) const
+    //{
+    //    if (padding == "valid")
+    //        return conv2d_valid_dilation(
+    //            std::move(arg), std::move(kernel), dilation_rate);
+
+    //    else if (padding == "same")
+    //        return conv2d_same_dilation(
+    //            std::move(arg), std::move(kernel), dilation_rate);
+
+    //    // padding == causal
+    //    return conv2d_causal_dilation(
+    //        std::move(arg), std::move(kernel), dilation_rate);
+    //}
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> conv2d_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.size() < 2 || operands.size() > 5)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "conv2d_operation::eval",
+                generate_error_message("the conv2d_operation primitive requires "
+                                       "between 2 and 5 operands"));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "conv2d_operation::eval",
+                    generate_error_message(
+                        "the conv2d_operation primitive requires that the "
+                        "arguments given by the operands array are valid"));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping([this_ = std::move(this_)](
+                                      primitive_arguments_type&& args)
+                                      -> primitive_argument_type {
+
+                std::size_t ndim = extract_numeric_value_dimension(
+                    args[0], this_->name_, this_->codename_);
+
+                if (ndim !=
+                        extract_numeric_value_dimension(
+                            args[1], this_->name_, this_->codename_) ||
+                    ndim != 2)
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "conv2d_operation::eval",
+                        this_->generate_error_message(
+                            "conv2d operation requires for x and kernel to be "
+                            "matrices"));
+
+                std::string padding = "valid";
+                if (args.size() > 2)
+                {
+                    padding = extract_string_value(
+                        args[2], this_->name_, this_->codename_);
+
+                    if (padding != "valid" && padding != "same" &&
+                        padding != "causal")
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "conv2d_operation::eval",
+                            this_->generate_error_message(
+                                "invalid padding. Padding can be either valid "
+                                "or same"));
+                }
+
+                //if (padding == "valid")
+                //{
+                //    if (extract_numeric_value_dimension(
+                //            args[0], this_->name_, this_->codename_) <
+                //        extract_numeric_value_dimension(
+                //            args[1], this_->name_, this_->codename_))
+                //        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                //            "conv2d_operation::eval",
+                //            this_->generate_error_message(
+                //                "the kernel size cannot be greater than the "
+                //                "array size in the valid padding mode"));
+                //}
+
+                ir::range strides(0);    // an empty range
+                if (args.size() > 3)
+                {
+                    if (is_list_operand_strict(args[3]))
+                    {
+                        ir::range s = extract_list_value(
+                            args[3], this_->name_, this_->codename_);
+                        if (s.size() == 1)
+                            strides =
+                                extract_scalar_integer_value_strict(*s.begin());
+                        else
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "conv2d_operation::eval",
+                                this_->generate_error_message(
+                                    "conv2d_operation requires the strides to "
+                                    "be of rank 2"));
+                    }
+                    //else
+                    //    strides = extract_scalar_integer_value_strict(
+                    //        args[3], this_->name_, this_->codename_);
+
+                    //if (strides <= 0)
+                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    //        "conv2d_operation::eval",
+                    //        this_->generate_error_message(
+                    //            "invalid strides. Strides must be positive"));
+                }
+
+                ir::range dilation_rate(0);    // an empty range
+                if (args.size() > 4)
+                {
+                    //if (is_list_operand_strict(args[4]))
+                    //{
+                    //    ir::range d = extract_list_value(
+                    //        args[4], this_->name_, this_->codename_);
+                    //    if (d.size() == 1)
+                    //        dilation_rate =
+                    //            extract_scalar_integer_value_strict(*d.begin());
+                    //    else
+                    //        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    //            "conv2d_operation::eval",
+                    //            this_->generate_error_message(
+                    //                "conv2d_operation requires the "
+                    //                "dilation_rate to be of rank 1"));
+                    //}
+                    //else
+                    //    dilation_rate = extract_scalar_integer_value_strict(
+                    //        args[4], this_->name_, this_->codename_);
+
+                    //if (dilation_rate <= 0)
+                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    //        "conv2d_operation::eval",
+                    //        this_->generate_error_message(
+                    //            "dilation_rate must be positive"));
+
+                    //if (strides != 1 && dilation_rate != 1)
+                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    //        "conv2d_operation::eval",
+                    //        this_->generate_error_message(
+                    //            "strides > 1 not supported in conjunction with "
+                    //            "dilation_rate > 1"));
+                }
+
+                if (strides.empty() && dilation_rate.empty())
+                {
+                    return this_->conv2d_any_pad(
+                        extract_numeric_value(
+                            std::move(args[0]), this_->name_, this_->codename_),
+                        extract_numeric_value(
+                            std::move(args[1]), this_->name_, this_->codename_),
+                        std::move(padding));
+                }
+                //else if (dilation_rate == 1)
+                //{
+                //    return this_->conv2d_any_pad(
+                //        extract_numeric_value(
+                //            std::move(args[0]), this_->name_, this_->codename_),
+                //        extract_numeric_value(
+                //            std::move(args[1]), this_->name_, this_->codename_),
+                //        std::move(padding), strides);
+                //}
+                //// strides == 1 and dilation_rate > 1
+                //return this_->conv2d_any_pad_dilation(
+                //    extract_numeric_value(
+                //        std::move(args[0]), this_->name_, this_->codename_),
+                //    extract_numeric_value(
+                //        std::move(args[1]), this_->name_, this_->codename_),
+                //    std::move(padding), dilation_rate);
+
+            }),
+            detail::map_operands(
+                operands, functional::value_operand{}, args, name_, codename_));
+    }
+}}}

--- a/src/plugins/keras_support/conv2d_operation.cpp
+++ b/src/plugins/keras_support/conv2d_operation.cpp
@@ -15,6 +15,7 @@
 #include <hpx/throw_exception.hpp>
 #include <hpx/util/optional.hpp>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -34,8 +35,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::vector<std::string>{R"(
             conv2d(_1, _2_kernel,
             __arg(_3_padding, "valid"),
-            __arg(_4_strides, 1),
-            __arg(_5_dilation_rate, 1))
+            __arg(_4_strides, list(1,1)),
+            __arg(_5_dilation_rate, list(1,1)))
         )"},
         &create_conv2d_operation, &create_primitive<conv2d_operation>,
         R"(x, kernel, padding, strides, dilation_rate
@@ -72,31 +73,37 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return blaze::sum(m1 % m2);
     }
 
-    //template <typename Vector1, typename Vector2>
-    //double conv2d_operation::convolve_step(const Vector1& v1, const Vector2& v2,
-    //    std::int64_t dilation_rate, std::size_t kernel_size) const
-    //{
-    //    return blaze::sum(blaze::elements(
-    //                          v1,
-    //                          [dilation_rate, kernel_size](
-    //                              std::size_t i) { return i * dilation_rate; },
-    //                          kernel_size) *
-    //        v2);
-    //}
+    template <typename Matrix1, typename Matrix2>
+    double conv2d_operation::convolve_step(const Matrix1& m1, const Matrix2& m2,
+        std::size_t dilation_height, std::size_t dilation_width,
+        std::size_t kernel_rows, std::size_t kernel_columns) const
+    {
+        return blaze::sum(
+            blaze::columns(
+                blaze::rows(
+                    m1,
+                    [dilation_height, kernel_rows](
+                        std::size_t i) { return i * dilation_height; },
+                    kernel_rows),
+                [dilation_width, kernel_columns](
+                    std::size_t j) { return j * dilation_width; },
+                kernel_columns) %
+            m2);
+    }
 
-    //template <typename Vector1, typename Vector2>
-    //double conv2d_operation::convolve_step(const Vector1& v1, const Vector2& v2,
-    //    std::int64_t dilation_rate, std::size_t kernel_size,
-    //    std::size_t r) const
-    //{
-    //    return blaze::sum(blaze::elements(
-    //                          v1,
-    //                          [dilation_rate, kernel_size, r](std::size_t i) {
-    //                              return i * dilation_rate + r;
-    //                          },
-    //                          kernel_size) *
-    //        v2);
-    //}
+    template <typename Vector1, typename Vector2>
+    double conv2d_operation::convolve_step(const Vector1& v1, const Vector2& v2,
+        std::int64_t dilation_rate, std::size_t kernel_size,
+        std::size_t r) const
+    {
+        return blaze::sum(blaze::elements(
+                              v1,
+                              [dilation_rate, kernel_size, r](std::size_t i) {
+                                  return i * dilation_rate + r;
+                              },
+                              kernel_size) *
+            v2);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type conv2d_operation::conv2d_valid(
@@ -105,59 +112,85 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         auto m = arg.matrix();
         auto k = kernel.matrix();
-        std::size_t krows = k.rows();
-        std::size_t kcolumns = k.columns();
-        std::size_t result_rows = m.rows() - krows + 1;
-        std::size_t result_columns = m.columns() - kcolumns + 1;
+        std::size_t filter_height = k.rows();
+        std::size_t filter_width = k.columns();
+        std::size_t result_rows = m.rows() - filter_height + 1;
+        std::size_t result_columns = m.columns() - filter_width + 1;
 
         blaze::DynamicMatrix<double> result(result_rows, result_columns);
 
         for (std::size_t i = 0; i != result_rows; ++i)
             for (std::size_t j = 0; j != result_columns; ++j)
                 result(i, j) = convolve_step(
-                    blaze::submatrix(m, i, j, krows, kcolumns), k);
+                    blaze::submatrix(m, i, j, filter_height, filter_width), k);
 
         return primitive_argument_type{std::move(result)};
     }
 
-    //primitive_argument_type conv2d_operation::conv2d_valid(
-    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-    //    std::int64_t strides) const
-    //{
-    //    auto v = arg.vector();
-    //    auto k = kernel.vector();
-    //    std::size_t k_size = kernel.size();
-    //    std::size_t result_size =
-    //        blaze::ceil(static_cast<float>(arg.size() - k_size + 1) /
-    //            static_cast<float>(strides));
+    primitive_argument_type conv2d_operation::conv2d_valid(
+        ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        ir::range&& strides) const
+    {
+        auto m = arg.matrix();
+        auto k = kernel.matrix();
+        std::size_t filter_height = k.rows();
+        std::size_t filter_width = k.columns();
 
-    //    blaze::DynamicVector<double> result(result_size);
+        auto it = strides.begin();
+        std::size_t stride_height = extract_scalar_integer_value_strict(*it);
+        std::size_t stride_width = extract_scalar_integer_value_strict(*++it);
 
-    //    for (std::size_t i = 0; i != result_size; ++i)
-    //        result[i] =
-    //            convolve_step(blaze::subvector(v, i * strides, k_size), k);
+        std::size_t result_rows =
+            blaze::ceil(static_cast<float>(m.rows() - filter_height + 1) /
+                static_cast<float>(stride_height));
+        std::size_t result_columns =
+            blaze::ceil(static_cast<float>(m.columns() - filter_width + 1) /
+                static_cast<float>(stride_width));
 
-    //    return primitive_argument_type{std::move(result)};
-    //}
+        blaze::DynamicMatrix<double> result(result_rows, result_columns);
 
-    //primitive_argument_type conv2d_operation::conv2d_valid_dilation(
-    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-    //    std::int64_t dilation_rate) const
-    //{
-    //    auto v = arg.vector();
-    //    auto k = kernel.vector();
-    //    std::size_t k_size = kernel.size();
-    //    std::size_t dilated_k_size = dilation_rate * (k_size - 1) + 1;
-    //    std::size_t result_size = arg.size() - dilated_k_size + 1;
+        for (std::size_t i = 0; i != result_rows; ++i)
+            for (std::size_t j = 0; j != result_columns; ++j)
+                result(i, j) = convolve_step(
+                    blaze::submatrix(m, i * stride_height, j * stride_width,
+                        filter_height, filter_width),
+                    k);
 
-    //    blaze::DynamicVector<double> result(result_size);
+        return primitive_argument_type{std::move(result)};
+    }
 
-    //    for (std::size_t i = 0; i != result_size; ++i)
-    //        result[i] = convolve_step(blaze::subvector(v, i, dilated_k_size), k,
-    //            dilation_rate, k_size);
+    primitive_argument_type conv2d_operation::conv2d_valid_dilation(
+        ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        ir::range&& dilation_rate) const
+    {
+        auto m = arg.matrix();
+        auto k = kernel.matrix();
+        std::size_t filter_height = k.rows();
+        std::size_t filter_width = k.columns();
 
-    //    return primitive_argument_type{std::move(result)};
-    //}
+        auto it = dilation_rate.begin();
+        std::size_t dilation_height = extract_scalar_integer_value_strict(*it);
+        std::size_t dilation_width = extract_scalar_integer_value_strict(*++it);
+
+        std::size_t dilated_filter_height =
+            dilation_height * (filter_height - 1) + 1;
+        std::size_t dilated_filter_width =
+            dilation_width * (filter_width - 1) + 1;
+
+        blaze::DynamicMatrix<double> result(
+            m.rows() - dilated_filter_height + 1,
+            m.columns() - dilated_filter_width + 1);
+
+        for (std::size_t i = 0; i != result.rows(); ++i)
+            for (std::size_t j = 0; j != result.columns(); ++j)
+                result(i, j) = convolve_step(
+                    blaze::submatrix(
+                        m, i, j, dilated_filter_height, dilated_filter_width),
+                    k, dilation_height, dilation_width, filter_height,
+                    filter_width);
+
+        return primitive_argument_type{std::move(result)};
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     primitive_argument_type conv2d_operation::conv2d_same(
@@ -272,144 +305,272 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return primitive_argument_type{std::move(result)};
     }
 
-    //primitive_argument_type conv2d_operation::conv2d_same(
-    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-    //    std::int64_t strides) const
-    //{
-    //    auto v = arg.vector();
-    //    auto k = kernel.vector();
-    //    std::size_t k_size = kernel.size();
-    //    std::size_t v_size = arg.size();
-    //    std::size_t pad_width;
-    //    std::int64_t i_rel;
+    primitive_argument_type conv2d_operation::conv2d_same(
+        ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        ir::range&& strides) const
+    {
+        auto m = arg.matrix();
+        auto k = kernel.matrix();
+        std::size_t filter_height = k.rows();
+        std::size_t filter_width = k.columns();
+        std::size_t nrows = m.rows();
+        std::size_t ncolumns = m.columns();
 
-    //    if (v_size % strides == 0)
-    //        pad_width =
-    //            (blaze::max)(k_size - strides, static_cast<std::size_t>(0));
+        auto it = strides.begin();
+        std::size_t stride_height = extract_scalar_integer_value_strict(*it);
+        std::size_t stride_width = extract_scalar_integer_value_strict(*++it);
 
-    //    else
-    //        pad_width = (blaze::max)(
-    //            k_size - (v_size % strides), static_cast<std::size_t>(0));
+        std::size_t pad_top;
+        std::size_t pad_left;
+        std::size_t pad_height;
+        std::size_t pad_width;
 
-    //    std::size_t result_size = blaze::ceil(
-    //        static_cast<float>(v_size + pad_width - k_size + 1) /
-    //        static_cast<float>(strides));
+        if (nrows % stride_height == 0)
+            pad_height = (blaze::max)(
+                filter_height - stride_height, static_cast<std::size_t>(0));
+        else
+            pad_height = (blaze::max)(filter_height - (nrows % stride_height),
+                static_cast<std::size_t>(0));
 
-    //    blaze::DynamicVector<double> result(result_size);
+        if (ncolumns % stride_width == 0)
+            pad_width = (blaze::max)(
+                filter_width - stride_width, static_cast<std::size_t>(0));
+        else
+            pad_width = (blaze::max)(filter_width - (ncolumns % stride_width),
+                static_cast<std::size_t>(0));
 
-    //    std::size_t pad_left = pad_width / 2;
+        pad_top = pad_height / 2;
+        pad_left = pad_width / 2;
 
-    //    for (std::size_t i = 0; i != result_size; ++i)
-    //    {
-    //        i_rel = i * strides - pad_left;
-    //        if (i_rel < 0)
-    //        {
-    //            result[i] =
-    //                convolve_step(blaze::subvector(v, 0, k_size + i_rel),
-    //                    blaze::subvector(k, -i_rel, k_size + i_rel));
-    //        }
-    //        else if (i_rel > static_cast<std::int64_t>(v_size) -
-    //                static_cast<std::int64_t>(k_size))
-    //        {
-    //            result[i] =
-    //                convolve_step(blaze::subvector(v, i_rel, v_size - i_rel),
-    //                    blaze::subvector(k, 0, v_size - i_rel));
-    //        }
-    //        else
-    //        {
-    //            result[i] =
-    //                convolve_step(blaze::subvector(v, i_rel, k_size), k);
-    //        }
-    //    }
-    //    return primitive_argument_type{std::move(result)};
-    //}
+        std::int64_t r_rel;    //relative row
+        std::int64_t c_rel;    //relative column
 
-    //primitive_argument_type conv2d_operation::conv2d_same_dilation(
-    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-    //    std::int64_t dilation_rate) const
-    //{
-    //    auto v = arg.vector();
-    //    auto k = kernel.vector();
-    //    std::size_t k_size = kernel.size();
-    //    std::size_t dilated_k_size = dilation_rate * (k_size - 1) + 1;
-    //    std::size_t v_size = arg.size();
-    //    std::size_t pad_left = (dilated_k_size - 1) / 2;
-    //    std::int64_t i_rel;
+        blaze::DynamicMatrix<double> result(
+            blaze::ceil(
+                static_cast<float>(nrows + pad_height - filter_height + 1) /
+                static_cast<float>(stride_height)),
+            blaze::ceil(
+                static_cast<float>(ncolumns + pad_width - filter_width + 1) /
+                static_cast<float>(stride_width)));
 
-    //    blaze::DynamicVector<double> result(v_size);
 
-    //    for (std::size_t i = 0; i != v_size; ++i)
-    //    {
-    //        i_rel = i - pad_left;
-    //        if (i_rel < 0)
-    //        {
-    //            std::size_t kernel_size;
-    //            std::size_t remainder = -i_rel % dilation_rate;
-    //            if (dilated_k_size + i_rel > v_size)
-    //            {
-    //                kernel_size =
-    //                    blaze::ceil(static_cast<float>(v_size - remainder) /
-    //                        static_cast<float>(dilation_rate));
-    //                if (remainder == 0)
-    //                    result[i] = convolve_step(v,
-    //                        blaze::subvector(k,
-    //                            blaze::ceil(static_cast<float>(-i_rel) /
-    //                                static_cast<float>(dilation_rate)),
-    //                            kernel_size),
-    //                        dilation_rate, kernel_size);
-    //                else
-    //                    result[i] = convolve_step(v,
-    //                        blaze::subvector(k,
-    //                            blaze::ceil(static_cast<float>(-i_rel) /
-    //                                static_cast<float>(dilation_rate)),
-    //                            kernel_size),
-    //                        dilation_rate, kernel_size,
-    //                        dilation_rate - remainder);
-    //            }
-    //            else
-    //            {
-    //                kernel_size =
-    //                blaze::ceil(static_cast<float>(dilated_k_size + i_rel) /
-    //                    static_cast<float>(dilation_rate));
-    //                if (remainder == 0)
-    //                    result[i] = convolve_step(
-    //                        blaze::subvector(v, 0, dilated_k_size + i_rel),
-    //                        blaze::subvector(k,
-    //                            blaze::ceil(static_cast<float>(-i_rel) /
-    //                                static_cast<float>(dilation_rate)),
-    //                            kernel_size),
-    //                        dilation_rate, kernel_size);
-    //                else
-    //                    result[i] = convolve_step(
-    //                        blaze::subvector(v, 0, dilated_k_size + i_rel),
-    //                        blaze::subvector(k,
-    //                            blaze::ceil(static_cast<float>(-i_rel) /
-    //                                static_cast<float>(dilation_rate)),
-    //                            kernel_size),
-    //                        dilation_rate, kernel_size,
-    //                        dilation_rate - remainder);
-    //            }
-    //        }
-    //        else if (i_rel > static_cast<std::int64_t>(v_size) -
-    //                static_cast<std::int64_t>(dilated_k_size))
-    //        {
-    //            std::size_t kernel_size =
-    //                blaze::ceil(static_cast<float>(v_size - i_rel) /
-    //                    static_cast<float>(dilation_rate));
-    //            result[i] = convolve_step(
-    //                blaze::subvector(v, i_rel, v_size - i_rel),
-    //                blaze::subvector(k, 0, kernel_size),
-    //                dilation_rate, kernel_size);
-    //        }
-    //        else
-    //        {
-    //            result[i] =
-    //                convolve_step(blaze::subvector(v, i_rel, dilated_k_size), k,
-    //                    dilation_rate, k_size);
-    //        }
-    //    }
-    //    return primitive_argument_type{std::move(result)};
-    //}
+        for (std::size_t r = 0; r != result.rows(); ++r)
+        {
+            r_rel = r * stride_height - pad_top;
+            for (std::size_t c = 0; c != result.columns(); ++c)
+            {
+                c_rel = c * stride_width - pad_left;
+                if (r_rel < 0)
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, 0, filter_height + r_rel,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, -r_rel, -c_rel,
+                                filter_height + r_rel, filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, c_rel, filter_height + r_rel,
+                                ncolumns - c_rel),
+                            blaze::submatrix(k, -r_rel, 0,
+                                filter_height + r_rel, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, c_rel, filter_height + r_rel,
+                                filter_width),
+                            blaze::submatrix(k, -r_rel, 0,
+                                filter_height + r_rel, filter_width));
+                    }
+                }
+                else if (r_rel > static_cast<std::int64_t>(nrows) -
+                        static_cast<std::int64_t>(filter_height))
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, r_rel, 0, nrows - r_rel,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, 0, -c_rel, nrows - r_rel,
+                                filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              nrows - r_rel, ncolumns - c_rel),
+                                blaze::submatrix(
+                                    k, 0, 0, nrows - r_rel, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              nrows - r_rel, filter_width),
+                                blaze::submatrix(
+                                    k, 0, 0, nrows - r_rel, filter_width));
+                    }
+                }
+                else
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, r_rel, 0, filter_height,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, 0, -c_rel, filter_height,
+                                filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              filter_height, ncolumns - c_rel),
+                                blaze::submatrix(
+                                    k, 0, 0, filter_height, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              filter_height, filter_width),
+                                k);
+                    }
+                }
+            }
+        }
+        return primitive_argument_type{std::move(result)};
+    }
+
+    primitive_argument_type conv2d_operation::conv2d_same_dilation(
+        ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        ir::range&& dilation_rate) const
+    {
+        auto m = arg.matrix();
+        auto k = kernel.matrix();
+        std::size_t filter_height = k.rows();
+        std::size_t filter_width = k.columns();
+        std::size_t nrows = m.rows();
+        std::size_t ncolumns = m.columns();
+
+        auto it = dilation_rate.begin();
+        std::size_t dilation_height = extract_scalar_integer_value_strict(*it);
+        std::size_t dilation_width = extract_scalar_integer_value_strict(*++it);
+
+        std::size_t dilated_filter_height =
+            dilation_height * (filter_height - 1) + 1;
+        std::size_t dilated_filter_width =
+            dilation_width * (filter_width - 1) + 1;
+
+        std::size_t pad_top = (dilated_filter_height - 1) / 2;
+        std::size_t pad_left = (dilated_filter_width - 1) / 2;
+
+        std::int64_t r_rel;    //relative row
+        std::int64_t c_rel;    //relative column
+
+        blaze::DynamicMatrix<double> result(nrows, ncolumns);
+
+        for (std::size_t r = 0; r != nrows; ++r)
+        {
+            r_rel = r - pad_top;
+            for (std::size_t c = 0; c != ncolumns; ++c)
+            {
+                c_rel = c - pad_left;
+                if (r_rel < 0)
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, 0, filter_height + r_rel,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, -r_rel, -c_rel,
+                                filter_height + r_rel, filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, c_rel, filter_height + r_rel,
+                                ncolumns - c_rel),
+                            blaze::submatrix(k, -r_rel, 0,
+                                filter_height + r_rel, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, 0, c_rel, filter_height + r_rel,
+                                filter_width),
+                            blaze::submatrix(k, -r_rel, 0,
+                                filter_height + r_rel, filter_width));
+                    }
+                }
+                else if (r_rel > static_cast<std::int64_t>(nrows) -
+                        static_cast<std::int64_t>(filter_height))
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, r_rel, 0, nrows - r_rel,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, 0, -c_rel, nrows - r_rel,
+                                filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              nrows - r_rel, ncolumns - c_rel),
+                                blaze::submatrix(
+                                    k, 0, 0, nrows - r_rel, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              nrows - r_rel, filter_width),
+                                blaze::submatrix(
+                                    k, 0, 0, nrows - r_rel, filter_width));
+                    }
+                }
+                else
+                {
+                    if (c_rel < 0)
+                    {
+                        result(r, c) = convolve_step(
+                            blaze::submatrix(m, r_rel, 0, filter_height,
+                                filter_width + c_rel),
+                            blaze::submatrix(k, 0, -c_rel, filter_height,
+                                filter_width + c_rel));
+                    }
+                    else if (c_rel > static_cast<std::int64_t>(ncolumns) -
+                            static_cast<std::int64_t>(filter_width))
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              filter_height, ncolumns - c_rel),
+                                blaze::submatrix(
+                                    k, 0, 0, filter_height, ncolumns - c_rel));
+                    }
+                    else
+                    {
+                        result(r, c) =
+                            convolve_step(blaze::submatrix(m, r_rel, c_rel,
+                                              filter_height, filter_width),
+                                k);
+                    }
+                }
+            }
+        }
+        return primitive_argument_type{std::move(result)};
+    }
 
     /////////////////////////////////////////////////////////////////////////////
     primitive_argument_type conv2d_operation::conv2d_any_pad(
@@ -423,36 +584,31 @@ namespace phylanx { namespace execution_tree { namespace primitives
         return conv2d_same(std::move(arg), std::move(kernel));
     }
 
-    //primitive_argument_type conv2d_operation::conv2d_any_pad(
-    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-    //    std::string&& padding, std::int64_t strides) const
-    //{
-    //    if (padding == "valid")
-    //        return conv2d_valid(std::move(arg), std::move(kernel), strides);
+    primitive_argument_type conv2d_operation::conv2d_any_pad(
+        ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        std::string&& padding, ir::range&& strides) const
+    {
+        if (padding == "valid")
+            return conv2d_valid(
+                std::move(arg), std::move(kernel), std::move(strides));
 
-    //    else if (padding == "same")
-    //        return conv2d_same(std::move(arg), std::move(kernel), strides);
+        // padding == "same"
+        return conv2d_same(
+            std::move(arg), std::move(kernel), std::move(strides));
+    }
 
-    //    // padding == causal
-    //    return conv2d_causal(std::move(arg), std::move(kernel), strides);
-    //}
+    primitive_argument_type conv2d_operation::conv2d_any_pad_dilation(
+        ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
+        std::string&& padding, ir::range&& dilation_rate) const
+    {
+        if (padding == "valid")
+            return conv2d_valid_dilation(
+                std::move(arg), std::move(kernel), std::move(dilation_rate));
 
-    //primitive_argument_type conv2d_operation::conv2d_any_pad_dilation(
-    //    ir::node_data<double>&& arg, ir::node_data<double>&& kernel,
-    //    std::string&& padding, std::int64_t dilation_rate) const
-    //{
-    //    if (padding == "valid")
-    //        return conv2d_valid_dilation(
-    //            std::move(arg), std::move(kernel), dilation_rate);
-
-    //    else if (padding == "same")
-    //        return conv2d_same_dilation(
-    //            std::move(arg), std::move(kernel), dilation_rate);
-
-    //    // padding == causal
-    //    return conv2d_causal_dilation(
-    //        std::move(arg), std::move(kernel), dilation_rate);
-    //}
+        // padding == "same"
+        return conv2d_same_dilation(
+                std::move(arg), std::move(kernel), std::move(dilation_rate));
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> conv2d_operation::eval(
@@ -496,96 +652,115 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "conv2d operation requires for x and kernel to be "
                             "matrices"));
 
-                std::string padding = "valid";
-                if (args.size() > 2)
-                {
-                    padding = extract_string_value(
-                        args[2], this_->name_, this_->codename_);
+                std::string padding;
+                padding = extract_string_value(
+                    args[2], this_->name_, this_->codename_);
 
-                    if (padding != "valid" && padding != "same" &&
-                        padding != "causal")
+                if (padding != "valid" && padding != "same")
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "conv2d_operation::eval",
+                        this_->generate_error_message(
+                            "invalid padding. Padding can be either valid "
+                            "or same"));
+
+
+                if (padding == "valid")
+                {
+                    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> x_dims =
+                        extract_numeric_value_dimensions(
+                            args[0], this_->name_, this_->codename_);
+                    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
+                        kernel_dims = extract_numeric_value_dimensions(
+                            args[1], this_->name_, this_->codename_);
+                    if (x_dims[0]<kernel_dims[0] || x_dims[1]<kernel_dims[1])
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
                             "conv2d_operation::eval",
                             this_->generate_error_message(
-                                "invalid padding. Padding can be either valid "
-                                "or same"));
+                                "the kernel size cannot be greater than the "
+                                "array size in any direction in the valid "
+                                "padding mode"));
                 }
 
-                //if (padding == "valid")
-                //{
-                //    if (extract_numeric_value_dimension(
-                //            args[0], this_->name_, this_->codename_) <
-                //        extract_numeric_value_dimension(
-                //            args[1], this_->name_, this_->codename_))
-                //        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                //            "conv2d_operation::eval",
-                //            this_->generate_error_message(
-                //                "the kernel size cannot be greater than the "
-                //                "array size in the valid padding mode"));
-                //}
+                ir::range strides;
+                if (!is_list_operand_strict(args[3]))
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "conv2d_operation::eval",
+                        this_->generate_error_message(
+                            "strides should be a tuple of two positive "
+                            "integers"));
 
-                ir::range strides(0);    // an empty range
-                if (args.size() > 3)
+                strides = extract_list_value_strict(
+                    args[3], this_->name_, this_->codename_);
+
+                if (strides.size() != 2)
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "conv2d_operation::eval",
+                        this_->generate_error_message(
+                            "conv2d_operation requires the strides to "
+                            "be of rank 2"));
+
+                bool flag = true;
+                for (auto const it : strides)
                 {
-                    if (is_list_operand_strict(args[3]))
-                    {
-                        ir::range s = extract_list_value(
-                            args[3], this_->name_, this_->codename_);
-                        if (s.size() == 1)
-                            strides =
-                                extract_scalar_integer_value_strict(*s.begin());
-                        else
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "conv2d_operation::eval",
-                                this_->generate_error_message(
-                                    "conv2d_operation requires the strides to "
-                                    "be of rank 2"));
-                    }
-                    //else
-                    //    strides = extract_scalar_integer_value_strict(
-                    //        args[3], this_->name_, this_->codename_);
+                    std::int64_t temp =
+                        extract_scalar_integer_value_strict(it);
+                    if (temp <= 0)
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "conv2d_operation::eval",
+                            this_->generate_error_message(
+                                "strides on each dimension are required to "
+                                "be positive"));
 
-                    //if (strides <= 0)
-                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    //        "conv2d_operation::eval",
-                    //        this_->generate_error_message(
-                    //            "invalid strides. Strides must be positive"));
+                    if (temp != 1)
+                        flag = false;
                 }
+                if (flag == true)
+                    strides = ir::range(0);     // an empty range
 
-                ir::range dilation_rate(0);    // an empty range
-                if (args.size() > 4)
+
+                ir::range dilation_rate;
+                if (!is_list_operand_strict(args[4]))
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "conv2d_operation::eval",
+                        this_->generate_error_message(
+                            "dilation_rate should be a tuple of two "
+                            "positive integers"));
+
+                dilation_rate = extract_list_value_strict(
+                    args[4], this_->name_, this_->codename_);
+
+                if (dilation_rate.size() != 2)
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "conv2d_operation::eval",
+                        this_->generate_error_message(
+                            "conv2d_operation requires the dilation_rate "
+                            "to be of rank 2"));
+
+                flag = true;
+                for (auto const it : dilation_rate)
                 {
-                    //if (is_list_operand_strict(args[4]))
-                    //{
-                    //    ir::range d = extract_list_value(
-                    //        args[4], this_->name_, this_->codename_);
-                    //    if (d.size() == 1)
-                    //        dilation_rate =
-                    //            extract_scalar_integer_value_strict(*d.begin());
-                    //    else
-                    //        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    //            "conv2d_operation::eval",
-                    //            this_->generate_error_message(
-                    //                "conv2d_operation requires the "
-                    //                "dilation_rate to be of rank 1"));
-                    //}
-                    //else
-                    //    dilation_rate = extract_scalar_integer_value_strict(
-                    //        args[4], this_->name_, this_->codename_);
+                    std::int64_t temp =
+                        extract_scalar_integer_value_strict(it);
+                    if (temp <= 0)
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "conv2d_operation::eval",
+                            this_->generate_error_message(
+                                "dilation_rates on each dimension are "
+                                "required to be positive"));
 
-                    //if (dilation_rate <= 0)
-                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    //        "conv2d_operation::eval",
-                    //        this_->generate_error_message(
-                    //            "dilation_rate must be positive"));
-
-                    //if (strides != 1 && dilation_rate != 1)
-                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    //        "conv2d_operation::eval",
-                    //        this_->generate_error_message(
-                    //            "strides > 1 not supported in conjunction with "
-                    //            "dilation_rate > 1"));
+                    if (temp != 1)
+                        flag = false;
                 }
+                if (flag == true)
+                    dilation_rate = ir::range(0);     // an empty range
+
+                if (!strides.empty() && !dilation_rate.empty())
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "conv2d_operation::eval",
+                        this_->generate_error_message(
+                            "strides > 1 not supported in conjunction with "
+                            "dilation_rate > 1"));
+
 
                 if (strides.empty() && dilation_rate.empty())
                 {
@@ -596,22 +771,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             std::move(args[1]), this_->name_, this_->codename_),
                         std::move(padding));
                 }
-                //else if (dilation_rate == 1)
-                //{
-                //    return this_->conv2d_any_pad(
-                //        extract_numeric_value(
-                //            std::move(args[0]), this_->name_, this_->codename_),
-                //        extract_numeric_value(
-                //            std::move(args[1]), this_->name_, this_->codename_),
-                //        std::move(padding), strides);
-                //}
-                //// strides == 1 and dilation_rate > 1
-                //return this_->conv2d_any_pad_dilation(
-                //    extract_numeric_value(
-                //        std::move(args[0]), this_->name_, this_->codename_),
-                //    extract_numeric_value(
-                //        std::move(args[1]), this_->name_, this_->codename_),
-                //    std::move(padding), dilation_rate);
+                else if (dilation_rate.empty())
+                {
+                    return this_->conv2d_any_pad(
+                        extract_numeric_value(
+                            std::move(args[0]), this_->name_, this_->codename_),
+                        extract_numeric_value(
+                            std::move(args[1]), this_->name_, this_->codename_),
+                        std::move(padding), std::move(strides));
+                }
+                // strides == 1 and dilation_rate > 1
+                return this_->conv2d_any_pad_dilation(
+                    extract_numeric_value(
+                        std::move(args[0]), this_->name_, this_->codename_),
+                    extract_numeric_value(
+                        std::move(args[1]), this_->name_, this_->codename_),
+                    std::move(padding), std::move(dilation_rate));
 
             }),
             detail::map_operands(

--- a/src/plugins/keras_support/keras_support.cpp
+++ b/src/plugins/keras_support/keras_support.cpp
@@ -17,6 +17,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(batch_dot_operation_plugin,
     phylanx::execution_tree::primitives::batch_dot_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(conv1d_operation_plugin,
     phylanx::execution_tree::primitives::conv1d_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(conv2d_operation_plugin,
+    phylanx::execution_tree::primitives::conv2d_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(ctc_decode_operation_plugin,
     phylanx::execution_tree::primitives::ctc_decode_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(elu_operation_plugin,

--- a/tests/unit/plugins/keras_support/CMakeLists.txt
+++ b/tests/unit/plugins/keras_support/CMakeLists.txt
@@ -7,6 +7,7 @@ set(tests
 
     batch_dot_operation
     conv1d_operation
+    conv2d_operation
     ctc_decode_operation
     elu_operation
     hard_sigmoid_operation

--- a/tests/unit/plugins/keras_support/conv1d_operation.cpp
+++ b/tests/unit/plugins/keras_support/conv1d_operation.cpp
@@ -109,6 +109,17 @@ int main(int argc, char* argv[])
         R"(conv1d([4, 33, 13, 42, 0, 1, -1, 2, 6, 5, -3, 1], [ 1, -2, 3],
         "causal",  1, 4))",
         "[ 12., 99., 39., 126., -8., -63., -29., -78.,  22., 46., 6., 41.]");
+    test_conv1d_operation(R"(conv1d([33, 13, 42], [1, -2, -3], "same",  1, 5))",
+        "[-66., -26., -84.]");
+    test_conv1d_operation(
+        R"(conv1d([33, 13, 42], [1, -2, -3], "causal",  1, 5))",
+        "[ -99.,  -39., -126.]");
+    test_conv1d_operation(
+        R"(conv1d([33, 13, 42], [1, 1 ,1 ,10, 1, 1, 1], "same",  1, 5))",
+        "[ 330.,  130.,  420.]");
+    test_conv1d_operation(
+        R"(conv1d([33, 13, 42], [1, 1 ,1 ,10, 1, 1, 1], "causal",  1, 5))",
+        "[ 33.,  13.,  42.]");
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/keras_support/conv2d_operation.cpp
+++ b/tests/unit/plugins/keras_support/conv2d_operation.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <string>
+#include <utility>
+
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_conv2d_operation(std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(code), compile_and_run(expected_str));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_conv2d_operation(
+        "conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1], "
+        "[0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]])",
+        "[[ 41., -48., -44., -62.], [ -1., -28., -21.,  70.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same"))",
+        "[[ -58., -8., -5., -139., -101.],[  41., -48., -44., -62., -28.], "
+        "[ -1.,  -28.,  -21.,  70.,  40.],[  -1.,  25.,  11.,   1.,   1.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "valid", list(1,2)))",
+        "[[ 41., -44.],[ -1., -21.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same", list(1,2)))",
+        "[[ -58.,   -5., -101.],[  41.,  -44.,  -28.],[  -1.,  -21.,   40.],"
+        "[  -1.,   11.,    1.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same", list(2,2)))",
+        "[[ 41., -44., -28.], [ -1.,  11.,   1.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same", list(2,1)))",
+        "[[ 41., -48., -44., -62., -28.],[ -1.,  25.,  11.,   1.,   1.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "valid", list(1,1),
+        list(1,2)))",
+        "[[-13.,  -4., -96.], [-25., -10.,  63.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same", list(1,1),
+        list(1,2)))",
+        "[[ -10., -50., -10., -137.,  -3.], [   4., -13.,  -4.,  -96.,  -4.],"
+        "[ -2.,  -25., -10.,  63.,  -6.], [  -2.,   27., -3.,   15.,  -1.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same", list(1,1),
+        list(2,2)))",
+        "[[ -6., -99.,  -7., -40.,  -3.], [   -6.,  -2., -14., -58.,  -7.],"
+        "[ 6.,  17.,   1.,  -6.,  -1.], [  0.,   2.,  -2.,  70.,  -1.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same", list(1,1),
+        list(2,1)))",
+        "[[-51., -57., -44.,  -3.,   1.], [ -8.,  -4., -10., -65., -27.],"
+        "[ 47., -21., -14.,   5.,   3.], [  2.,   0.,  -2.,  69.,  35.]]");
+    test_conv2d_operation(
+        R"(conv2d([[42, 3, 1, 0, 2],[2, 1, 0, 1, 33],[1, 0, 13, 1, -1],
+        [0, 1, 0, 2, -2]], [[ 1, 2],[-1,-2],[-3,-4]], "same", list(1,1),
+        list(5,6)))",
+        "[[  0.,  -4.,   0., -42.,  -3.], [ -2., -66.,   0.,  -2.,  -1.],"
+        "[ -2.,   2.,   0.,  -1.,   0.], [ -4.,   4.,   0.,   0.,  -1.]]");
+    test_conv2d_operation(
+        R"(conv2d([[ 1, 2],[-1,-2],[-3,-4]], [[42, 3, 1, 0, 2],[2, 1, 0, 1, 33]
+        ,[1, 0, 13, 1, -1], [0, 1, 0, 2, -2]],  "same", list(1,1),
+        list(2,3)))",
+        "[[-13., -26.], [-39., -52.], [  0.,   0.]]");
+    test_conv2d_operation(
+        R"(conv2d([[ 1, 2 ,3],[-2,-3,-4]], [[42, 3, 1, 0, 2],[2, 1, 0, 1, 33]
+        ,[1, 0, 13, 1, -1], [0, 1, 0, 2, -2]],  "same", list(1,1),
+        list(2,3)))",
+        "[[-26., -39., -52.], [  0.,   0.,   0.]]");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This PR adds conv2d which imitates the functionality of Keras [conv2d](https://keras.io/backend/#conv2d).
It also modifies conv1d for the cases that the image is shorter than the filter having `same` padding.
Toward solving #857 