### PR TITLE
Fix #1104.

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -1083,8 +1083,10 @@ class PhySL:
         symbol = get_symbol_info(node, 'lambda')
         args = self._apply_rule(node.args)
         body = self._block(node.body)
-
-        return [symbol, (args, body)]
+        if args:
+            return [symbol, (args, body)]
+        else:
+            return [symbol, (body)]
 
     def _List(self, node):
         """class List(elts, ctx)"""

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -238,6 +238,17 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
                     });
             },
             "evaluate execution tree")
+        .def("__call__", [](phylanx::execution_tree::primitive const& p)
+            {
+                pybind11::gil_scoped_release release;       // release GIL
+                return hpx::threads::run_as_hpx_thread(
+                    [&]() {
+                        using namespace phylanx::execution_tree;
+                        return value_operand(primitive_argument_type{p},
+                            primitive_argument_type{}).get();
+                    });
+            },
+            "evaluate execution tree")
         .def("assign", [](phylanx::execution_tree::primitive p, double d)
             {
                 pybind11::gil_scoped_release release;       // release GIL

--- a/tests/regressions/python/1104_no_arg_lambda.py
+++ b/tests/regressions/python/1104_no_arg_lambda.py
@@ -1,0 +1,17 @@
+#  Copyright (c) 2020 R. Tohid
+#  Copyright (c) 2020 Steven R. Brandt
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #1104 No arg lambdas don't work
+
+from phylanx import Phylanx
+
+@Phylanx
+def foo():
+    f = lambda : print("Hello")
+
+    return True
+
+assert True == foo()

--- a/tests/regressions/python/1104_no_arg_lambda.py
+++ b/tests/regressions/python/1104_no_arg_lambda.py
@@ -8,10 +8,10 @@
 
 from phylanx import Phylanx
 
+
 @Phylanx
 def foo():
-    f = lambda : print("Hello")
+    return lambda: True
 
-    return True
 
-assert True == foo()
+assert foo()()

--- a/tests/regressions/python/1104_no_arg_lambda.py
+++ b/tests/regressions/python/1104_no_arg_lambda.py
@@ -11,7 +11,8 @@ from phylanx import Phylanx
 
 @Phylanx
 def foo():
-    return lambda: True
+    f = lambda: True    # noqa E731
+    return f
 
 
 assert foo()()

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -50,6 +50,7 @@ set(tests
     1052_variable_set_dtype
     1054_variable_shape
     1056_client_base
+    1104_no_arg_lambda
     array_len_494
     array_shape_486
     array_subscript_403


### PR DESCRIPTION
- If `lambda` has no argument, generate PhySL accordingly- ignore the `arg` entry.