### PR TITLE
Fixing issue #1080.

### DIFF
--- a/tests/unit/plugins/solvers/linear_solver.cpp
+++ b/tests/unit/plugins/solvers/linear_solver.cpp
@@ -432,15 +432,15 @@ int main()
     test_linear_solver_cholesky_u_PhySL();
     test_linear_solver_cholesky_l_PhySL();
 
+#ifdef PHYLANX_HAVE_BLAZE_ITERATIVE
     test_linear_solver_cg_jacobi_PhySL();
     test_linear_solver_cg_ssor_PhySL();
     test_linear_solver_cg_incompleteCholesky_PhySL();
     test_linear_solver_cg_symmetric_gauss_seidel_PhySL();
-
     test_linear_solver_lanczos_PhySL();
     test_linear_solver_arnoldi_PhySL();
-
     test_linear_solver_gmres_PhySL();
+#endif
 
     test_linear_solver_lu("linear_solver_lu");
 


### PR DESCRIPTION
When running the test, some tests should only be executed if
PHYLANX_HAVE_BLAZE_ITERATIVE is defined.  Those tests are run
twice with different methods, the first case is always run.
This PR prevents that.