### PR TITLE
Append to the PYTHONPATH, don't replace it

### DIFF
--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -79,7 +79,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Regression"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.regressions.python_dir.${test}_py)
   add_phylanx_pseudo_dependencies(

--- a/tests/unit/python/CMakeLists.txt
+++ b/tests/unit/python/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python.${test}_py)
   add_phylanx_pseudo_dependencies(

--- a/tests/unit/python/ast/CMakeLists.txt
+++ b/tests/unit/python/ast/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit/AST"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python_ast.${test}_py)
   add_phylanx_pseudo_dependencies(tests.unit.python_ast tests.unit.python_ast.${test}_py)

--- a/tests/unit/python/execution_tree/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit/ExecutionTree"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python_execution_tree.${test}_py)
   add_phylanx_pseudo_dependencies(

--- a/tests/unit/python/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/python/execution_tree/primitives/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit/ExecutionTree/Primitives"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python_execution_tree.python_primitives.${test}_py)
   add_phylanx_pseudo_dependencies(

--- a/tests/unit/python/plugins/CMakeLists.txt
+++ b/tests/unit/python/plugins/CMakeLists.txt
@@ -14,7 +14,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit/Plugins"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python_plugins.${test}_py)
   add_phylanx_pseudo_dependencies(

--- a/tests/unit/python/plugins/keras/CMakeLists.txt
+++ b/tests/unit/python/plugins/keras/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit/Plugins/Keras"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python_plugins.python_keras.${test}_py)
   add_phylanx_pseudo_dependencies(

--- a/tests/unit/python/plugins/matrixops/CMakeLists.txt
+++ b/tests/unit/python/plugins/matrixops/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit/Plugins/Matrixops"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python_plugins.python_matrixops.${test}_py)
   add_phylanx_pseudo_dependencies(

--- a/tests/unit/python/util/CMakeLists.txt
+++ b/tests/unit/python/util/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(test ${tests})
     FOLDER "Tests/Python/Unit/Util"
     DEPENDS phylanx_py python_setup
     WORKING_DIRECTORY ${PHYLANX_PYTHON_EXTENSION_LOCATION}
-    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}")
+    ENVIRONMENT "PYTHONPATH=${PHYLANX_PYTHON_EXTENSION_LOCATION}:$ENV{PYTHONPATH}")
 
   add_phylanx_pseudo_target(tests.unit.python_util.${test}_py)
   add_phylanx_pseudo_dependencies(tests.unit.python_util tests.unit.python_util.${test}_py)


### PR DESCRIPTION
The python tests completely replace PYTHONPATH, this fix will
append the Phylanx library to the path without replacing the path.
I am not sure if this is the right fix, but it worked.

Background: on my build/test system, the numpy installation location is in the PYTHONPATH.  When the path is replaced, python can't find numpy.