### PR TITLE
Adding spatial_2d_padding operation

### DIFF
--- a/phylanx/plugins/keras_support/keras_support.hpp
+++ b/phylanx/plugins/keras_support/keras_support.hpp
@@ -26,6 +26,7 @@
 #include <phylanx/plugins/keras_support/softmax_operation.hpp>
 #include <phylanx/plugins/keras_support/softplus_operation.hpp>
 #include <phylanx/plugins/keras_support/softsign_operation.hpp>
+#include <phylanx/plugins/keras_support/spatial_2d_padding_operation.hpp>
 #include <phylanx/plugins/keras_support/switch_operation.hpp>
 
 #endif

--- a/phylanx/plugins/keras_support/spatial_2d_padding_operation.hpp
+++ b/phylanx/plugins/keras_support/spatial_2d_padding_operation.hpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_KERAS_SUPPORT_SPATIAL_2D_PADDING)
+#define PHYLANX_PRIMITIVES_KERAS_SUPPORT_SPATIAL_2D_PADDING
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives {
+/// \brief Pads the 2nd and 3rd dimensions of a 4D array with zeros
+/// \param x        The 4d array (the quaternion) to pad
+/// \param padding  Optional. The default is ((1,1),(1,1)) which means to pad
+///                 1 page in the front, 1 page in the rear, 1 row on the top
+///                 and 1 row on the buttom respectively.
+
+    class spatial_2d_padding_operation
+        : public primitive_component_base
+        , public std::enable_shared_from_this<spatial_2d_padding_operation>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+    public:
+        static match_pattern_type const match_data;
+
+        spatial_2d_padding_operation() = default;
+
+        spatial_2d_padding_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    private:
+        primitive_argument_type spatial_padding(
+            ir::node_data<double>&& arg) const;
+        primitive_argument_type spatial_padding(ir::node_data<double>&& arg,
+            std::size_t pad_front, std::size_t pad_rear, std::size_t pad_top,
+            std::size_t pad_bottom) const;
+    };
+    inline primitive create_spatial_2d_padding_operation(
+        hpx::id_type const& locality, primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(locality, "spatial_2d_padding",
+            std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -2028,7 +2028,7 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::extract_scalar_positive_integer_value_strict",
             util::generate_error_message(
-                "primitive_argument_type does not hold an integer "
+                "primitive_argument_type does not hold a positive integer "
                 "value type (type held: '" +
                     type + "')",
                 name, codename));

--- a/src/plugins/keras_support/keras_support.cpp
+++ b/src/plugins/keras_support/keras_support.cpp
@@ -57,5 +57,7 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(softplus_operation_plugin,
     phylanx::execution_tree::primitives::softplus_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(softsign_operation_plugin,
     phylanx::execution_tree::primitives::softsign_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(spatial_2d_padding_operation_plugin,
+    phylanx::execution_tree::primitives::spatial_2d_padding_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(switch_operation_plugin,
     phylanx::execution_tree::primitives::switch_operation::match_data);

--- a/src/plugins/keras_support/spatial_2d_padding_operation.cpp
+++ b/src/plugins/keras_support/spatial_2d_padding_operation.cpp
@@ -1,0 +1,209 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/keras_support/spatial_2d_padding_operation.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/throw_exception.hpp>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives {
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const spatial_2d_padding_operation::match_data =
+    {
+        hpx::util::make_tuple("spatial_2d_padding",
+        std::vector<std::string>{R"(
+            spatial_2d_padding(_1,
+            __arg(_2_padding, list(list(1,1),list(1,1))))
+        )"},
+        &create_spatial_2d_padding_operation,
+        &create_primitive<spatial_2d_padding_operation>,
+        R"(x, padding
+        Args:
+
+            x (array_like) : input 4d array
+            padding (optional, a tuple of two tuples): the first tuple contains
+                two integers which indicate number of pages to pad on front and
+                rear respectively. The second tuple also contains two integers
+                that indicate number of rows to pad on the top and bottom of
+                the data. The default is ((1,1),(1,1)).
+
+        Returns:
+
+        Pads the second and third dimensions of a 4d array with zeros)")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    spatial_2d_padding_operation::spatial_2d_padding_operation(
+        primitive_arguments_type&& operands, std::string const& name,
+        std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type spatial_2d_padding_operation::spatial_padding(
+        ir::node_data<double>&& arg) const
+    {
+        auto q = arg.quatern();
+        std::size_t quats = q.quats();
+        std::size_t pages = q.pages();
+        std::size_t rows  = q.rows();
+        std::size_t columns = q.columns();
+        blaze::DynamicArray<4UL, double> result(blaze::init_from_value, 0.0,
+            quats, pages + 2UL, rows + 2UL, columns);
+
+        for (std::size_t l = 0; l != quats; ++l)
+        {
+            auto rtensor = blaze::quatslice(result, l);
+            auto qtensor = blaze::quatslice(q, l);
+            blaze::subtensor(rtensor, 1UL, 1UL, 0UL, pages, rows, columns) =
+                qtensor;
+        }
+        return primitive_argument_type{std::move(result)};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type spatial_2d_padding_operation::spatial_padding(
+        ir::node_data<double>&& arg, std::size_t pad_front,
+        std::size_t pad_rear, std::size_t pad_top, std::size_t pad_bottom) const
+    {
+        auto q = arg.quatern();
+        std::size_t quats = q.quats();
+        std::size_t pages = q.pages();
+        std::size_t rows  = q.rows();
+        std::size_t columns = q.columns();
+        blaze::DynamicArray<4UL, double> result(blaze::init_from_value, 0.0,
+            quats, pages + pad_front + pad_rear, rows + pad_top + pad_bottom,
+            columns);
+
+        for (std::size_t l = 0; l != quats; ++l)
+        {
+            auto rtensor = blaze::quatslice(result, l);
+            auto qtensor = blaze::quatslice(q, l);
+            blaze::subtensor(rtensor, pad_front, pad_top, 0UL, pages, rows,
+                columns) = qtensor;
+        }
+        return primitive_argument_type{std::move(result)};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> spatial_2d_padding_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args,
+        eval_context ctx) const
+    {
+        if (operands.empty() || operands.size() > 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "spatial_2d_padding_operation::eval",
+                util::generate_error_message("the spatial_2d_padding "
+                                             "primitive requires one, or "
+                                             "two operands",
+                    name_, codename_));
+        }
+
+        for (auto const& i : operands)
+        {
+            if (!valid(i))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "spatial_2d_padding_operation::eval",
+                    util::generate_error_message(
+                        "the spatial_2d_padding primitive requires "
+                        "that the arguments given by the operands array are "
+                        "valid",
+                        name_, codename_));
+            }
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+            hpx::util::unwrapping([this_ = std::move(this_)](
+                                      primitive_arguments_type&& args)
+                                      -> primitive_argument_type {
+
+                ir::range padding(0);
+                std::size_t pad_front, pad_rear, pad_top, pad_bottom;
+                if (args.size() > 1)
+                {
+                    padding = extract_list_value_strict(
+                        args[1], this_->name_, this_->codename_);
+                    if (padding.size() != 2)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "spatial_2d_padding_operation::eval",
+                            this_->generate_error_message(
+                                "spatial_2d_padding requires padding to be a "
+                                "tuple of 2 tuples"));
+                    }
+                    auto it = padding.begin();
+                    auto it_pages = extract_list_value_strict(
+                        *it, this_->name_, this_->codename_);
+                    auto it_rows = extract_list_value_strict(
+                        *++it, this_->name_, this_->codename_);
+                    if (it_pages.size() != 2 || it_rows.size() != 2)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "spatial_2d_padding_operation::eval",
+                            this_->generate_error_message(
+                                "spatial_2d_padding requires padding to be a "
+                                "tuple of 2 tuples, each contains two "
+                                "non-negative integers"));
+                    }
+                    pad_front = extract_scalar_integer_value_strict(
+                        *it_pages.begin());
+                    pad_rear = extract_scalar_integer_value_strict(
+                        *++it_pages.begin());
+                    pad_top = extract_scalar_integer_value_strict(
+                        *it_rows.begin());
+                    pad_bottom = extract_scalar_integer_value_strict(
+                        *++it_rows.begin());
+
+                    if (pad_front < 0 && pad_rear < 0 && pad_top < 0 &&
+                        pad_bottom < 0)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "spatial_2d_padding_operation::eval",
+                            this_->generate_error_message(
+                                "spatial_2d_padding requires each pad to be a "
+                                "non-negative integers"));
+                    }
+
+                    if (pad_front == 1 && pad_rear == 1 && pad_top == 1 &&
+                        pad_bottom == 1)
+                    {
+                        padding = ir::range(0);
+                    }
+                }
+
+                if (padding.empty()) // all paddings are set to 1
+                {
+                    return this_->spatial_padding(extract_numeric_value(
+                        std::move(args[0]), this_->name_, this_->codename_));
+                }
+                return this_->spatial_padding(
+                    extract_numeric_value(
+                        std::move(args[0]), this_->name_, this_->codename_),
+                    pad_front, pad_rear, pad_top, pad_bottom);
+            }),
+            detail::map_operands(operands, functional::value_operand{}, args,
+                name_, codename_, std::move(ctx)));
+    }
+}}}

--- a/src/plugins/keras_support/spatial_2d_padding_operation.cpp
+++ b/src/plugins/keras_support/spatial_2d_padding_operation.cpp
@@ -15,6 +15,7 @@
 #include <hpx/throw_exception.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
@@ -140,7 +141,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                                       -> primitive_argument_type {
 
                 ir::range padding(0);
-                std::size_t pad_front, pad_rear, pad_top, pad_bottom;
+                std::int64_t pad_front, pad_rear, pad_top, pad_bottom;
                 if (args.size() > 1)
                 {
                     padding = extract_list_value_strict(
@@ -167,23 +168,23 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                                 "tuple of 2 tuples, each contains two "
                                 "non-negative integers"));
                     }
-                    pad_front = extract_scalar_integer_value_strict(
-                        *it_pages.begin());
+                    pad_front =
+                        extract_scalar_integer_value_strict(*it_pages.begin());
                     pad_rear = extract_scalar_integer_value_strict(
                         *++it_pages.begin());
-                    pad_top = extract_scalar_integer_value_strict(
-                        *it_rows.begin());
-                    pad_bottom = extract_scalar_integer_value_strict(
-                        *++it_rows.begin());
+                    pad_top =
+                        extract_scalar_integer_value_strict(*it_rows.begin());
+                    pad_bottom =
+                        extract_scalar_integer_value_strict(*++it_rows.begin());
 
-                    if (pad_front < 0 && pad_rear < 0 && pad_top < 0 &&
+                    if (pad_front < 0 || pad_rear < 0 || pad_top < 0 ||
                         pad_bottom < 0)
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
                             "spatial_2d_padding_operation::eval",
                             this_->generate_error_message(
                                 "spatial_2d_padding requires each pad to be a "
-                                "non-negative integers"));
+                                "non-negative integer"));
                     }
 
                     if (pad_front == 1 && pad_rear == 1 && pad_top == 1 &&

--- a/tests/unit/plugins/keras_support/CMakeLists.txt
+++ b/tests/unit/plugins/keras_support/CMakeLists.txt
@@ -23,6 +23,7 @@ set(tests
     softmax_operation
     softplus_operation
     softsign_operation
+    spatial_2d_padding_operation
     switch_operation
    )
 

--- a/tests/unit/plugins/keras_support/spatial_2d_padding_operation.cpp
+++ b/tests/unit/plugins/keras_support/spatial_2d_padding_operation.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 Bita Hasheminezhad
+// Copyright (c) 2019 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/testing.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_spatial_2d_padding_operation(std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(code), compile_and_run(expected_str));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_spatial_2d_padding_operation(
+        "spatial_2d_padding([[[[1,2,3],[4,5,6]],[[7,8,9],[10,11,12]]],"
+        "[[[-1,-2,-3],[-4,-5,-6]],[[-7,-8,-9],[-10,-11,-12]]]])",
+        "[[[[  0.,   0.,   0.], [  0.,   0.,   0.],   [  0.,   0.,   0.],"
+        "[ 0.,   0.,   0.]], [[  0.,   0.,   0.],   [  1.,   2.,   3.], "
+        "[  4.,   5.,   6.], [  0.,   0.,   0.]], [[  0.,   0.,   0.], "
+        "[  7.,   8.,   9.], [ 10.,  11.,  12.], [  0.,   0.,   0.]],"
+        "[[  0.,   0.,   0.], [  0.,   0.,   0.], [  0.,   0.,   0.], "
+        "[  0.,   0.,   0.]]], [[[  0.,   0.,   0.],  [  0.,   0.,   0.],  "
+        "[  0.,   0.,   0.], [  0.,   0.,   0.]], [[  0.,   0.,   0.], "
+        "[ -1.,  -2.,  -3.], [ -4.,  -5.,  -6.],   [  0.,   0.,   0.]], "
+        "[[  0.,   0.,   0.],[ -7.,  -8.,  -9.], [-10., -11., -12.], "
+        "[  0.,   0.,   0.]], [[  0.,   0.,   0.], [  0.,   0.,   0.], "
+        "[  0.,   0.,   0.], [  0.,   0.,   0.]]]]");
+    test_spatial_2d_padding_operation(
+        "spatial_2d_padding([[[[1,2,3],[4,5,6]],[[7,8,9],[10,11,12]]],"
+        "[[[-1,-2,-3],[-4,-5,-6]],[[-7,-8,-9],[-10,-11,-12]]]],"
+        "list(list(1,0),list(2,3)))",
+        "[[[[  0.,   0.,   0.],  [  0.,   0.,   0.],  [  0.,   0.,   0.], "
+        "  [  0.,   0.,   0.],  [  0.,   0.,   0.],  [  0.,   0.,   0.],  "
+        "  [  0.,   0.,   0.]], [[  0.,   0.,   0.],  [  0.,   0.,   0.], "
+        "  [  1.,   2.,   3.],  [  4.,   5.,   6.],  [  0.,   0.,   0.],  "
+        "  [  0.,   0.,   0.],  [  0.,   0.,   0.]], [[  0.,   0.,   0.], "
+        "  [  0.,   0.,   0.],  [  7.,   8.,   9.],  [ 10.,  11.,  12.],  "
+        "  [  0.,   0.,   0.],  [  0.,   0.,   0.],  [  0.,   0.,   0.]]],"
+        "[[[  0.,   0.,   0.],  [  0.,   0.,   0.],  [  0.,   0.,   0.],  "
+        "  [  0.,   0.,   0.],  [  0.,   0.,   0.],  [  0.,   0.,   0.],  "
+        "  [  0.,   0.,   0.]], [[  0.,   0.,   0.],  [  0.,   0.,   0.], "
+        "  [ -1.,  -2.,  -3.],  [ -4.,  -5.,  -6.],  [  0.,   0.,   0.],  "
+        "  [  0.,   0.,   0.],  [  0.,   0.,   0.]], [[  0.,   0.,   0.], "
+        "  [  0.,   0.,   0.],  [ -7.,  -8.,  -9.],  [-10., -11., -12.],  "
+        "  [  0.,   0.,   0.],  [  0.,   0.,   0.],  [  0.,   0.,   0.]]]]");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
This PR adds the spatial_2d_padding operation which imitates the functionality of [Keras spatial_2d_padding](https://keras.io/backend/#spatial_2d_padding).
The input is a 4d array which 2nd and 3rd dimensions are padded using this operation.