### PR TITLE
Modifying Cannon product

### DIFF
--- a/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
@@ -200,7 +200,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         // the rows with the same index as the columns the LHS has
         std::size_t iter_idx = (lhs_local_tile_index + 1) % lhs_tile_row_size;
 
-        for (int i = 0; i < lhs_tile_row_size; i++)
+        for (std::size_t i = 0; i < lhs_tile_row_size; i++)
         {
             blaze::DynamicMatrix<T> lhs_tmp;
             if (iter_idx == lhs_local_tile_index)

--- a/src/plugins/dist_matrixops/dist_cannon_product.cpp
+++ b/src/plugins/dist_matrixops/dist_cannon_product.cpp
@@ -63,7 +63,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         execution_tree::primitive_argument_type&& rhs) const
     {
         using namespace execution_tree;
-
+        // what about a local matrix
         if (!lhs.has_annotation() || !rhs.has_annotation())
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -140,13 +140,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
     {
         using namespace execution_tree;
 
-        if (operands.size() != 2 && operands.size() != 3)
+        if (operands.size() != 2)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "dist_cannon_product::eval",
                 generate_error_message(
                     "the dist_cannon_product primitive requires exactly "
-                    "two or three operands"));
+                    "two operands"));
         }
 
         if (!valid(operands[0]) || !valid(operands[1]))

--- a/src/plugins/dist_matrixops/dist_dot_operation.cpp
+++ b/src/plugins/dist_matrixops/dist_dot_operation.cpp
@@ -281,13 +281,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     {
         using namespace execution_tree;
 
-        if (operands.size() != 2 && operands.size() != 3)
+        if (operands.size() != 2)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "dist_dot_operation::eval",
                 generate_error_message(
                     "the dist_dot_operation primitive requires exactly "
-                        "two or three operands"));
+                        "two operands"));
         }
 
         if (!valid(operands[0]) || !valid(operands[1]))

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -7,10 +7,12 @@ set(tests
     dist_dot_operation
     dist_transpose_operation
     dist_cannon_product
+    dist_cannon_product_9_loc
    )
 
 set(dist_dot_operation_PARAMETERS LOCALITIES 2)
 set(dist_cannon_product_PARAMETERS LOCALITIES 4)
+set(dist_cannon_product_9_loc_PARAMETERS LOCALITIES 9)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product.cpp
@@ -38,7 +38,7 @@ void test_cannon_product(std::string const& name, std::string const& code,
         compile_and_run(name, code);
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
-    hpx::cout << cannon_result << " : " << comparison << hpx::endl;
+
     HPX_TEST_EQ(cannon_result, comparison);
 }
 
@@ -48,21 +48,21 @@ void test_cannon_product_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_cannon_product("test2d2d_2", R"(
+        test_cannon_product("test2d2d_0", R"(
             cannon_product(
-                annotate_d([[1], [2], [3]], "test2d2d_2_1",
+                annotate_d([[1], [2], [3]], "test2d2d_0_1",
                     list("args",
                         list("locality", 0, 4),
                         list("tile", list("columns", 0, 1), list("rows", 0, 3)))),
-                annotate_d([[1, 2, 3]], "test2d2d_2_2",
+                annotate_d([[1, 2, 3]], "test2d2d_0_2",
                     list("args",
                         list("locality", 0, 4),
                         list("tile", list("columns", 0, 3), list("rows", 0, 1))))
             )
         )",
             R"(
-            annotate_d([[2, 4, 6], [4, 8, 12], [6, 12, 18]],
-                "test2d2d_2_1/1",
+            annotate_d([[1, 2, 3], [4, 8, 12], [6, 12, 18]],
+                "test2d2d_0_1/1",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 3), list("rows", 0, 3))))
@@ -70,21 +70,21 @@ void test_cannon_product_0()
     }
     else if (hpx::get_locality_id() == 1)
     {
-        test_cannon_product("test2d2d_2", R"(
+        test_cannon_product("test2d2d_0", R"(
             cannon_product(
-                annotate_d([[1], [2], [3]], "test2d2d_2_1",
+                annotate_d([[0], [2], [3]], "test2d2d_0_1",
                     list("args",
                         list("locality", 1, 4),
                         list("tile", list("columns", 1, 2), list("rows", 0, 3)))),
-                annotate_d([[4, 5, 6]], "test2d2d_2_2",
+                annotate_d([[4, 0, 6]], "test2d2d_0_2",
                     list("args",
                         list("locality", 1, 4),
                         list("tile", list("columns", 3, 6), list("rows", 0, 1))))
             )
         )",
             R"(
-            annotate_d([[8, 10, 12], [16, 20, 24], [24, 30, 36]],
-                "test2d2d_2_1/1",
+            annotate_d([[4, 0, 6], [16, 10, 24], [24, 15, 36]],
+                "test2d2d_0_1/1",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 3, 6), list("rows", 0, 3))))
@@ -92,21 +92,21 @@ void test_cannon_product_0()
     }
     else if (hpx::get_locality_id() == 2)
     {
-        test_cannon_product("test2d2d_2", R"(
+        test_cannon_product("test2d2d_0", R"(
             cannon_product(
-                annotate_d([[4], [5], [6]], "test2d2d_2_1",
+                annotate_d([[4], [5], [6]], "test2d2d_0_1",
                     list("args",
                         list("locality", 2, 4),
                         list("tile", list("columns", 0, 1), list("rows", 3, 6)))),
-                annotate_d([[1, 2, 3]], "test2d2d_2_2",
+                annotate_d([[1, 2, 3]], "test2d2d_0_2",
                     list("args",
                         list("locality", 2, 4),
                         list("tile", list("columns", 0, 3), list("rows", 1, 2))))
             )
         )",
             R"(
-            annotate_d([[8, 16, 24], [10, 20, 30], [12, 24, 36]],
-                "test2d2d_2_1/1",
+            annotate_d([[8, 16, 24], [10, 20, 30], [6, 12, 18]],
+                "test2d2d_0_1/1",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 0, 3), list("rows", 3, 6))))
@@ -114,21 +114,113 @@ void test_cannon_product_0()
     }
     else
     {
-        test_cannon_product("test2d2d_2", R"(
+        test_cannon_product("test2d2d_0", R"(
             cannon_product(
-                annotate_d([[4], [5], [6]], "test2d2d_2_1",
+                annotate_d([[4], [5], [0]], "test2d2d_0_1",
                     list("args",
                         list("locality", 3, 4),
                         list("tile", list("columns", 1, 2), list("rows", 3, 6)))),
-                annotate_d([[4, 5, 6]], "test2d2d_2_2",
+                annotate_d([[4, 5, 6]], "test2d2d_0_2",
                     list("args",
                         list("locality", 3, 4),
                         list("tile", list("columns", 3, 6), list("rows", 1, 2))))
             )
         )",
             R"(
-            annotate_d([[32, 40, 48], [40, 50, 60], [48, 60, 72]],
-                "test2d2d_2_1/1",
+            annotate_d([[32, 20, 48], [40, 25, 60], [24, 0, 36]],
+                "test2d2d_0_1/1",
+                list("args",
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 3, 6), list("rows", 3, 6))))
+        )");
+    }
+}
+
+void test_cannon_product_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_cannon_product("test2d2d_1", R"(
+            cannon_product(
+                annotate_d([[1, 1], [2, 2], [3, 3]], "test2d2d_1_1",
+                    list("args",
+                        list("locality", 0, 4),
+                        list("tile", list("columns", 0, 2), list("rows", 0, 3)))),
+                annotate_d([[0, 0, 0],[1, 2, 3]], "test2d2d_1_2",
+                    list("args",
+                        list("locality", 0, 4),
+                        list("tile", list("columns", 0, 3), list("rows", 0, 2))))
+            )
+        )",
+            R"(
+            annotate_d([[2, 4, 6], [4, 8, 12], [6, 12, 18]],
+                "test2d2d_1_1/1",
+                list("args",
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 3))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_cannon_product("test2d2d_1", R"(
+            cannon_product(
+                annotate_d([[1, 0], [2, 0], [3, 0]], "test2d2d_1_1",
+                    list("args",
+                        list("locality", 1, 4),
+                        list("tile", list("columns", 2, 4), list("rows", 0, 3)))),
+                annotate_d([[4, 5, 6], [4, 5, 6]], "test2d2d_1_2",
+                    list("args",
+                        list("locality", 1, 4),
+                        list("tile", list("columns", 3, 6), list("rows", 0, 2))))
+            )
+        )",
+            R"(
+            annotate_d([[12, 15, 18], [24, 30, 36], [36, 45, 54]],
+                "test2d2d_1_1/1",
+                list("args",
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 3, 6), list("rows", 0, 3))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_cannon_product("test2d2d_1", R"(
+            cannon_product(
+                annotate_d([[4, 4], [5, 5], [6, 6]], "test2d2d_1_1",
+                    list("args",
+                        list("locality", 2, 4),
+                        list("tile", list("columns", 0, 2), list("rows", 3, 6)))),
+                annotate_d([[1, 2, 3], [1, 2, 0]], "test2d2d_1_2",
+                    list("args",
+                        list("locality", 2, 4),
+                        list("tile", list("columns", 0, 3), list("rows", 2, 4))))
+            )
+        )",
+            R"(
+            annotate_d([[5, 10, 12], [7, 14, 15], [9, 18, 18]],
+                "test2d2d_1_1/1",
+                list("args",
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 0, 3), list("rows", 3, 6))))
+        )");
+    }
+    else
+    {
+        test_cannon_product("test2d2d_1", R"(
+            cannon_product(
+                annotate_d([[0, 1], [0, 2], [0, 3]], "test2d2d_1_1",
+                    list("args",
+                        list("locality", 3, 4),
+                        list("tile", list("columns", 2, 4), list("rows", 3, 6)))),
+                annotate_d([[4, 5, 6], [0, 0, 6]], "test2d2d_1_2",
+                    list("args",
+                        list("locality", 3, 4),
+                        list("tile", list("columns", 3, 6), list("rows", 2, 4))))
+            )
+        )",
+            R"(
+            annotate_d([[32, 40, 54], [40, 50, 72], [48, 60, 90]],
+                "test2d2d_1_1/1",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 3, 6), list("rows", 3, 6))))
@@ -140,6 +232,7 @@ void test_cannon_product_0()
 int hpx_main(int argc, char* argv[])
 {
     test_cannon_product_0();
+    test_cannon_product_1();
 
     return hpx::finalize();
 }

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product.cpp
@@ -25,6 +25,7 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
     phylanx::execution_tree::compiler::environment env =
         phylanx::execution_tree::compiler::default_environment();
 
+
     auto const& code =
         phylanx::execution_tree::compile(name, codestr, snippets, env);
     return code.run().arg_;
@@ -234,7 +235,8 @@ int hpx_main(int argc, char* argv[])
     test_cannon_product_0();
     test_cannon_product_1();
 
-    return hpx::finalize();
+    hpx::finalize();
+    return hpx::util::report_errors();
 }
 
 int main(int argc, char* argv[])

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
@@ -1,0 +1,265 @@
+//   Copyright (c) 2017-2019 Hartmut Kaiser
+//   Copyright (c) 2019 Bita Hasheminezhad
+//   Copyright (c) 2019 Maxwell Reeser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_cannon_product(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type cannon_result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(cannon_result, comparison);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void test_cannon_product_2()
+{
+    switch (hpx::get_locality_id())
+    {
+    case 0: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[1, 1], [2, 2], [3, 3]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 0, 9),
+                        list("tile", list("columns", 0, 2), list("rows", 0, 3)))),
+                annotate_d([[0], [1]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 0, 9),
+                        list("tile", list("columns", 0, 1), list("rows", 0, 2))))
+            )
+        )",
+            R"(
+            annotate_d([[10], [20], [30]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 0, 9),
+                    list("tile", list("columns", 0, 1), list("rows", 0, 3))))
+        )");
+        break;
+    }
+    case 1: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[1, 0], [2, 0], [3, 0]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 1, 9),
+                        list("tile", list("columns", 2, 4), list("rows", 0, 3)))),
+                annotate_d([[0], [2]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 1, 9),
+                        list("tile", list("columns", 1, 2), list("rows", 0, 2))))
+            )
+        )",
+            R"(
+            annotate_d([[14], [28], [42]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 1, 9),
+                    list("tile", list("columns", 1, 2), list("rows", 0, 3))))
+        )");
+        break;
+    }
+    case 2: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[1, 1], [2, 2], [3, 3]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 2, 9),
+                        list("tile", list("columns", 4, 6), list("rows", 0, 3)))),
+                annotate_d([[0], [3]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 2, 9),
+                        list("tile", list("columns", 2, 3), list("rows", 0, 2))))
+            )
+        )",
+            R"(
+            annotate_d([[18], [36], [54]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 2, 9),
+                    list("tile", list("columns", 2, 3), list("rows", 0, 3))))
+        )");
+        break;
+    }
+    case 3: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[4, 4], [5, 5], [6, 6]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 3, 9),
+                        list("tile", list("columns", 0, 2), list("rows", 3, 6)))),
+                annotate_d([[1], [0]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 3, 9),
+                        list("tile", list("columns", 0, 1), list("rows", 2, 4))))
+            )
+        )",
+            R"(
+            annotate_d([[36], [45], [54]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 3, 9),
+                    list("tile", list("columns", 0, 1), list("rows", 3, 6))))
+        )");
+        break;
+    }
+    case 4: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[0, 1], [0, 2], [0, 3]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 4, 9),
+                        list("tile", list("columns", 2, 4), list("rows", 3, 6)))),
+                annotate_d([[2], [0]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 4, 9),
+                        list("tile", list("columns", 1, 2), list("rows", 2, 4))))
+            )
+        )",
+            R"(
+            annotate_d([[48], [60], [72]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 4, 9),
+                    list("tile", list("columns", 1, 2), list("rows", 3, 6))))
+        )");
+        break;
+    }
+    case 5: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[4, 4], [5, 5], [6, 6]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 5, 9),
+                        list("tile", list("columns", 4, 6), list("rows", 3, 6)))),
+                annotate_d([[3], [6]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 5, 9),
+                        list("tile", list("columns", 2, 3), list("rows", 2, 4))))
+            )
+        )",
+            R"(
+            annotate_d([[66], [87], [108]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 5, 9),
+                    list("tile", list("columns", 2, 3), list("rows", 3, 6))))
+        )");
+        break;
+    }
+    case 6: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[7, 0], [8, 8], [9, 0]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 6, 9),
+                        list("tile", list("columns", 0, 2), list("rows", 6, 9)))),
+                annotate_d([[4], [4]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 6, 9),
+                        list("tile", list("columns", 0, 1), list("rows", 4, 6))))
+            )
+        )",
+            R"(
+            annotate_d([[35], [72], [36]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 6, 9),
+                    list("tile", list("columns", 0, 1), list("rows", 6, 9))))
+        )");
+        break;
+    }
+    case 7: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[7, 0], [0, 0], [0, 0]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 7, 9),
+                        list("tile", list("columns", 2, 4), list("rows", 6, 9)))),
+                annotate_d([[5], [5]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 7, 9),
+                        list("tile", list("columns", 1, 2), list("rows", 4, 6))))
+            )
+        )",
+            R"(
+            annotate_d([[49], [96], [45]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 7, 9),
+                    list("tile", list("columns", 1, 2), list("rows", 6, 9))))
+        )");
+        break;
+    }
+    case 8: {
+        test_cannon_product("test2d2d_2", R"(
+            cannon_product(
+                annotate_d([[7, 0], [8, 8], [0, 9]], "test2d2d_2_1",
+                    list("args",
+                        list("locality", 8, 9),
+                        list("tile", list("columns", 4, 6), list("rows", 6, 9)))),
+                annotate_d([[6], [6]], "test2d2d_2_2",
+                    list("args",
+                        list("locality", 8, 9),
+                        list("tile", list("columns", 2, 3), list("rows", 4, 6))))
+            )
+        )",
+            R"(
+            annotate_d([[63], [120], [54]],
+                "test2d2d_2_1/1",
+                list("args",
+                    list("locality", 8, 9),
+                    list("tile", list("columns", 2, 3), list("rows", 6, 9))))
+        )");
+        break;
+    }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_cannon_product_2();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {"hpx.run_hpx_main!=1"};
+
+    return hpx::init(argc, argv, cfg);
+}

--- a/tests/unit/plugins/dist_matrixops/dist_dot_operation.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_dot_operation.cpp
@@ -530,7 +530,8 @@ int hpx_main(int argc, char* argv[])
     test_dot_2d2d_4();
     test_dot_2d2d_5();
 
-    return hpx::finalize();
+    hpx::finalize();
+    return hpx::util::report_errors();
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
This PR modifies the algorithm to calculate matrix multiplication (both sides should use the same index). It removes using `fetch` for local tiles and adds more tests.