### PR TITLE
Making sure execution_tree::primitive attached to Python object is not moved away during translation

### DIFF
--- a/python/src/bindings/type_casters.hpp
+++ b/python/src/bindings/type_casters.hpp
@@ -1108,6 +1108,10 @@ namespace pybind11 { namespace detail
             handle src, bool convert, type_list<U, Us...>);
 
         template <typename... Us>
+        bool load_alternative(handle src, bool convert,
+            type_list<phylanx::execution_tree::primitive, Us...>);
+
+        template <typename... Us>
         bool load_alternative(
             handle src, bool convert, type_list<phylanx::ast::nil, Us...>);
 
@@ -1284,6 +1288,21 @@ namespace pybind11 { namespace detail
         if (caster.load(src, convert))
         {
             value = Derived{std::move(cast_op<U>(caster))};
+            return true;
+        }
+        return load_alternative(src, convert, type_list<Us...>{});
+    }
+
+    template <typename Derived, template <typename...> class V, typename... Ts>
+    template <typename... Us>
+    bool variant_caster_helper<Derived, V<Ts...>>::load_alternative(handle src,
+        bool convert, type_list<phylanx::execution_tree::primitive, Us...>)
+    {
+        auto caster = make_caster<phylanx::execution_tree::primitive>();
+        if (caster.load(src, convert))
+        {
+            value =
+                Derived{cast_op<phylanx::execution_tree::primitive>(caster)};
             return true;
         }
         return load_alternative(src, convert, type_list<Us...>{});

--- a/tests/regressions/python/1056_client_base.py
+++ b/tests/regressions/python/1056_client_base.py
@@ -1,0 +1,66 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #1056: RuntimeError: this client_base has no valid shared state: HPX(no_state)
+
+
+from phylanx import Phylanx, PhylanxSession, execution_tree
+import numpy as np
+
+
+PhylanxSession.init(1)
+
+
+def variable(value, dtype=None, name=None):
+    if dtype is None:
+        dtype = "float64"
+    from phylanx.ast.physl import PhySL
+    if isinstance(value, PhySL.eval_wrapper):
+        return execution_tree.variable(value.code(), dtype)
+    if isinstance(value, execution_tree.variable):
+        return value
+    return execution_tree.variable(value, dtype=dtype, name=name)
+
+
+def eval(x):
+    return x.eval()
+
+
+@Phylanx
+def sum_eager(x, axis, keepdims):
+    return np.sum(x, axis, keepdims)
+
+
+def sum(x, axis=None, keepdims=False):
+    return sum_eager.lazy(x, axis, keepdims)
+
+
+@Phylanx
+def reshape_eager(x, shape):
+    return np.reshape(x, shape)
+
+
+def reshape(x, shape):
+    return reshape_eager.lazy(x, shape)
+
+
+@Phylanx
+def squeeze_eager(x, axis):
+    return np.squeeze(x, axis)
+
+
+def squeeze(x, axis):
+    return squeeze_eager.lazy(x, axis)
+
+
+y_test = variable(np.array([0, 0, 2, 0]))
+assert(np.all(eval(y_test) == [0, 0, 2, 0]))
+
+y_test = reshape(y_test, (4, 1))
+y_test = squeeze(y_test, 1)
+assert(np.all(eval(y_test) == [0, 0, 2, 0]))
+
+sum_y_test = sum(y_test)
+assert(eval(sum_y_test) == 2)

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -48,6 +48,7 @@ set(tests
     979_lazy_compilation_with_init
     1052_variable_set_dtype
     1054_variable_shape
+    1056_client_base
     array_len_494
     array_shape_486
     array_subscript_403


### PR DESCRIPTION
Fixes #1056