### PR TITLE
Fix string output

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -1234,7 +1234,7 @@ class PhySL:
     def _Str(self, node):
         """class Str(s)"""
 
-        return '"' + node.s + '"'
+        return '"' + re.sub(r'(["|\\])',r'\\\1',node.s) + '"'
 
     def _Sub(self, node):
         """Leaf node, returning raw string of the 'subtraction' operation."""

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -1234,7 +1234,7 @@ class PhySL:
     def _Str(self, node):
         """class Str(s)"""
 
-        return '"' + re.sub(r'(["|\\])',r'\\\1',node.s) + '"'
+        return '"' + re.sub(r'(["|\\])', r'\\\1', node.s) + '"'
 
     def _Sub(self, node):
         """Leaf node, returning raw string of the 'subtraction' operation."""


### PR DESCRIPTION
If quotes are embedded in a string, they need to be formatted with escapes intact in the PhySL source. This PR fixes that issue.