### PR TITLE
Make sure the CMAKE standard is set.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,9 +64,14 @@ if(NOT PHYLANX_CMAKE_LOGLEVEL)
   set(PHYLANX_CMAKE_LOGLEVEL "WARN")
 endif()
 
+################################################################################
 # print initial diagnostics
 phylanx_info("CMake version: " ${CMAKE_VERSION})
 phylanx_info("Phylanx version: " ${PHYLANX_VERSION})
+
+################################################################################
+# Locate HPX as we need to ensure to use at least the same C++ dialect as HPX uses
+phylanx_setup_hpx()
 
 ################################################################################
 # Special compiler flags
@@ -141,11 +146,10 @@ else()
     ON CATEGORY "Build Targets")
 endif()
 
-# Locate dependencies
+# Locate remaining dependencies
 phylanx_setup_blaze()
 phylanx_setup_pybind11()
 phylanx_setup_highfive()
-phylanx_setup_hpx()
 
 phylanx_include(GitCommit)
 

--- a/cmake/Phylanx_DetectCppDialect.cmake
+++ b/cmake/Phylanx_DetectCppDialect.cmake
@@ -9,6 +9,7 @@ macro(phylanx_detect_cpp_dialect_non_msvc)
 
   if(PHYLANX_WITH_CUDA AND NOT PHYLANX_WITH_CUDA_CLANG)
     set(CXX_FLAG -std=c++11)
+    set(CMAKE_CXX_STANDARD 11)
     phylanx_info("C++ mode used: C++11")
   else()
 
@@ -31,6 +32,7 @@ macro(phylanx_detect_cpp_dialect_non_msvc)
 
       if(PHYLANX_WITH_CXX1Z)
         set(CXX_FLAG -std=c++1z)
+        set(CMAKE_CXX_STANDARD 14)
         phylanx_info("C++ mode used: C++1z")
       else()
         # ... otherwise try -std=c++14
@@ -41,6 +43,7 @@ macro(phylanx_detect_cpp_dialect_non_msvc)
 
         if(PHYLANX_WITH_CXX14)
           set(CXX_FLAG -std=c++14)
+          set(CMAKE_CXX_STANDARD 14)
           phylanx_info("C++ mode used: C++14")
         else()
           # ... otherwise try -std=c++1y
@@ -51,18 +54,21 @@ macro(phylanx_detect_cpp_dialect_non_msvc)
 
           if(PHYLANX_WITH_CXX1Y)
             set(CXX_FLAG -std=c++1y)
+            set(CMAKE_CXX_STANDARD 11)
             phylanx_info("C++ mode used: C++1y")
           else()
             # ... otherwise try -std=c++11
             check_cxx_compiler_flag(-std=c++11 PHYLANX_WITH_CXX11)
             if(PHYLANX_WITH_CXX11)
               set(CXX_FLAG -std=c++11)
+              set(CMAKE_CXX_STANDARD 11)
               phylanx_info("C++ mode used: C++11")
             else()
               # ... otherwise try -std=c++0x
               check_cxx_compiler_flag(-std=c++0x PHYLANX_WITH_CXX0X)
               if(PHYLANX_WITH_CXX0X)
                 set(CXX_FLAG -std=c++0x)
+                set(CMAKE_CXX_STANDARD 11)
                 phylanx_info("C++ mode used: C++0x")
               endif()
             endif()
@@ -74,6 +80,29 @@ macro(phylanx_detect_cpp_dialect_non_msvc)
 endmacro()
 
 macro(phylanx_detect_cpp_dialect)
+
+  if(NOT PHYLANX_WITH_CXX17 AND NOT PHYLANX_WITH_CXX1Z AND
+     NOT PHYLANX_WITH_CXX14 AND NOT PHYLANX_WITH_CXX1X AND
+     NOT PHYLANX_WITH_CXX11 AND NOT PHYLANX_WITH_CXX0X)
+
+    if(HPX_CXX_STANDARD)
+      if(${HPX_CXX_STANDARD} STREQUAL "17")
+        set(PHYLANX_WITH_CXX17 ON)
+      elseif(${HPX_CXX_STANDARD} STREQUAL "1z")
+        set(PHYLANX_WITH_CXX1Z ON)
+      elseif(${HPX_CXX_STANDARD} STREQUAL "14")
+        set(PHYLANX_WITH_CXX14 ON)
+      elseif(${HPX_CXX_STANDARD} STREQUAL "1x")
+        set(PHYLANX_WITH_CXX1X ON)
+      elseif(${HPX_CXX_STANDARD} STREQUAL "11")
+        set(PHYLANX_WITH_CXX11 ON)
+      elseif(${HPX_CXX_STANDARD} STREQUAL "0x")
+        set(PHYLANX_WITH_CXX0X ON)
+      else()
+        phylanx_error("Unknown HPX_CXX_STANDARD value: ${HPX_CXX_STANDARD}")
+      endif()
+    endif()
+  endif()
 
   if(MSVC)
     set(CXX_FLAG)

--- a/cmake/Phylanx_DetectCppDialect.cmake
+++ b/cmake/Phylanx_DetectCppDialect.cmake
@@ -16,6 +16,7 @@ macro(phylanx_detect_cpp_dialect_non_msvc)
     if(PHYLANX_WITH_CXX17 OR NOT (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
                               AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)))
       check_cxx_compiler_flag(-std=c++17 PHYLANX_WITH_CXX17)
+      set(CMAKE_CXX_STANDARD 17)
     endif()
 
     if(PHYLANX_WITH_CXX17)

--- a/cmake/Phylanx_DetectCppDialect.cmake
+++ b/cmake/Phylanx_DetectCppDialect.cmake
@@ -16,11 +16,11 @@ macro(phylanx_detect_cpp_dialect_non_msvc)
     if(PHYLANX_WITH_CXX17 OR NOT (("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
                               AND (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 17)))
       check_cxx_compiler_flag(-std=c++17 PHYLANX_WITH_CXX17)
-      set(CMAKE_CXX_STANDARD 17)
     endif()
 
     if(PHYLANX_WITH_CXX17)
       set(CXX_FLAG -std=c++17)
+      set(CMAKE_CXX_STANDARD 17)
       phylanx_info("C++ mode used: C++17")
     else()
       # ... otherwise try -std=c++1z

--- a/cmake/Phylanx_SetupHPX.cmake
+++ b/cmake/Phylanx_SetupHPX.cmake
@@ -33,11 +33,15 @@ macro(phylanx_setup_hpx)
     include_directories(${HPX_INCLUDE_DIRS})
     link_directories(${HPX_LIBRARY_DIR})
 
+    if(HPX_CXX_STANDARD)
+      set(__hpx_standard "using C++${HPX_CXX_STANDARD}")
+    endif()
+
     if (HPX_GIT_COMMIT)
       string(SUBSTRING ${HPX_GIT_COMMIT} 0 10 __hpx_git_commit)
-      phylanx_info("HPX version: " ${HPX_VERSION_STRING} "(${__hpx_git_commit})")
+      phylanx_info("HPX version: " ${HPX_VERSION_STRING} "(${__hpx_git_commit})" ${__hpx_standard})
     else()
-      phylanx_info("HPX version: " ${HPX_VERSION_STRING})
+      phylanx_info("HPX version: " ${HPX_VERSION_STRING} ${__hpx_standard})
     endif()
 
     # make sure that HPX is not configured with jemalloc


### PR DESCRIPTION
Apparently, the CMAKE_CXX_STANDARD wasn't getting set when cmake detected C++17. This one line change fixes the issue.