### PR TITLE
Making sure random_d produces correctly sized 2d results

### DIFF
--- a/phylanx/plugins/dist_matrixops/dist_constant.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_constant.hpp
@@ -50,31 +50,27 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type constant1d_helper(
             execution_tree::primitive_argument_type&& value,
             std::size_t const& dim, std::uint32_t const& tile_idx,
-            std::uint32_t const& numtiles, std::string&& given_name,
-            std::string const& name, std::string const& codename) const;
+            std::uint32_t const& numtiles, std::string&& given_name) const;
 
         execution_tree::primitive_argument_type constant1d(
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-            std::string&& given_name, execution_tree::node_data_type dtype,
-            std::string const& name_, std::string const& codename_) const;
+            std::string&& given_name, execution_tree::node_data_type dtype) const;
 
         template <typename T>
         execution_tree::primitive_argument_type constant2d_helper(
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-            std::string&& given_name, std::string const& tiling_type,
-            std::string const& name, std::string const& codename) const;
+            std::string&& given_name, std::string const& tiling_type) const;
 
         execution_tree::primitive_argument_type constant2d(
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
             std::string&& given_name, std::string const& tiling_type,
-            execution_tree::node_data_type dtype, std::string const& name_,
-            std::string const& codename_) const;
+            execution_tree::node_data_type dtype) const;
 
     };
 

--- a/phylanx/plugins/dist_matrixops/dist_random.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_random.hpp
@@ -29,9 +29,6 @@
 
 namespace phylanx { namespace dist_matrixops { namespace primitives
 {
-    using distribution_parameters_type =
-        std::tuple<std::string, int, double, double>;
-
     class dist_random
       : public execution_tree::primitives::primitive_component_base
       , public std::enable_shared_from_this<dist_random>

--- a/phylanx/plugins/dist_matrixops/dist_random.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_random.hpp
@@ -52,14 +52,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
 
         execution_tree::primitive_argument_type dist_random1d(std::size_t dim,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-            std::string&& given_name, double const& mean, double const& std,
-            std::string const& name_, std::string const& codename_) const;
+            std::string&& given_name, double const& mean,
+            double const& std) const;
         execution_tree::primitive_argument_type dist_random2d(
             std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
             std::string&& given_name, std::string const& tiling_type,
-            double const& mean, double const& std, std::string const& name_,
-            std::string const& codename_) const;
+            double const& mean, double const& std) const;
     };
 
     inline execution_tree::primitive create_dist_random(hpx::id_type const& locality,

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -104,13 +104,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     execution_tree::primitive_argument_type dist_constant::constant1d_helper(
         execution_tree::primitive_argument_type&& value,
         std::size_t const& dim, std::uint32_t const& tile_idx,
-        std::uint32_t const& numtiles, std::string&& given_name,
-        std::string const& name, std::string const& codename) const
+        std::uint32_t const& numtiles, std::string&& given_name) const
     {
         using namespace execution_tree;
 
         T const_value =
-            extract_scalar_data<T>(std::move(value), name, codename);
+            extract_scalar_data<T>(std::move(value), name_, codename_);
 
         std::int64_t start;
         std::uint32_t size;
@@ -126,25 +125,23 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::string base_name =
             detail::generate_const_name(std::move(given_name));
 
-        annotation_information ann_info(base_name, 0);    //generation 0
+        annotation_information ann_info(
+            std::move(base_name), 0);    //generation 0
 
         auto attached_annotation =
-            std::make_shared<annotation>(localities_annotation(
-                locality_ann, tile_info.as_annotation(name, codename), ann_info,
-                name, codename));
+            std::make_shared<annotation>(localities_annotation(locality_ann,
+                tile_info.as_annotation(name_, codename_), ann_info, name_,
+                codename_));
 
-        primitive_argument_type res(
+        return primitive_argument_type(
             blaze::DynamicVector<T>(size, const_value), attached_annotation);
-
-        return std::move(res);
     }
 
     execution_tree::primitive_argument_type dist_constant::constant1d(
         execution_tree::primitive_argument_type&& value,
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-        std::string&& given_name, execution_tree::node_data_type dtype,
-        std::string const& name_, std::string const& codename_) const
+        std::string&& given_name, execution_tree::node_data_type dtype) const
     {
         using namespace execution_tree;
 
@@ -152,16 +149,16 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         {
         case node_data_type_bool:
             return constant1d_helper<std::uint8_t>(std::move(value), dims[0],
-                tile_idx, numtiles, std::move(given_name), name_, codename_);
+                tile_idx, numtiles, std::move(given_name));
 
         case node_data_type_int64:
             return constant1d_helper<std::int64_t>(std::move(value), dims[0],
-                tile_idx, numtiles, std::move(given_name), name_, codename_);
+                tile_idx, numtiles, std::move(given_name));
 
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant1d_helper<double>(std::move(value), dims[0],
-                tile_idx, numtiles, std::move(given_name), name_, codename_);
+                tile_idx, numtiles, std::move(given_name));
 
         default:
             break;
@@ -180,13 +177,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type&& value,
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-        std::string&& given_name, std::string const& tiling_type,
-        std::string const& name, std::string const& codename) const
+        std::string&& given_name, std::string const& tiling_type) const
     {
         using namespace execution_tree;
 
         T const_value =
-            extract_scalar_data<T>(std::move(value), name, codename);
+            extract_scalar_data<T>(std::move(value), name_, codename_);
 
         std::int64_t row_start, column_start;
         std::size_t row_size, column_size;
@@ -207,18 +203,17 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::string base_name =
             detail::generate_const_name(std::move(given_name));
 
-        annotation_information ann_info(base_name, 0);    //generation 0
+        annotation_information ann_info(
+            std::move(base_name), 0);    //generation 0
 
         auto attached_annotation =
-            std::make_shared<annotation>(localities_annotation(
-                locality_ann, tile_info.as_annotation(name, codename), ann_info,
-                name, codename));
+            std::make_shared<annotation>(localities_annotation(locality_ann,
+                tile_info.as_annotation(name_, codename_), ann_info, name_,
+                codename_));
 
-        primitive_argument_type res(
+        return primitive_argument_type(
             blaze::DynamicMatrix<T>(row_size, column_size, const_value),
             attached_annotation);
-
-        return std::move(res);
     }
 
     execution_tree::primitive_argument_type dist_constant::constant2d(
@@ -226,8 +221,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type,
-        execution_tree::node_data_type dtype, std::string const& name_,
-        std::string const& codename_) const
+        execution_tree::node_data_type dtype) const
     {
         using namespace execution_tree;
 
@@ -235,18 +229,16 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         {
         case node_data_type_bool:
             return constant2d_helper<std::uint8_t>(std::move(value), dims,
-                tile_idx, numtiles, std::move(given_name), tiling_type, name_,
-                codename_);
+                tile_idx, numtiles, std::move(given_name), tiling_type);
 
         case node_data_type_int64:
             return constant2d_helper<std::int64_t>(std::move(value), dims,
-                tile_idx, numtiles, std::move(given_name), tiling_type, name_,
-                codename_);
+                tile_idx, numtiles, std::move(given_name), tiling_type);
 
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant2d_helper<double>(std::move(value), dims, tile_idx,
-                numtiles, std::move(given_name), tiling_type, name_, codename_);
+                numtiles, std::move(given_name), tiling_type);
 
         default:
             break;
@@ -349,7 +341,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                                 "dist_constant::eval",
                                 this_->generate_error_message(
-                                    "invalid tling_type. the tiling_type cane "
+                                    "invalid tling_type. the tiling_type can be "
                                     "one of these: `sym`, `row` or `column`"));
                         }
                     }
@@ -384,12 +376,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                         case 1:
                             return this_->constant1d(std::move(args[0]), dims,
                                 tile_idx, numtiles, std::move(given_name),
-                                dtype, this_->name_, this_->codename_);
+                                dtype);
 
                         case 2:
                             return this_->constant2d(std::move(args[0]), dims,
                                 tile_idx, numtiles, std::move(given_name),
-                                tiling_type, dtype, this_->name_, this_->codename_);
+                                tiling_type, dtype);
 
                         default:
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/src/plugins/dist_matrixops/dist_random.cpp
+++ b/src/plugins/dist_matrixops/dist_random.cpp
@@ -153,8 +153,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     execution_tree::primitive_argument_type dist_random::dist_random1d(
         std::size_t dim, std::uint32_t const& tile_idx,
         std::uint32_t const& numtiles, std::string&& given_name,
-        double const& mean, double const& std, std::string const& name_,
-        std::string const& codename_) const
+        double const& mean, double const& std) const
     {
         using namespace execution_tree;
 
@@ -174,7 +173,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::string base_name =
             detail::generate_random_name(std::move(given_name));
 
-        annotation_information ann_info(base_name, 0);    //generation 0
+        annotation_information ann_info(
+            std::move(base_name), 0);    //generation 0
 
         auto attached_annotation =
             std::make_shared<execution_tree::annotation>(localities_annotation(
@@ -187,17 +187,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             v[i] = dist(util::rng_);
         }
 
-        primitive_argument_type res(std::move(v), attached_annotation);
-
-        return std::move(res);
+        return primitive_argument_type(std::move(v), attached_annotation);
     }
 
     execution_tree::primitive_argument_type dist_random::dist_random2d(
         std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type,
-        double const& mean, double const& std, std::string const& name_,
-        std::string const& codename_) const
+        double const& mean, double const& std) const
     {
         using namespace execution_tree;
 
@@ -222,25 +219,24 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::string base_name =
             detail::generate_random_name(std::move(given_name));
 
-        annotation_information ann_info(base_name, 0);    //generation 0
+        annotation_information ann_info(
+            std::move(base_name), 0);    //generation 0
 
         auto attached_annotation =
             std::make_shared<execution_tree::annotation>(localities_annotation(
                 locality_ann, tile_info.as_annotation(name_, codename_),
                 ann_info, name_, codename_));
 
-        blaze::DynamicMatrix<double> m(rows, columns);
-        for (std::size_t i = 0; i != rows; ++i)
+        blaze::DynamicMatrix<double> m(row_size, column_size);
+        for (std::size_t i = 0; i != row_size; ++i)
         {
-            for (std::size_t j = 0; j != columns; ++j)
+            for (std::size_t j = 0; j != column_size; ++j)
             {
                 m(i, j) = dist(util::rng_);
             }
         }
 
-        primitive_argument_type res(std::move(m), attached_annotation);
-
-        return std::move(res);
+        return primitive_argument_type(std::move(m), attached_annotation);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -334,7 +330,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                                 "dist_constant::eval",
                                 this_->generate_error_message(
-                                    "invalid tling_type. the tiling_type cane "
+                                    "invalid tling_type. the tiling_type can be "
                                     "one of these: `sym`, `row` or `column`"));
                         }
                     }
@@ -357,13 +353,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     {
                     case 1:
                         return this_->dist_random1d(dims[0], tile_idx, numtiles,
-                            std::move(given_name), mean, std, this_->name_,
-                            this_->codename_);
+                            std::move(given_name), mean, std);
 
                     case 2:
                         return this_->dist_random2d(dims, tile_idx, numtiles,
-                            std::move(given_name), tiling_type, mean, std,
-                            this_->name_, this_->codename_);
+                            std::move(given_name), tiling_type, mean, std);
 
                     default:
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
     negative_integral_value_131
     no_integers_313
     out_of_scope_variable_232
+    random_d_1139
     shape1d_357
     shape_2nd_argument_406
     slicing_nil_358
@@ -41,6 +42,8 @@ set(cout_prints_twice_155_FLAGS DEPENDENCIES HPX::iostreams_component)
 set(define_loses_values_177_FLAGS DEPENDENCIES HPX::iostreams_component)
 set(out_of_scope_variable_232_FLAGS DEPENDENCIES HPX::iostreams_component)
 set(external_functions_337_FLAGS DEPENDENCIES HPX::iostreams_component)
+
+set(random_d_1139_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/tests/regressions/execution_tree/random_d_1139.cpp
+++ b/tests/regressions/execution_tree/random_d_1139.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/testing.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include<iostream>
+
+///////////////////////////////////////////////////////////////////////////////
+void execution_time(std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& compiled_code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+
+    hpx::cout << "Locality: " << hpx::get_locality_id()
+              << "  Starting execution for: " << name << hpx::endl;
+    std::uint64_t t = hpx::util::high_resolution_clock::now();
+    phylanx::execution_tree::primitive_argument_type a = compiled_code.run().arg_;
+    t = hpx::util::high_resolution_clock::now() - t;
+
+    std::cout << *(a.annotation()) << "\n\n\n";
+    hpx::cout << "       " << (t / 1e6) << " ms.\n" << hpx::flush;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+void test__0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        execution_time("perftest_0", R"(
+            dot_d(
+                constant_d(13., list(100, 100), 0, 2, "const_1"),
+                constant_d(13., list(100, 100), 0, 2, "const_2")
+            )
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        execution_time("perftest_0", R"(
+            dot_d(
+                constant_d(13., list(100, 100), 1, 2, "const_1"),
+                constant_d(13., list(100, 100), 1, 2, "const_2")
+            )
+        )");
+    }
+}
+
+void test__1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        execution_time("perftest_1", R"(
+            dot_d(
+                random_d(list(100, 100), 0, 2, "rand_1"),
+                random_d(list(100, 100), 0, 2, "rand_2")
+            )
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        execution_time("perftest_1", R"(
+            dot_d(
+                random_d(list(100, 100), 1, 2, "rand_1"),
+                random_d(list(100, 100), 1, 2, "rand_2")
+            )
+        )");
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test__0();
+    test__1();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {"hpx.run_hpx_main!=1"};
+
+    return hpx::init(argc, argv, cfg);
+}

--- a/tests/regressions/execution_tree/random_d_1139.cpp
+++ b/tests/regressions/execution_tree/random_d_1139.cpp
@@ -6,7 +6,6 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/testing.hpp>
@@ -28,14 +27,13 @@ void execution_time(std::string const& name, std::string const& codestr)
     auto const& compiled_code =
         phylanx::execution_tree::compile(name, codestr, snippets, env);
 
-    hpx::cout << "Locality: " << hpx::get_locality_id()
-              << "  Starting execution for: " << name << hpx::endl;
+    std::cout << "Locality: " << hpx::get_locality_id()
+              << "  Starting execution for: " << name << std::endl;
     std::uint64_t t = hpx::util::high_resolution_clock::now();
     phylanx::execution_tree::primitive_argument_type a = compiled_code.run().arg_;
     t = hpx::util::high_resolution_clock::now() - t;
 
-    std::cout << *(a.annotation()) << "\n\n\n";
-    hpx::cout << "       " << (t / 1e6) << " ms.\n" << hpx::flush;
+    std::cout << "       " << (t / 1e6) << " ms.\n" << std::endl;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -45,8 +43,8 @@ void test__0()
     {
         execution_time("perftest_0", R"(
             dot_d(
-                constant_d(13., list(100, 100), 0, 2, "const_1"),
-                constant_d(13., list(100, 100), 0, 2, "const_2")
+                constant_d(13., list(10, 10), 0, 2, "const_1"),
+                constant_d(13., list(10, 10), 0, 2, "const_2")
             )
         )");
     }
@@ -54,8 +52,8 @@ void test__0()
     {
         execution_time("perftest_0", R"(
             dot_d(
-                constant_d(13., list(100, 100), 1, 2, "const_1"),
-                constant_d(13., list(100, 100), 1, 2, "const_2")
+                constant_d(13., list(10, 10), 1, 2, "const_1"),
+                constant_d(13., list(10, 10), 1, 2, "const_2")
             )
         )");
     }
@@ -67,8 +65,8 @@ void test__1()
     {
         execution_time("perftest_1", R"(
             dot_d(
-                random_d(list(100, 100), 0, 2, "rand_1"),
-                random_d(list(100, 100), 0, 2, "rand_2")
+                random_d(list(10, 10), 0, 2, "rand_1"),
+                random_d(list(10, 10), 0, 2, "rand_2")
             )
         )");
     }
@@ -76,8 +74,8 @@ void test__1()
     {
         execution_time("perftest_1", R"(
             dot_d(
-                random_d(list(100, 100), 1, 2, "rand_1"),
-                random_d(list(100, 100), 1, 2, "rand_2")
+                random_d(list(10, 10), 1, 2, "rand_1"),
+                random_d(list(10, 10), 1, 2, "rand_2")
             )
         )");
     }


### PR DESCRIPTION
- flyby: added missing std::move, remove superfluous std::move invocations

Fixes #1139