### PR TITLE
Exclude HighFive examples from building in the base image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,12 +149,11 @@ jobs:
                         -DPHYLANX_WITH_GIT_COMMIT=${CIRCLE_SHA1}    \
                         -DPHYLANX_WITH_GIT_BRANCH="${CIRCLE_BRANCH}"\
                         -DPHYLANX_WITH_GIT_TAG="${CIRCLE_TAG}"      \
-                        -DPHYLANX_WITH_TOOLS=On                     \
-                        -DPHYLANX_WITH_BLAZE_TENSOR=ON              \
+                        -DPHYLANX_WITH_TOOLS=ON                     \
                         -DPHYLANX_WITH_ITERATIVE_SOLVERS=ON         \
-                        -DPHYLANX_WITH_DOCUMENTATION=On             \
-                        -DPHYLANX_WITH_HIGHFIVE=On                  \
-                        -DPHYLANX_WITH_CXX14=On
+                        -DPHYLANX_WITH_DOCUMENTATION=ON             \
+                        -DPHYLANX_WITH_HIGHFIVE=ON                  \
+                        -DPHYLANX_WITH_CXX14=ON
             - persist_to_workspace:
                 root: /
                 paths:

--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update &&                                                           
                                                                                     \
     git clone --depth=1 https://github.com/BlueBrain/HighFive.git /highfive-src  && \
     cmake -H/highfive-src -B/highfive-build -DHIGHFIVE_UNIT_TESTS=OFF               \
+        -DHIGHFIVE_EXAMPLES=OFF                                                     \
         -DUSE_BOOST=OFF                                                          && \
     cmake --build /highfive-build --target install                               && \
     rm -rf /highfive-{src,build}


### PR DESCRIPTION
  * HPX image was upgraded to Clang 7.0.1
  * `<algorithm>` header is not automatically included anymore
  * Caused a build failure in a HighFive example
* Remove outdated `PHYLANX_WITH_BLAZE_TENSOR` flag from CircleCI config.yml