### PR TITLE
Implementing async() primitive and related infrastructure

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -15,7 +15,6 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/ir/ranges.hpp>
 #include <phylanx/util/generate_error_message.hpp>
-#include <phylanx/util/small_vector.hpp>
 
 #include <hpx/include/runtime.hpp>
 #include <hpx/include/util.hpp>
@@ -73,8 +72,8 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct value_operand_sync
         {
             template <typename... Ts>
@@ -84,7 +83,7 @@ namespace phylanx { namespace execution_tree
                     std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     PHYLANX_EXPORT primitive_argument_type value_operand_ref_sync(
         primitive_argument_type const& val,
@@ -188,6 +187,7 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    ///////////////////////////////////////////////////////////////////////////
     // Extract a literal type from a given primitive_argument_type, throw
     // if it doesn't hold one.
     PHYLANX_EXPORT primitive_argument_type extract_literal_value(
@@ -205,6 +205,7 @@ namespace phylanx { namespace execution_tree
 
     PHYLANX_EXPORT bool is_literal_operand(primitive_argument_type const& val);
 
+    ///////////////////////////////////////////////////////////////////////////
     // Extract a ir::node_data<double> type from a given primitive_argument_type,
     // throw if it doesn't hold one.
     PHYLANX_EXPORT ir::node_data<double> extract_numeric_value(
@@ -215,6 +216,7 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type && val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+
     PHYLANX_EXPORT double extract_scalar_numeric_value(
         primitive_argument_type const& val,
         std::string const& name = "",
@@ -229,6 +231,15 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT ir::node_data<double>&& extract_numeric_value_strict(
+        primitive_argument_type && val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    PHYLANX_EXPORT double extract_scalar_numeric_value_strict(
+        primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT double extract_scalar_numeric_value_strict(
         primitive_argument_type && val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
@@ -254,14 +265,14 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>");
 
     ///////////////////////////////////////////////////////////////////////////
-    // Extract a ir::node_data<std::uint8_t> type from a given primitive_argument_type,
-    // throw if it doesn't hold one.
+    // Extract a ir::node_data<std::uint8_t> type from a given
+    // primitive_argument_type, throw if it doesn't hold one.
     PHYLANX_EXPORT bool is_boolean_data_operand(
         primitive_argument_type const& val);
 
     ///////////////////////////////////////////////////////////////////////////
-    // Extract a ir::node_data<std::int64_t> type from a given primitive_argument_type,
-    // throw if it doesn't hold one.
+    // Extract a ir::node_data<std::int64_t> type from a given
+    // primitive_argument_type, throw if it doesn't hold one.
     PHYLANX_EXPORT ir::node_data<std::int64_t> extract_integer_value(
         primitive_argument_type const& val,
         std::string const& name = "",
@@ -305,17 +316,18 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct integer_operand
         {
             template <typename... Ts>
-            hpx::future<ir::node_data<std::int64_t>> operator()(Ts&&... ts) const
+            hpx::future<ir::node_data<std::int64_t>> operator()(
+                Ts&&... ts) const
             {
                 return execution_tree::integer_operand(std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     PHYLANX_EXPORT bool is_integer_operand(primitive_argument_type const& val);
 
@@ -336,6 +348,7 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type&& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+
     PHYLANX_EXPORT std::int64_t extract_scalar_integer_value_strict(
         primitive_argument_type const& val,
         std::string const& name = "",
@@ -371,17 +384,19 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct integer_operand_strict
         {
             template <typename... Ts>
-            hpx::future<ir::node_data<std::int64_t>> operator()(Ts&&... ts) const
+            hpx::future<ir::node_data<std::int64_t>> operator()(
+                Ts&&... ts) const
             {
-                return execution_tree::integer_operand_strict(std::forward<Ts>(ts)...);
+                return execution_tree::integer_operand_strict(
+                    std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     PHYLANX_EXPORT bool is_integer_operand_strict(
         primitive_argument_type const& val);
@@ -395,6 +410,7 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type&& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
+
     PHYLANX_EXPORT std::int64_t extract_scalar_positive_integer_value_strict(
         primitive_argument_type const& val,
         std::string const& name = "",
@@ -452,67 +468,69 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
+    PHYLANX_EXPORT std::uint8_t extract_scalar_boolean_value_strict(
+        primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+    PHYLANX_EXPORT std::uint8_t extract_scalar_boolean_value_strict(
+        primitive_argument_type && val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
     PHYLANX_EXPORT bool is_boolean_operand(primitive_argument_type const& val);
     PHYLANX_EXPORT bool is_boolean_operand_strict(
         primitive_argument_type const& val);
 
+    ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    ir::node_data<T> extract_node_data(
-        primitive_argument_type const& val,
+    ir::node_data<T> extract_node_data(primitive_argument_type const& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
     template <>
     inline ir::node_data<double> extract_node_data(
-        primitive_argument_type const& val,
-        std::string const& name,
+        primitive_argument_type const& val, std::string const& name,
         std::string const& codename)
     {
         return extract_numeric_value(val, name, codename);
     }
     template <>
     inline ir::node_data<std::int64_t> extract_node_data(
-        primitive_argument_type const& val,
-        std::string const& name,
+        primitive_argument_type const& val, std::string const& name,
         std::string const& codename)
     {
         return extract_integer_value(val, name, codename);
     }
     template <>
     inline ir::node_data<std::uint8_t> extract_node_data(
-        primitive_argument_type const& val,
-        std::string const& name,
+        primitive_argument_type const& val, std::string const& name,
         std::string const& codename)
     {
         return extract_boolean_value(val, name, codename);
     }
 
     template <typename T>
-    ir::node_data<T> extract_node_data(
-        primitive_argument_type && val,
+    ir::node_data<T> extract_node_data(primitive_argument_type&& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
     template <>
     inline ir::node_data<double> extract_node_data(
-        primitive_argument_type && val,
-        std::string const& name,
+        primitive_argument_type&& val, std::string const& name,
         std::string const& codename)
     {
         return extract_numeric_value(std::move(val), name, codename);
     }
     template <>
     inline ir::node_data<std::int64_t> extract_node_data(
-        primitive_argument_type && val,
-        std::string const& name,
+        primitive_argument_type&& val, std::string const& name,
         std::string const& codename)
     {
         return extract_integer_value(std::move(val), name, codename);
     }
     template <>
     inline ir::node_data<std::uint8_t> extract_node_data(
-        primitive_argument_type && val,
-        std::string const& name,
+        primitive_argument_type&& val, std::string const& name,
         std::string const& codename)
     {
         return extract_boolean_value(std::move(val), name, codename);
@@ -520,65 +538,162 @@ namespace phylanx { namespace execution_tree
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    T extract_scalar_data(
-        primitive_argument_type const& val,
+    ir::node_data<T> extract_node_data_strict(
+        primitive_argument_type const& val, std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <>
+    inline ir::node_data<double> extract_node_data_strict(
+        primitive_argument_type const& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_numeric_value_strict(val, name, codename);
+    }
+    template <>
+    inline ir::node_data<std::int64_t> extract_node_data_strict(
+        primitive_argument_type const& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_integer_value_strict(val, name, codename);
+    }
+    template <>
+    inline ir::node_data<std::uint8_t> extract_node_data_strict(
+        primitive_argument_type const& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_boolean_value_strict(val, name, codename);
+    }
+
+    template <typename T>
+    ir::node_data<T> extract_node_data_strict(primitive_argument_type&& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
     template <>
-    inline double extract_scalar_data(
-        primitive_argument_type const& val,
-        std::string const& name,
+    inline ir::node_data<double> extract_node_data_strict(
+        primitive_argument_type&& val, std::string const& name,
         std::string const& codename)
+    {
+        return extract_numeric_value_strict(std::move(val), name, codename);
+    }
+    template <>
+    inline ir::node_data<std::int64_t> extract_node_data_strict(
+        primitive_argument_type&& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_integer_value_strict(std::move(val), name, codename);
+    }
+    template <>
+    inline ir::node_data<std::uint8_t> extract_node_data_strict(
+        primitive_argument_type&& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_boolean_value_strict(std::move(val), name, codename);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    T extract_scalar_data(primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <>
+    inline double extract_scalar_data(primitive_argument_type const& val,
+        std::string const& name, std::string const& codename)
     {
         return extract_scalar_numeric_value(val, name, codename);
     }
     template <>
-    inline std::int64_t extract_scalar_data(
-        primitive_argument_type const& val,
-        std::string const& name,
-        std::string const& codename)
+    inline std::int64_t extract_scalar_data(primitive_argument_type const& val,
+        std::string const& name, std::string const& codename)
     {
         return extract_scalar_integer_value(val, name, codename);
     }
     template <>
-    inline std::uint8_t extract_scalar_data(
-        primitive_argument_type const& val,
-        std::string const& name,
-        std::string const& codename)
+    inline std::uint8_t extract_scalar_data(primitive_argument_type const& val,
+        std::string const& name, std::string const& codename)
     {
         return extract_scalar_boolean_value(val, name, codename);
     }
 
     template <typename T>
-    T extract_scalar_data(
-        primitive_argument_type && val,
+    T extract_scalar_data(primitive_argument_type&& val,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 
     template <>
-    inline double extract_scalar_data(
-        primitive_argument_type && val,
-        std::string const& name,
-        std::string const& codename)
+    inline double extract_scalar_data(primitive_argument_type&& val,
+        std::string const& name, std::string const& codename)
     {
         return extract_scalar_numeric_value(std::move(val), name, codename);
     }
     template <>
-    inline std::int64_t extract_scalar_data(
-        primitive_argument_type && val,
-        std::string const& name,
-        std::string const& codename)
+    inline std::int64_t extract_scalar_data(primitive_argument_type&& val,
+        std::string const& name, std::string const& codename)
     {
         return extract_scalar_integer_value(std::move(val), name, codename);
     }
     template <>
-    inline std::uint8_t extract_scalar_data(
-        primitive_argument_type && val,
-        std::string const& name,
-        std::string const& codename)
+    inline std::uint8_t extract_scalar_data(primitive_argument_type&& val,
+        std::string const& name, std::string const& codename)
     {
         return extract_scalar_boolean_value(std::move(val), name, codename);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    T extract_scalar_data_strict(primitive_argument_type const& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <>
+    inline double extract_scalar_data_strict(primitive_argument_type const& val,
+        std::string const& name, std::string const& codename)
+    {
+        return extract_scalar_numeric_value_strict(val, name, codename);
+    }
+    template <>
+    inline std::int64_t extract_scalar_data_strict(
+        primitive_argument_type const& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_integer_value_strict(val, name, codename);
+    }
+    template <>
+    inline std::uint8_t extract_scalar_data_strict(
+        primitive_argument_type const& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_boolean_value_strict(val, name, codename);
+    }
+
+    template <typename T>
+    T extract_scalar_data_strict(primitive_argument_type&& val,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <>
+    inline double extract_scalar_data_strict(primitive_argument_type&& val,
+        std::string const& name, std::string const& codename)
+    {
+        return extract_scalar_numeric_value_strict(
+            std::move(val), name, codename);
+    }
+    template <>
+    inline std::int64_t extract_scalar_data_strict(
+        primitive_argument_type&& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_integer_value_strict(
+            std::move(val), name, codename);
+    }
+    template <>
+    inline std::uint8_t extract_scalar_data_strict(
+        primitive_argument_type&& val, std::string const& name,
+        std::string const& codename)
+    {
+        return extract_scalar_boolean_value_strict(
+            std::move(val), name, codename);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -607,19 +722,7 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT bool is_string_operand_strict(
         primitive_argument_type const& val);
 
-    // Extract an AST type from a given primitive_argument_type,
-    // throw if it doesn't hold one.
-    PHYLANX_EXPORT std::vector<ast::expression> extract_ast_value(
-        primitive_argument_type const& val,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
-    PHYLANX_EXPORT std::vector<ast::expression> extract_ast_value(
-        primitive_argument_type && val,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
-
-    PHYLANX_EXPORT bool is_ast_operand(primitive_argument_type const& val);
-
+    ///////////////////////////////////////////////////////////////////////////
     // Extract a list type from a given primitive_argument_type,
     // Create a list from argument if it does not hold one.
     PHYLANX_EXPORT ir::range extract_list_value(
@@ -672,6 +775,7 @@ namespace phylanx { namespace execution_tree
         compiler::primitive_name_parts const& parts,
         std::string const& codename = "<unknown>");
 
+    ///////////////////////////////////////////////////////////////////////////
     // Extract a primitive_argument_type from a primitive_argument_type (that
     // could be a value type).
     PHYLANX_EXPORT hpx::future<primitive_argument_type> value_operand(
@@ -704,8 +808,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "", std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct value_operand
         {
             template <typename... Ts>
@@ -714,7 +818,7 @@ namespace phylanx { namespace execution_tree
                 return execution_tree::value_operand(std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     // was declared above
     //     PHYLANX_EXPORT primitive_argument_type value_operand_sync(
@@ -748,8 +852,8 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct literal_operand
         {
             template <typename... Ts>
@@ -758,7 +862,7 @@ namespace phylanx { namespace execution_tree
                 return execution_tree::literal_operand(std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     PHYLANX_EXPORT primitive_argument_type literal_operand_sync(
         primitive_argument_type const& val,
@@ -800,8 +904,8 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct numeric_operand
         {
             template <typename... Ts>
@@ -810,7 +914,7 @@ namespace phylanx { namespace execution_tree
                 return execution_tree::numeric_operand(std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     PHYLANX_EXPORT ir::node_data<double> numeric_operand_sync(
         primitive_argument_type const& val,
@@ -821,13 +925,13 @@ namespace phylanx { namespace execution_tree
 
     // Extract a boolean from a primitive_argument_type (that
     // could be a primitive or a literal value).
-    PHYLANX_EXPORT hpx::future<std::uint8_t> boolean_operand(
+    PHYLANX_EXPORT hpx::future<ir::node_data<uint8_t>> boolean_operand(
         primitive_argument_type const& val,
         primitive_arguments_type const& args,
         std::string const& name = "",
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
-    PHYLANX_EXPORT std::uint8_t boolean_operand_sync(
+    PHYLANX_EXPORT std::uint8_t scalar_boolean_operand_sync(
         primitive_argument_type const& val,
         primitive_arguments_type const& args,
         std::string const& name = "",
@@ -903,18 +1007,17 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct list_operand
         {
             template <typename... Ts>
-            hpx::future<ir::range> operator()(
-                Ts&&... ts) const
+            hpx::future<ir::range> operator()(Ts&&... ts) const
             {
                 return execution_tree::list_operand(std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     PHYLANX_EXPORT ir::range list_operand_sync(
         primitive_argument_type const& val,
@@ -950,19 +1053,18 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>",
         eval_context ctx = eval_context{});
 
-    namespace functional
-    {
+    namespace functional {
+
         struct list_operand_strict
         {
             template <typename... Ts>
-            hpx::future<ir::range> operator()(
-                Ts&&... ts) const
+            hpx::future<ir::range> operator()(Ts&&... ts) const
             {
                 return execution_tree::list_operand_strict(
                     std::forward<Ts>(ts)...);
             }
         };
-    }
+    }    // namespace functional
 
     PHYLANX_EXPORT ir::range list_operand_strict_sync(
         primitive_argument_type const& val,
@@ -1039,47 +1141,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             for (auto && d : in)
             {
                 out.emplace_back(
-                    hpx::util::invoke(f, std::move(d), std::ref(ts)...));
-            }
-            return out;
-        }
-
-        // Invoke the given function on all items in the input vector, while
-        // returning another vector holding the respective results.
-        template <typename T, typename Allocator, typename F, typename ... Ts>
-        auto map_operands_sv(std::vector<T, Allocator> const& in, F && f,
-                Ts && ... ts)
-        ->  util::small_vector<decltype(
-                    hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )>
-        {
-            util::small_vector<decltype(
-                    hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )> out;
-            out.reserve(in.size());
-
-            for (auto const& d : in)
-            {
-                out.push_back(hpx::util::invoke(f, d, std::ref(ts)...));
-            }
-            return out;
-        }
-
-        template <typename T, typename Allocator, typename F, typename ... Ts>
-        auto map_operands_sv(std::vector<T, Allocator> && in, F && f,
-                Ts && ... ts)
-        ->  util::small_vector<decltype(
-                    hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )>
-        {
-            util::small_vector<decltype(
-                    hpx::util::invoke(f, std::declval<T>(), std::ref(ts)...)
-                )> out;
-            out.reserve(in.size());
-
-            for (auto && d : in)
-            {
-                out.push_back(
                     hpx::util::invoke(f, std::move(d), std::ref(ts)...));
             }
             return out;

--- a/phylanx/plugins/booleans/comparison_impl.hpp
+++ b/phylanx/plugins/booleans/comparison_impl.hpp
@@ -389,29 +389,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
     struct comparison<Op>::visit_comparison
     {
         template <typename T1, typename T2>
-        primitive_argument_type operator()(T1, T2) const
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "comparison<Op>::eval",
-                util::generate_error_message(
-                    "left hand side and right hand side are incompatible "
-                        "and can't be compared",
-                    comparison_.name_, comparison_.codename_));
-        }
-
-        primitive_argument_type operator()(std::vector<ast::expression>&&,
-            std::vector<ast::expression>&&) const
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "comparison<Op>::eval",
-                util::generate_error_message(
-                    "left hand side and right hand side are incompatible "
-                        "and can't be compared",
-                    comparison_.name_, comparison_.codename_));
-        }
-
-        primitive_argument_type operator()(
-            ast::expression&&, ast::expression&&) const
+        primitive_argument_type operator()(T1&&, T2&&) const
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "comparison<Op>::eval",
@@ -432,10 +410,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         template <typename T>
-        primitive_argument_type operator()(T && lhs, T && rhs) const
+        primitive_argument_type operator()(T&& lhs, T&& rhs) const
         {
             return primitive_argument_type(
                 ir::node_data<std::uint8_t>{Op{}(lhs, rhs)});
+        }
+
+        primitive_argument_type operator()(
+            util::recursive_wrapper<
+                hpx::shared_future<primitive_argument_type>>&&,
+            util::recursive_wrapper<
+                hpx::shared_future<primitive_argument_type>>&&) const
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "comparison<Op>::eval",
+                util::generate_error_message(
+                    "left hand side and right hand side are incompatible "
+                        "and can't be compared",
+                    comparison_.name_, comparison_.codename_));
         }
 
         primitive_argument_type operator()(ir::range&&, ir::range&&) const

--- a/phylanx/plugins/booleans/logical_operation_impl.hpp
+++ b/phylanx/plugins/booleans/logical_operation_impl.hpp
@@ -48,18 +48,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     logical_.name_, logical_.codename_));
         }
 
-        primitive_argument_type operator()(std::vector<ast::expression>&&,
-            std::vector<ast::expression>&&) const
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "logical::eval",
-                util::generate_error_message(
-                    "left hand side logical right hand side can't be compared",
-                    logical_.name_, logical_.codename_));
-        }
-
         primitive_argument_type operator()(
-            ast::expression&&, ast::expression&&) const
+            util::recursive_wrapper<
+                hpx::shared_future<primitive_argument_type>>&&,
+            util::recursive_wrapper<
+                hpx::shared_future<primitive_argument_type>>&&) const
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "logical::eval",

--- a/phylanx/plugins/controls/async_operation.hpp
+++ b/phylanx/plugins/controls/async_operation.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_ASYNC_OPERATION_MAR_13_2020_1156AM)
+#define PHYLANX_ASYNC_OPERATION_MAR_13_2020_1156AM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <string>
+#include <utility>
+
+namespace phylanx { namespace execution_tree { namespace primitives {
+
+    class async_operation
+      : public primitive_component_base
+    {
+    public:
+        static match_pattern_type const match_data;
+
+        async_operation() = default;
+
+        async_operation(primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+    };
+
+    inline primitive create_async_operation(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "async", std::move(operands), name, codename);
+    }
+}}}    // namespace phylanx::execution_tree::primitives
+
+#endif

--- a/phylanx/plugins/controls/controls.hpp
+++ b/phylanx/plugins/controls/controls.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_PLUGINS_CONTROLS_APR_07_2108_1223PM
 
 #include <phylanx/plugins/controls/apply.hpp>
+#include <phylanx/plugins/controls/async_operation.hpp>
 #include <phylanx/plugins/controls/block_operation.hpp>
 #include <phylanx/plugins/controls/filter_operation.hpp>
 #include <phylanx/plugins/controls/fold_left_operation.hpp>

--- a/phylanx/util/variant.hpp
+++ b/phylanx/util/variant.hpp
@@ -55,10 +55,10 @@ namespace phylanx { namespace util
         {
         }
 
-        recursive_wrapper(recursive_wrapper && operand)
-          : p_(new T)
+        recursive_wrapper(recursive_wrapper && operand) noexcept
+          : p_(operand.p_)
         {
-            swap(operand);
+            operand.p_ = nullptr;
         }
 
         recursive_wrapper(T && operand)

--- a/python/src/bindings/binding_helpers.cpp
+++ b/python/src/bindings/binding_helpers.cpp
@@ -651,7 +651,7 @@ namespace phylanx { namespace bindings
                 case primitive_argument_type::primitive_index:
                     return pybind11::dtype("O");
 
-                case primitive_argument_type::expression_index:
+                case primitive_argument_type::future_index:
                     return pybind11::dtype("O");
 
                 case primitive_argument_type::list_index:

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -266,4 +266,23 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
             &phylanx::bindings::as_string<phylanx::execution_tree::primitive>)
         .def("__repr__",
             &phylanx::bindings::repr<phylanx::execution_tree::primitive>);
+
+    // phylanx.execution_tree.primitive_argument_future
+    pybind11::class_<
+        hpx::shared_future<phylanx::execution_tree::primitive_argument_type>>(
+        execution_tree, "primitive_argument_future",
+        "future type representing a value")
+        .def(
+            "get",
+            [](hpx::shared_future<
+                phylanx::execution_tree::primitive_argument_type> const& f)
+            {
+                pybind11::gil_scoped_release release;    // release GIL
+                return hpx::threads::run_as_hpx_thread(
+                    [&]() -> phylanx::execution_tree::primitive_argument_type
+                    {
+                        return f.get();
+                    });
+            },
+            "wait for future to become ready");
 }

--- a/src/execution_tree/primitives/assert_condition.cpp
+++ b/src/execution_tree/primitives/assert_condition.cpp
@@ -78,7 +78,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 }
                 return {};
             }),
-            boolean_operand(
+            scalar_boolean_operand(
                 operands_[0], args, name_, codename_, std::move(ctx)));
     }
 }}}

--- a/src/execution_tree/primitives/enable_tracing.cpp
+++ b/src/execution_tree/primitives/enable_tracing.cpp
@@ -72,7 +72,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         primitive::enable_tracing =
-            boolean_operand_sync(
+            scalar_boolean_operand_sync(
                 operands[0], args, name_, codename_, std::move(ctx)) != 0;
 
         return hpx::make_ready_future(primitive_argument_type{});

--- a/src/execution_tree/primitives/find_all_localities.cpp
+++ b/src/execution_tree/primitives/find_all_localities.cpp
@@ -62,14 +62,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [this_ = std::move(this_)](primitive_arguments_type&& args)
                 -> primitive_argument_type
             {
-                std::vector<primitive_argument_type> values;
+                primitive_arguments_type values;
                 for (auto const& loc : hpx::find_all_localities())
                 {
                     std::int64_t v = hpx::naming::get_locality_id_from_id(loc);
                     values.push_back(primitive_argument_type{v});
                 }
 
-                phylanx::execution_tree::primitive_argument_type p{values};
+                phylanx::execution_tree::primitive_argument_type p(values);
                 return p;
             }),
             detail::map_operands(

--- a/src/plugins/controls/async_operation.cpp
+++ b/src/plugins/controls/async_operation.cpp
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/annotation.hpp>
+#include <phylanx/plugins/controls/async_operation.hpp>
+
+#include <hpx/errors/throw_exception.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives {
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const async_operation::match_data =
+    {
+        hpx::util::make_tuple("async",
+            std::vector<std::string>{"async(_1)"},
+            &create_async_operation, &create_primitive<async_operation>, R"(
+            expr
+
+            Args:
+
+                expr : an arbitrary expression that will be evaluated
+                       asynchronously
+
+            Returns:\n"
+
+            Returns a future representing the result of the evaluation of the
+            given expression)")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    async_operation::async_operation(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {
+    }
+
+    hpx::future<primitive_argument_type> async_operation::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.size() != 1)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "async_operation::eval",
+                generate_error_message(
+                    "the async_operation primitive requires exactly "
+                    "one operand"));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "async_operation::eval",
+                generate_error_message(
+                    "the async_operation primitive requires that the "
+                    "argument given by the operand is valid"));
+        }
+
+        annotation_wrapper wrap(operands[0]);
+        return hpx::make_ready_future(wrap.propagate(primitive_argument_type{
+            value_operand(operands[0], args, name_, codename_, std::move(ctx))
+                .share()}));
+    }
+}}}    // namespace phylanx::execution_tree::primitives

--- a/src/plugins/controls/controls.cpp
+++ b/src/plugins/controls/controls.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018 Hartmut Kaiser
+//  Copyright (c) 2018-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,6 +11,8 @@ PHYLANX_REGISTER_PLUGIN_MODULE();
 
 PHYLANX_REGISTER_PLUGIN_FACTORY(apply_plugin,
     phylanx::execution_tree::primitives::apply::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(async_operation_plugin,
+    phylanx::execution_tree::primitives::async_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(block_operation_plugin,
     phylanx::execution_tree::primitives::block_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(filter_operation_plugin,

--- a/src/plugins/controls/filter_operation.cpp
+++ b/src/plugins/controls/filter_operation.cpp
@@ -114,7 +114,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 for (auto && curr : list)
                 {
                     primitive_arguments_type arg2(1, extract_ref_value(curr));
-                    if (boolean_operand_sync(bound_func, std::move(arg2),
+                    if (scalar_boolean_operand_sync(bound_func, std::move(arg2),
                             this_->name_, this_->codename_, ctx))
                     {
                         result.push_back(std::move(curr));
@@ -123,8 +123,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                 return primitive_argument_type{std::move(result)};
             }),
-            value_operand(operands_[0], args, name_, codename_,
+            value_operand(operands[0], args, name_, codename_,
                 add_mode(ctx, eval_dont_evaluate_lambdas)),
-            list_operand(operands_[1], args, name_, codename_, ctx));
+            list_operand(operands[1], args, name_, codename_, ctx));
     }
 }}}

--- a/src/plugins/controls/if_conditional.cpp
+++ b/src/plugins/controls/if_conditional.cpp
@@ -90,7 +90,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         // Keep data alive with a shared pointer
-        auto f = boolean_operand(operands_[0], args, name_, codename_, ctx);
+        auto f =
+            scalar_boolean_operand(operands_[0], args, name_, codename_, ctx);
         auto this_ = this->shared_from_this();
         return f.then(hpx::launch::sync,
             [this_ = std::move(this_), args = args, ctx = std::move(ctx)](

--- a/src/plugins/matrixops/random.cpp
+++ b/src/plugins/matrixops/random.cpp
@@ -102,19 +102,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         switch (val.index())
         {
-        case 1:    // phylanx::ir::node_data<std::uint8_t>
+        case primitive_argument_type::bool_index:
             return detail::adjust_dimensions(
                 util::get<1>(val), name, codename);
 
-        case 2:    // std::uint64_t
+        case primitive_argument_type::int64_index:
             return detail::adjust_dimensions(
                 util::get<2>(val), name, codename);
 
-        case 4:    // phylanx::ir::node_data<double>
+        case primitive_argument_type::float64_index:
             return detail::adjust_dimensions(
                 util::get<4>(val), name, codename);
 
-        case 7:    // phylanx::ir::range
+        case primitive_argument_type::list_index:
             {
                 std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result{};
                 auto const& args = util::get<7>(val);
@@ -172,12 +172,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
             break;
 
-        case 0:     // nil
+        case primitive_argument_type::nil_index:
             return std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>{};
 
-        case 3: HPX_FALLTHROUGH;    // string
-        case 5: HPX_FALLTHROUGH;    // primitive
-        case 6: HPX_FALLTHROUGH;    // std::vector<ast::expression>
+        case primitive_argument_type::string_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::primitive_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::future_index: HPX_FALLTHROUGH;
         default:
             break;
         }

--- a/tests/unit/ast/node.cpp
+++ b/tests/unit/ast/node.cpp
@@ -112,9 +112,9 @@ void test_expression()
 {
     phylanx::ast::primary_expr p1(true);
     phylanx::ast::operand op1(p1);
-    phylanx::ast::expression e1(std::move(op1));
+    phylanx::ast::expression e1(op1);
 
-    phylanx::ast::operation u1(phylanx::ast::optoken::op_plus, op1);
+    phylanx::ast::operation u1(phylanx::ast::optoken::op_plus, std::move(op1));
     e1.append(u1);
 
     std::vector<phylanx::ast::operation> ops = {u1, u1};

--- a/tests/unit/plugins/controls/CMakeLists.txt
+++ b/tests/unit/plugins/controls/CMakeLists.txt
@@ -1,9 +1,10 @@
-# Copyright (c) 2018 Hartmut Kaiser
+# Copyright (c) 2018-2020 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    async_operation
     block_operation
     filter_operation
     fold_left_operation

--- a/tests/unit/plugins/controls/async_operation.cpp
+++ b/tests/unit/plugins/controls/async_operation.cpp
@@ -1,0 +1,124 @@
+//   Copyright (c) 2018 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/testing.hpp>
+
+#include <cstdint>
+#include <string>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run().arg_;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_async_operation_immediate()
+{
+    std::string const code = R"(block(
+            async(42)
+        ))";
+
+    auto a = compile_and_run(code);
+    HPX_TEST_EQ(
+        phylanx::execution_tree::extract_scalar_integer_value_strict(a()),
+        std::int64_t(42));
+}
+
+void test_async_operation_immediate_concurrent()
+{
+    std::string const code_str = R"(
+            list(async(42), async(43))
+        )";
+
+    auto code = compile_and_run(code_str);
+    auto l = phylanx::execution_tree::extract_list_value(code());
+
+    auto it = l.begin();
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_integer_value(*it++),
+        std::int64_t(42));
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_integer_value(*it),
+        std::int64_t(43));
+}
+
+void test_async_operation_immediate_concurrent_add()
+{
+    std::string const code_str = R"(
+            async(42) + async(43)
+        )";
+
+    auto code = compile_and_run(code_str);
+
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_integer_value(code()),
+        std::int64_t(85));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_async_operation_variable()
+{
+    std::string const code = R"(block(
+            define(a, async(42)), a
+        ))";
+
+    auto a = compile_and_run(code);
+    HPX_TEST_EQ(
+        phylanx::execution_tree::extract_scalar_integer_value_strict(a()),
+        std::int64_t(42));
+}
+
+void test_async_operation_variable_concurrent()
+{
+    std::string const code_str = R"(block(
+            define(a, async(42)),
+            define(b, async(43)),
+            list(a, b)
+        ))";
+
+    auto code = compile_and_run(code_str);
+    auto l = phylanx::execution_tree::extract_list_value(code());
+
+    auto it = l.begin();
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_integer_value(*it++),
+        std::int64_t(42));
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_integer_value(*it),
+        std::int64_t(43));
+}
+
+void test_async_operation_variable_concurrent_add()
+{
+    std::string const code_str = R"(block(
+            define(a, async(42)),
+            define(b, async(43)),
+            a + b
+        ))";
+
+    auto code = compile_and_run(code_str);
+
+    HPX_TEST_EQ(phylanx::execution_tree::extract_scalar_integer_value(code()),
+        std::int64_t(85));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main(int argc, char* argv[])
+{
+    test_async_operation_immediate();
+    test_async_operation_immediate_concurrent();
+    test_async_operation_immediate_concurrent_add();
+
+    test_async_operation_variable();
+    test_async_operation_variable_concurrent();
+    test_async_operation_variable_concurrent_add();
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- remove vector<ast::expression> as a possible type stored in
  primitive_argument_type
- add phylanx.execution_tree.primitive_argument_future wrapping
  shared_future<primitive_argument_type>
- general cleanup of infrastructure related to primitive_argument_type