### PR TITLE
Support lazy compilation.

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -355,6 +355,7 @@ def check_return(ir):
         for s in ir:
             check_return(s)
 
+
 class PhySLFunction:
     def __init__(self, file_name, function_name, src):
         self.file_name = file_name
@@ -427,7 +428,6 @@ class PhySL:
             func_name = self.wrapped_function.__name__
             func = PhySLFunction(self.file_name, func_name, self.__src__)
             PhySL.functions.append(func)
-
 
     def generate_physl(self, ir):
         if len(ir) == 2 and isinstance(ir[0], str) and isinstance(
@@ -532,7 +532,7 @@ class PhySL:
 
         if not PhylanxSession.is_initialized:
             PhylanxSession.init(1)
-                    
+
             for func in PhySL.functions:
                 func.compile()
 

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -357,24 +357,32 @@ def check_return(ir):
 
 
 class PhySLFunction:
+
+    functions = []
+
     def __init__(self, file_name, function_name, src):
         self.file_name = file_name
         self.func_name = function_name
         self.src = src
 
-    def compile(self):
+    def compile_function(self):
         if PhySL.compiler_state is None:
             PhySL.compiler_state = phylanx.execution_tree.compiler_state(
                 self.file_name)
         phylanx.execution_tree.compile(PhySL.compiler_state, self.file_name,
                                        self.func_name, self.src)
 
+    @staticmethod
+    def compile():
+        for func in PhySLFunction.functions:
+            func.compile_function()
+        PhySLFunction.functions = []
+
 
 class PhySL:
     """Python AST to PhySL Transducer."""
 
     compiler_state = None
-    functions = []
 
     def __init__(self, func, tree, kwargs):
         self.defined = set()
@@ -419,6 +427,8 @@ class PhySL:
                 PhySL.compiler_state = phylanx.execution_tree.compiler_state(
                     self.file_name)
 
+            PhySLFunction.compile()
+
             phylanx.execution_tree.compile(
                 PhySL.compiler_state, self.file_name,
                 self.wrapped_function.__name__, self.__src__)
@@ -427,7 +437,7 @@ class PhySL:
         else:
             func_name = self.wrapped_function.__name__
             func = PhySLFunction(self.file_name, func_name, self.__src__)
-            PhySL.functions.append(func)
+            PhySLFunction.functions.append(func)
 
     def generate_physl(self, ir):
         if len(ir) == 2 and isinstance(ir[0], str) and isinstance(
@@ -533,10 +543,8 @@ class PhySL:
         if not PhylanxSession.is_initialized:
             PhylanxSession.init(1)
 
-            for func in PhySL.functions:
-                func.compile()
-
         if not self.is_compiled:
+            PhySLFunction.compile()
             if "compiler_state" in self.kwargs:
                 PhySL.compiler_state = self.kwargs['compiler_state']
             elif PhySL.compiler_state is None:

--- a/tests/regressions/python/979_lazy_compilation.py
+++ b/tests/regressions/python/979_lazy_compilation.py
@@ -6,12 +6,15 @@
 # #979
 from phylanx import Phylanx
 
+
 @Phylanx
 def fx_inner():
     return 40 + 2
 
+
 @Phylanx
 def fx():
     return fx_inner()
+
 
 assert 42 == fx()

--- a/tests/regressions/python/979_lazy_compilation.py
+++ b/tests/regressions/python/979_lazy_compilation.py
@@ -1,0 +1,17 @@
+#  Copyright (c) 2019 R. Tohid
+#  Copyright (c) 2019 Parsa Amini
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+# #979
+from phylanx import Phylanx
+
+@Phylanx
+def fx_inner():
+    return 40 + 2
+
+@Phylanx
+def fx():
+    return fx_inner()
+
+assert 42 == fx()

--- a/tests/regressions/python/979_lazy_compilation_with_init.py
+++ b/tests/regressions/python/979_lazy_compilation_with_init.py
@@ -1,0 +1,23 @@
+#  Copyright (c) 2019 R. Tohid
+#  Copyright (c) 2019 Parsa Amini
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+# #979
+from phylanx import Phylanx, PhylanxSession
+
+
+@Phylanx
+def fx_inner():
+    return 40 + 2
+
+
+PhylanxSession.init(1)
+
+
+@Phylanx
+def fx():
+    return fx_inner()
+
+
+assert 42 == fx()

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -43,6 +43,7 @@ set(tests
     936_arithmetic_operations
     956_named_argument_underscore
     962_broadcast_logical_operations
+    979_lazy_compilation
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -44,6 +44,7 @@ set(tests
     956_named_argument_underscore
     962_broadcast_logical_operations
     979_lazy_compilation
+    979_lazy_compilation_with_init
     array_len_494
     array_shape_486
     array_subscript_403


### PR DESCRIPTION
When Phylanx is not initialized, a list of all transformed functions is
created but the compilation is postponed. Once Phylanx is initialized,
all the functions are compiled in the order they were discovered.

Fixes #979