### PR TITLE
Adding simplified distributed object to Phylanx

### DIFF
--- a/phylanx/include/util.hpp
+++ b/phylanx/include/util.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_UTIL_HPP
 
 #include <phylanx/config.hpp>
+#include <phylanx/util/distributed_object.hpp>
 #include <phylanx/util/hashed_string.hpp>
 #include <phylanx/util/none_manip.hpp>
 #include <phylanx/util/performance_data.hpp>

--- a/phylanx/util/distributed_object.hpp
+++ b/phylanx/util/distributed_object.hpp
@@ -1,0 +1,568 @@
+// Copyright (c) 2019 Weile Wei
+// Copyright (c) 2019 Maxwell Reeser
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_DISTRIBUTED_OBJECT_HPP)
+#define PHYLANX_UTIL_DISTRIBUTED_OBJECT_HPP
+
+#include <phylanx/config.hpp>
+
+#include <hpx/lcos/local/barrier.hpp>
+#include <hpx/lcos/local/spinlock.hpp>
+#include <hpx/preprocessor/cat.hpp>
+#include <hpx/runtime/actions/component_action.hpp>
+#include <hpx/runtime/basename_registration_fwd.hpp>
+#include <hpx/runtime/components/component_factory.hpp>
+#include <hpx/runtime/components/new.hpp>
+#include <hpx/runtime/components/server/component.hpp>
+#include <hpx/runtime/get_locality_id.hpp>
+#include <hpx/runtime/get_num_localities.hpp>
+#include <hpx/runtime/get_ptr.hpp>
+#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/throw_exception.hpp>
+#include <hpx/util/assert.hpp>
+#include <hpx/util/bind.hpp>
+#include <hpx/util/unlock_guard.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+
+/// \cond NOINTERNAL
+namespace phylanx { namespace util { namespace server
+{
+    ////////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    class distributed_object_part
+      : public hpx::components::component_base<distributed_object_part<T>>
+    {
+    public:
+        using data_type = T;
+
+        distributed_object_part() = default;
+
+        explicit distributed_object_part(data_type const& data)
+          : data_(data)
+        {
+        }
+
+        explicit distributed_object_part(data_type&& data)
+          : data_(std::move(data))
+        {
+        }
+
+        data_type& operator*()
+        {
+            return data_;
+        }
+
+        data_type const& operator*() const
+        {
+            return data_;
+        }
+
+        data_type* operator->()
+        {
+            return &data_;
+        }
+
+        data_type const* operator->() const
+        {
+            return &data_;
+        }
+
+        data_type fetch() const
+        {
+            return data_;
+        }
+
+        HPX_DEFINE_COMPONENT_ACTION(distributed_object_part, fetch);
+
+    private:
+        data_type data_;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    class distributed_object_part<T&>
+      : public hpx::components::component_base<distributed_object_part<T&>>
+    {
+    public:
+        using data_type = T&;
+
+        distributed_object_part() = default;
+
+        explicit distributed_object_part(data_type data)
+          : data_(data)
+        {
+        }
+
+        data_type operator*()
+        {
+            return data_;
+        }
+
+        data_type operator*() const
+        {
+            return data_;
+        }
+
+        T* operator->()
+        {
+            return data_;
+        }
+
+        T const* operator->() const
+        {
+            return data_;
+        }
+
+        T fetch() const
+        {
+            return data_;
+        }
+
+        HPX_DEFINE_COMPONENT_ACTION(distributed_object_part, fetch);
+
+    private:
+        data_type data_;
+    };
+}}}
+
+#define REGISTER_DISTRIBUTED_OBJECT_DECLARATION(type)                          \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        phylanx::util::server::distributed_object_part<type>::fetch_action,    \
+        HPX_PP_CAT(__distributed_object_part_fetch_action_, type));
+
+/**/
+
+#define REGISTER_DISTRIBUTED_OBJECT(type)                                      \
+    HPX_REGISTER_ACTION(                                                       \
+        phylanx::util::server::distributed_object_part<type>::fetch_action,    \
+        HPX_PP_CAT(__distributed_object_part_fetch_action_, type));            \
+    typedef ::hpx::components::component<                                      \
+        phylanx::util::server::distributed_object_part<type>>                  \
+        HPX_PP_CAT(__distributed_object_part_, type);                          \
+    HPX_REGISTER_COMPONENT(HPX_PP_CAT(__distributed_object_part_, type))       \
+    /**/
+
+namespace phylanx { namespace util
+{
+    enum class construction_type
+    {
+        meta_object,
+        all_to_all
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    // The front end for the distributed_object itself. Essentially wraps
+    // actions for the server, and stores information locally about the
+    // localities/servers that it needs to know about.
+
+    /// The distributed_object is a single logical object partitioned over a set
+    /// of localities/nodes/machines, where every locality shares the same global
+    /// name locality for the distributed object (i.e. a universal name), but
+    /// owns its local value. In other words, local data of the distributed
+    /// object can be different, but they share access to one another's data
+    /// globally.
+    template <typename T, construction_type C = construction_type::all_to_all>
+    class distributed_object;
+
+    template <typename T>
+    class distributed_object<T, construction_type::all_to_all>
+    {
+    private:
+        using data_type =
+            typename server::distributed_object_part<T>::data_type;
+
+    public:
+        /// Creates a distributed_object in every locality
+        ///
+        /// A distributed_object \a base_name is created through default
+        /// constructor.
+        distributed_object() = default;
+
+        /// Creates a distributed_object in every locality with a given
+        /// base_name string, data, and a type and construction_type in the
+        /// template parameters.
+        ///
+        /// \param construction_type The construction_type in the template
+        ///             parameters accepts either meta_object or all_to_all,
+        ///             and it is set to all_to_all by default. The meta_object
+        ///             option provides meta object registration in the root
+        ///             locality and meta object is essentially a table that
+        ///             can find the instances of distributed_object in all
+        ///             localities. The all_to_all option only locally holds
+        ///             the client and server of the distributed_object.
+        /// \param base_name The name of the distributed_object, which should
+        ///             be a unique string across the localities
+        /// \param data The data of the type T of the distributed_object
+        /// \param sub_localities The sub_localities accepts a list of locality
+        ///             index. By default, it is initialized to a list of all
+        ///             provided locality index.
+        ///
+        distributed_object(char const* basename, data_type const& data,
+                std::size_t num_sites = std::size_t(-1),
+                std::size_t this_site = std::size_t(-1))
+          : num_sites_(num_sites == std::size_t(-1) ?
+                    hpx::get_num_localities(hpx::launch::sync) :
+                    num_sites)
+          , this_site_(this_site == std::size_t(-1) ? hpx::get_locality_id() :
+                                                      this_site)
+          , basename_(basename)
+        {
+            if (this_site_ >= num_sites_)
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success,
+                    "distributed_object::distributed_object",
+                    "attempting to construct invalid part of the "
+                        "distributed object");
+            }
+            create_and_register_server(data);
+        }
+
+        /// Creates a distributed_object in every locality with a given
+        /// base_name string, data, and a type and construction_type in the
+        /// template parameters
+        ///
+        /// \param construction_type The construction_type in the template
+        ///             parameters accepts either meta_object or all_to_all,
+        ///             and it is set to all_to_all by default. The meta_object
+        ///             option provides meta object registration in the root
+        ///             locality and meta object is essentially a table that
+        ///             can find the instances of distributed_object in all
+        ///             localities. The all_to_all option only locally holds
+        ///             the client and server of the distributed_object.
+        /// \param base_name The name of the distributed_object, which should
+        ///             be a unique string across the localities
+        /// \param data The data of the type T of the distributed_object
+        /// \param sub_localities The sub_localities accepts a list of locality
+        ///             index. By default, it is initialized to a list of all
+        ///             provided locality index.
+        ///
+        distributed_object(char const* basename, data_type&& data,
+                std::size_t num_sites = std::size_t(-1),
+                std::size_t this_site = std::size_t(-1))
+          : num_sites_(num_sites == std::size_t(-1) ?
+                    hpx::get_num_localities(hpx::launch::sync) :
+                    num_sites)
+          , this_site_(this_site == std::size_t(-1) ? hpx::get_locality_id() :
+                                                      this_site)
+          , basename_(basename)
+        {
+            if (this_site_ >= num_sites_)
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success,
+                    "distributed_object::distributed_object",
+                    "attempting to construct invalid part of the "
+                        "distributed object");
+            }
+            create_and_register_server(std::move(data));
+        }
+
+        /// Destroy the local reference to the distributed object, unregister
+        /// the symbolic name
+        ~distributed_object()
+        {
+            hpx::unregister_with_basename(basename_, this_site_);
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type& operator*()
+        {
+            HPX_ASSERT(!!ptr_);
+            return **ptr_;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type const& operator*() const
+        {
+            HPX_ASSERT(!!ptr_);
+            return **ptr_;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type* operator->()
+        {
+            HPX_ASSERT(!!ptr_);
+            return &**ptr_;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type const* operator->() const
+        {
+            HPX_ASSERT(!!ptr_);
+            return &**ptr_;
+        }
+
+        /// fetch() function is an asynchronous function. This returns a future
+        /// of a copy of the instance of this distributed_object associated with
+        /// the given locality index. The provided locality index must be valid
+        /// within the sub localities where this distributed object is
+        /// constructed. Also, if the provided locality index is same as current
+        /// locality, fetch function still returns a future of it local data copy.
+        /// It is suggested to use star operator to access local data.
+        hpx::future<data_type> fetch(std::size_t idx) const
+        {
+            /// \cond NOINTERNAL
+            HPX_ASSERT(!!ptr_);
+            using action_type =
+                typename server::distributed_object_part<T>::fetch_action;
+
+            return hpx::async<action_type>(get_part_id(idx));
+            /// \endcond
+        }
+
+    private:
+        /// \cond NOINTERNAL
+        template <typename Arg>
+        hpx::id_type create_and_register_server(Arg&& value)
+        {
+            hpx::id_type part_id =
+                hpx::local_new<server::distributed_object_part<T>>(
+                    hpx::launch::sync, std::forward<Arg>(value));
+
+            hpx::register_with_basename(basename_, part_id, this_site_);
+
+            part_ids_[this_site_] = part_id;
+            ptr_ = hpx::get_ptr<server::distributed_object_part<T>>(
+                hpx::launch::sync, part_id);
+
+            return part_id;
+        }
+
+        hpx::id_type const& get_part_id(std::size_t idx) const
+        {
+            if (idx == this_site_)
+            {
+                return part_ids_[idx];
+            }
+
+            if (idx >= num_sites_)
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success,
+                    "distributed_object::get_part_id",
+                    "attempting to access invalid part of the ditributed object");
+            }
+
+            std::lock_guard<hpx::lcos::local::spinlock> l(part_ids_mtx_);
+            auto it = part_ids_.find(idx);
+            if (it == part_ids_.end())
+            {
+                hpx::id_type id;
+
+                {
+                    hpx::util::unlock_guard<hpx::lcos::local::spinlock> ul(
+                        part_ids_mtx_);
+
+                    id = hpx::agas::on_symbol_namespace_event(
+                        hpx::detail::name_from_basename(basename_, idx), true).get();
+                }
+
+                it = part_ids_.find(idx);
+                if (it == part_ids_.end())
+                {
+                    it = part_ids_.emplace(idx, std::move(id)).first;
+                }
+            }
+            return it->second;
+        }
+
+    private:
+        std::size_t const num_sites_;
+        std::size_t const this_site_;
+        std::string const basename_;
+        std::shared_ptr<server::distributed_object_part<T>> ptr_;
+
+        mutable hpx::lcos::local::spinlock part_ids_mtx_;
+        mutable std::map<std::size_t, hpx::id_type> part_ids_;
+        /// \endcond
+    };
+
+    /// The distributed_object is a single logical object partitioned over a set of
+    /// localities/nodes/machines, where every locality shares the same global
+    /// name locality for the distributed object (i.e. a universal name), but
+    /// owns its local value. In other words, local data of the distributed
+    /// object can be different, but they share access to one another's data
+    /// globally.
+    template <typename T>
+    class distributed_object<T&, construction_type::all_to_all>
+    {
+    private:
+        /// \cond NOINTERNAL
+        using data_type =
+            typename server::distributed_object_part<T&>::data_type;
+        /// \endcond
+
+    public:
+        /// Creates a distributed_object in every locality
+        ///
+        /// A distributed_object \a base_name is created through default constructor.
+        distributed_object() = default;
+
+        /// Creates a distributed_object in every locality with a given base_name
+        /// string, data, and a type and construction_type in the template
+        /// parameters. This constructor of the distributed_object wraps an
+        /// existing local instance and thus is internally referring to the
+        /// local instance.
+        ///
+        /// \param construction_type The construction_type in the template
+        ///             parameters accepts either meta_object or all_to_all, and
+        ///             it is set to all_to_all by default. The meta_object
+        ///             option provides meta object registration in the root
+        ///             locality and meta object is essentially a table that
+        ///             can find the instances of distributed_object in all
+        ///             localities. The all_to_all option only locally holds the
+        ///             client and server of the distributed_object.
+        /// \param base_name The name of the distributed_object, which should
+        ///             be a unique string across the localities
+        /// \param data The data of the type T of the distributed_object
+        /// \param sub_localities The sub_localities accepts a list of locality
+        ///             index. By
+        /// default, it is initialized to a list of all provided locality index.
+        ///
+        distributed_object(char const* basename, data_type data,
+                std::size_t num_sites = std::size_t(-1),
+                std::size_t this_site = std::size_t(-1))
+          : num_sites_(num_sites == std::size_t(-1) ?
+                    hpx::get_num_localities(hpx::launch::sync) :
+                    num_sites)
+          , this_site_(this_site == std::size_t(-1) ? hpx::get_locality_id() :
+                                                      this_site)
+          , basename_(basename)
+        {
+            if (this_site_ >= num_sites_)
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success,
+                    "distributed_object::distributed_object",
+                    "attempting to construct invalid part of the "
+                        "distributed object");
+            }
+            create_and_register_server(data);
+        }
+
+        /// Destroy the local reference to the distributed object, unregister
+        /// the symbolic name
+        ~distributed_object()
+        {
+            hpx::unregister_with_basename(basename_, this_site_);
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type const operator*() const
+        {
+            HPX_ASSERT(!!ptr_);
+            return **ptr_;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        data_type operator*()
+        {
+            HPX_ASSERT(!!ptr_);
+            return **ptr_;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        T const* operator->() const
+        {
+            HPX_ASSERT(!!ptr_);
+            return &**ptr_;
+        }
+
+        /// Access the calling locality's value instance for this distributed_object
+        T* operator->()
+        {
+            HPX_ASSERT(!!ptr_);
+            return &**ptr_;
+        }
+
+        /// fetch() function is an asynchronous function. This returns a future
+        /// of a copy of the instance of this distributed_object associated with
+        /// the given locality index. The provided locality index must be valid
+        /// within the sub localities where this distributed object is
+        /// constructed. Also, if the provided locality index is same as current
+        /// locality, fetch function still returns a future of it local data copy.
+        /// It is suggested to use star operator to access local data.
+        hpx::future<T> fetch(std::size_t idx)
+        {
+            HPX_ASSERT(!!ptr_);
+            using action_type =
+                typename server::distributed_object_part<T&>::fetch_action;
+
+            return hpx::async<action_type>(get_part_id(idx));
+        }
+
+    private:
+        /// \cond NOINTERNAL
+        template <typename Arg>
+        hpx::id_type create_and_register_server(Arg& value)
+        {
+            hpx::id_type part_id =
+                hpx::local_new<server::distributed_object_part<T&>>(
+                    hpx::launch::sync, value);
+
+            hpx::register_with_basename(basename_, part_id, this_site_);
+
+            part_ids_[this_site_] = part_id;
+            ptr_ = hpx::get_ptr<server::distributed_object_part<T&>>(
+                hpx::launch::sync, part_id);
+
+            return part_id;
+        }
+
+        hpx::id_type const& get_part_id(std::size_t idx) const
+        {
+            if (idx == this_site_)
+            {
+                return part_ids_[idx];
+            }
+
+            if (idx >= num_sites_)
+            {
+                HPX_THROW_EXCEPTION(hpx::no_success,
+                    "distributed_object::get_part_id",
+                    "attempting to access invalid part of the ditributed object");
+            }
+
+            std::lock_guard<hpx::lcos::local::spinlock> l(part_ids_mtx_);
+            auto it = part_ids_.find(idx);
+            if (it == part_ids_.end())
+            {
+                hpx::id_type id;
+
+                {
+                    hpx::util::unlock_guard<hpx::lcos::local::spinlock> ul(
+                        part_ids_mtx_);
+
+                    id = hpx::agas::on_symbol_namespace_event(
+                        hpx::detail::name_from_basename(basename_, idx), true).get();
+                }
+
+                it = part_ids_.find(idx);
+                if (it == part_ids_.end())
+                {
+                    it = part_ids_.emplace(idx, std::move(id)).first;
+                }
+            }
+            return it->second;
+        }
+
+    private:
+        std::size_t const num_sites_;
+        std::size_t const this_site_;
+        std::string const basename_;
+        std::shared_ptr<server::distributed_object_part<T&>> ptr_;
+
+        mutable hpx::lcos::local::spinlock part_ids_mtx_;
+        mutable std::map<std::size_t, hpx::id_type> part_ids_;
+        /// \endcond
+    };
+}}
+#endif /*HPX_LCOS_DISTRIBUTED_OBJECT_HPP*/

--- a/tests/unit/util/CMakeLists.txt
+++ b/tests/unit/util/CMakeLists.txt
@@ -1,13 +1,16 @@
-# Copyright (c) 2017 Hartmut Kaiser
+# Copyright (c) 2017-2019 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    distributed_object
     matrix_iterators
     performance_data
     serialization_variant
    )
+
+set(distributed_object_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/tests/unit/util/distributed_object.cpp
+++ b/tests/unit/util/distributed_object.cpp
@@ -1,0 +1,554 @@
+// Copyright (c) 2019 Weile Wei
+// Copyright (c) 2019 Maxwell Reeser
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+////////////////////////////////////////////////////////////////////////////////
+/// This is a distributed_object example using HPX component.
+///
+/// A distributed object is a single logical object partitioned across
+/// a set of localities. (A locality is a single node in a cluster or a
+/// NUMA domian in a SMP machine.) Each locality constructs an instance of
+/// distributed_object<T>, where a value of type T represents the value of this
+/// this locality's instance value. Once distributed_object<T> is conctructed, it
+/// has a universal name which can be used on any locality in the given
+/// localities to locate the resident instance.
+
+#include <phylanx/config.hpp>
+#include <phylanx/include/util.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/lcos/barrier.hpp>
+#include <hpx/parallel/algorithms/for_each.hpp>
+
+#include <hpx/lcos/async.hpp>
+#include <hpx/lcos/dataflow.hpp>
+#include <hpx/lcos/when_all.hpp>
+#include <hpx/util/lightweight_test.hpp>
+
+#include <boost/range/irange.hpp>
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+REGISTER_DISTRIBUTED_OBJECT(int);
+
+using vector_int = std::vector<int>;
+REGISTER_DISTRIBUTED_OBJECT(vector_int);
+using matrix_int = std::vector<std::vector<int>>;
+REGISTER_DISTRIBUTED_OBJECT(matrix_int);
+
+REGISTER_DISTRIBUTED_OBJECT(double);
+using vector_double = std::vector<double>;
+REGISTER_DISTRIBUTED_OBJECT(vector_double);
+using matrix_double = std::vector<std::vector<double>>;
+REGISTER_DISTRIBUTED_OBJECT(matrix_double);
+using vector_double_const = std::vector<double> const;
+REGISTER_DISTRIBUTED_OBJECT(vector_double_const);
+
+using int_ref = int&;
+REGISTER_DISTRIBUTED_OBJECT(int_ref);
+using vector_int_ref = std::vector<int>&;
+REGISTER_DISTRIBUTED_OBJECT(vector_int_ref);
+using vector_double_const_ref = std::vector<double> const&;
+REGISTER_DISTRIBUTED_OBJECT(vector_double_const_ref);
+
+// addition/sum reduced to locality  for distributed_object
+void test_distributed_object_int_reduce_to_locality_0()
+{
+    using phylanx::util::distributed_object;
+    size_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    size_t cur_locality = hpx::get_locality_id();
+
+    // Construct a distributed object of type int in all provided localities
+    // User needs to provide the distributed object with a unique basename
+    // and data for construction. The unique basename string enables HPX
+    // register and retrieve the distributed object.
+    distributed_object<int> dist_int(
+        "test_distributed_object_int_reduce_to_locality_0", cur_locality,
+        num_localities, cur_locality);
+
+    // If there exists more than 2 (and include) localities, we are able to
+    // asynchronously fetch a future of a copy of the instance of this
+    // distributed object associated with the given locality
+    if (hpx::get_locality_id() >= 2)
+    {
+        HPX_TEST_EQ(dist_int.fetch(1).get(), 1);
+    }
+
+    if (cur_locality == 0 && num_localities >= 2)
+    {
+        using hpx::parallel::for_each;
+        using hpx::parallel::execution::par;
+        auto range = boost::irange(std::size_t(1), num_localities);
+
+        // compute expect result in parallel locality 0 fetches all values
+        int expect_res = 0;
+        for_each(par, std::begin(range), std::end(range),
+            [&](std::uint64_t b) { expect_res += dist_int.fetch(b).get(); });
+        hpx::wait_all();
+
+        // compute target result
+        // to verify the accumulation results
+        int target_res = 0;
+        for (int i = 0; i < num_localities; i++)
+        {
+            target_res += i;
+        }
+
+        HPX_TEST_EQ(expect_res, target_res);
+    }
+
+    hpx::lcos::barrier wait_for_operation(
+        "barrier_test_distributed_object_int_reduce_to_locality_0",
+        hpx::get_num_localities(hpx::launch::sync),
+        hpx::get_locality_id());
+    wait_for_operation.wait();
+}
+
+// element-wise addition for vector<int> for distributed_object
+void test_distributed_object_vector_elem_wise_add()
+{
+    using phylanx::util::distributed_object;
+    size_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    size_t cur_locality = hpx::get_locality_id();
+
+    // define vector based on the locality that it is running
+    int here_ = 42 + static_cast<int>(hpx::get_locality_id());
+    int len = 10;
+
+    // data for distributed object
+    std::vector<int> local(len, here_);
+
+    // construct a distributed_object with vector<int> type
+    distributed_object<std::vector<int>> local_do(
+        "test_distributed_object_vector_elem_wise_add", local);
+
+    // testing -> operator
+    HPX_TEST_EQ(local_do->size(), static_cast<size_t>(len));
+
+    // testing dist_object and its vector underneath
+    // testing * operator
+    HPX_TEST((*local_do) == local);
+
+    // perform element-wise addition between distributed_objects
+    for (int i = 0; i < len; i++)
+    {
+        (*local_do)[i] += 1;
+    }
+
+    if (cur_locality == 0 && num_localities >= 2)
+    {
+        using hpx::parallel::for_each;
+        using hpx::parallel::execution::par;
+        auto range = boost::irange(std::size_t(1), num_localities);
+
+        std::vector<std::vector<int>> res(num_localities);
+
+        // compute expect result in parallel, locality 0 fetches all values
+        for_each(par, std::begin(range), std::end(range), [&](std::uint64_t b) {
+            res[b] = local_do.fetch(b).get();
+            for (int i = 0; i < len; i++)
+            {
+                HPX_TEST_EQ(res[b][i], static_cast<int>((*local_do)[i] + b));
+            }
+        });
+    }
+
+    hpx::lcos::barrier wait_for_operation(
+        "barrier_test_distributed_object_vector_elem_wise_add",
+        hpx::get_num_localities(hpx::launch::sync),
+        hpx::get_locality_id());
+    wait_for_operation.wait();
+}
+
+// element-wise addition for vector<vector<double>> for distributed_object
+void test_distributed_object_matrix()
+{
+    using phylanx::util::distributed_object;
+    double val = 42.0 + static_cast<double>(hpx::get_locality_id());
+    int rows = 5, cols = 5;
+
+    matrix_double lhs_data(rows, std::vector<double>(cols, val));
+    matrix_double rhs_data(rows, std::vector<double>(cols, val));
+    matrix_double res_data(rows, std::vector<double>(cols, 0));
+
+    distributed_object<matrix_double> lhs(
+        "test_distributed_object_matrix_m1", lhs_data);
+    distributed_object<matrix_double> rhs(
+        "test_distributed_object_matrix_m2", rhs_data);
+    distributed_object<matrix_double> res(
+        "test_distributed_object_matrix_m3", res_data);
+
+    for (int i = 0; i < rows; i++)
+    {
+        for (int j = 0; j < cols; j++)
+        {
+            (*res)[i][j] = (*lhs)[i][j] + (*rhs)[i][j];
+            res_data[i][j] = lhs_data[i][j] + rhs_data[i][j];
+        }
+    }
+
+    HPX_TEST((*res) == res_data );
+    HPX_TEST_EQ(res->size(), static_cast<size_t>(rows));
+
+    // test fetch function when 2 or more localities provided
+    if (hpx::get_num_localities(hpx::launch::sync) > 1)
+    {
+        if (hpx::get_locality_id() == 0)
+        {
+            hpx::future<matrix_double> res_first = res.fetch(1);
+            HPX_TEST_EQ(res_first.get()[0][0], 86);
+        }
+        else
+        {
+            hpx::future<matrix_double> res_first = res.fetch(0);
+            HPX_TEST_EQ(res_first.get()[0][0], 84);
+        }
+    }
+
+    hpx::lcos::barrier b_dist_matrix("barrier_test_distributed_object_matrix",
+        hpx::get_num_localities(hpx::launch::sync),
+        hpx::get_locality_id());
+    b_dist_matrix.wait();
+}
+
+// test constructor in all_to_all option
+void test_distributed_object_matrix_all_to_all()
+{
+    using phylanx::util::distributed_object;
+    double val = 42.0 + static_cast<double>(hpx::get_locality_id());
+    int rows = 5, cols = 5;
+
+    matrix_double lhs_data(rows, std::vector<double>(cols, val));
+    matrix_double rhs_data(rows, std::vector<double>(cols, val));
+    matrix_double res_data(rows, std::vector<double>(cols, 0));
+
+    using c_t = phylanx::util::construction_type;
+
+    distributed_object<matrix_double, c_t::all_to_all> lhs(
+        "test_distributed_object_matrix_all_to_all_m1", lhs_data);
+    distributed_object<matrix_double, c_t::all_to_all> rhs(
+        "test_distributed_object_matrix_all_to_all_m2", rhs_data);
+    distributed_object<matrix_double, c_t::all_to_all> res(
+        "test_distributed_object_matrix_all_to_all_m3", res_data);
+
+    for (int i = 0; i < rows; i++)
+    {
+        for (int j = 0; j < cols; j++)
+        {
+            (*res)[i][j] = (*lhs)[i][j] + (*rhs)[i][j];
+            res_data[i][j] = lhs_data[i][j] + rhs_data[i][j];
+        }
+    }
+    HPX_TEST((*res) == res_data);
+    HPX_TEST_EQ(res->size(), static_cast<size_t>(rows));
+
+    // test fetch function when 2 or more localities provided
+    if (hpx::get_num_localities(hpx::launch::sync) > 1)
+    {
+        if (hpx::get_locality_id() == 0)
+        {
+            hpx::future<matrix_double> res_first = res.fetch(1);
+            HPX_TEST_EQ(res_first.get()[0][0], 86);
+        }
+        else
+        {
+            hpx::future<matrix_double> res_first = res.fetch(0);
+            HPX_TEST_EQ(res_first.get()[0][0], 84);
+        }
+    }
+
+    hpx::lcos::barrier b_dist_matrix_2(
+        "barrier_test_distributed_object_matrix_all_to_all",
+        hpx::get_num_localities(hpx::launch::sync),
+        hpx::get_locality_id());
+    b_dist_matrix_2.wait();
+}
+
+// test constructor option with reference to an existing object
+void test_distributed_object_ref()
+{
+    using phylanx::util::distributed_object;
+    size_t n = 10;
+    int val = 2;
+
+    int val_update = 42;
+    vector_int vec1(n, val);
+    distributed_object<vector_int&> dist_vec(
+        "test_distributed_object_ref", vec1);
+
+    // The update/change to the existing/referring object
+    // will reflect the change to the distributed object
+    vec1[2] = val_update;
+
+    HPX_TEST_EQ((*dist_vec)[2], val_update);
+    HPX_TEST_EQ(dist_vec->size(), static_cast<size_t>(n));
+
+    hpx::lcos::barrier b(
+        "barrier_test_distributed_object_ref",
+        hpx::get_num_localities(hpx::launch::sync),
+        hpx::get_locality_id());
+    b.wait();
+}
+
+// test constructor option with reference to a const existing object
+void test_distributed_object_const_ref()
+{
+    using phylanx::util::distributed_object;
+    int n = 10;
+    double val = 42.0;
+
+    vector_double_const vec1(n, val);
+    distributed_object<vector_double_const_ref> dist_vec(
+        "test_distributed_object_const_ref", vec1);
+
+    hpx::lcos::barrier b(
+        "barrier_test_distributed_object_const_ref",
+        hpx::get_num_localities(hpx::launch::sync),
+        hpx::get_locality_id());
+    b.wait();
+}
+
+// simple matrix multiplication example
+void test_distributed_object_matrix_mul()
+{
+    using phylanx::util::distributed_object;
+    size_t cols = 5;    // Decide how big the matrix should be
+
+    size_t num_locs = hpx::get_num_localities(hpx::launch::sync);
+    std::vector<std::pair<size_t, size_t>> ranges(num_locs);
+
+    // Create a list of row ranges for each partition
+    size_t start = 0;
+    size_t diff = (int) std::ceil((double) cols / ((double) num_locs));
+    for (size_t i = 0; i < num_locs; i++)
+    {
+        size_t second = (std::min)(cols, start + diff);
+        ranges[i] = std::make_pair(start, second);
+        start += diff;
+    }
+
+    // Create our data, stored in all_data's. This way we can check for validity
+    // without using anything distributed. The seed being a constant is needed
+    // in order for all nodes to generate the same data
+    size_t here = hpx::get_locality_id();
+    size_t local_rows = ranges[here].second - ranges[here].first;
+    std::vector<std::vector<std::vector<int>>> all_data_m1(
+        hpx::get_num_localities(hpx::launch::sync));
+
+    std::srand(123456);
+
+    for (size_t i = 0; i < all_data_m1.size(); i++)
+    {
+        size_t tmp_num_rows = ranges[i].second - ranges[i].first;
+        all_data_m1[i] = std::vector<std::vector<int>>(
+            tmp_num_rows, std::vector<int>(cols, 0));
+        for (size_t j = 0; j < tmp_num_rows; j++)
+        {
+            for (size_t k = 0; k < cols; k++)
+            {
+                all_data_m1[i][j][k] = std::rand();
+            }
+        }
+    }
+
+    std::vector<std::vector<std::vector<int>>> all_data_m2(
+        hpx::get_num_localities(hpx::launch::sync));
+
+    std::srand(7891011);
+
+    for (size_t i = 0; i < all_data_m2.size(); i++)
+    {
+        size_t tmp_num_rows = ranges[i].second - ranges[i].first;
+        all_data_m2[i] = std::vector<std::vector<int>>(
+            tmp_num_rows, std::vector<int>(cols, 0));
+        for (size_t j = 0; j < tmp_num_rows; j++)
+        {
+            for (size_t k = 0; k < cols; k++)
+            {
+                all_data_m2[i][j][k] = std::rand();
+            }
+        }
+    }
+
+    std::vector<std::vector<int>> here_data_m3(
+        local_rows, std::vector<int>(cols, 0));
+
+    using c_t = phylanx::util::construction_type;
+
+    distributed_object<matrix_int, c_t::all_to_all> M1(
+        "M1_meta_mat_mul", all_data_m1[here]);
+    distributed_object<matrix_int, c_t::all_to_all> M2(
+        "M2_meta_mat_mul", all_data_m2[here]);
+    distributed_object<matrix_int, c_t::all_to_all> M3(
+        "M3_meta_mat_mul", here_data_m3);
+
+    // Actual matrix multiplication. For non-local values, get the data
+    // and then use it, for local, just use the local data without doing
+    // a fetch to get it
+    size_t num_before_me = here;
+    for (size_t p = 0; p < num_before_me; p++)
+    {
+        std::vector<std::vector<int>> non_local = M2.fetch(p).get();
+        for (size_t i = 0; i < local_rows; i++)
+        {
+            for (size_t j = ranges[p].first; j < ranges[p].second; j++)
+            {
+                for (size_t k = 0; k < cols; k++)
+                {
+                    (*M3)[i][j] +=
+                        (*M1)[i][k] * non_local[j - ranges[p].first][k];
+                    here_data_m3[i][j] += all_data_m1[here][i][k] *
+                        all_data_m2[p][j - ranges[p].first][k];
+                }
+            }
+        }
+    }
+    for (size_t i = 0; i < local_rows; i++)
+    {
+        for (size_t j = ranges[here].first; j < ranges[here].second; j++)
+        {
+            for (size_t k = 0; k < cols; k++)
+            {
+                (*M3)[i][j] += (*M1)[i][k] * (*M2)[j - ranges[here].first][k];
+                here_data_m3[i][j] += all_data_m1[here][i][k] *
+                    all_data_m2[here][j - ranges[here].first][k];
+            }
+        }
+    }
+    for (size_t p = here + 1; p < num_locs; p++)
+    {
+        std::vector<std::vector<int>> non_local = M2.fetch(p).get();
+        for (size_t i = 0; i < local_rows; i++)
+        {
+            for (size_t j = ranges[p].first; j < ranges[p].second; j++)
+            {
+                for (size_t k = 0; k < cols; k++)
+                {
+                    (*M3)[i][j] +=
+                        (*M1)[i][k] * non_local[j - ranges[p].first][k];
+                    here_data_m3[i][j] += all_data_m1[here][i][k] *
+                        all_data_m2[p][j - ranges[p].first][k];
+                }
+            }
+        }
+    }
+    HPX_TEST((*M3) == here_data_m3);
+
+    hpx::lcos::barrier b(
+        "barrier_test_distributed_object_const_ref",
+        hpx::get_num_localities(hpx::launch::sync),
+        hpx::get_locality_id());
+    b.wait();
+}
+
+void test_dist_object_vector_mo_sub_localities_constructor()
+{
+    using c_t = phylanx::util::construction_type;
+    using phylanx::util::distributed_object;
+    size_t num_localities = hpx::get_num_localities(hpx::launch::sync);
+    size_t cur_locality = static_cast<size_t>(hpx::get_locality_id());
+
+    // define vector based on the locality that it is running
+    int here_ = 42 + static_cast<int>(hpx::get_locality_id());
+    int len = 10;
+
+    // prepare vector data
+    std::vector<int> local(len, here_);
+    std::vector<size_t> sub_localities{0, 1};
+
+    if (num_localities >= 2 &&
+        std::find(sub_localities.begin(), sub_localities.end(),
+            static_cast<size_t>(cur_locality)) != sub_localities.end())
+    {
+        // construct a distributed_object with vector<int> type
+        distributed_object<std::vector<int>, c_t::all_to_all> local_do(
+            "test_dist_object_vector_mo_sub_localities_constructor", local, 2);
+
+        // testing -> operator
+        HPX_TEST_EQ(local_do->size(), static_cast<size_t>(len));
+
+        // testing dist_object and its vector underneath
+        // testing * operator
+        HPX_TEST((*local_do) == local);
+
+        // perform element-wise addition between distributed_objects
+        for (int i = 0; i < len; i++)
+        {
+            (*local_do)[i] += 1;
+        }
+
+        hpx::lcos::barrier b(
+            "barrier_test_dist_object_vector_mo_sub_localities_constructor",
+            sub_localities.size(), cur_locality);
+        b.wait();
+
+        std::sort(sub_localities.begin(), sub_localities.end());
+        if (cur_locality == sub_localities[0])
+        {
+            using hpx::parallel::for_each;
+            using hpx::parallel::execution::par;
+
+            std::vector<std::vector<int>> res(num_localities);
+
+            // compute expect result in parallel, locality 0 fetches all values
+            for_each(par, std::begin(sub_localities) + 1, std::end(sub_localities),
+                [&](std::uint64_t b) {
+                    res[b] = local_do.fetch(b).get();
+                    for (int i = 0; i < len; i++)
+                    {
+                        HPX_TEST_EQ(
+                            res[b][i], static_cast<int>((*local_do)[i] + b));
+                    }
+                });
+        }
+
+        b.wait();
+    }
+}
+
+void test_distributed_object_sub_localities_constructor()
+{
+    using phylanx::util::distributed_object;
+    std::vector<int> input(10, 1);
+    if (hpx::get_locality_id() == 0)
+    {
+        distributed_object<std::vector<int>> vec1(
+            "test_distributed_object_sub_localities_constructor", input, 1, 0);
+    }
+}
+
+int hpx_main()
+{
+    {
+        test_distributed_object_int_reduce_to_locality_0();
+        test_distributed_object_vector_elem_wise_add();
+        test_distributed_object_matrix();
+        test_distributed_object_matrix_all_to_all();
+        test_distributed_object_matrix_mul();
+        test_distributed_object_ref();
+        test_distributed_object_const_ref();
+        test_dist_object_vector_mo_sub_localities_constructor();
+        test_distributed_object_sub_localities_constructor();
+    }
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}


### PR DESCRIPTION
This adds a simplified version of `distributed_object` (taken from here: https://github.com/STEllAR-GROUP/hpx/pull/3807) to Phylanx. @weilewei, @folshost please verify.

This is the first step towards distributed primitives.