### PR TITLE
Disable HIGHFIVE_UNIT_TESTS in the base image

### DIFF
--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -1,4 +1,5 @@
 # Copyright (c) 2017 R. Tohid
+# Copyright (c) 2018-2019 Parsa Amini
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -28,7 +29,7 @@ RUN apt-get update &&                                                           
         python3-pip                                                                 \
         libblas-dev                                                                 \
         liblapack-dev                                                               \
-        libhdf5-dev &&                                                              \
+        libhdf5-dev                                                              && \
     apt-get purge && apt-get clean && rm -rf /var/lib/apt/lists/*                && \
                                                                                     \
     pip3 --no-cache-dir install setuptools                                       && \
@@ -38,36 +39,27 @@ RUN apt-get update &&                                                           
     pip3 --no-cache-dir install flake8                                           && \
                                                                                     \
     git clone --depth=1 https://github.com/pybind/pybind11.git /pybind11-src     && \
-    (                                                                               \
-    cd /pybind11-src                                                             && \
-    cmake -H. -Bbuild -DPYBIND11_TEST=OFF                                        && \
-    cmake --build build -- install                                                  \
-    )                                                                            && \
-    rm -rf /pybind11-src                                                         && \
+    cmake -H/pybind11-src -B/pybind11-build -DPYBIND11_TEST=OFF                  && \
+    cmake --build /pybind11-build --target install                               && \
+    rm -rf /pybind11-{src,build}                                                 && \
                                                                                     \
     git clone --depth=1 https://bitbucket.org/blaze-lib/blaze.git /blaze-src     && \
-    (                                                                               \
-    cd /blaze-src                                                                && \
-    cmake -H. -Bbuild -DBLAZE_SMP_THREADS=C++11                                  && \
-    cmake --build build -- install                                                  \
-    )                                                                            && \
-    rm -rf /blaze-src                                                            && \
-
+    cmake -H/blaze-src -B/blaze-build -DBLAZE_SMP_THREADS=C++11                  && \
+    cmake --build /blaze-build --target install                                  && \
+    rm -rf /blaze-{src,build}                                                    && \
+                                                                                    \
     git clone --depth=1 https://github.com/STEllAR-GROUP/BlazeIterative.git         \
         /blazeiterative-src                                                      && \
-    (                                                                               \
-    cd /blazeiterative-src                                                       && \
-    cmake -H. -Bbuild -Dblaze_DIR=/blaze/share/blaze/cmake                       && \
-    cmake --build build -- install                                                  \
-    )                                                                            && \
-    rm -rf /blaze-iterative-src                                                  && \
+    cmake -H/blazeiterative-src -B/blazeiterative-build                             \
+        -Dblaze_DIR=/blaze/share/blaze/cmake                                     && \
+    cmake --build /blazeiterative-build --target install                         && \
+    rm -rf /blazeiterative-{src,build}                                           && \
                                                                                     \
     git clone --depth=1 https://github.com/BlueBrain/HighFive.git /highfive-src  && \
-    (                                                                               \
-    cd /highfive-src                                                             && \
-    cmake -H. -Bbuild -DUSE_BOOST=Off                                            && \
-    cmake --build build -- install                                                  \
-    )                                                                            && \
-    rm -rf /highfive-src
+    cmake -H/highfive-src -B/highfive-build -DHIGHFIVE_UNIT_TESTS=OFF               \
+        -DUSE_BOOST=OFF                                                          && \
+    cmake --build /highfive-build --target install                               && \
+    rm -rf /highfive-{src,build}
 WORKDIR /
 CMD /bin/bash
+


### PR DESCRIPTION
This PR updates the base Docker image Phylanx is built on in CircleCI. It does not have any effects until it gets into master.

Log for the error that is addressed by this PR:
```
-- The C compiler identification is Clang 7.1.0
-- The CXX compiler identification is Clang 7.1.0
-- Check for working C compiler: /usr/bin/clang
-- Check for working C compiler: /usr/bin/clang -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/clang++
-- Check for working CXX compiler: /usr/bin/clang++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Setting build type to 'RelWithDebInfo' as none was specified.
-- HDF5: Using hdf5 compiler wrapper to determine C configuration
-- Found HDF5: /usr/lib/x86_64-linux-gnu/hdf5/serial/libhdf5.so;/usr/lib/x86_64-linux-gnu/libpthread.so;/usr/lib/x86_64-linux-gnu/libsz.so;/usr/lib/x86_64-linux-gnu/libz.so;/usr/lib/x86_64-linux-gnu/libdl.so;/usr/lib/x86_64-linux-gnu/libm.so (found version "1.10.0.1")
CMake Error at CMakeLists.txt:90 (message):
Unit tests require boost. Please disable HIGHFIVE_UNIT_TESTS or enable
USE_BOOST
-- Configuring incomplete, errors occurred!
See also "/highfive-src/build/CMakeFiles/CMakeOutput.log".
```