### PR TITLE
Adding distributed random

### DIFF
--- a/phylanx/plugins/common/constant_nd.hpp
+++ b/phylanx/plugins/common/constant_nd.hpp
@@ -25,8 +25,6 @@ namespace phylanx { namespace common
 
     PHYLANX_COMMON_EXPORT std::size_t extract_num_dimensions(
         ir::range const& shape);
-    PHYLANX_COMMON_EXPORT std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
-    extract_dimensions(ir::range const& shape);
 
     PHYLANX_COMMON_EXPORT std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
     extract_dimensions(ir::range const& shape);

--- a/phylanx/plugins/common/constant_nd.hpp
+++ b/phylanx/plugins/common/constant_nd.hpp
@@ -25,6 +25,8 @@ namespace phylanx { namespace common
 
     PHYLANX_COMMON_EXPORT std::size_t extract_num_dimensions(
         ir::range const& shape);
+    PHYLANX_COMMON_EXPORT std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
+    extract_dimensions(ir::range const& shape);
 
     PHYLANX_COMMON_EXPORT std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
     extract_dimensions(ir::range const& shape);

--- a/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
@@ -9,6 +9,7 @@
 #include <phylanx/plugins/dist_matrixops/dist_cannon_product.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_constant.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_dot_operation.hpp>
+#include <phylanx/plugins/dist_matrixops/dist_random.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_transpose_operation.hpp>
 
 #endif

--- a/phylanx/plugins/dist_matrixops/dist_random.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_random.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 Hartmut Kaiser
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_DIST_RANDOM)
+#define PHYLANX_PRIMITIVES_DIST_RANDOM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/util/random.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+namespace phylanx { namespace dist_matrixops { namespace primitives
+{
+    using distribution_parameters_type =
+        std::tuple<std::string, int, double, double>;
+
+    class dist_random
+      : public execution_tree::primitives::primitive_component_base
+      , public std::enable_shared_from_this<dist_random>
+    {
+    public:
+        static execution_tree::match_pattern_type const match_data;
+
+        dist_random() = default;
+
+        dist_random(execution_tree::primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    protected:
+        hpx::future<execution_tree::primitive_argument_type> eval(
+            execution_tree::primitive_arguments_type const& operands,
+            execution_tree::primitive_arguments_type const& args,
+            execution_tree::eval_context ctx) const override;
+
+        execution_tree::primitive_argument_type dist_random1d(std::size_t dim,
+            std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
+            std::string&& given_name, double const& mean, double const& std,
+            std::string const& name_, std::string const& codename_) const;
+        execution_tree::primitive_argument_type dist_random2d(
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
+            std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
+            std::string&& given_name, std::string const& tiling_type,
+            double const& mean, double const& std, std::string const& name_,
+            std::string const& codename_) const;
+    };
+
+    inline execution_tree::primitive create_dist_random(hpx::id_type const& locality,
+        execution_tree::primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "random_d", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_DIST_MATRIXOPS_TILE_CALCULATION_HELPER)
+#define PHYLANX_DIST_MATRIXOPS_TILE_CALCULATION_HELPER
+
+#include <phylanx/util/generate_error_message.hpp>
+
+#include <hpx/errors/throw_exception.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <tuple>
+
+#include <blaze/Math.h>
+
+namespace tile_calculation
+{
+    ///////////////////////////////////////////////////////////////////////////
+    inline std::tuple<std::int64_t, std::size_t> tile_calculation_1d(
+        std::uint32_t const& tile_idx, std::size_t const& dim,
+        std::uint32_t const& numtiles)
+    {
+        // calculates start and size or the tile_index-th tile on the given
+        // dimension with the given dim size
+        std::int64_t start;
+        std::size_t size = static_cast<std::size_t>(dim / numtiles);
+        std::size_t remainder = dim % numtiles;
+        if (tile_idx < remainder)
+        {
+            size++;
+        }
+
+        if (remainder != 0 && tile_idx >= remainder)
+        {
+            start = (size + 1) * remainder + size * (tile_idx - remainder);
+        }
+        else
+        {
+            start = size * tile_idx;
+        }
+        return std::make_tuple(start, size);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    inline std::tuple<std::size_t, std::size_t> middle_divisors(std::size_t num)
+    {
+        std::size_t first = blaze::sqrt(num);
+        std::size_t second;
+        while (true)
+        {
+            if (num % first == 0)
+            {
+                // the worst case scenario is a prime number where `first`
+                // becomes 1
+                second = num / first;
+                break;
+            }
+            first -= 1;
+        }
+        return std::make_tuple(first, second);
+    }
+
+    inline std::tuple<std::int64_t, std::int64_t, std::size_t, std::size_t>
+    tile_calculation_2d(std::uint32_t const& tile_idx,
+        std::size_t const& row_dim, std::size_t const& column_dim,
+        std::uint32_t const& numtiles, std::string const& tiling_type)
+    {
+        std::int64_t row_start, column_start;
+        std::size_t row_size, column_size;
+        if (tiling_type == "row" ||
+            (row_dim > column_dim && numtiles == 2 && tiling_type != "column"))
+        {
+            // row_tiling (horizontal tiling)
+            if (row_dim < numtiles)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "tile_calculation::tile_calculation_2d",
+                    phylanx::util::generate_error_message(
+                        "the row dimension should not be less than number of "
+                        "tiles"));
+            }
+
+            column_start = 0;
+            column_size = column_dim;
+            std::tie(row_start, row_size) =
+                tile_calculation_1d(tile_idx, row_dim, numtiles);
+        }
+        else if (tiling_type == "column" ||
+            (row_dim < column_dim && numtiles == 2))
+        {
+            // column_tiling (vertical tiling)
+            if (column_dim < numtiles)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "tile_calculation::tile_calculation_2d",
+                    phylanx::util::generate_error_message(
+                        "the column dimension should not be less than number "
+                        "of tiles"));
+            }
+
+            row_start = 0;
+            row_size = row_dim;
+            std::tie(column_start, column_size) =
+                tile_calculation_1d(tile_idx, column_dim, numtiles);
+        }
+        else if (tiling_type == "sym" && numtiles == 4)
+        {
+            // distributing the matrix over 4 blocks
+            if (column_dim < 2 || row_dim < 2)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "tile_calculation::tile_calculation_2d",
+                    phylanx::util::generate_error_message(
+                        "each dimension should have at least the length of 2 "
+                        "to make 4 blocks"));
+            }
+
+            std::tie(row_start, row_size) =
+                tile_calculation_1d(blaze::floor(tile_idx / 2), row_dim, 2);
+            std::tie(column_start, column_size) =
+                tile_calculation_1d(tile_idx % 2, column_dim, 2);
+        }
+        else if (tiling_type == "sym")
+        {
+            // the assumption is tiles are numbered in a row-major fashion
+            std::uint32_t first_div,
+                second_div;    // first_div is the smaller one
+            std::tie(first_div, second_div) = middle_divisors(numtiles);
+            if (row_dim > column_dim)
+            {
+                // larger number of rows (larger row_dim)
+                if (column_dim < first_div || row_dim < second_div)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "tile_calculation::tile_calculation_2d",
+                        phylanx::util::generate_error_message(
+                            "at least one of the marix dimensions is smaller "
+                            "than the number of tiles in that direction"));
+                }
+                std::tie(row_start, row_size) = tile_calculation_1d(
+                    blaze::floor(tile_idx / first_div), row_dim, second_div);
+                std::tie(column_start, column_size) = tile_calculation_1d(
+                    tile_idx % first_div, column_dim, first_div);
+            }
+            else
+            {
+                // larger column_dim
+                if (column_dim < second_div || row_dim < first_div)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "tile_calculation::tile_calculation_2d",
+                        phylanx::util::generate_error_message(
+                            "at least one of the marix dimensions is smaller "
+                            "than the number of tiles in that direction"));
+                }
+                std::tie(row_start, row_size) = tile_calculation_1d(
+                    blaze::floor(tile_idx / second_div), row_dim, first_div);
+                std::tie(column_start, column_size) = tile_calculation_1d(
+                    tile_idx % second_div, column_dim, second_div);
+            }
+        }
+        else
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "tile_calculation::tile_calculation_2d",
+                phylanx::util::generate_error_message(
+                    "the given tiling_type is invalid. tiling_type can be "
+                    "`sym`, `row` or `column` for a matrix"));
+        }
+        return std::make_tuple(row_start, column_start, row_size, column_size);
+    }
+}
+#endif

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -13,6 +13,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/common/constant_nd.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_constant.hpp>
+#include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
 #include <phylanx/execution_tree/localities_annotation.hpp>
 
 #include <hpx/include/lcos.hpp>
@@ -85,54 +86,6 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     {}
 
     ///////////////////////////////////////////////////////////////////////////
-    namespace detail
-    {
-        std::tuple<std::uint32_t, std::uint32_t> middle_divisors(
-            std::uint32_t num)
-        {
-            std::uint32_t first = blaze::sqrt(num);
-            std::uint32_t second;
-            while (true)
-            {
-                if (num % first == 0)
-                {
-                    // worst case scenario is a prime number where first
-                    // becomes 1
-                    second = num / first;
-                    break;
-                }
-                first -= 1;
-            }
-            return std::make_tuple(first, second);
-        }
-
-        std::tuple<std::int64_t, std::size_t> tile_calculation(
-            std::uint32_t const& tile_idx, std::size_t const& dim,
-            std::uint32_t const& numtiles)
-        {
-            // calculates start and size or the tile_index-th tile on the given
-            // dimension with the given dim size
-            std::int64_t start;
-            std::size_t size = static_cast<std::size_t>(dim / numtiles);
-            std::size_t remainder = dim % numtiles;
-            if (tile_idx < remainder)
-            {
-                size++;
-            }
-
-            if (remainder != 0 && tile_idx >= remainder)
-            {
-                start = (size + 1) * remainder + size * (tile_idx - remainder);
-            }
-            else
-            {
-                start = size * tile_idx;
-            }
-            return std::make_tuple(start, size);
-        }
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     execution_tree::primitive_argument_type dist_constant::constant1d_helper(
         execution_tree::primitive_argument_type&& value,
@@ -156,7 +109,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::int64_t start;
         std::uint32_t size;
         std::tie(start, size) =
-            detail::tile_calculation(tile_idx, dim, numtiles);
+            tile_calculation::tile_calculation_1d(tile_idx, dim, numtiles);
 
         tiling_information_1d tile_info(
             tiling_information_1d::tile1d_type::columns,
@@ -242,104 +195,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::uint32_t row_dim = dims[0];
         std::uint32_t column_dim = dims[1];
 
-        if (tiling_type == "row" ||
-            (row_dim > column_dim && numtiles == 2 && tiling_type != "column"))
-        {
-            // row_tiling (horizontal tiling)
-            if (row_dim < numtiles)
-            {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "dist_matrixops::dist_constant::constant2d_helper",
-                    util::generate_error_message(
-                        "the row dimension should not be "
-                        "less than number of tiles"));
-            }
-
-            column_start = 0;
-            column_size = column_dim;
-            std::tie(row_start, row_size) =
-                detail::tile_calculation(tile_idx, row_dim, numtiles);
-        }
-        else if (tiling_type == "column" ||
-            (row_dim < column_dim && numtiles == 2))
-        {
-            // column_tiling (vertical tiling)
-            if (column_dim < numtiles)
-            {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "dist_matrixops::dist_constant::constant2d_helper",
-                    util::generate_error_message(
-                        "the column dimension should not be "
-                        "less than number of tiles"));
-            }
-
-            row_start = 0;
-            row_size = row_dim;
-            std::tie(column_start, column_size) =
-                detail::tile_calculation(tile_idx, column_dim, numtiles);
-        }
-        else if (tiling_type == "sym" && numtiles == 4)
-        {
-            // distributing the matrix over 4 blocks
-            if (column_dim < 2 || row_dim < 2)
-            {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "dist_matrixops::dist_constant::constant2d_helper",
-                    util::generate_error_message(
-                        "each dimension should have at least the length of 2"));
-            }
-
-            std::tie(row_start, row_size) = detail::tile_calculation(
-                blaze::floor(tile_idx / 2), row_dim, 2);
-            std::tie(column_start, column_size) =
-                detail::tile_calculation(tile_idx % 2, column_dim, 2);
-        }
-        else if (tiling_type == "sym")
-        {
-            // the assumption is tiles are numbered in a row-major fashion
-            std::uint32_t first_div,
-                second_div;    // first_div is the smaller one
-            std::tie(first_div, second_div) = detail::middle_divisors(numtiles);
-            if (row_dim > column_dim)
-            {
-                // larger number of rows (larger row_dim)
-                if (column_dim < first_div || row_dim < second_div)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "dist_matrixops::dist_constant::constant2d_helper",
-                        util::generate_error_message(
-                            "at least one of the marix dimensions is smaller "
-                            "than the number of tiles in that direction"));
-                }
-                std::tie(row_start, row_size) = detail::tile_calculation(
-                    blaze::floor(tile_idx / first_div), row_dim, second_div);
-                std::tie(column_start, column_size) = detail::tile_calculation(
-                    tile_idx % first_div, column_dim, first_div);
-            }
-            else
-            {
-                // larger column_dim
-                if (column_dim < second_div || row_dim < first_div)
-                {
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "dist_matrixops::dist_constant::constant2d_helper",
-                        util::generate_error_message(
-                            "at least one of the marix dimensions is smaller "
-                            "than the number of tiles in that direction"));
-                }
-                std::tie(row_start, row_size) = detail::tile_calculation(
-                    blaze::floor(tile_idx / second_div), row_dim, first_div);
-                std::tie(column_start, column_size) = detail::tile_calculation(
-                    tile_idx % second_div, column_dim, second_div);
-            }
-        }
-        else
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "dist_matrixops::dist_constant::constant2d_helper",
-                util::generate_error_message(
-                    "the given tiling_type is invalid"));
-        }
+        std::tie(row_start, column_start, row_size, column_size) =
+            tile_calculation::tile_calculation_2d(
+                tile_idx, row_dim, column_dim, numtiles, tiling_type);
 
         tiling_information_2d tile_info(
             tiling_span(column_start, column_start + column_size),

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -106,27 +106,27 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             return std::make_tuple(first, second);
         }
 
-        std::tuple<std::int64_t, std::uint32_t> tile_calculation(
+        std::tuple<std::int64_t, std::size_t> tile_calculation(
             std::uint32_t const& tile_idx, std::size_t const& dim,
             std::uint32_t const& numtiles)
         {
-            // calculates start and size or the tile_idx-th tile on the given
-            // dimension with th given dim size
+            // calculates start and size or the tile_index-th tile on the given
+            // dimension with the given dim size
             std::int64_t start;
-            std::uint32_t size = static_cast<std::size_t>(dim / numtiles);
-            std::uint32_t remainder = dim % numtiles;
+            std::size_t size = static_cast<std::size_t>(dim / numtiles);
+            std::size_t remainder = dim % numtiles;
             if (tile_idx < remainder)
             {
                 size++;
             }
 
-            if (remainder == 0)
-            {
-                start = size * tile_idx;
-            }
-            else if (tile_idx >= remainder)
+            if (remainder != 0 && tile_idx >= remainder)
             {
                 start = (size + 1) * remainder + size * (tile_idx - remainder);
+            }
+            else
+            {
+                start = size * tile_idx;
             }
             return std::make_tuple(start, size);
         }
@@ -178,11 +178,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         annotation_information ann_info(base_name, 0);    //generation 0
 
         auto attached_annotation =
-            std::make_shared<execution_tree::annotation>(localities_annotation(
+            std::make_shared<annotation>(localities_annotation(
                 locality_ann, tile_info.as_annotation(name, codename), ann_info,
                 name, codename));
 
-        execution_tree::primitive_argument_type res(
+        primitive_argument_type res(
             blaze::DynamicVector<T>(size, const_value), attached_annotation);
 
         return std::move(res);
@@ -362,11 +362,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         annotation_information ann_info(base_name, 0);    //generation 0
 
         auto attached_annotation =
-            std::make_shared<execution_tree::annotation>(localities_annotation(
+            std::make_shared<annotation>(localities_annotation(
                 locality_ann, tile_info.as_annotation(name, codename), ann_info,
                 name, codename));
 
-        execution_tree::primitive_argument_type res(
+        primitive_argument_type res(
             blaze::DynamicMatrix<T>(row_size, column_size, const_value),
             attached_annotation);
 

--- a/src/plugins/dist_matrixops/dist_matrixops.cpp
+++ b/src/plugins/dist_matrixops/dist_matrixops.cpp
@@ -17,5 +17,7 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(dist_constant_plugin,
     phylanx::dist_matrixops::primitives::dist_constant::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_dot_operation_plugin,
     phylanx::dist_matrixops::primitives::dist_dot_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(dist_random_plugin,
+    phylanx::dist_matrixops::primitives::dist_random::match_data)
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_transpose_operation_plugin,
     phylanx::dist_matrixops::primitives::dist_transpose_operation::match_data);

--- a/src/plugins/dist_matrixops/dist_random.cpp
+++ b/src/plugins/dist_matrixops/dist_random.cpp
@@ -1,0 +1,568 @@
+// Copyright (c) 2020 Hartmut Kaiser
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/annotation.hpp>
+#include <phylanx/execution_tree/locality_annotation.hpp>
+#include <phylanx/execution_tree/localities_annotation.hpp>
+#include <phylanx/execution_tree/meta_annotation.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/tiling_annotations.hpp>
+#include <phylanx/execution_tree/primitives/generic_function.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/dist_matrixops/dist_random.hpp>
+#include <phylanx/util/random.hpp>
+
+#include <hpx/assertion.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/errors/throw_exception.hpp>
+
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <ctime>
+#include <map>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+#include <sstream>
+#include <type_traits>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace dist_matrixops { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    execution_tree::match_pattern_type const dist_random::match_data =
+    {
+        hpx::util::make_tuple("random_d", std::vector<std::string>{R"(
+                random_d(
+                    _1_shape,
+                    _2_tile_index,
+                    _3_numtiles,
+                    __arg(_4_name, ""),
+                    __arg(_5_tiling_type, "sym"),
+                    __arg(_6_mean, 0.0),
+                    __arg(_7_std, 1.0)
+                )
+            )"},
+            &create_dist_random,
+            &execution_tree::create_primitive<dist_random>, R"(
+            shape, tile_index, numtiles, name, tiling_type, mean, std
+            Args:
+
+                shape (int or list of ints): overall shape of the array. It
+                    only contains positive integers.
+                tile_index (int): the tile index we need to generate the
+                    random array for. A non-negative integer.
+                numtiles (int): number of tiles of the returned array
+                name (string, optional): the array given name. If not given, a
+                    globally unique name will be generated.
+                tiling_type (string, optional): defaults to `sym` which is a
+                    balanced way of tiling among all the numtiles localities.
+                    Other options are `row` or `column` tiling. For a vector
+                    all these three tiling_types are the same.
+                mean (float, optional): the mean value of the distribution. It
+                    sets to 0.0 by default.
+                std (float, optional): the standard deviation of the normal
+                    distribution. It sets to 1.0 by default.
+
+            Returns:
+
+            A part of an array of random numbers on tile_index-th tile out of
+            numtiles using the nrmal distribution)")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        std::size_t extract_num_dimensions_(ir::range const& shape)
+        {
+            return shape.size();
+        }
+
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> extract_dimensions_(
+            ir::range const& shape)
+        {
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
+            if (!shape.empty())
+            {
+                if (shape.size() == 1)
+                {
+                    result[0] = extract_scalar_positive_integer_value_strict(
+                        *shape.begin());
+                }
+                else if (shape.size() == 2)
+                {
+                    auto elem_1 = shape.begin();
+                    result[0] =
+                        extract_scalar_positive_integer_value_strict(*elem_1);
+                    result[1] =
+                        extract_scalar_positive_integer_value_strict(*++elem_1);
+                }
+                else if (shape.size() == 3)
+                {
+                    auto elem_1 = shape.begin();
+                    result[0] =
+                        extract_scalar_positive_integer_value_strict(*elem_1);
+                    result[1] =
+                        extract_scalar_positive_integer_value_strict(*++elem_1);
+                    result[2] =
+                        extract_scalar_positive_integer_value_strict(*++elem_1);
+                }
+                else if (shape.size() == 4)
+                {
+                    auto elem_1 = shape.begin();
+                    result[0] =
+                        extract_scalar_positive_integer_value_strict(*elem_1);
+                    result[1] =
+                        extract_scalar_positive_integer_value_strict(*++elem_1);
+                    result[2] =
+                        extract_scalar_positive_integer_value_strict(*++elem_1);
+                    result[3] =
+                        extract_scalar_positive_integer_value_strict(*++elem_1);
+                }
+            }
+            return result;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    dist_random::dist_random(execution_tree::primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        std::tuple<std::size_t, std::size_t> middle_divisors_(
+            std::size_t num)
+        {
+            std::size_t first = blaze::sqrt(num);
+            std::size_t second;
+            while (true)
+            {
+                if (num % first == 0)
+                {
+                    // worst case scenario is a prime number where first
+                    // becomes 1
+                    second = num / first;
+                    break;
+                }
+                first -= 1;
+            }
+            return std::make_tuple(first, second);
+        }
+
+        std::tuple<std::int64_t, std::size_t> tile_calculation_1d(
+            std::uint32_t const& tile_idx, std::size_t const& dim,
+            std::uint32_t const& numtiles)
+        {
+            // calculates start and size or the tile_index-th tile on the given
+            // dimension with the given dim size
+            std::int64_t start;
+            std::size_t size = static_cast<std::size_t>(dim / numtiles);
+            std::size_t remainder = dim % numtiles;
+            if (tile_idx < remainder)
+            {
+                size++;
+            }
+
+            if (remainder != 0 && tile_idx >= remainder)
+            {
+                start = (size + 1) * remainder + size * (tile_idx - remainder);
+            }
+            else
+            {
+                start = size * tile_idx;
+            }
+            return std::make_tuple(start, size);
+        }
+
+        std::tuple<std::int64_t, std::int64_t, std::size_t, std::size_t>
+        tile_calculation_2d(std::uint32_t const& tile_idx,
+            std::size_t const& row_dim, std::size_t const& column_dim,
+            std::uint32_t const& numtiles, std::string const& tiling_type)
+        {
+            std::int64_t row_start, column_start;
+            std::size_t row_size, column_size;
+            if (tiling_type == "row" ||
+                (row_dim > column_dim && numtiles == 2 &&
+                    tiling_type != "column"))
+            {
+                // row_tiling (horizontal tiling)
+                if (row_dim < numtiles)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "dist_matrixops::dist_constant::constant2d_helper",
+                        util::generate_error_message(
+                            "the row dimension should not be "
+                            "less than number of tiles"));
+                }
+
+                column_start = 0;
+                column_size = column_dim;
+                std::tie(row_start, row_size) =
+                    detail::tile_calculation_1d(tile_idx, row_dim, numtiles);
+            }
+            else if (tiling_type == "column" ||
+                (row_dim < column_dim && numtiles == 2))
+            {
+                // column_tiling (vertical tiling)
+                if (column_dim < numtiles)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "dist_matrixops::dist_constant::constant2d_helper",
+                        util::generate_error_message(
+                            "the column dimension should not be "
+                            "less than number of tiles"));
+                }
+
+                row_start = 0;
+                row_size = row_dim;
+                std::tie(column_start, column_size) =
+                    detail::tile_calculation_1d(tile_idx, column_dim, numtiles);
+            }
+            else if (tiling_type == "sym" && numtiles == 4)
+            {
+                // distributing the matrix over 4 blocks
+                if (column_dim < 2 || row_dim < 2)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "dist_matrixops::dist_constant::constant2d_helper",
+                        util::generate_error_message(
+                            "each dimension should have at least the length of "
+                            "2"));
+                }
+
+                std::tie(row_start, row_size) = detail::tile_calculation_1d(
+                    blaze::floor(tile_idx / 2), row_dim, 2);
+                std::tie(column_start, column_size) =
+                    detail::tile_calculation_1d(tile_idx % 2, column_dim, 2);
+            }
+            else if (tiling_type == "sym")
+            {
+                // the assumption is tiles are numbered in a row-major fashion
+                std::uint32_t first_div,
+                    second_div;    // first_div is the smaller one
+                std::tie(first_div, second_div) =
+                    detail::middle_divisors_(numtiles);
+                if (row_dim > column_dim)
+                {
+                    // larger number of rows (larger row_dim)
+                    if (column_dim < first_div || row_dim < second_div)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "dist_matrixops::dist_constant::constant2d_helper",
+                            util::generate_error_message(
+                                "at least one of the marix dimensions is "
+                                "smaller "
+                                "than the number of tiles in that direction"));
+                    }
+                    std::tie(row_start, row_size) = detail::tile_calculation_1d(
+                        blaze::floor(tile_idx / first_div), row_dim,
+                        second_div);
+                    std::tie(column_start, column_size) =
+                        detail::tile_calculation_1d(
+                            tile_idx % first_div, column_dim, first_div);
+                }
+                else
+                {
+                    // larger column_dim
+                    if (column_dim < second_div || row_dim < first_div)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "dist_matrixops::dist_constant::constant2d_helper",
+                            util::generate_error_message(
+                                "at least one of the marix dimensions is "
+                                "smaller "
+                                "than the number of tiles in that direction"));
+                    }
+                    std::tie(row_start, row_size) = detail::tile_calculation_1d(
+                        blaze::floor(tile_idx / second_div), row_dim,
+                        first_div);
+                    std::tie(column_start, column_size) =
+                        detail::tile_calculation_1d(
+                            tile_idx % second_div, column_dim, second_div);
+                }
+            }
+            else
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "dist_matrixops::dist_constant::constant2d_helper",
+                    util::generate_error_message(
+                        "the given tiling_type is invalid"));
+            }
+            return std::make_tuple(
+                row_start, column_start, row_size, column_size);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    execution_tree::primitive_argument_type dist_random::dist_random1d(
+        std::size_t dim, std::uint32_t const& tile_idx,
+        std::uint32_t const& numtiles, std::string&& given_name,
+        double const& mean, double const& std, std::string const& name_,
+        std::string const& codename_) const
+    {
+        if (dim < numtiles)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "dist_matrixops::dist_random::dist_random1d",
+                util::generate_error_message("the vector length should not be "
+                                             "less than number of tiles"));
+        }
+
+        using namespace execution_tree;
+
+        std::normal_distribution<> dist(mean, std);
+
+        std::int64_t start;
+        std::size_t size;
+        std::tie(start, size) =
+            detail::tile_calculation_1d(tile_idx, dim, numtiles);
+
+        tiling_information_1d tile_info(
+            tiling_information_1d::tile1d_type::columns,
+            tiling_span(start, start + size));
+        locality_information locality_info(tile_idx, numtiles);
+        annotation locality_ann = locality_info.as_annotation();
+        // TODO: check for the name uniqueness
+        std::string base_name;
+        if (given_name.empty())
+        {
+            base_name = "random_vector_" + std::to_string(numtiles) + "_" +
+                std::to_string(dim);
+        }
+        else
+        {
+            base_name = std::move(given_name);
+        }
+
+        annotation_information ann_info(base_name, 0);    //generation 0
+
+        auto attached_annotation =
+            std::make_shared<execution_tree::annotation>(localities_annotation(
+                locality_ann, tile_info.as_annotation(name_, codename_),
+                ann_info, name_, codename_));
+
+        blaze::DynamicVector<double> v(size);
+        for (std::size_t i = 0; i != size; ++i)
+        {
+            v[i] = dist(util::rng_);
+        }
+
+        primitive_argument_type res(std::move(v), attached_annotation);
+
+        return std::move(res);
+    }
+
+    execution_tree::primitive_argument_type dist_random::dist_random2d(
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
+        std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
+        std::string&& given_name, std::string const& tiling_type,
+        double const& mean, double const& std, std::string const& name_,
+        std::string const& codename_) const
+    {
+        using namespace execution_tree;
+
+        std::normal_distribution<> dist(mean, std);
+        std::size_t const rows = dims[0];
+        std::size_t const columns = dims[1];
+        std::int64_t row_start, column_start;
+        std::size_t row_size, column_size;
+
+        std::tie(row_start, column_start, row_size, column_size) =
+            detail::tile_calculation_2d(
+                tile_idx, rows, columns, numtiles, tiling_type);
+
+        tiling_information_2d tile_info(
+            tiling_span(column_start, column_start + column_size),
+            tiling_span(row_start, row_start + row_size));
+
+        locality_information locality_info(tile_idx, numtiles);
+        annotation locality_ann = locality_info.as_annotation();
+        // TODO: check for the name uniqueness
+        std::string base_name;
+        if (given_name.empty())
+        {
+            base_name = "constant_matrix_" + std::to_string(numtiles) + "_" +
+                std::to_string(dims[0]) + "x" + std::to_string(dims[1]);
+        }
+        else
+        {
+            base_name = std::move(given_name);
+        }
+
+        annotation_information ann_info(base_name, 0);    //generation 0
+
+        auto attached_annotation =
+            std::make_shared<execution_tree::annotation>(localities_annotation(
+                locality_ann, tile_info.as_annotation(name_, codename_), ann_info,
+                name_, codename_));
+
+
+        blaze::DynamicMatrix<double> m(rows, columns);
+        for (std::size_t i = 0; i != rows; ++i)
+        {
+            for (std::size_t j = 0; j != columns; ++j)
+            {
+                m(i, j) = dist(util::rng_);
+            }
+        }
+
+        primitive_argument_type res(std::move(m), attached_annotation);
+
+        return std::move(res);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<execution_tree::primitive_argument_type> dist_random::eval(
+        execution_tree::primitive_arguments_type const& operands,
+        execution_tree::primitive_arguments_type const& args,
+        execution_tree::eval_context ctx) const
+    {
+        if (operands.size() < 3 || operands.size() > 7)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "dist_random::eval",
+                generate_error_message(
+                    "the random_d primitive requires at most three operand"));
+        }
+
+        if (!valid(operands[1]) || !valid(operands[2]) || !valid(operands[3]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "dist_random::eval",
+                generate_error_message(
+                    "the random_d primitive requires that the arguments "
+                        "given by the operands array are valid"));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+                [this_ = std::move(this_)](
+                        execution_tree::primitive_arguments_type&& args)
+                ->  execution_tree::primitive_argument_type
+                {
+                    using namespace execution_tree;
+
+                    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> dims{0};
+                    std::size_t numdims = 0;
+                    if (is_list_operand_strict(args[0]))
+                    {
+                        ir::range&& shape = extract_list_value_strict(
+                            std::move(args[0]), this_->name_, this_->codename_);
+
+                        if (shape.size() > PHYLANX_MAX_DIMENSIONS)
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "dist_random::eval",
+                                this_->generate_error_message(
+                                    "the given shape has a number of "
+                                    "dimensions that is not supported"));
+                        }
+
+                        dims = detail::extract_dimensions_(shape);
+                        numdims = detail::extract_num_dimensions_(shape);
+                    }
+                    else if (is_numeric_operand(args[0]))
+                    {
+                        numdims = 1;
+                        dims[0] = extract_scalar_positive_integer_value_strict(
+                            std::move(args[0]), this_->name_, this_->codename_);
+                    }
+
+                    std::uint32_t tile_idx =
+                        extract_scalar_nonneg_integer_value_strict(
+                            std::move(args[1]), this_->name_, this_->codename_);
+                    std::uint32_t numtiles =
+                        extract_scalar_positive_integer_value_strict(
+                            std::move(args[2]), this_->name_, this_->codename_);
+                    if (tile_idx >= numtiles)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "dist_constant::eval",
+                            this_->generate_error_message(
+                                "invalid tile index. Tile indices start from 0 "
+                                "and should be smaller than number of tiles"));
+                    }
+
+                    std::string given_name = "";
+                    if (valid(args[3]))
+                    {
+                        given_name = extract_string_value(std::move(args[3]),
+                            this_->name_, this_->codename_);
+                    }
+
+                    // using balanced symmetric tiles
+                    std::string tiling_type = "sym";
+                    if (valid(args[4]))
+                    {
+                        tiling_type = extract_string_value(
+                            std::move(args[4]), this_->name_, this_->codename_);
+                        if ((tiling_type != "sym" && tiling_type != "row") &&
+                            tiling_type != "column")
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "dist_constant::eval",
+                                this_->generate_error_message(
+                                    "invalid tling_type. the tiling_type cane "
+                                    "one of these: `sym`, `row` or `column`"));
+                        }
+                    }
+
+                    double mean = 0.0;
+                    if (valid(args[5]))
+                    {
+                        mean = extract_scalar_numeric_value(
+                            std::move(args[5]), this_->name_, this_->codename_);
+                    }
+
+                    double std = 1.0;
+                    if (valid(args[6]))
+                    {
+                        std = extract_scalar_numeric_value(
+                            std::move(args[6]), this_->name_, this_->codename_);
+                    }
+
+                    switch (numdims)
+                    {
+                    case 1:
+                        return this_->dist_random1d(dims[0], tile_idx, numtiles,
+                            std::move(given_name), mean, std, this_->name_,
+                            this_->codename_);
+
+                    case 2:
+                        return this_->dist_random2d(dims, tile_idx, numtiles,
+                            std::move(given_name), tiling_type, mean, std,
+                            this_->name_, this_->codename_);
+
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "dist_random::eval",
+                            this_->generate_error_message(
+                                "the given shape is of an unsupported "
+                                "dimensionality"));
+                    }
+                }),
+            execution_tree::primitives::detail::map_operands(operands,
+                execution_tree::functional::value_operand{}, args, name_,
+                codename_, std::move(ctx)));
+    }
+
+
+}}}
+

--- a/src/plugins/matrixops/constant.cpp
+++ b/src/plugins/matrixops/constant.cpp
@@ -16,7 +16,6 @@
 #include <hpx/errors/throw_exception.hpp>
 
 #include <array>
-#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/tests/unit/execution_tree/annotation.cpp
+++ b/tests/unit/execution_tree/annotation.cpp
@@ -38,9 +38,27 @@ void test_annotation_equality_0()
         compile_and_run("annotation_1", annotation_1));
 }
 
+void test_annotation_equality_1()
+{
+    std::string annotation_0 = R"(
+            annotate_d([[91, 91]], "test2d2d_4_1/1",
+                list("tile", list("columns", 0, 2), list("rows", 0, 1)))
+        )";
+    std::string annotation_1 = R"(
+            annotate_d([[91, 91]], "test2d2d_4_1/1",
+                list("args",
+                    list("locality", 0, 1),
+                    list("tile", list("rows", 0, 1), list("columns", 0, 2))))
+        )";
+
+    HPX_TEST_EQ(compile_and_run("annotation_0", annotation_0),
+        compile_and_run("annotation_1", annotation_1));
+}
+
 int main(int argc, char* argv[])
 {
     test_annotation_equality_0();
+    test_annotation_equality_1();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -11,7 +11,10 @@ set(tests
     dist_constant_6_loc
     dist_dot_operation
     dist_transpose_operation
+    dist_random_2_loc
+    dist_random_4_loc
    )
+
 
 set(dist_cannon_product_PARAMETERS LOCALITIES 4)
 set(dist_cannon_product_9_loc_PARAMETERS LOCALITIES 9)
@@ -19,6 +22,9 @@ set(dist_constant_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_dot_operation_PARAMETERS LOCALITIES 2)
+set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_random_4_loc_PARAMETERS LOCALITIES 4)
+
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -12,7 +12,7 @@ set(tests
     dist_dot_operation
     dist_transpose_operation
     dist_random_2_loc
-    dist_random_4_loc
+    dist_random_5_loc
    )
 
 
@@ -23,7 +23,7 @@ set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_dot_operation_PARAMETERS LOCALITIES 2)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
-set(dist_random_4_loc_PARAMETERS LOCALITIES 4)
+set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
 
 
 foreach(test ${tests})

--- a/tests/unit/plugins/dist_matrixops/dist_constant_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_2_loc.cpp
@@ -52,7 +52,7 @@ void test_constant_1d_0()
         test_constant_d_operation("test_constant_2loc1d_0", R"(
             constant_d(42, list(4), 0, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "constant_vector_2_4",
+            annotate_d([42.0, 42.0], "full_array_1",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 2))))
@@ -63,7 +63,7 @@ void test_constant_1d_0()
         test_constant_d_operation("test_constant_2loc1d_0", R"(
             constant_d(42, list(4), 1, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "constant_vector_2_4",
+            annotate_d([42.0, 42.0], "full_array_1",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 2, 4))))
@@ -78,7 +78,7 @@ void test_constant_1d_1()
         test_constant_d_operation("test_constant_2loc1d_1", R"(
             constant_d(42, list(5), 0, 2)
         )", R"(
-            annotate_d([42.0, 42.0, 42.0], "constant_vector_2_5",
+            annotate_d([42.0, 42.0, 42.0], "full_array_2",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 3))))
@@ -89,7 +89,7 @@ void test_constant_1d_1()
         test_constant_d_operation("test_constant_2loc1d_1", R"(
             constant_d(42, list(5), 1, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "constant_vector_2_5",
+            annotate_d([42.0, 42.0], "full_array_2",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 3, 5))))
@@ -161,7 +161,7 @@ void test_constant_2d_0()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "constant_matrix_2_4x6",
+                "full_array_3",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 3), list("rows", 0, 4))))
@@ -174,7 +174,7 @@ void test_constant_2d_0()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "constant_matrix_2_4x6",
+                "full_array_3",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 3, 6), list("rows", 0, 4))))

--- a/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
@@ -52,7 +52,7 @@ void test_constant_4loc_1d_0()
         test_constant_d_operation("test_constant_4loc1d_0", R"(
             constant_d(42, list(13), 0, 4)
         )", R"(
-            annotate_d([42.0, 42.0, 42.0, 42.0], "constant_vector_4_13",
+            annotate_d([42.0, 42.0, 42.0, 42.0], "full_array_1",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 4))))
@@ -63,7 +63,7 @@ void test_constant_4loc_1d_0()
         test_constant_d_operation("test_constant_4loc1d_0", R"(
             constant_d(42, list(13), 1, 4)
         )", R"(
-            annotate_d([42.0, 42.0, 42.0], "constant_vector_4_13",
+            annotate_d([42.0, 42.0, 42.0], "full_array_1",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 4, 7))))
@@ -74,7 +74,7 @@ void test_constant_4loc_1d_0()
         test_constant_d_operation("test_constant_4loc1d_0", R"(
             constant_d(42, list(13), 2, 4)
         )", R"(
-            annotate_d([42.0, 42.0, 42.0], "constant_vector_4_13",
+            annotate_d([42.0, 42.0, 42.0], "full_array_1",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 7, 10))))
@@ -85,7 +85,7 @@ void test_constant_4loc_1d_0()
         test_constant_d_operation("test_constant_4loc1d_0", R"(
             constant_d(42, list(13), 3, 4)
         )", R"(
-            annotate_d([42.0, 42.0, 42.0], "constant_vector_4_13",
+            annotate_d([42.0, 42.0, 42.0], "full_array_1",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 10, 13))))
@@ -101,7 +101,7 @@ void test_constant_4loc_2d_0()
             constant_d(42, list(4, 7), 0, 4)
         )", R"(
             annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0]],
-                "constant_matrix_4_4x7",
+                "full_array_2",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 4), list("rows", 0, 2))))
@@ -113,7 +113,7 @@ void test_constant_4loc_2d_0()
             constant_d(42, list(4, 7), 1, 4)
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "constant_matrix_4_4x7",
+                "full_array_2",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 4, 7), list("rows", 0, 2))))
@@ -125,7 +125,7 @@ void test_constant_4loc_2d_0()
             constant_d(42, list(4, 7), 2, 4)
         )", R"(
             annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0]],
-                "constant_matrix_4_4x7",
+                "full_array_2",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 0, 4), list("rows", 2, 4))))
@@ -137,7 +137,7 @@ void test_constant_4loc_2d_0()
             constant_d(42, list(4, 7), 3, 4)
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "constant_matrix_4_4x7",
+                "full_array_2",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 4, 7), list("rows", 2, 4))))
@@ -154,7 +154,7 @@ void test_constant_4loc_2d_1()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0]],
-                "constant_matrix_4_3x9",
+                "full_array_3",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 3), list("rows", 0, 3))))
@@ -166,7 +166,7 @@ void test_constant_4loc_2d_1()
             constant_d(42, list(3, 9), 1, 4, "", "column")
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0]],
-                "constant_matrix_4_3x9",
+                "full_array_3",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 3, 5), list("rows", 0, 3))))
@@ -178,7 +178,7 @@ void test_constant_4loc_2d_1()
             constant_d(42, list(3, 9), 2, 4, "", "column")
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0]],
-                "constant_matrix_4_3x9",
+                "full_array_3",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 5, 7), list("rows", 0, 3))))
@@ -190,7 +190,7 @@ void test_constant_4loc_2d_1()
             constant_d(42, list(3, 9), 3, 4, "", "column")
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0]],
-                "constant_matrix_4_3x9",
+                "full_array_3",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 7, 9), list("rows", 0, 3))))

--- a/tests/unit/plugins/dist_matrixops/dist_constant_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_6_loc.cpp
@@ -54,7 +54,7 @@ void test_constant_6loc_2d_0()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0]],
-                "constant_vector_6_5x8",
+                "full_array_1",
                 list("args",
                     list("locality", 0, 6),
                     list("tile", list("columns", 0, 3), list("rows", 0, 3))))
@@ -67,7 +67,7 @@ void test_constant_6loc_2d_0()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0]],
-                "constant_vector_6_5x8",
+                "full_array_1",
                 list("args",
                     list("locality", 1, 6),
                     list("tile", list("columns", 3, 6), list("rows", 0, 3))))
@@ -79,7 +79,7 @@ void test_constant_6loc_2d_0()
             constant_d(42, list(5, 8), 2, 6)
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0]],
-                "constant_vector_6_5x8",
+                "full_array_1",
                 list("args",
                     list("locality", 2, 6),
                     list("tile", list("columns", 6, 8), list("rows", 0, 3))))
@@ -91,7 +91,7 @@ void test_constant_6loc_2d_0()
             constant_d(42, list(5, 8), 3, 6)
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "constant_vector_6_5x8",
+                "full_array_1",
                 list("args",
                     list("locality", 3, 6),
                     list("tile", list("columns", 0, 3), list("rows", 3, 5))))
@@ -103,7 +103,7 @@ void test_constant_6loc_2d_0()
             constant_d(42, list(5, 8), 4, 6)
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "constant_vector_6_5x8",
+                "full_array_1",
                 list("args",
                     list("locality", 4, 6),
                     list("tile", list("columns", 3, 6), list("rows", 3, 5))))
@@ -115,7 +115,7 @@ void test_constant_6loc_2d_0()
             constant_d(42, list(5, 8), 5, 6)
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0]],
-                "constant_vector_6_5x8",
+                "full_array_1",
                 list("args",
                     list("locality", 5, 6),
                     list("tile", list("columns", 6, 8), list("rows", 3, 5))))
@@ -132,7 +132,7 @@ void test_constant_6loc_2d_1()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0]],
-                "constant_vector_6_8x5",
+                "full_array_2",
                 list("args",
                     list("locality", 0, 6),
                     list("tile", list("columns", 0, 3), list("rows", 0, 3))))
@@ -144,7 +144,7 @@ void test_constant_6loc_2d_1()
             constant_d(42, list(8, 5), 1, 6)
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0]],
-                "constant_vector_6_8x5",
+                "full_array_2",
                 list("args",
                     list("locality", 1, 6),
                     list("tile", list("columns", 3, 5), list("rows", 0, 3))))
@@ -157,7 +157,7 @@ void test_constant_6loc_2d_1()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0]],
-                "constant_vector_6_8x5",
+                "full_array_2",
                 list("args",
                     list("locality", 2, 6),
                     list("tile", list("columns", 0, 3), list("rows", 3, 6))))
@@ -169,7 +169,7 @@ void test_constant_6loc_2d_1()
             constant_d(42, list(8, 5), 3, 6)
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0]],
-                "constant_vector_6_8x5",
+                "full_array_2",
                 list("args",
                     list("locality", 3, 6),
                     list("tile", list("columns", 3, 5), list("rows", 3, 6))))
@@ -181,7 +181,7 @@ void test_constant_6loc_2d_1()
             constant_d(42, list(8, 5), 4, 6)
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "constant_vector_6_8x5",
+                "full_array_2",
                 list("args",
                     list("locality", 4, 6),
                     list("tile", list("columns", 0, 3), list("rows", 6, 8))))
@@ -193,7 +193,7 @@ void test_constant_6loc_2d_1()
             constant_d(42, list(8, 5), 5, 6)
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0]],
-                "constant_vector_6_8x5",
+                "full_array_2",
                 list("args",
                     list("locality", 5, 6),
                     list("tile", list("columns", 3, 5), list("rows", 6, 8))))

--- a/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
@@ -211,9 +211,39 @@ void test_random_2d_1()
     }
 }
 
+void test_random_2d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc2d_2", R"(
+            random_d(list(5, 4), 0, 2, "rand_5_4", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0],
+                [42.0, 42.0, 42.0, 42.0]],
+                "rand_5_4",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4), list("rows", 0, 3))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc2d_2", R"(
+            random_d(list(5, 4), 1, 2, "rand_5_4", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0]],
+                "rand_5_4",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 4), list("rows", 3, 5))))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
+    // only annotations are compared
     test_random_1d_0();
     test_random_1d_1();
     test_random_1d_2();
@@ -221,6 +251,7 @@ int hpx_main(int argc, char* argv[])
 
     test_random_2d_0();
     test_random_2d_1();
+    test_random_2d_2();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
@@ -1,0 +1,236 @@
+// Copyright (c) 2020 Hartmut Kaiser
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_random_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    // comparing annotations
+    HPX_TEST_EQ(*(result.annotation()),*(comparison.annotation()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_random_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc1d_0", R"(
+            random_d(list(4), 0, 2)
+        )", R"(
+            annotate_d([42.0, 42.0], "random_vector_2_4",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc1d_0", R"(
+            random_d(list(4), 1, 2)
+        )", R"(
+            annotate_d([42.0, 42.0], "random_vector_2_4",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 4))))
+        )");
+    }
+}
+
+void test_random_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc1d_1", R"(
+            random_d(list(5), 0, 2)
+        )", R"(
+            annotate_d([42.0, 42.0, 42.0], "random_vector_2_5",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 3))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc1d_1", R"(
+            random_d(list(5), 1, 2)
+        )", R"(
+            annotate_d([42.0, 42.0], "random_vector_2_5",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 3, 5))))
+        )");
+    }
+}
+
+void test_random_1d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc1d_2", R"(
+            random_d(list(7), 0, 2, "my_rand_13")
+        )", R"(
+            annotate_d([13.0, 13.0, 13.0, 13.0], "my_rand_13",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc1d_2", R"(
+            random_d(list(7), 1, 2, "my_rand_13")
+        )", R"(
+            annotate_d([13.0, 13.0, 13.0], "my_rand_13",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 4, 7))))
+        )");
+    }
+}
+
+void test_random_1d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test1d_3", R"(
+            random_d(list(7), 0, 2, "my_rand_13_2", "sym")
+        )", R"(
+            annotate_d([13, 13, 13, 13], "my_rand_13_2",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test1d_3", R"(
+            random_d(list(7), 1, 2, "my_rand_13_2", "sym")
+        )", R"(
+            annotate_d([13, 13, 13], "my_rand_13_2",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 4, 7))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_random_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc2d_0", R"(
+            random_d(list(4, 6), 0, 2)
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
+                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
+                "random_matrix_2_4x6",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc2d_0", R"(
+            random_d(list(4, 6), 1, 2)
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
+                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
+                "random_matrix_2_4x6",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 3, 6), list("rows", 0, 4))))
+        )");
+    }
+}
+
+void test_random_2d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc2d_1", R"(
+            random_d(list(5, 4), 0, 2, "rand_42", "column")
+        )", R"(
+            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
+                        [42.0, 42.0], [42.0, 42.0]],
+                "rand_42",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 5))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc2d_1", R"(
+            random_d(list(5, 4), 1, 2, "rand_42", "column")
+        )", R"(
+            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
+                        [42.0, 42.0], [42.0, 42.0]],
+                "rand_42",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 5))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_random_1d_0();
+    test_random_1d_1();
+    test_random_1d_2();
+    test_random_1d_3();
+
+    test_random_2d_0();
+    test_random_2d_1();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
@@ -53,7 +53,7 @@ void test_random_1d_0()
         test_random_d_operation("test_random_2loc1d_0", R"(
             random_d(list(4), 0, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "random_vector_2_4",
+            annotate_d([42.0, 42.0], "random_array_1",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 2))))
@@ -64,7 +64,7 @@ void test_random_1d_0()
         test_random_d_operation("test_random_2loc1d_0", R"(
             random_d(list(4), 1, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "random_vector_2_4",
+            annotate_d([42.0, 42.0], "random_array_1",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 2, 4))))
@@ -79,7 +79,7 @@ void test_random_1d_1()
         test_random_d_operation("test_random_2loc1d_1", R"(
             random_d(list(5), 0, 2)
         )", R"(
-            annotate_d([42.0, 42.0, 42.0], "random_vector_2_5",
+            annotate_d([42.0, 42.0, 42.0], "random_array_2",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 3))))
@@ -90,7 +90,7 @@ void test_random_1d_1()
         test_random_d_operation("test_random_2loc1d_1", R"(
             random_d(list(5), 1, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "random_vector_2_5",
+            annotate_d([42.0, 42.0], "random_array_2",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 3, 5))))
@@ -160,7 +160,7 @@ void test_random_2d_0()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "random_matrix_2_4x6",
+                "random_array_3",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 3), list("rows", 0, 4))))
@@ -173,7 +173,7 @@ void test_random_2d_0()
         )", R"(
             annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
                         [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "random_matrix_2_4x6",
+                "random_array_3",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 3, 6), list("rows", 0, 4))))

--- a/tests/unit/plugins/dist_matrixops/dist_random_5_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_5_loc.cpp
@@ -119,7 +119,7 @@ void test_random_5loc_2d_1()
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
                 [42.0, 42.0]],
-                "random_matrix_5_5x8",
+                "random_array_1",
                 list("args",
                     list("locality", 0, 5),
                     list("tile", list("columns", 0, 2), list("rows", 0, 5))))
@@ -132,7 +132,7 @@ void test_random_5loc_2d_1()
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
                 [42.0, 42.0]],
-                "random_matrix_5_5x8",
+                "random_array_1",
                 list("args",
                     list("locality", 1, 5),
                     list("tile", list("columns", 2, 4), list("rows", 0, 5))))
@@ -145,7 +145,7 @@ void test_random_5loc_2d_1()
         )", R"(
             annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
                 [42.0, 42.0]],
-                "random_matrix_5_5x8",
+                "random_array_1",
                 list("args",
                     list("locality", 2, 5),
                     list("tile", list("columns", 4, 6), list("rows", 0, 5))))
@@ -157,7 +157,7 @@ void test_random_5loc_2d_1()
             random_d(list(5, 8), 3, 5)
         )", R"(
             annotate_d([[42.0], [42.0], [42.0], [42.0], [42.0]],
-                "random_matrix_5_5x8",
+                "random_array_1",
                 list("args",
                     list("locality", 3, 5),
                     list("tile", list("columns", 6, 7), list("rows", 0, 5))))
@@ -169,7 +169,7 @@ void test_random_5loc_2d_1()
             random_d(list(5, 8), 4, 5)
         )", R"(
             annotate_d([[42.0], [42.0], [42.0], [42.0], [42.0]],
-                "random_matrix_5_5x8",
+                "random_array_1",
                 list("args",
                     list("locality", 4, 5),
                     list("tile", list("columns", 7, 8), list("rows", 0, 5))))

--- a/tests/unit/plugins/dist_matrixops/dist_random_5_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_5_loc.cpp
@@ -1,0 +1,198 @@
+// Copyright (c) 2020 Hartmut Kaiser
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_random_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    // comparing annotations
+    HPX_TEST_EQ(*(result.annotation()),*(comparison.annotation()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_random_5loc_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_5loc2d_0", R"(
+            random_d(list(5, 8), 0, 5, "rand58", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0]],
+                "rand58",
+                list("args",
+                    list("locality", 0, 5),
+                    list("tile", list("columns", 0, 8), list("rows", 0, 1))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_random_d_operation("test_random_5loc2d_0", R"(
+            random_d(list(5, 8), 1, 5, "rand58", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0]],
+                "rand58",
+                list("args",
+                    list("locality", 1, 5),
+                    list("tile", list("columns", 0, 8), list("rows", 1, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_random_d_operation("test_random_5loc2d_0", R"(
+            random_d(list(5, 8), 2, 5, "rand58", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0]],
+                "rand58",
+                list("args",
+                    list("locality", 2, 5),
+                    list("tile", list("columns", 0, 8), list("rows", 2, 3))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_random_d_operation("test_random_5loc2d_0", R"(
+            random_d(list(5, 8), 3, 5, "rand58", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0]],
+                "rand58",
+                list("args",
+                    list("locality", 3, 5),
+                    list("tile", list("columns", 0, 8), list("rows", 3, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_random_d_operation("test_random_5loc2d_0", R"(
+            random_d(list(5, 8), 4, 5, "rand58", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0, 42.0]],
+                "rand58",
+                list("args",
+                    list("locality", 4, 5),
+                    list("tile", list("columns", 0, 8), list("rows", 4, 5))))
+        )");
+    }
+}
+
+void test_random_5loc_2d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_5loc2d_1", R"(
+            random_d(list(5, 8), 0, 5)
+        )", R"(
+            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
+                [42.0, 42.0]],
+                "random_matrix_5_5x8",
+                list("args",
+                    list("locality", 0, 5),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_random_d_operation("test_random_5loc2d_1", R"(
+            random_d(list(5, 8), 1, 5)
+        )", R"(
+            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
+                [42.0, 42.0]],
+                "random_matrix_5_5x8",
+                list("args",
+                    list("locality", 1, 5),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_random_d_operation("test_random_5loc2d_1", R"(
+            random_d(list(5, 8), 2, 5)
+        )", R"(
+            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
+                [42.0, 42.0]],
+                "random_matrix_5_5x8",
+                list("args",
+                    list("locality", 2, 5),
+                    list("tile", list("columns", 4, 6), list("rows", 0, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_random_d_operation("test_random_5loc2d_1", R"(
+            random_d(list(5, 8), 3, 5)
+        )", R"(
+            annotate_d([[42.0], [42.0], [42.0], [42.0], [42.0]],
+                "random_matrix_5_5x8",
+                list("args",
+                    list("locality", 3, 5),
+                    list("tile", list("columns", 6, 7), list("rows", 0, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_random_d_operation("test_random_5loc2d_1", R"(
+            random_d(list(5, 8), 4, 5)
+        )", R"(
+            annotate_d([[42.0], [42.0], [42.0], [42.0], [42.0]],
+                "random_matrix_5_5x8",
+                list("args",
+                    list("locality", 4, 5),
+                    list("tile", list("columns", 7, 8), list("rows", 0, 5))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    // only annotations are compared
+    test_random_5loc_2d_0();
+    test_random_5loc_2d_1();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+


### PR DESCRIPTION
This PR adds a distributed random primitive, that generates the array and its attached annotation for the given tile index and the number of tiles, using a normal distribution.
As parts of tile calculations were the same as those in distributed constant, they are moved to a header file. Also, for both distributed constant and random arrays, unique names are generated using atomic counters.