### PR TITLE
Modifying l2_normalize

### DIFF
--- a/src/plugins/keras_support/l2_normalize_operation.cpp
+++ b/src/plugins/keras_support/l2_normalize_operation.cpp
@@ -247,14 +247,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         arg_type&& arg) const
     {
         auto t = arg.tensor();
-    //    if (!arg.is_ref())
-    //    {
-    //        t = t / blaze::l2Norm(t);
+        if (!arg.is_ref())
+        {
+            t = t / blaze::l2Norm(t);
             return primitive_argument_type{std::move(arg)};
-    //    }
+        }
 
-    //    blaze::DynamicMatrix<val_type> result = t / blaze::l2Norm(t);
-    //    return primitive_argument_type{std::move(result)};
+        blaze::DynamicTensor<val_type> result = t / blaze::l2Norm(t);
+        return primitive_argument_type{std::move(result)};
     }
 
     primitive_argument_type l2_normalize_operation::l2_normalize3d(

--- a/tests/unit/plugins/keras_support/l2_normalize_operation.cpp
+++ b/tests/unit/plugins/keras_support/l2_normalize_operation.cpp
@@ -311,7 +311,7 @@ int main(int argc, char* argv[])
     test_l2_normalize_operation_2d_axis0();
 
 #if defined(PHYLANX_HAVE_BLAZE_TENSOR)
-    //test_l2_normalize_operation_3d();
+    test_l2_normalize_operation_3d();
     test_l2_normalize_operation_3d_axis0();
     test_l2_normalize_operation_3d_axis1();
     test_l2_normalize_operation_3d_axis2();


### PR DESCRIPTION
This PR updates l2_normalize3d_flatten of `l2_normalize` having l2Norm for tensors.