### PR TITLE
Enabling simplified definition of lazy functions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,7 @@
 # Copyright (c) 2016 Thomas Heller
 # Copyright (c) 2016-2018 Hartmut Kaiser
 #
+# SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
@@ -18,9 +19,7 @@
 #   file while saving edits to disk
 # - Please do _not_ reformat a full source file without dire need.
 
-# PLEASE NOTE: This file requires to use a recent version of clang-format. It
-#              is known to work with clang-format V7.0, other (earlier) version
-#              may work as well.
+# PLEASE NOTE: This file requires to use a recent version clang-format V8.0
 
 ---
 AccessModifierOffset: -4
@@ -67,18 +66,24 @@ ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-ExperimentalAutoDetectBinPacking: true
-FixNamespaceComments: false
+#ExperimentalAutoDetectBinPacking: true # Do weird reformatting
+FixNamespaceComments: true
 # ForEachMacros: ['']
 IncludeCategories:
-  - Regex:           '^<phylanx/config\.hpp>'
+  - Regex:           '^<hpx/config\.hpp>'
     Priority:        1
-  - Regex:           '^<phylanx/.*\.hpp>'
+  - Regex:           '^<hpx/.*/config\.hpp>'
     Priority:        2
-  - Regex:           '^<.*'
+  - Regex:           '^<hpx/.*/config/defines\.hpp>'
     Priority:        3
-  - Regex:           '.*'
+  - Regex:           '^<hpx/.*\.hpp>'
     Priority:        4
+  - Regex:           '^<hpx/parallel/.*\.hpp>'
+    Priority:        5
+  - Regex:           '^<.*'
+    Priority:        6
+  - Regex:           '.*'
+    Priority:        7
 # IncludeIsMainRegex: ''
 IndentCaseLabels: false
 IndentWidth: 4

--- a/python/phylanx/exceptions.py
+++ b/python/phylanx/exceptions.py
@@ -6,6 +6,7 @@
 
 
 class InvalidDecoratorArgumentError(Exception):
+    """Phylanx decorator or Phylanx.lazy used with invalid arguments"""
     pass
 
 

--- a/tests/regressions/python/942_lazy_fmap.py
+++ b/tests/regressions/python/942_lazy_fmap.py
@@ -1,0 +1,61 @@
+#  Copyright (c) 2019 Bita Hasheminezhad
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #942: `fold_left`, `fold_right` and `fmap` do not work with a lazy function
+
+
+import numpy as np
+from phylanx import Phylanx, PhylanxSession, execution_tree
+
+
+PhylanxSession.init(1)
+
+
+def variable(value, dtype=None, name=None, constraint=None):
+    if dtype is None:
+        dtype = "float32"
+    if constraint is not None:
+        raise TypeError("Constraint is the projection function to be "
+                        "applied to the variable after an optimizer update")
+    from phylanx.ast.physl import PhySL
+    if isinstance(value, PhySL.eval_wrapper):
+        return execution_tree.variable(value.code(), dtype)
+    if isinstance(value, execution_tree.variable):
+        return value
+    return execution_tree.variable(value, dtype=dtype, name=name)
+
+
+def eval(func):
+    return func.eval()
+
+
+def fmap(fn, elems):
+    pass      # make flake happy
+
+
+@Phylanx
+def map_fn_eager(fn, elems, dtype):
+    return fmap(fn, elems)
+
+
+map_fn = Phylanx.lazy(map_fn_eager)
+
+
+@Phylanx
+def sum_eager(x, axis=None, keepdims=False):
+    return np.sum(x, axis, keepdims)
+
+
+sum = Phylanx.lazy(sum_eager)
+
+
+def test_map():
+    x = [1, 2, 3]
+    vx = variable(x)
+    kx = eval(map_fn(sum, vx))
+    return kx
+
+
+assert(test_map() == [1, 2, 3])

--- a/tests/regressions/python/942_lazy_fmap.py
+++ b/tests/regressions/python/942_lazy_fmap.py
@@ -51,11 +51,11 @@ def sum_eager(x, axis=None, keepdims=False):
 sum = Phylanx.lazy(sum_eager)
 
 
-def test_map():
-    x = [1, 2, 3]
+def test_map(x):
     vx = variable(x)
     kx = eval(map_fn(sum, vx))
     return kx
 
 
-assert(test_map() == [1, 2, 3])
+assert(np.all(test_map(np.array([[1, 2, 3]])) == [6]))
+assert(np.all(test_map(np.array([1, 2, 3])) == [1, 2, 3]))

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -41,6 +41,7 @@ set(tests
     933_arange
     933_eval_wrapper
     936_arithmetic_operations
+    942_lazy_fmap
     956_named_argument_underscore
     962_broadcast_logical_operations
     966_named_arguments


### PR DESCRIPTION
- lazy functions are now recognized by the translation layer to refer to
  the backend execution tree (similar to original decorator objects)

Fixes #942