### PR TITLE
Remove CMake 3.11 installed as a temporary workaround

### DIFF
--- a/tools/docker/base/Dockerfile
+++ b/tools/docker/base/Dockerfile
@@ -31,12 +31,6 @@ RUN apt-get update &&                                                           
         liblapack-dev                                                               \
         libhdf5-dev                                                              && \
                                                                                     \
-    (                                                                               \
-        curl -JLO https://cmake.org/files/v3.11/cmake-3.11.0-Linux-x86_64.sh     && \
-        sh ./cmake-3.11.0-Linux-x86_64.sh --prefix=/usr --exclude-subdir         && \
-        rm -f ./cmake-3.11.0-Linux-x86_64.sh                                        \
-    )                                                                            && \
-                                                                                    \
     apt-get purge && apt-get clean && rm -rf /var/lib/apt/lists/*                && \
                                                                                     \
     pip3 --no-cache-dir install setuptools                                       && \


### PR DESCRIPTION
`stellargroup/hpx:dev` image now comes with CMake 3.13 installed and CMake 3.11 does not seem to be sufficient anymore. This PR removes CMake 3.11 installed into the image on top of the existing CMake in `stellargroup/hpx:dev`.

NOTE: This PR does not show its impact until it is merged into master and the builder on Docker Hub builds the new base image for CircleCI to use.