### PR TITLE
Refactoring conv1D, extract index calculations

### DIFF
--- a/phylanx/plugins/keras_support/conv1d_operation.hpp
+++ b/phylanx/plugins/keras_support/conv1d_operation.hpp
@@ -49,14 +49,11 @@ namespace phylanx { namespace execution_tree { namespace primitives {
 
     private:
         template <typename Vector1, typename Vector2>
-        double convolve_step(const Vector1& v1, const Vector2& v2) const;
+        static double convolve_step(Vector1 const& v1, Vector2 const& v2);
         template <typename Vector1, typename Vector2>
-        double convolve_step(const Vector1& v1, const Vector2& v2,
-            std::int64_t dilation_rate, std::size_t kernel_size) const;
-        template <typename Vector1, typename Vector2>
-        double convolve_step(const Vector1& v1, const Vector2& v2,
+        static double convolve_step(Vector1 const& v1, Vector2 const& v2,
             std::int64_t dilation_rate, std::size_t kernel_size,
-            std::size_t r) const;
+            std::size_t offset = 0);
 
         primitive_argument_type conv1d_valid(ir::node_data<double>&& arg,
             ir::node_data<double>&& kernel) const;


### PR DESCRIPTION
@taless474 This is the best I was able to come up with. The index calculation functions should be sufficiently generic to be usable for 2D/3D convolution without modification.