### PR TITLE
Adding 4D array support to node_data

### DIFF
--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -341,6 +341,19 @@ namespace phylanx { namespace ast
         {
         }
 
+        template <typename T>
+        primary_expr(
+            std::vector<std::vector<std::vector<std::vector<T>>>> const& val)
+          : expr_node_type(phylanx::ir::node_data<T>{val})
+        {
+        }
+        template <typename T>
+        primary_expr(
+            std::vector<std::vector<std::vector<std::vector<T>>>>&& val)
+          : expr_node_type(phylanx::ir::node_data<T>{std::move(val)})
+        {
+        }
+
         primary_expr(identifier const& val)
           : expr_node_type(val)
         {

--- a/phylanx/ast/parser/expression.hpp
+++ b/phylanx/ast/parser/expression.hpp
@@ -46,6 +46,15 @@ namespace phylanx { namespace ast { namespace parser
         qi::rule<Iterator, ast::operand(), skipper<Iterator>> unary_expr;
         qi::rule<Iterator, ast::operand(), skipper<Iterator>> primary_expr;
 
+        qi::rule<Iterator,
+            std::vector<std::vector<std::vector<std::vector<double>>>>(),
+            skipper<Iterator>>
+            double_quatern;
+        qi::rule<Iterator,
+            std::vector<std::vector<std::vector<std::vector<std::int64_t>>>>(),
+            skipper<Iterator>>
+            int64_quatern;
+
         qi::rule<Iterator, std::vector<std::vector<std::vector<double>>>(),
             skipper<Iterator>>
             double_tensor;

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -122,22 +122,26 @@ namespace phylanx { namespace ast { namespace parser
             |   bool_
             |   long_long
             |   string
+            |   int64_quatern
             |   int64_tensor
             |   int64_matrix
             |   int64_vector
+            |   double_quatern
             |   double_tensor
             |   double_matrix
             |   double_vector
             |   '(' > expr > ')'
             ;
 
-        int64_tensor %= '[' >> (int64_matrix % ',') >> ']';
+        int64_quatern %= '[' >> (int64_tensor % ',') >> ']';
+        int64_tensor  %= '[' >> (int64_matrix % ',') >> ']';
 
         int64_matrix %= '[' >> (int64_vector % ',') >> ']';
 
         int64_vector %= '[' >> -(long_long % ',') >> ']';
 
-        double_tensor %= '[' >> (double_matrix % ',') > ']';
+        double_quatern %= '[' >> (double_tensor % ',') > ']';
+        double_tensor  %= '[' >> (double_matrix % ',') > ']';
 
         double_matrix %= '[' >> (double_vector % ',') > ']';
 
@@ -180,7 +184,9 @@ namespace phylanx { namespace ast { namespace parser
         ///////////////////////////////////////////////////////////////////////
         // Debugging and error handling and reporting support.
         BOOST_SPIRIT_DEBUG_NODES(
+            (int64_quatern)
             (int64_tensor)
+            (double_quatern)
             (double_tensor)
             (expr)
             (unary_expr)

--- a/phylanx/config.hpp
+++ b/phylanx/config.hpp
@@ -38,6 +38,7 @@
 #undef BLAZE_USE_BOOST_THREADS
 
 ///////////////////////////////////////////////////////////////////////////////
-#  define PHYLANX_MAX_DIMENSIONS 3
+#  define PHYLANX_MAX_DIMENSIONS 4
+
 
 #endif // PHYLANX_CONFIG_AUG_25_2017_0711PM

--- a/phylanx/execution_tree/primitives/primitive_argument_type.hpp
+++ b/phylanx/execution_tree/primitives/primitive_argument_type.hpp
@@ -412,6 +412,15 @@ namespace phylanx { namespace execution_tree
         explicit primitive_argument_type(blaze::DynamicTensor<std::uint8_t>&& val)
           : argument_value_type{ir::node_data<std::uint8_t>{std::move(val)}}
         {}
+        explicit primitive_argument_type(
+            blaze::DynamicArray<4UL, std::uint8_t> const& val)
+          : argument_value_type{phylanx::ir::node_data<std::uint8_t>{val}}
+        {}
+        explicit primitive_argument_type(
+            blaze::DynamicArray<4UL, std::uint8_t>&& val)
+          : argument_value_type{
+                phylanx::ir::node_data<std::uint8_t>{std::move(val)}}
+        {}
 
         primitive_argument_type(bool val, annotation_ptr const& ann)
           : argument_value_type{ir::node_data<std::uint8_t>{val}}
@@ -497,6 +506,15 @@ namespace phylanx { namespace execution_tree
         {}
         explicit primitive_argument_type(blaze::DynamicTensor<std::int64_t>&& val)
           : argument_value_type{ir::node_data<std::int64_t>{std::move(val)}}
+        {}
+        explicit primitive_argument_type(
+            blaze::DynamicArray<4UL, std::int64_t> const& val)
+          : argument_value_type{phylanx::ir::node_data<std::int64_t>{val}}
+        {}
+        explicit primitive_argument_type(
+            blaze::DynamicArray<4UL, std::int64_t>&& val)
+          : argument_value_type{
+                phylanx::ir::node_data<std::int64_t>{std::move(val)}}
         {}
 
         primitive_argument_type(std::int64_t val,
@@ -599,6 +617,13 @@ namespace phylanx { namespace execution_tree
         {}
         explicit primitive_argument_type(blaze::DynamicTensor<double>&& val)
           : argument_value_type{ir::node_data<double>{std::move(val)}}
+        {}
+        explicit primitive_argument_type(
+            blaze::DynamicArray<4UL, double> const& val)
+          : argument_value_type{phylanx::ir::node_data<double>{val}}
+        {}
+        explicit primitive_argument_type(blaze::DynamicArray<4UL, double>&& val)
+          : argument_value_type{phylanx::ir::node_data<double>{std::move(val)}}
         {}
 
         primitive_argument_type(double val, annotation_ptr const& ann)

--- a/phylanx/ir/node_data.hpp
+++ b/phylanx/ir/node_data.hpp
@@ -134,10 +134,13 @@ namespace phylanx { namespace ir
         using storage3d_type = blaze::DynamicTensor<T>;
         using custom_storage3d_type = blaze::CustomTensor<T, true, true>;
 
-        using storage_type = util::variant<
-            storage0d_type, storage1d_type, storage2d_type, storage3d_type,
-            custom_storage0d_type, custom_storage1d_type,
-            custom_storage2d_type, custom_storage3d_type>;
+        using storage4d_type = blaze::DynamicArray<4UL, T>;
+        using custom_storage4d_type = blaze::CustomArray<4UL, T, true, true>;
+
+        using storage_type = util::variant<storage0d_type, storage1d_type,
+            storage2d_type, storage3d_type, storage4d_type,
+            custom_storage0d_type, custom_storage1d_type, custom_storage2d_type,
+            custom_storage3d_type, custom_storage4d_type>;
 
         enum variant_index
         {
@@ -145,10 +148,12 @@ namespace phylanx { namespace ir
             storage1d = 1,
             storage2d = 2,
             storage3d = 3,
-            custom_storage0d = 4,
-            custom_storage1d = 5,
-            custom_storage2d = 6,
-            custom_storage3d = 7
+            storage4d = 4,
+            custom_storage0d = 5,
+            custom_storage1d = 6,
+            custom_storage2d = 7,
+            custom_storage3d = 8,
+            custom_storage4d = 9
         };
 
         using dimensions_type = std::array<std::size_t, max_dimensions>;
@@ -186,6 +191,13 @@ namespace phylanx { namespace ir
         explicit node_data(custom_storage3d_type const& values);
         explicit node_data(custom_storage3d_type && values);
 
+        /// Create node data for a 4-dimensional value
+        explicit node_data(storage4d_type const& values);
+        explicit node_data(storage4d_type && values);
+
+        explicit node_data(custom_storage4d_type const& values);
+        explicit node_data(custom_storage4d_type && values);
+
         // conversion helpers for Python bindings and AST parsing
         explicit node_data(std::vector<T> const& values);
         explicit node_data(std::vector<std::vector<T>> const& values);
@@ -209,6 +221,10 @@ namespace phylanx { namespace ir
 
         explicit node_data(
             std::vector<std::vector<std::vector<T>>> const& values);
+
+        explicit node_data(
+            std::vector<std::vector<std::vector<std::vector<T>>>> const&
+                values);
 
     private:
         static storage_type init_data_from(node_data const& d);
@@ -239,6 +255,10 @@ namespace phylanx { namespace ir
                 increment_copy_construction_count();
                 return storage_type(d.tensor());
 
+            case storage4d:         HPX_FALLTHROUGH;
+            case custom_storage4d:
+                increment_copy_construction_count();
+                return storage_type(d.quatern());
             default:
                 HPX_THROW_EXCEPTION(hpx::invalid_status,
                     "phylanx::ir::node_data<T>::node_data<U>",
@@ -281,12 +301,21 @@ namespace phylanx { namespace ir
         node_data& operator=(custom_storage3d_type const& val);
         node_data& operator=(custom_storage3d_type && val);
 
+        node_data& operator=(storage4d_type const& val);
+        node_data& operator=(storage4d_type && val);
+
+        node_data& operator=(custom_storage4d_type const& val);
+        node_data& operator=(custom_storage4d_type && val);
         // conversion helpers for Python bindings and AST parsing
         node_data& operator=(std::vector<T> const& val);
         node_data& operator=(std::vector<std::vector<T>> const& values);
 
         node_data& operator=(
             std::vector<std::vector<std::vector<T>>> const& values);
+
+        node_data& operator=(
+            std::vector<std::vector<std::vector<std::vector<T>>>> const&
+                values);
 
     private:
         static storage_type copy_data_from(node_data const& d);
@@ -310,11 +339,25 @@ namespace phylanx { namespace ir
         T& operator[](dimensions_type const& indicies);
         T const& operator[](dimensions_type const& indicies) const;
 
-        T& at(std::size_t index1, std::size_t index2, std::size_t index3 = 0);
+        T& at(std::size_t index1, std::size_t index2, std::size_t index3 = 0,
+            std::size_t index4 = 0);
         T const& at(std::size_t index1, std::size_t index2,
-            std::size_t index3 = 0) const;
+            std::size_t index3 = 0, std::size_t index4 = 0) const;
 
         std::size_t size() const;
+
+        storage4d_type& quatern_non_ref();
+        storage4d_type const& quatern_non_ref() const;
+
+        storage4d_type quatern_copy() &;
+        storage4d_type quatern_copy() const&;
+        storage4d_type quatern_copy() &&;
+        storage4d_type quatern_copy() const&&;
+
+        custom_storage4d_type quatern() &;
+        custom_storage4d_type quatern() const&;
+        custom_storage4d_type quatern() &&;
+        custom_storage4d_type quatern() const&&;
 
         storage3d_type& tensor_non_ref();
         storage3d_type const& tensor_non_ref() const;
@@ -407,6 +450,8 @@ namespace phylanx { namespace ir
         std::vector<T> as_vector() const;
         std::vector<std::vector<T>> as_matrix() const;
         std::vector<std::vector<std::vector<T>>> as_tensor() const;
+        std::vector<std::vector<std::vector<std::vector<T>>>> as_quatern()
+            const;
 
         std::size_t index() const { return data_.index(); }
 

--- a/phylanx/plugins/matrixops/constant.hpp
+++ b/phylanx/plugins/matrixops/constant.hpp
@@ -64,7 +64,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         template <typename T>
         ir::node_data<T> constant3d_helper(primitive_argument_type&& op,
             operand_type::dimensions_type const& dim) const;
+        template <typename T>
+        ir::node_data<T> constant4d_helper(primitive_argument_type&& op,
+            operand_type::dimensions_type const& dim) const;
+
         primitive_argument_type constant3d(primitive_argument_type&& op,
+            operand_type::dimensions_type const& dim,
+            node_data_type dtype) const;
+        primitive_argument_type constant4d(primitive_argument_type&& op,
             operand_type::dimensions_type const& dim,
             node_data_type dtype) const;
 

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -2245,21 +2245,19 @@ namespace phylanx { namespace ir
         case storage2d:
             return node_data<T>{matrix()};
 
-        case custom_storage0d: HPX_FALLTHROUGH;
-        case custom_storage1d: HPX_FALLTHROUGH;
-        case custom_storage2d:
-            return *this;
-
         case storage3d:
             return node_data<T>{tensor()};
 
         case storage4d:
             return node_data<T>{quatern()};
 
+        case custom_storage0d: HPX_FALLTHROUGH;
+        case custom_storage1d: HPX_FALLTHROUGH;
+        case custom_storage2d: HPX_FALLTHROUGH;
         case custom_storage3d: HPX_FALLTHROUGH;
         case custom_storage4d:
             return *this;
-#endif
+
         default:
             break;
         }
@@ -2283,17 +2281,15 @@ namespace phylanx { namespace ir
         case storage2d:
             return node_data<T>{matrix()};
 
-        case custom_storage0d: HPX_FALLTHROUGH;
-        case custom_storage1d: HPX_FALLTHROUGH;
-        case custom_storage2d:
-            return *this;
-
         case storage3d:
             return node_data<T>{tensor()};
 
         case storage4d:
             return node_data<T>{quatern()};
 
+        case custom_storage0d: HPX_FALLTHROUGH;
+        case custom_storage1d: HPX_FALLTHROUGH;
+        case custom_storage2d: HPX_FALLTHROUGH;
         case custom_storage3d: HPX_FALLTHROUGH;
         case custom_storage4d:
             return *this;
@@ -2331,7 +2327,9 @@ namespace phylanx { namespace ir
         {
         case storage0d: HPX_FALLTHROUGH;
         case storage1d: HPX_FALLTHROUGH;
-        case storage2d:
+        case storage2d: HPX_FALLTHROUGH;
+        case storage3d: HPX_FALLTHROUGH;
+        case storage4d:
             return *this;
 
         case custom_storage0d:
@@ -2343,15 +2341,13 @@ namespace phylanx { namespace ir
         case custom_storage2d:
             return node_data<T>{matrix_copy()};
 
-        case storage3d: HPX_FALLTHROUGH;
-        case storage4d:
-            return *this;
-
         case custom_storage3d:
             return node_data<T>{tensor_copy()};
 
         case custom_storage4d:
             return node_data<T>{quatern_copy()};
+
+
         default:
             break;
         }
@@ -2414,15 +2410,9 @@ namespace phylanx { namespace ir
         case custom_storage2d:  HPX_FALLTHROUGH;
         case storage3d:         HPX_FALLTHROUGH;
         case custom_storage3d:  HPX_FALLTHROUGH;
-<<<<<<< .mine
         case storage4d:         HPX_FALLTHROUGH;
         case custom_storage4d:  HPX_FALLTHROUGH;
-#endif
-=======
 
-
-
->>>>>>> .theirs
         default:
             break;
         }

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -145,7 +145,11 @@ namespace phylanx { namespace ir
     template <typename T>
     node_data<T>::node_data(dimensions_type const& dims)
     {
-        if (dims[2] != 0)
+        if (dims[3] != 0)
+        {
+            data_ = storage4d_type(dims[0], dims[1], dims[2], dims[3]);
+        }
+        else if (dims[2] != 0)
         {
             data_ = storage3d_type(dims[0], dims[1], dims[2]);
         }
@@ -166,7 +170,12 @@ namespace phylanx { namespace ir
     template <typename T>
     node_data<T>::node_data(dimensions_type const& dims, T default_value)
     {
-        if (dims[2] != 0)
+        if (dims[3] != 0)
+        {
+            data_ = storage4d_type(blaze::init_from_value, default_value,
+                dims[0], dims[1], dims[2], dims[3]);
+        }
+        else if (dims[2] != 0)
         {
             data_ = storage3d_type(dims[0], dims[1], dims[2], default_value);
         }
@@ -259,6 +268,37 @@ namespace phylanx { namespace ir
         increment_move_construction_count();
     }
 
+    // Create node data for a 4-dimensional value
+    template <typename T>
+    node_data<T>::node_data(storage4d_type const& values)
+      : data_(values)
+    {
+        increment_copy_construction_count();
+    }
+
+    template <typename T>
+    node_data<T>::node_data(storage4d_type&& values)
+      : data_(std::move(values))
+    {
+        increment_move_construction_count();
+    }
+
+    template <typename T>
+    node_data<T>::node_data(custom_storage4d_type const& values)
+      : data_(custom_storage4d_type{const_cast<T*>(values.data()),
+            values.quats(), values.pages(), values.rows(), values.columns(),
+            values.spacing()})
+    {
+        increment_copy_construction_count();
+    }
+
+    template <typename T>
+    node_data<T>::node_data(custom_storage4d_type&& values)
+      : data_(std::move(values))
+    {
+        increment_move_construction_count();
+    }
+
     // conversion helpers for Python bindings and AST parsing
     template <typename T>
     node_data<T>::node_data(std::vector<T> const& values)
@@ -307,6 +347,38 @@ namespace phylanx { namespace ir
                 for (std::size_t j = 0; j != nz; ++j)
                 {
                     util::get<storage3d>(data_)(k, i, j) = row[j];
+                }
+            }
+        }
+    }
+
+    template <typename T>
+    node_data<T>::node_data(
+        std::vector<std::vector<std::vector<std::vector<T>>>> const& values)
+      : data_(storage4d_type{values.size(),
+            !values.empty() ? values[0].size() : 0,
+            !values.empty() && !values[0].empty() ? values[0][0].size() : 0,
+            !values.empty() && !values[0].empty() && !values[0][0].empty() ?
+                values[0][0][0].size() :
+                0})
+    {
+        std::size_t const nw = values.size();
+        for (std::size_t l = 0; l != nw; ++l)
+        {
+            std::vector<std::vector<std::vector<T>>> const& quat = values[l];
+            std::size_t const nx = quat.size();
+            for (std::size_t k = 0; k != nx; ++k)
+            {
+                std::vector<std::vector<T>> const& page = quat[k];
+                std::size_t const ny = page.size();
+                for (std::size_t i = 0; i != ny; ++i)
+                {
+                    std::vector<T> const& row = page[i];
+                    std::size_t const nz = row.size();
+                    for (std::size_t j = 0; j != nz; ++j)
+                    {
+                        util::get<storage4d>(data_)(l, k, i, j) = row[j];
+                    }
                 }
             }
         }
@@ -365,6 +437,22 @@ namespace phylanx { namespace ir
                 auto t = d.tensor();
                 return custom_storage3d_type{
                     t.data(), t.pages(), t.rows(), t.columns(), t.spacing()};
+            }
+            break;
+
+        case storage4d:
+            {
+                increment_copy_construction_count();
+                return d.data_;
+            }
+            break;
+
+        case custom_storage4d:
+            {
+                increment_move_construction_count();
+                auto q = d.quatern();
+                return custom_storage4d_type{q.data(), q.quats(), q.pages(),
+                    q.rows(), q.columns(), q.spacing()};
             }
             break;
 
@@ -512,6 +600,40 @@ namespace phylanx { namespace ir
         return *this;
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    node_data<T>& node_data<T>::operator=(storage4d_type const& val)
+    {
+        increment_copy_assignment_count();
+        data_ = val;
+        return *this;
+    }
+
+    template <typename T>
+    node_data<T>& node_data<T>::operator=(storage4d_type && val)
+    {
+        increment_move_assignment_count();
+        data_ = std::move(val);
+        return *this;
+    }
+
+    template <typename T>
+    node_data<T>& node_data<T>::operator=(custom_storage4d_type const& val)
+    {
+        increment_move_assignment_count();
+        data_ = custom_storage4d_type{const_cast<T*>(val.data()), val.quats(),
+            val.pages(), val.rows(), val.columns(), val.spacing()};
+        return *this;
+    }
+
+    template <typename T>
+    node_data<T>& node_data<T>::operator=(custom_storage4d_type && val)
+    {
+        increment_move_assignment_count();
+        data_ = std::move(val);
+        return *this;
+    }
+
     // conversion helpers for Python bindings and AST parsing
     template <typename T>
     node_data<T>& node_data<T>::operator=(std::vector<T> const& values)
@@ -562,6 +684,36 @@ namespace phylanx { namespace ir
                 for (std::size_t j = 0; j != nz; ++j)
                 {
                     util::get<storage3d>(data_)(k, i, j) = row[j];
+                }
+            }
+        }
+        return *this;
+    }
+
+    template <typename T>
+    node_data<T>& node_data<T>::operator=(
+        std::vector<std::vector<std::vector<std::vector<T>>>> const& values)
+    {
+        data_ = storage4d_type{values.size(), values[0].size(),
+            values[0][0].size(), values[0][0][0].size()};
+
+        std::size_t const nw = values.size();
+        for (std::size_t l = 0; l != nw; ++l)
+        {
+            std::vector<std::vector<std::vector<T>>> const& quat = values[l];
+            std::size_t const nx = quat.size();
+            for (std::size_t k = 0; k != nx; ++k)
+            {
+                std::vector<std::vector<T>> const& page = quat[k];
+                std::size_t const ny = page.size();
+                for (std::size_t i = 0; i != ny; ++i)
+                {
+                    std::vector<T> const& row = page[i];
+                    std::size_t const nz = row.size();
+                    for (std::size_t j = 0; j != nz; ++j)
+                    {
+                        util::get<storage4d>(data_)(l, k, i, j) = row[j];
+                    }
                 }
             }
         }
@@ -625,6 +777,22 @@ namespace phylanx { namespace ir
             }
             break;
 
+        case storage4d:
+            {
+                increment_copy_assignment_count();
+                return d.data_;
+            }
+            break;
+
+        case custom_storage4d:
+            {
+                increment_move_construction_count();
+                auto q = d.quatern();
+                return custom_storage4d_type{q.data(), q.quats(), q.pages(),
+                    q.rows(), q.columns(), q.spacing()};
+            }
+            break;
+
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "phylanx::ir::node_data<T>::node_data<T>",
@@ -677,7 +845,9 @@ namespace phylanx { namespace ir
             }
 
         case storage3d:         HPX_FALLTHROUGH;
-        case custom_storage3d:
+        case custom_storage3d:  HPX_FALLTHROUGH;
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
             {
                 HPX_THROW_EXCEPTION(hpx::invalid_status,
                     "phylanx::ir::node_data<T>::operator[]()",
@@ -716,6 +886,11 @@ namespace phylanx { namespace ir
         case custom_storage3d:
             return tensor()(indicies[0], indicies[1], indicies[2]);
 
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            return quatern()(
+                indicies[0], indicies[1], indicies[2], indicies[3]);
+
         default:
             break;
         }
@@ -726,8 +901,8 @@ namespace phylanx { namespace ir
     }
 
     template <typename T>
-    T& node_data<T>::at(
-        std::size_t index1, std::size_t index2, std::size_t index3)
+    T& node_data<T>::at(std::size_t index1, std::size_t index2,
+        std::size_t index3, std::size_t index4)
     {
         switch(data_.index())
         {
@@ -746,6 +921,10 @@ namespace phylanx { namespace ir
         case storage3d:         HPX_FALLTHROUGH;
         case custom_storage3d:
             return tensor()(index1, index2, index3);
+
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            return quatern()(index1, index2, index3, index4);
 
         default:
             break;
@@ -779,7 +958,9 @@ namespace phylanx { namespace ir
             }
 
         case storage3d:         HPX_FALLTHROUGH;
-        case custom_storage3d:
+        case custom_storage3d:  HPX_FALLTHROUGH;
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
             {
                 HPX_THROW_EXCEPTION(hpx::invalid_status,
                     "phylanx::ir::node_data<T>::operator[]()",
@@ -798,7 +979,7 @@ namespace phylanx { namespace ir
     }
 
     template <typename T>
-    T const& node_data<T>::operator[](dimensions_type const& indicies) const
+    T const& node_data<T>::operator[](dimensions_type const& indices) const
     {
         switch(data_.index())
         {
@@ -808,15 +989,19 @@ namespace phylanx { namespace ir
 
         case storage1d: HPX_FALLTHROUGH;
         case custom_storage1d:
-            return vector()[indicies[0]];
+            return vector()[indices[0]];
 
         case storage2d: HPX_FALLTHROUGH;
         case custom_storage2d:
-            return matrix()(indicies[0], indicies[1]);
+            return matrix()(indices[0], indices[1]);
 
         case storage3d:         HPX_FALLTHROUGH;
         case custom_storage3d:
-            return tensor()(indicies[0], indicies[1], indicies[2]);
+            return tensor()(indices[0], indices[1], indices[2]);
+
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            return quatern()(indices[0], indices[1], indices[2], indices[3]);
 
         default:
             break;
@@ -828,8 +1013,8 @@ namespace phylanx { namespace ir
     }
 
     template <typename T>
-    T const& node_data<T>::at(
-        std::size_t index1, std::size_t index2, std::size_t index3) const
+    T const& node_data<T>::at(std::size_t index1, std::size_t index2,
+        std::size_t index3, std::size_t index4) const
     {
         switch(data_.index())
         {
@@ -848,6 +1033,10 @@ namespace phylanx { namespace ir
         case storage3d:         HPX_FALLTHROUGH;
         case custom_storage3d:
             return tensor()(index1, index2, index3);
+
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            return quatern()(index1, index2, index3, index4);
 
         default:
             break;
@@ -885,6 +1074,13 @@ namespace phylanx { namespace ir
                 return t.rows() * t.columns() * t.pages();
             }
 
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            {
+                auto q = quatern();
+                return q.quats() * q.pages() * q.rows() * q.columns() ;
+            }
+
         default:
             break;
         }
@@ -916,6 +1112,196 @@ namespace phylanx { namespace ir
     typename node_data<T>::const_iterator  node_data<T>::cend() const
     {
         return const_iterator(*this, size());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    typename node_data<T>::storage4d_type& node_data<T>::quatern_non_ref()
+    {
+        storage4d_type* t = util::get_if<storage4d_type>(&data_);
+        if (t == nullptr)
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::ir::node_data<T>::quatern_non_ref()",
+                "node_data object holds unsupported data type");
+        }
+        return *t;
+    }
+
+    template <typename T>
+    typename node_data<T>::storage4d_type const& node_data<T>::quatern_non_ref()
+        const
+    {
+        storage4d_type const* t = util::get_if<storage4d_type>(&data_);
+        if (t == nullptr)
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::ir::node_data<T>::quatern_non_ref()",
+                "node_data object holds unsupported data type");
+        }
+        return *t;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    typename node_data<T>::storage4d_type node_data<T>::quatern_copy() &
+    {
+        custom_storage4d_type* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return storage4d_type{*ct};
+        }
+
+        storage4d_type* t = util::get_if<storage4d_type>(&data_);
+        if (t != nullptr)
+        {
+            return *t;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern_copy() &",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    typename node_data<T>::storage4d_type node_data<T>::quatern_copy() const&
+    {
+        custom_storage4d_type const* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return storage4d_type{*ct};
+        }
+
+        storage4d_type const* t = util::get_if<storage4d_type>(&data_);
+        if (t != nullptr)
+        {
+            return *t;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern_copy() const&",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    typename node_data<T>::storage4d_type node_data<T>::quatern_copy() &&
+    {
+        custom_storage4d_type* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return storage4d_type{*ct};
+        }
+
+        storage4d_type* t = util::get_if<storage4d_type>(&data_);
+        if (t != nullptr)
+        {
+            return std::move(*t);
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern_copy() &&",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    typename node_data<T>::storage4d_type node_data<T>::quatern_copy() const&&
+    {
+        custom_storage4d_type const* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return storage4d_type{*ct};
+        }
+
+        storage4d_type const* t = util::get_if<storage4d_type>(&data_);
+        if (t != nullptr)
+        {
+            return *t;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern_copy() const&&",
+            "node_data object holds unsupported data type");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    typename node_data<T>::custom_storage4d_type node_data<T>::quatern() &
+    {
+        custom_storage4d_type* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return *ct;
+        }
+
+        storage4d_type* t = util::get_if<storage4d_type>(&data_);
+        if (t != nullptr)
+        {
+            return custom_storage4d_type(t->data(), t->quats(), t->pages(),
+                t->rows(), t->columns(), t->spacing());
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern() &",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    typename node_data<T>::custom_storage4d_type node_data<T>::quatern() const&
+    {
+        custom_storage4d_type const* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return custom_storage4d_type(const_cast<T*>(ct->data()),
+                ct->quats(), ct->pages(), ct->rows(), ct->columns(),
+                ct->spacing());
+        }
+
+        storage4d_type const* t = util::get_if<storage4d_type>(&data_);
+        if (t != nullptr)
+        {
+            return custom_storage4d_type(const_cast<T*>(t->data()), t->quats(),
+                t->pages(), t->rows(), t->columns(), t->spacing());
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern() const&",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    typename node_data<T>::custom_storage4d_type node_data<T>::quatern() &&
+    {
+        custom_storage4d_type* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return *ct;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern() &&",
+            "node_data::quatern() shouldn't be called on an rvalue");
+    }
+
+    template <typename T>
+    typename node_data<T>::custom_storage4d_type node_data<T>::quatern() const&&
+    {
+        custom_storage4d_type const* ct =
+            util::get_if<custom_storage4d_type>(&data_);
+        if (ct != nullptr)
+        {
+            return *ct;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::quatern() const&&",
+            "node_data::quatern() shouldn't be called on an rvalue");
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1686,6 +2072,9 @@ namespace phylanx { namespace ir
         case custom_storage3d:
             return 3;
 
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            return 4;
         default:
             break;
         }
@@ -1723,6 +2112,13 @@ namespace phylanx { namespace ir
                 return dimensions_type{t.pages(), t.rows(), t.columns()};
             }
 
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            {
+                auto q = quatern();
+                return dimensions_type{
+                    q.quats(), q.pages(), q.rows(), q.columns()};
+            }
         default:
             break;
         }
@@ -1800,6 +2196,31 @@ namespace phylanx { namespace ir
                 }
             }
 
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            {
+                auto q = quatern();
+                switch (dim)
+                {
+                case 0:
+                    return q.quats();
+
+                case 1:
+                    return q.pages();
+
+                case 2:
+                    return q.rows();
+
+                case 3:
+                    return q.columns();
+
+                default:
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "phylanx::ir::node_data<T>::dimension()",
+                        "unknown dimension requested");
+                    break;
+                }
+            }
         default:
             break;
         }
@@ -1832,9 +2253,13 @@ namespace phylanx { namespace ir
         case storage3d:
             return node_data<T>{tensor()};
 
-        case custom_storage3d:
-            return *this;
+        case storage4d:
+            return node_data<T>{quatern()};
 
+        case custom_storage3d: HPX_FALLTHROUGH;
+        case custom_storage4d:
+            return *this;
+#endif
         default:
             break;
         }
@@ -1866,7 +2291,11 @@ namespace phylanx { namespace ir
         case storage3d:
             return node_data<T>{tensor()};
 
-        case custom_storage3d:
+        case storage4d:
+            return node_data<T>{quatern()};
+
+        case custom_storage3d: HPX_FALLTHROUGH;
+        case custom_storage4d:
             return *this;
 
         default:
@@ -1914,12 +2343,15 @@ namespace phylanx { namespace ir
         case custom_storage2d:
             return node_data<T>{matrix_copy()};
 
-        case storage3d:
+        case storage3d: HPX_FALLTHROUGH;
+        case storage4d:
             return *this;
 
         case custom_storage3d:
             return node_data<T>{tensor_copy()};
 
+        case custom_storage4d:
+            return node_data<T>{quatern_copy()};
         default:
             break;
         }
@@ -1946,10 +2378,12 @@ namespace phylanx { namespace ir
         case custom_storage2d:
             return true;
 
-        case storage3d:
+        case storage3d: HPX_FALLTHROUGH;
+        case storage4d:
             return false;
 
-        case custom_storage3d:
+        case custom_storage3d: HPX_FALLTHROUGH;
+        case custom_storage4d:
             return true;
 
         default:
@@ -1980,6 +2414,15 @@ namespace phylanx { namespace ir
         case custom_storage2d:  HPX_FALLTHROUGH;
         case storage3d:         HPX_FALLTHROUGH;
         case custom_storage3d:  HPX_FALLTHROUGH;
+<<<<<<< .mine
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:  HPX_FALLTHROUGH;
+#endif
+=======
+
+
+
+>>>>>>> .theirs
         default:
             break;
         }
@@ -2012,6 +2455,8 @@ namespace phylanx { namespace ir
         case custom_storage1d:  HPX_FALLTHROUGH;
         case storage3d:         HPX_FALLTHROUGH;
         case custom_storage3d:  HPX_FALLTHROUGH;
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:  HPX_FALLTHROUGH;
         default:
             break;
         }
@@ -2049,12 +2494,60 @@ namespace phylanx { namespace ir
         case custom_storage0d:  HPX_FALLTHROUGH;
         case custom_storage1d:  HPX_FALLTHROUGH;
         case custom_storage2d:  HPX_FALLTHROUGH;
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:  HPX_FALLTHROUGH;
         default:
             break;
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::ir::node_data<T>::as_tensor()",
+            "node_data object holds unsupported data type");
+    }
+
+    template <typename T>
+    std::vector<std::vector<std::vector<std::vector<T>>>>
+    node_data<T>::as_quatern() const
+    {
+        switch(data_.index())
+        {
+        case storage4d:         HPX_FALLTHROUGH;
+        case custom_storage4d:
+            {
+                auto q = quatern();
+                std::vector<std::vector<std::vector<std::vector<T>>>> result(
+                    q.quats());
+                for (std::size_t l = 0; l != q.quats(); ++l)
+                {
+                    std::vector<std::vector<std::vector<T>>> quats(q.pages());
+                    for (std::size_t k = 0; k != q.pages(); ++k)
+                    {
+                        std::vector<std::vector<T>> pages(q.rows());
+                        for (std::size_t i = 0; i != q.rows(); ++i)
+                        {
+                            pages[i].assign(q.begin(i, l, k), q.end(i, l, k));
+                        }
+                        quats[k] = std::move(pages);
+                    }
+                    result[l] = std::move(quats);
+                }
+                return result;
+            }
+
+        case storage0d:         HPX_FALLTHROUGH;
+        case storage1d:         HPX_FALLTHROUGH;
+        case storage2d:         HPX_FALLTHROUGH;
+        case custom_storage0d:  HPX_FALLTHROUGH;
+        case custom_storage1d:  HPX_FALLTHROUGH;
+        case custom_storage2d:  HPX_FALLTHROUGH;
+        case storage3d:         HPX_FALLTHROUGH;
+        case custom_storage3d:  HPX_FALLTHROUGH;
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::ir::node_data<T>::as_quatern()",
             "node_data object holds unsupported data type");
     }
 
@@ -2085,6 +2578,9 @@ namespace phylanx { namespace ir
         case node_data<double>::custom_storage3d:
             return lhs.tensor() == rhs.tensor();
 
+        case node_data<double>::storage4d:          HPX_FALLTHROUGH;
+        case node_data<double>::custom_storage4d:
+            return lhs.quatern() == rhs.quatern();
         default:
             break;
         }
@@ -2121,6 +2617,9 @@ namespace phylanx { namespace ir
         case node_data<std::uint8_t>::custom_storage3d:
             return lhs.tensor() == rhs.tensor();
 
+        case node_data<std::uint8_t>::storage4d:          HPX_FALLTHROUGH;
+        case node_data<std::uint8_t>::custom_storage4d:
+            return lhs.quatern() == rhs.quatern();
         default:
             break;
         }
@@ -2157,6 +2656,9 @@ namespace phylanx { namespace ir
         case node_data<std::int64_t>::custom_storage3d:
             return lhs.tensor() == rhs.tensor();
 
+        case node_data<std::int64_t>::storage4d:          HPX_FALLTHROUGH;
+        case node_data<std::int64_t>::custom_storage4d:
+            return lhs.quatern() == rhs.quatern();
         default:
             break;
         }
@@ -2218,6 +2720,11 @@ namespace phylanx { namespace ir
                 blaze::map(lhs.tensor(), rhs.tensor(), isclose),
                 std::logical_and<bool>{});
 
+        case node_data<double>::storage4d:          HPX_FALLTHROUGH;
+        case node_data<double>::custom_storage4d:
+            return blaze::reduce(
+                blaze::map(lhs.quatern(), rhs.quatern(), isclose),
+                std::logical_and<bool>{});
         default:
             break;
         }
@@ -2231,7 +2738,7 @@ namespace phylanx { namespace ir
     namespace detail
     {
         template <typename T, typename Range>
-        void print_array(std::ostream& out, Range const& r, std::size_t size)
+        void print_vector(std::ostream& out, Range const& r, std::size_t size)
         {
             out << "[";
             for (std::size_t i = 0; i != size; ++i)
@@ -2254,7 +2761,7 @@ namespace phylanx { namespace ir
             {
                 if (row != 0)
                     out << ", ";
-                print_array<T>(out, blaze::row(data, row), columns);
+                print_vector<T>(out, blaze::row(data, row), columns);
             }
             out << "]";
         }
@@ -2270,6 +2777,22 @@ namespace phylanx { namespace ir
                     out << ", ";
                 print_matrix<T>(
                     out, blaze::pageslice(data, page), rows, columns);
+            }
+            out << "]";
+        }
+
+        template <typename T, typename Quatern>
+        void print_quatern(std::ostream& out, Quatern const& data,
+            std::size_t quats, ::size_t pages, std::size_t rows,
+            std::size_t columns)
+        {
+            out << "[";
+            for (std::size_t quat = 0; quat != quats; ++quat)
+            {
+                if (quat != 0)
+                    out << ", ";
+                print_tensor<T>(
+                    out, blaze::quatslice(data, quat), pages, rows, columns);
             }
             out << "]";
         }
@@ -2289,7 +2812,7 @@ namespace phylanx { namespace ir
 
             case node_data<double>::storage1d:          HPX_FALLTHROUGH;
             case node_data<double>::custom_storage1d:
-                detail::print_array<double>(out, nd.vector(), nd.size());
+                detail::print_vector<double>(out, nd.vector(), nd.size());
                 break;
 
             case node_data<double>::storage2d:          HPX_FALLTHROUGH;
@@ -2309,6 +2832,14 @@ namespace phylanx { namespace ir
                 }
                 break;
 
+            case node_data<double>::storage4d:          HPX_FALLTHROUGH;
+            case node_data<double>::custom_storage4d:
+                {
+                    auto q = nd.quatern();
+                    detail::print_quatern<double>(
+                        out, q, q.quats(), q.pages(), q.rows(), q.columns());
+                }
+                break;
             default:
                 throw std::runtime_error("invalid dimensionality: " +
                     std::to_string(nd.num_dimensions()));
@@ -2342,7 +2873,7 @@ namespace phylanx { namespace ir
 
             case node_data<std::int64_t>::storage1d:          HPX_FALLTHROUGH;
             case node_data<std::int64_t>::custom_storage1d:
-                detail::print_array<std::int64_t>(out, nd.vector(), nd.size());
+                detail::print_vector<std::int64_t>(out, nd.vector(), nd.size());
                 break;
 
             case node_data<std::int64_t>::storage2d:          HPX_FALLTHROUGH;
@@ -2363,6 +2894,14 @@ namespace phylanx { namespace ir
                 }
                 break;
 
+            case node_data<std::int64_t>::storage4d:          HPX_FALLTHROUGH;
+            case node_data<std::int64_t>::custom_storage4d:
+                {
+                    auto q = nd.quatern();
+                    detail::print_quatern<std::int64_t>(
+                        out, q, q.quats(), q.pages(), q.rows(), q.columns());
+                }
+                break;
             default:
                 throw std::runtime_error("invalid dimensionality: " +
                     std::to_string(nd.num_dimensions()));
@@ -2398,7 +2937,7 @@ namespace phylanx { namespace ir
             case node_data<std::uint8_t>::storage1d:
             case node_data<std::uint8_t>::custom_storage1d:
                 out << std::boolalpha;
-                detail::print_array<bool>(out, nd.vector(), nd.size());
+                detail::print_vector<bool>(out, nd.vector(), nd.size());
                 break;
 
             case node_data<std::uint8_t>::storage2d:
@@ -2419,6 +2958,14 @@ namespace phylanx { namespace ir
                 }
                 break;
 
+            case node_data<std::uint8_t>::storage4d:          HPX_FALLTHROUGH;
+            case node_data<std::uint8_t>::custom_storage4d:
+                {
+                    auto q = nd.quatern();
+                    detail::print_quatern<bool>(
+                        out, q, q.quats(), q.pages(), q.rows(), q.columns());
+                }
+                break;
             default:
                 throw std::runtime_error("invalid dimensionality: " +
                     std::to_string(nd.num_dimensions()));
@@ -2459,6 +3006,9 @@ namespace phylanx { namespace ir
         case custom_storage3d:
             return tensor().nonZeros() != 0;
 
+        case storage4d:          HPX_FALLTHROUGH;
+        case custom_storage4d:
+            return quatern().nonZeros() != 0;
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "node_data<double>::operator bool",
@@ -2505,10 +3055,17 @@ namespace phylanx { namespace ir
             ar << util::get<storage3d>(data_);
             break;
 
+        case storage4d:
+            ar << util::get<storage4d>(data_);
+            break;
+
         case custom_storage3d:
             ar << util::get<custom_storage3d>(data_);
             break;
 
+        case custom_storage4d:
+            ar << util::get<custom_storage4d>(data_);
+            break;
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "node_data<T>::serialize",
@@ -2552,15 +3109,23 @@ namespace phylanx { namespace ir
             }
             break;
 
-        case storage3d:
+        case storage3d:         HPX_FALLTHROUGH;
         case custom_storage3d:     // deserialize CustomTensor as DynamicTensor
             {
-                storage3d_type m;
-                ar >> m;
-                data_ = std::move(m);
+                storage3d_type t;
+                ar >> t;
+                data_ = std::move(t);
             }
             break;
 
+        case storage4d:
+        case custom_storage4d:     // deserialize 4d CustomArray as 4d DynamicArray
+            {
+                storage4d_type q;
+                ar >> q;
+                data_ = std::move(q);
+            }
+            break;
         default:
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "node_data<T>::serialize",

--- a/tests/regressions/execution_tree/negative_integral_value_131.cpp
+++ b/tests/regressions/execution_tree/negative_integral_value_131.cpp
@@ -14,7 +14,7 @@
 
 std::string const code = R"(block(
     define(x, y,
-        slice(y, 0, 569, -1, 0)
+        slice(y, list(0, 569), list(-1, 0))
     ),
     x
 ))";

--- a/tests/unit/ir/node_data.cpp
+++ b/tests/unit/ir/node_data.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2017 Hartmut Kaiser
 //  Copyright (c) 2018 Tianyi Zhang
+//  Copyright (c) 2019 Bita Hasheminezhad
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -193,6 +194,49 @@ int main(int argc, char* argv[])
         HPX_TEST(array_value.dimensions() ==
             phylanx::ir::node_data<std::int64_t>::dimensions_type({
                 t.pages(), t.rows(), t.columns()}));
+
+        test_serialization(array_value);
+    }
+
+    {
+        blaze::Rand<blaze::DynamicArray<4UL, double>> gen{};
+        blaze::DynamicArray<4UL, double> q =
+            gen.generate(13UL, 3UL, 42UL, 101UL);
+
+        phylanx::ir::node_data<double> array_value(q);
+
+        HPX_TEST_EQ(array_value.num_dimensions(), std::size_t(4UL));
+        HPX_TEST(array_value.dimensions() ==
+            phylanx::ir::node_data<double>::dimensions_type({
+                q.quats(), q.pages(), q.rows(), q.columns()}));
+
+        test_serialization(array_value);
+    }
+
+    {
+        blaze::Rand<blaze::DynamicArray<4UL, double>> gen{};
+        blaze::DynamicArray<4UL, double> q =
+            gen.generate(3UL, 13UL, 42UL, 101UL);
+
+        phylanx::ir::node_data<std::uint8_t> array_value(q);
+
+        HPX_TEST_EQ(array_value.num_dimensions(), std::size_t(4UL));
+        HPX_TEST(array_value.dimensions() ==
+            phylanx::ir::node_data<std::uint8_t>::dimensions_type({
+                q.quats(), q.pages(), q.rows(), q.columns()}));
+    }
+
+    {
+        blaze::Rand<blaze::DynamicArray<4UL, double>> gen{};
+        blaze::DynamicArray<4UL, double> q =
+            gen.generate(3UL, 42UL, 33UL, 101UL);
+
+        phylanx::ir::node_data<double> array_value(q);
+
+        HPX_TEST_EQ(array_value.num_dimensions(), std::size_t(4UL));
+        HPX_TEST(array_value.dimensions() ==
+            phylanx::ir::node_data<std::int64_t>::dimensions_type({
+                q.quats(), q.pages(), q.rows(), q.columns()}));
 
         test_serialization(array_value);
     }

--- a/tests/unit/plugins/matrixops/constant.cpp
+++ b/tests/unit/plugins/matrixops/constant.cpp
@@ -281,17 +281,9 @@ int main(int argc, char* argv[])
     test_empty_operation(
         R"(constant(nil, list(2, 2, 2), __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2, 2});
-<<<<<<< .mine
     test_empty_operation(
         R"(constant(nil, list(2, 3, 4, 5), __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 3, 4, 5});
-#endif
-=======
-
-
-
-
->>>>>>> .theirs
 
     // empty_like
     test_empty_operation(

--- a/tests/unit/plugins/matrixops/constant.cpp
+++ b/tests/unit/plugins/matrixops/constant.cpp
@@ -126,6 +126,40 @@ void test_constant_3d()
     HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), result);
 }
 
+void test_constant_4d()
+{
+    phylanx::execution_tree::primitive val =
+        phylanx::execution_tree::primitives::create_variable(
+            hpx::find_here(), phylanx::ir::node_data<double>(42.0));
+
+    phylanx::execution_tree::primitive const_ =
+        phylanx::execution_tree::primitives::create_constant(hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                std::move(val),
+                phylanx::execution_tree::primitive_argument_type{
+                    phylanx::execution_tree::primitive_arguments_type{
+                        phylanx::ir::node_data<std::int64_t>(3),
+                        phylanx::ir::node_data<std::int64_t>(13),
+                        phylanx::ir::node_data<std::int64_t>(33),
+                        phylanx::ir::node_data<std::int64_t>(105)}
+                    }});
+
+    hpx::future<phylanx::execution_tree::primitive_argument_type> f =
+        const_.eval();
+
+    blaze::DynamicArray<4UL, double> expected =
+        blaze::DynamicArray<4UL, double>(
+            blaze::init_from_value, 42.0, 3UL, 13UL, 33UL, 105UL);
+    auto result = phylanx::execution_tree::extract_numeric_value(f.get());
+
+    HPX_TEST_EQ(result.num_dimensions(), 4);
+    HPX_TEST_EQ(result.dimension(0), 3);
+    HPX_TEST_EQ(result.dimension(1), 13);
+    HPX_TEST_EQ(result.dimension(2), 33);
+    HPX_TEST_EQ(result.dimension(3), 105);
+    HPX_TEST_EQ(phylanx::ir::node_data<double>(std::move(expected)), result);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(
     std::string const& codestr)
@@ -167,6 +201,19 @@ void test_empty_operation(std::string const& code,
     HPX_TEST_EQ(dims[2], result_dims[2]);
 }
 
+void test_empty_operation(std::string const& code,
+    std::array<int, 4> const& dims)
+{
+    auto f = compile_and_run(code);
+    auto result_dims =
+        phylanx::execution_tree::extract_numeric_value_dimensions(f());
+
+    HPX_TEST_EQ(dims[0], result_dims[0]);
+    HPX_TEST_EQ(dims[1], result_dims[1]);
+    HPX_TEST_EQ(dims[2], result_dims[2]);
+    HPX_TEST_EQ(dims[3], result_dims[3]);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int main(int argc, char* argv[])
 {
@@ -174,6 +221,7 @@ int main(int argc, char* argv[])
     test_constant_1d();
     test_constant_2d();
     test_constant_3d();
+    test_constant_4d();
 
     // zeros, ones, full, default dtype is 'float64'
     test_constant_operation(
@@ -233,6 +281,17 @@ int main(int argc, char* argv[])
     test_empty_operation(
         R"(constant(nil, list(2, 2, 2), __arg(dtype, "int")))",
         std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2, 2});
+<<<<<<< .mine
+    test_empty_operation(
+        R"(constant(nil, list(2, 3, 4, 5), __arg(dtype, "int")))",
+        std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 3, 4, 5});
+#endif
+=======
+
+
+
+
+>>>>>>> .theirs
 
     // empty_like
     test_empty_operation(
@@ -250,7 +309,15 @@ int main(int argc, char* argv[])
                 [[[1, 2], [3, 4]], [[1, 2], [3, 4]]],
                 __arg(dtype, "int"))
         )",
-        std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2, 2});
+    std::array<int, PHYLANX_MAX_DIMENSIONS>{2, 2, 2});
+        test_empty_operation(
+        R"(constant_like(
+                nil,
+                [[[[1, 2, 3, 4], [3, 4, 5, 6], [7, 8, 9, 10]],
+                [[1, 2, 3, 4], [3, 4, 5, 6], [7, 8, 9, 10]]]],
+                __arg(dtype, "int"))
+        )",
+        std::array<int, PHYLANX_MAX_DIMENSIONS>{1, 2, 3, 4});
 
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
This PR adds 4D support to node_data and `constant` primitive. Calling `quatern()` on a node_data containing a 4D array would give you the underlying array.