### PR TITLE
Make distributed span indices compatible with phylanx conventions

### DIFF
--- a/phylanx/execution_tree/localities_annotation.hpp
+++ b/phylanx/execution_tree/localities_annotation.hpp
@@ -37,7 +37,7 @@ namespace phylanx { namespace execution_tree
             std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims);
 
         // extract dimensionality and sizes
-        std::size_t dimension() const;
+        std::size_t num_dimensions() const;
         std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> dimensions(
             std::string const& name, std::string const& codename) const;
 

--- a/phylanx/execution_tree/tiling_annotations.hpp
+++ b/phylanx/execution_tree/tiling_annotations.hpp
@@ -67,7 +67,8 @@ namespace phylanx { namespace execution_tree
     {
         static char const* get_span_name(std::size_t i)
         {
-            static const char* const names[] = {"columns", "rows", "pages"};
+            static const char* const names[] = {
+                "columns", "rows", "pages", "quats"};
             return names[i];
         }
 
@@ -81,10 +82,10 @@ namespace phylanx { namespace execution_tree
             std::string const& name, std::string const& codename) const
         {
             annotation ann("tile");
-            for (std::size_t i = 0; i != spans_.size(); ++i)
+            for (std::size_t i = spans_.size(); i != 0; --i)
             {
-                ann.add_annotation(get_span_name(i),
-                    ir::range(spans_[i].start_, spans_[i].stop_), name,
+                ann.add_annotation(get_span_name(i - 1),
+                    ir::range(spans_[i - 1].start_, spans_[i - 1].stop_), name,
                     codename);
             }
             return ann;
@@ -147,7 +148,7 @@ namespace phylanx { namespace execution_tree
     {
         tiling_information_2d(
             tiling_span const& row_span, tiling_span const& column_span)
-          : spans_{column_span, row_span}
+          : spans_{row_span, column_span}
         {}
 
         PHYLANX_EXPORT tiling_information_2d(annotation const& ann,
@@ -161,7 +162,7 @@ namespace phylanx { namespace execution_tree
 
         PHYLANX_EXPORT void transpose();
 
-        tiling_span spans_[2];    // column and row spans
+        tiling_span spans_[2];    // row and column spans
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -179,7 +180,7 @@ namespace phylanx { namespace execution_tree
         PHYLANX_EXPORT void transpose(
             std::int64_t const* data, std::size_t count);
 
-        tiling_span spans_[3];    // column, row and page spans
+        tiling_span spans_[3];    // page, row and column spans
     };
 }}
 

--- a/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
@@ -292,7 +292,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         execution_tree::localities_information&& lhs_localities,
         execution_tree::localities_information const& rhs_localities) const
     {
-        if (lhs_localities.dimension() < 2 || rhs_localities.dimension() < 2)
+        if (lhs_localities.num_dimensions() < 2 ||
+            rhs_localities.num_dimensions() < 2)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "dist_cannon_product::dot2d2d_par",

--- a/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
@@ -73,14 +73,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         std::size_t lhs_num_cols = lhs_localities.columns();
         std::size_t rhs_num_rows = rhs_localities.rows();
         execution_tree::tiling_span const& lhs_col_span =
-            lhs_localities.get_span(0);
-        execution_tree::tiling_span const& lhs_row_span =
             lhs_localities.get_span(1);
+        execution_tree::tiling_span const& lhs_row_span =
+            lhs_localities.get_span(0);
 
         execution_tree::tiling_span const& rhs_col_span =
-            rhs_localities.get_span(0);
-        execution_tree::tiling_span const& rhs_row_span =
             rhs_localities.get_span(1);
+        execution_tree::tiling_span const& rhs_row_span =
+            rhs_localities.get_span(0);
 
         // Maybe this error should be split to be more descriptive
         if (lhs_num_cols % lhs_col_span.size() != 0 ||
@@ -114,13 +114,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             // guaranteed to be sorted by locality index
             auto const& tmp_lhs_tile = lhs_localities.tiles_[i];
             auto const& tmp_rhs_tile = rhs_localities.tiles_[i];
-            if (tmp_lhs_tile.spans_[1].start_ == lhs_row_span.start_ &&
-                tmp_lhs_tile.spans_[1].size() == lhs_row_span.size())
+            if (tmp_lhs_tile.spans_[0].start_ == lhs_row_span.start_ &&
+                tmp_lhs_tile.spans_[0].size() == lhs_row_span.size())
             {
                 lhs_tile_row.push_back(count);
             }
-            if (tmp_rhs_tile.spans_[0].start_ == rhs_col_span.start_ &&
-                tmp_rhs_tile.spans_[0].size() == rhs_col_span.size())
+            if (tmp_rhs_tile.spans_[1].start_ == rhs_col_span.start_ &&
+                tmp_rhs_tile.spans_[1].size() == rhs_col_span.size())
             {
                 rhs_tile_col.push_back(count);
             }
@@ -147,13 +147,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             std::size_t lhs_tile_idx = lhs_tile_row[i];
             std::size_t rhs_tile_idx = rhs_tile_col[i];
             std::size_t lhs_local_width =
-                lhs_localities.tiles_[lhs_tile_idx].spans_[0].size();
+                lhs_localities.tiles_[lhs_tile_idx].spans_[1].size();
             std::size_t rhs_local_height =
-                rhs_localities.tiles_[rhs_tile_idx].spans_[1].size();
-            if (lhs_localities.tiles_[lhs_tile_idx].spans_[0].start_ <
+                rhs_localities.tiles_[rhs_tile_idx].spans_[0].size();
+            if (lhs_localities.tiles_[lhs_tile_idx].spans_[1].start_ <
                     max_start_col ||
                 lhs_local_width != lhs_col_span.size() ||
-                rhs_localities.tiles_[rhs_tile_idx].spans_[1].start_ <
+                rhs_localities.tiles_[rhs_tile_idx].spans_[0].start_ <
                     max_start_row ||
                 rhs_local_height != rhs_row_span.size())
             {
@@ -163,9 +163,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                         "tiles not sorted in order of locality"));
             }
             max_start_col =
-                lhs_localities.tiles_[lhs_tile_idx].spans_[0].start_;
+                lhs_localities.tiles_[lhs_tile_idx].spans_[1].start_;
             max_start_row =
-                rhs_localities.tiles_[rhs_tile_idx].spans_[1].start_;
+                rhs_localities.tiles_[rhs_tile_idx].spans_[0].start_;
         }
 
         std::uint32_t lhs_locality_id = lhs_localities.locality_.locality_id_;
@@ -267,10 +267,10 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             execution_tree::primitive_argument_type{std::move(result_matrix)};
 
         execution_tree::annotation ann{ir::range("tile",
-            ir::range("columns", rhs_localities.get_span(0).start_,
-                rhs_localities.get_span(0).stop_),
-            ir::range("rows", lhs_localities.get_span(1).start_,
-                lhs_localities.get_span(1).stop_))};
+            ir::range("columns", rhs_localities.get_span(1).start_,
+                rhs_localities.get_span(1).stop_),
+            ir::range("rows", lhs_localities.get_span(0).start_,
+                lhs_localities.get_span(0).stop_))};
         // Generate new tiling annotation for the result matrix
         execution_tree::tiling_information_2d tile_info(ann, name_, codename_);
 

--- a/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
@@ -668,10 +668,10 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                 result = execution_tree::primitive_argument_type{
                     std::move(result_matrix)};
                 execution_tree::annotation ann{ir::range("tile",
-                    ir::range("rows", rhs_localities.get_span(0).start_,
-                        rhs_localities.get_span(0).stop_),
-                    ir::range("columns", lhs_localities.get_span(1).start_,
-                        lhs_localities.get_span(1).stop_))};
+                    ir::range("rows", lhs_localities.get_span(0).start_,
+                        lhs_localities.get_span(0).stop_),
+                    ir::range("columns", static_cast<std::int64_t>(0),
+                        static_cast<std::int64_t>(rhs_localities.columns())))};
                 // Generate new tiling annotation for the result vector
                 execution_tree::tiling_information_2d tile_info(
                     ann, name_, codename_);

--- a/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
@@ -237,8 +237,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
         // use the local tile of lhs and calculate the dot product with all
         // corresponding tiles of rhs
+        std::size_t lhs_span_index = 0;
+        if (!lhs_localities.has_span(0))
+        {
+            HPX_ASSERT(lhs_localities.has_span(1));
+            lhs_span_index = 1;
+        }
         execution_tree::tiling_span const& lhs_span =
-            lhs_localities.get_span(0);
+            lhs_localities.get_span(lhs_span_index);
 
         // go over all tiles of rhs matrix, the result size is determined by
         // the number of columns of the entire RHS
@@ -267,7 +273,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             // project global coordinates onto local ones
             execution_tree::tiling_span lhs_intersection =
                 lhs_localities.project_coords(
-                    lhs_localities.locality_.locality_id_, 0, intersection);
+                    lhs_localities.locality_.locality_id_, lhs_span_index,
+                    intersection);
             execution_tree::tiling_span rhs_intersection =
                 rhs_localities.project_coords(
                     loc, rhs_span_index, intersection);

--- a/src/execution_tree/localities_annotation.cpp
+++ b/src/execution_tree/localities_annotation.cpp
@@ -125,8 +125,6 @@ namespace phylanx { namespace execution_tree
                     "tile information", name, codename));
         }
 
-        auto a = extract_numeric_value_dimensions(arg, name, codename);
-        auto b = dimensions(name, codename);
         if (extract_numeric_value_dimensions(arg, name, codename) !=
             dimensions(name, codename))
         {

--- a/src/execution_tree/localities_annotation.cpp
+++ b/src/execution_tree/localities_annotation.cpp
@@ -264,7 +264,10 @@ namespace phylanx { namespace execution_tree
     // Is this helpful? It may only introduce confusion
     std::size_t localities_information::size() const
     {
-        return detail::dimension<0>(tiles_);
+        if (tiles_[0].spans_[0].is_valid())
+            return detail::dimension<0>(tiles_);
+
+        return detail::dimension<1>(tiles_);
     }
 
     // we assume that all tiles have the same number of dimension
@@ -298,7 +301,8 @@ namespace phylanx { namespace execution_tree
         {
         case 1:
             // assertion that it's a row vector
-            return detail::dimension<0>(tiles_);
+            HPX_ASSERT(tiles_[0].spans_[1].is_valid());
+            return detail::dimension<1>(tiles_);
 
         case 2:
             return detail::dimension<0>(tiles_);
@@ -346,7 +350,8 @@ namespace phylanx { namespace execution_tree
     bool localities_information::has_span(std::size_t dim) const
     {
         HPX_ASSERT(locality_.locality_id_ < tiles_.size());
-        HPX_ASSERT(dim < num_dimensions());
+        HPX_ASSERT(
+            dim < num_dimensions() || (dim == 1 && dim == num_dimensions()));
 
         return tiles_[locality_.locality_id_].spans_[dim].is_valid();
     }
@@ -354,7 +359,8 @@ namespace phylanx { namespace execution_tree
     tiling_span localities_information::get_span(std::size_t dim) const
     {
         HPX_ASSERT(locality_.locality_id_ < tiles_.size());
-        HPX_ASSERT(dim < num_dimensions());
+        HPX_ASSERT(
+            dim < num_dimensions() || (dim == 1 && dim == num_dimensions()));
 
         return tiles_[locality_.locality_id_].spans_[dim];
     }
@@ -364,7 +370,8 @@ namespace phylanx { namespace execution_tree
         std::uint32_t loc, std::size_t dim, tiling_span const& span) const
     {
         HPX_ASSERT(loc < tiles_.size());
-        HPX_ASSERT(dim < num_dimensions());
+        HPX_ASSERT(
+            dim < num_dimensions() || (dim == 1 && dim == num_dimensions()));
 
         auto const& gspan = tiles_[loc].spans_[dim];
         tiling_span result{

--- a/src/execution_tree/tiling_annotations.cpp
+++ b/src/execution_tree/tiling_annotations.cpp
@@ -74,17 +74,13 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
-        for (std::size_t i = 0; i != 3; ++i)
+        for (std::size_t i = PHYLANX_MAX_DIMENSIONS; i != 0; --i)
         {
             annotation tile_ann;
-            if (!ann.find(get_span_name(i), tile_ann, name, codename))
-            {
-                spans_.emplace_back();
-            }
-            else
+            if (ann.find(get_span_name(i - 1), tile_ann, name, codename))
             {
                 spans_.push_back(detail::extract_span(
-                    tile_ann, get_span_name(i), name, codename));
+                    tile_ann, get_span_name(i - 1), name, codename));
             }
         }
     }
@@ -93,11 +89,11 @@ namespace phylanx { namespace execution_tree
         std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims)
     {
         spans_.reserve(dim);
-        for (std::size_t i = dim; i != 0; --i)
+        for (std::size_t i = 0; i != dim; ++i)
         {
-            spans_.emplace_back(0, dims[i - 1]);
+            spans_.emplace_back(0, dims[i]);
         }
-        for (std::size_t i = dim; i != 3; ++i)
+        for (std::size_t i = dim; i != PHYLANX_MAX_DIMENSIONS; ++i)
         {
             spans_.emplace_back(0, 0);
         }
@@ -180,8 +176,8 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
-        spans_[1] = detail::extract_span(ann, "rows", name, codename);
-        spans_[0] = detail::extract_span(ann, "columns", name, codename);
+        spans_[0] = detail::extract_span(ann, "rows", name, codename);
+        spans_[1] = detail::extract_span(ann, "columns", name, codename);
     }
 
     tiling_information_2d::tiling_information_2d(tiling_information const& tile,
@@ -204,8 +200,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name, std::string const& codename) const
     {
         return annotation{ir::range("tile",
-            ir::range("rows", spans_[1].start_, spans_[1].stop_),
-            ir::range("columns", spans_[0].start_, spans_[0].stop_))};
+            ir::range("rows", spans_[0].start_, spans_[0].stop_),
+            ir::range("columns", spans_[1].start_, spans_[1].stop_))};
     }
 
     void tiling_information_2d::transpose()
@@ -227,9 +223,9 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
-        spans_[2] = detail::extract_span(ann, "pages", name, codename);
+        spans_[0] = detail::extract_span(ann, "pages", name, codename);
         spans_[1] = detail::extract_span(ann, "rows", name, codename);
-        spans_[0] = detail::extract_span(ann, "columns", name, codename);
+        spans_[2] = detail::extract_span(ann, "columns", name, codename);
     }
 
     tiling_information_3d::tiling_information_3d(tiling_information const& tile,
@@ -253,9 +249,9 @@ namespace phylanx { namespace execution_tree
         std::string const& name, std::string const& codename) const
     {
         return annotation{ir::range("tile",
-            ir::range("pages", spans_[2].start_, spans_[2].stop_),
+            ir::range("pages", spans_[0].start_, spans_[0].stop_),
             ir::range("rows", spans_[1].start_, spans_[1].stop_),
-            ir::range("columns", spans_[0].start_, spans_[0].stop_))};
+            ir::range("columns", spans_[2].start_, spans_[2].stop_))};
     }
 
     void tiling_information_3d::transpose(

--- a/src/execution_tree/tiling_annotations.cpp
+++ b/src/execution_tree/tiling_annotations.cpp
@@ -74,6 +74,14 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
+        annotation temp_tile_ann;
+        if (!ann.find(get_span_name(0), temp_tile_ann, name, codename))
+        {
+            // having a row vector, the first span should be empty
+            // so, a row vectoe has a spans size of 2
+            spans_.emplace_back();
+        }
+
         for (std::size_t i = PHYLANX_MAX_DIMENSIONS; i != 0; --i)
         {
             annotation tile_ann;
@@ -133,12 +141,12 @@ namespace phylanx { namespace execution_tree
 
         if (tile.spans_[0].is_valid())
         {
-            span_ = tile.spans_[0];
+            span_ = tile.spans_[0];    // column vector
         }
-        else if (tile.spans_.size() >= 2 && tile.spans_[1].is_valid())
+        else if (tile.spans_.size() == 2 && tile.spans_[1].is_valid())
         {
             type_ = rows;
-            span_ = tile.spans_[1];
+            span_ = tile.spans_[1];    //row vector
         }
         else
         {

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -198,8 +198,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                 tile_idx, row_dim, column_dim, numtiles, tiling_type);
 
         tiling_information_2d tile_info(
-            tiling_span(column_start, column_start + column_size),
-            tiling_span(row_start, row_start + row_size));
+            tiling_span(row_start, row_start + row_size),
+            tiling_span(column_start, column_start + column_size));
 
         locality_information locality_info(tile_idx, numtiles);
         annotation locality_ann = locality_info.as_annotation();

--- a/src/plugins/dist_matrixops/dist_random.cpp
+++ b/src/plugins/dist_matrixops/dist_random.cpp
@@ -213,8 +213,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::normal_distribution<> dist(mean, std);
 
         tiling_information_2d tile_info(
-            tiling_span(column_start, column_start + column_size),
-            tiling_span(row_start, row_start + row_size));
+            tiling_span(row_start, row_start + row_size),
+            tiling_span(column_start, column_start + column_size));
 
         locality_information locality_info(tile_idx, numtiles);
         annotation locality_ann = locality_info.as_annotation();

--- a/tests/unit/execution_tree/CMakeLists.txt
+++ b/tests/unit/execution_tree/CMakeLists.txt
@@ -4,7 +4,8 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-	annotation
+    annotation
+    annotation_2_loc
     compiler
     compiler_component
     expression_topology
@@ -13,6 +14,8 @@ set(tests
     parse_primitive_name
     variable_definition
    )
+
+set(annotation_2_loc_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/tests/unit/execution_tree/annotation.cpp
+++ b/tests/unit/execution_tree/annotation.cpp
@@ -23,17 +23,6 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
     return code.run().arg_;
 }
 
-void test_equality(std::string const& name, std::string const& code,
-    std::string const& expected_str)
-{
-    HPX_TEST_EQ(compile_and_run(name, code), compile_and_run(name, expected_str));
-}
-
-void test_non_equality(std::string const& name, std::string const& code,
-    std::string const& expected_str)
-{
-    HPX_TEST_EQ(compile_and_run(name, code), compile_and_run(name, expected_str));
-}
 
 void test_annotation_equality_0()
 {

--- a/tests/unit/execution_tree/annotation.cpp
+++ b/tests/unit/execution_tree/annotation.cpp
@@ -23,6 +23,18 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
     return code.run().arg_;
 }
 
+void test_equality(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(name, code), compile_and_run(name, expected_str));
+}
+
+void test_non_equality(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    HPX_TEST_EQ(compile_and_run(name, code), compile_and_run(name, expected_str));
+}
+
 void test_annotation_equality_0()
 {
     std::string annotation_0 = R"(
@@ -55,10 +67,44 @@ void test_annotation_equality_1()
         compile_and_run("annotation_1", annotation_1));
 }
 
+void test_annotation_equality_2()
+{
+    std::string annotation_0 = R"(
+            annotate_d([[91, 91]], "some_name",
+                list("tile", list("columns", 0, 2), list("rows", 0, 1)))
+        )";
+    std::string annotation_1 = R"(
+            annotate_d([[91, 91]], "test2d2d_2_1/1",
+                list("tile", list("columns", 0, 2), list("rows", 0, 1)))
+        )";
+
+    HPX_TEST_NEQ(compile_and_run("annotation_0", annotation_0),
+        compile_and_run("annotation_1", annotation_1));
+}
+
+void test_annotation_equality_3()
+{
+    std::string annotation_0 = R"(
+            annotate_d([[91, 91]], "test2d2d_3_1/1",
+                list("tile", list("columns", 0, 2), list("rows", 2, 4)))
+        )";
+    std::string annotation_1 = R"(
+            annotate_d([[91, 91]], "test2d2d_3_1/1",
+                list("args",
+                    list("locality", 0, 1),
+                    list("tile", list("rows", 0, 2), list("columns", 0, 2))))
+        )";
+
+    HPX_TEST_NEQ(compile_and_run("annotation_0", annotation_0),
+        compile_and_run("annotation_1", annotation_1));
+}
+
 int main(int argc, char* argv[])
 {
     test_annotation_equality_0();
     test_annotation_equality_1();
+    test_annotation_equality_2();
+    test_annotation_equality_3();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/annotation_2_loc.cpp
+++ b/tests/unit/execution_tree/annotation_2_loc.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_equality(std::string const& name, std::string const& lhs_codestr,
+    std::string const& rhs_codestr)
+{
+    HPX_TEST_EQ(
+        compile_and_run(name, lhs_codestr), compile_and_run(name, rhs_codestr));
+}
+
+void test_non_equality(std::string const& name, std::string const& lhs_codestr,
+    std::string const& rhs_codestr)
+{
+    HPX_TEST_NEQ(
+        compile_and_run(name, lhs_codestr), compile_and_run(name, rhs_codestr));
+}
+
+void test_annotation_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[1, 2]], "test_annotation_0_1",
+                list("tile", list("columns", 0, 2), list("rows", 0, 1)))
+        )";
+        std::string annotation_1 = R"(
+            annotate_d([[1, 2]], "test_annotation_0_1",
+                list("tile", list("rows", 0, 1), list("columns", 0, 2)))
+        )";
+        test_equality("test_annotation_0", annotation_0, annotation_1);
+    }
+    else
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[3, 4]], "test_annotation_0_1",
+                list("tile", list("columns", 0, 2), list("rows", 1, 2)))
+        )";
+        std::string annotation_1 = R"(
+            annotate_d([[3, 4]], "test_annotation_0_1",
+                list("tile", list("columns", 0, 2), list("rows", 1, 2)))
+        )";
+        test_equality("test_annotation_0", annotation_0, annotation_1);
+    }
+}
+
+
+void test_annotation_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[1, 2]], "test_annotation_1_1",
+                list("tile", list("columns", 0, 2), list("rows", 0, 1)))
+        )";
+        std::string annotation_1 = R"(
+            annotate_d([[3, 4]], "test_annotation_1_1",
+                list("tile", list("columns", 0, 2), list("rows", 1, 2)))
+        )";
+
+        test_non_equality("test_annotation_1", annotation_0, annotation_1);
+    }
+    else
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[3, 4]], "test_annotation_1_1",
+                list("tile", list("columns", 0, 2), list("rows", 1, 2)))
+        )";
+        std::string annotation_1 = R"(
+            annotate_d([[1, 2]], "test_annotation_1_1",
+                list("tile", list("rows", 0, 1), list("columns", 0, 2)))
+        )";
+
+        test_non_equality("test_annotation_1", annotation_0, annotation_1);
+    }
+}
+
+void test_annotation_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        std::string annotation_0 = R"(
+            annotate_d([1, 2], "test_annotation_2_1",
+                list("tile", list("columns", 0, 2)))
+        )";
+        std::string annotation_1 = R"(
+            annotate_d([[1, 2]], "test_annotation_2_1",
+                list("tile", list("rows", 0, 1), list("columns", 0, 2)))
+        )";
+        test_non_equality("test_annotation_2", annotation_0, annotation_1);
+    }
+    else
+    {
+        std::string annotation_0 = R"(
+            annotate_d([3, 4], "test_annotation_2_1",
+                list("tile", list("columns", 2, 4)))
+        )";
+        std::string annotation_1 = R"(
+            annotate_d([[3, 4]], "test_annotation_2_1",
+                list("tile", list("columns", 2, 4), list("rows", 0, 1)))
+        )";
+        test_non_equality("test_annotation_2", annotation_0, annotation_1);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_annotation_0();
+    test_annotation_1();
+    test_annotation_2();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}

--- a/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
@@ -41,6 +41,8 @@ void test_constant_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
+    std::cout << "comparison:" << comparison << "\n";
+    std::cout << "result" << result << "\n";
     HPX_TEST_EQ(result, comparison);
 }
 
@@ -253,11 +255,11 @@ void test_constant_4loc_2d_2()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    test_constant_4loc_1d_0();
+    //test_constant_4loc_1d_0();
 
     test_constant_4loc_2d_0();
-    test_constant_4loc_2d_1();
-    test_constant_4loc_2d_2();
+    //test_constant_4loc_2d_1();
+    //test_constant_4loc_2d_2();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
@@ -41,8 +41,6 @@ void test_constant_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
-    std::cout << "comparison:" << comparison << "\n";
-    std::cout << "result" << result << "\n";
     HPX_TEST_EQ(result, comparison);
 }
 
@@ -95,6 +93,7 @@ void test_constant_4loc_1d_0()
     }
 }
 
+///////////////////////////////////////////////////////////////////////////////
 void test_constant_4loc_2d_0()
 {
     if (hpx::get_locality_id() == 0)
@@ -255,11 +254,11 @@ void test_constant_4loc_2d_2()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    //test_constant_4loc_1d_0();
+    test_constant_4loc_1d_0();
 
     test_constant_4loc_2d_0();
-    //test_constant_4loc_2d_1();
-    //test_constant_4loc_2d_2();
+    test_constant_4loc_2d_1();
+    test_constant_4loc_2d_2();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/dist_dot_operation.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_dot_operation.cpp
@@ -112,7 +112,59 @@ void test_dot_1d_2()
     }
 }
 
+void test_dot_1d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_dot_operation("test1d_3", R"(
+            dot_d(
+                annotate_d([1, 2, 3], "test1d_3_1",
+                    list("tile", list("rows", 0, 3))),
+                annotate_d([0, 0, 0], "test1d_3_2",
+                    list("tile", list("columns", 3, 6)))
+            )
+        )", "14");
+    }
+    else
+    {
+        test_dot_operation("test1d_0", R"(
+            dot_d(
+                annotate_d([4, 5, 6], "test1d_3_1",
+                    list("tile", list("rows", 3, 6))),
+                annotate_d([1, 2, 3], "test1d_3_2",
+                    list("tile", list("columns", 0, 3)))
+            )
+        )", "14");
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////
+void test_dot_1d2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_dot_operation("test1d2d_0", R"(
+            dot_d(
+                annotate_d([1, 2, 3], "test1d2d_0_1",
+                    list("tile", list("rows", 0, 3))),
+                annotate_d([[4, 4], [5, 5], [6, 0]], "test1d2d_0_2",
+                    list("tile", list("columns", 0, 2), list("rows", 3, 6)))
+            )
+        )", "[91, 55]");
+    }
+    else
+    {
+        test_dot_operation("test1d2d_0", R"(
+            dot_d(
+                annotate_d([4, 5, 6], "test1d2d_0_1",
+                    list("tile", list("rows", 3, 6))),
+                annotate_d([[1, 1], [2, 2], [3, 3]], "test1d2d_0_2",
+                    list("tile", list("columns", 0, 2), list("rows", 0, 3)))
+            )
+        )", "[91, 55]");
+    }
+}
+
 void test_dot_1d2d_1()
 {
     if (hpx::get_locality_id() == 0)
@@ -512,7 +564,9 @@ int hpx_main(int argc, char* argv[])
     test_dot_1d_0();
     test_dot_1d_1();
     test_dot_1d_2();
+    test_dot_1d_3();
 
+    test_dot_1d2d_0();
     test_dot_1d2d_1();
     test_dot_1d2d_2();
     test_dot_1d2d_3();

--- a/tests/unit/plugins/dist_matrixops/dist_dot_operation.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_dot_operation.cpp
@@ -34,7 +34,8 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
 void test_dot_operation(std::string const& name, std::string const& code,
     std::string const& expected_str)
 {
-    HPX_TEST_EQ(compile_and_run(name, code), compile_and_run(name, expected_str));
+    HPX_TEST_EQ(
+        compile_and_run(name, code), compile_and_run(name, expected_str));
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR changes the starting dimension of tiling spans in a way that they are compatible with node data conventions. For example, in a 3d array, the first dimension is the page dimension, the second one is the row dimension and then we have the column dimension (pages x rows x columns).
The distributed version of `dot` and `cannon_product` uses `get_span` directly, so these primitives are modified.
Also, tiling_information dimensions are adapted for the PHYLANX_MAX_DIMENSIONS, 4.
To comply with node_data, the name of `dimension()` member function of the `localities_information` is changed to `num_dimensions()` (It returns a `size_t` that is the number of dimensions).