### PR TITLE
Add the NO_EXTRAS flag for the pybind11_add_module call

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -59,7 +59,7 @@ if(APPLE) # OSX requires this to be a shared library, not a module (default)
       ${phylanx_py_SOURCES}
       ${phylanx_py_HEADERS})
 else(APPLE)
-  pybind11_add_module(phylanx_py
+  pybind11_add_module(phylanx_py NO_EXTRAS
     ${phylanx_py_SOURCES}
     ${phylanx_py_HEADERS}
     ${phylanx_python_SOURCES})


### PR DESCRIPTION
Fixes #1085.  The NO_EXTRAS flag prevents the addition of `-flto` which is unfortunate, but more importantly prevents the stripping of binaries which causes the `std::basic_string::~basic_string` destructor to be undefined (for Release and RelWithDebInfo builds).