### PR TITLE
Bring in K-means fix from eval_move branch

### DIFF
--- a/examples/algorithms/CMakeLists.txt
+++ b/examples/algorithms/CMakeLists.txt
@@ -8,6 +8,7 @@ set(subdirs
     lir
     lra
     kmeans
+    nn
    )
 
 foreach(subdir ${subdirs})

--- a/examples/algorithms/kmeans/kmeans.cpp
+++ b/examples/algorithms/kmeans/kmeans.cpp
@@ -94,6 +94,7 @@ int hpx_main(boost::program_options::variables_map& vm)
     std::int64_t centroids = vm["centroids"].as<std::int64_t>();
     std::int64_t iterations = vm["iterations"].as<int64_t>();
     std::int64_t num_points = vm["points"].as<int64_t>();
+    bool show_result = vm["show_result"].as<bool>();
 
     auto points = generate_random(centroids, num_points);
 
@@ -109,8 +110,10 @@ int hpx_main(boost::program_options::variables_map& vm)
     // counter values
     hpx::reinit_active_counters(false);
 
-    std::cout << result
-              << "\nTime: " << elapsed << " seconds"
+    if (show_result)
+       std::cout<<result<<"\n";
+
+    std::cout << "Time: " << elapsed << " seconds"
               << std::endl;
 
     return hpx::finalize();
@@ -126,7 +129,9 @@ int main(int argc, char* argv[])
         ("iterations", boost::program_options::value<std::int64_t>()->default_value(2),
             "number of iterations (default: 2)")
         ("points", boost::program_options::value<std::int64_t>()->default_value(250),
-            "alpha (default: 250)");
+            "alpha (default: 250)")
+        ("show_result", boost::program_options::value<bool>()->default_value(false),
+            "show calculated result (default: false)");
 
     return hpx::init(desc, argc, argv);
 }

--- a/examples/algorithms/kmeans/kmeans.physl
+++ b/examples/algorithms/kmeans/kmeans.physl
@@ -66,10 +66,10 @@ define(kmeans, points, k, iterations, block(
 define(program, iterations, block(
     define(points, vstack(
         list(
-			apply(vstack, list(fmap(lambda(x, random(2) * .75), range(150)))) + [1., 0.],
-			apply(vstack, list(fmap(lambda(x, random(2) * .25), range(50)))) + [-.5, .5],
-			apply(vstack, list(fmap(lambda(x, random(2) * .5), range(50)))) + [-.5, -.5]
-		)
+            apply(vstack, list(fmap(lambda(x, random(2) * .75), range(150)))) + [1., 0.],
+            apply(vstack, list(fmap(lambda(x, random(2) * .25), range(50)))) + [-.5, .5],
+            apply(vstack, list(fmap(lambda(x, random(2) * .5), range(50)))) + [-.5, -.5]
+        )
     )),
     define(k, 3),
     kmeans(points, k, iterations)


### PR DESCRIPTION
This pull request brings in the fixes we have for the broken k-means example from the eval_move branch. 
Also, build neural networks example by default. 