### PR TITLE
Avoid problems with getting the directory of relative path names

### DIFF
--- a/python/phylanx/ast/physl_db.py
+++ b/python/phylanx/ast/physl_db.py
@@ -23,7 +23,7 @@ class db:
            open existing database otherwise"""
 
         # generate db name from given script name
-        head, tail = os.path.split(name)
+        head, tail = os.path.split(os.path.realpath(name))
         filename, _ = os.path.splitext(tail)
         dbname = '%s/__physlcache__/%s.db' % (head, filename)
 


### PR DESCRIPTION
I'm currently having difficulty creating the exact problem which leads to the error this PR solves, but the basic problem is, if a full path is not given for the source file, then the variable "head" on line 26 is set to the empty string and dbname winds up being `"/__physlcache__/..."` which is generally wrong.

Alternatively, one could set head = "." if head is "". One of the two things should be done, however.