### PR TITLE
Add the dist_identity primitive

### DIFF
--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -3,14 +3,16 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_PRIMITIVES_DIST_RANDOM)
-#define PHYLANX_PRIMITIVES_DIST_RANDOM
+#if !defined(PHYLANX_PRIMITIVES_DIST_IDENTITY)
+#define PHYLANX_PRIMITIVES_DIST_IDENTITY
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/annotation.hpp>
+#include <phylanx/execution_tree/localities_annotation.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
-#include <phylanx/util/random.hpp>
+
 
 #include <hpx/lcos/future.hpp>
 

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 Nanmiao Wu
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_DIST_RANDOM)
+#define PHYLANX_PRIMITIVES_DIST_RANDOM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/util/random.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+namespace phylanx { namespace dist_matrixops { namespace primitives
+{
+    class dist_identity
+      : public execution_tree::primitives::primitive_component_base
+      , public std::enable_shared_from_this<dist_identity>
+    {
+    public:
+        static execution_tree::match_pattern_type const match_data;
+
+        dist_identity() = default;
+
+        dist_identity(execution_tree::primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    protected:
+        hpx::future<execution_tree::primitive_argument_type> eval(
+            execution_tree::primitive_arguments_type const& operands,
+            execution_tree::primitive_arguments_type const& args,
+            execution_tree::eval_context ctx) const override;
+
+        execution_tree::primitive_argument_type dist_identity_helper(
+            std::int64_t&& sz, std::uint32_t const& tile_idx, 
+            std::uint32_t const& numtiles, std::string&& given_name, 
+            std::string const& tiling_type) const;   
+
+        execution_tree::primitive_argument_type dist_identity(
+            std::int64_t&& sz, std::uint32_t const& tile_idx, 
+            std::uint32_t const& numtiles, std::string&& given_name, 
+            std::string const& tiling_type, 
+            execution_tree::node_data_type dtype) const;
+
+        
+    };
+
+    inline execution_tree::primitive create_dist_identity(hpx::id_type const& locality,
+        execution_tree::primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "identity_d", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -51,12 +51,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             execution_tree::eval_context ctx) const override;
 
         execution_tree::primitive_argument_type dist_identity_helper(
-            std::int64_t&& sz, std::uint32_t const& tile_idx, 
+            std::size_t const& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type) const;   
 
         execution_tree::primitive_argument_type dist_identity(
-            std::int64_t&& sz, std::uint32_t const& tile_idx, 
+            std::size_t const& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type, 
             execution_tree::node_data_type dtype) const;

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -1,5 +1,7 @@
 // Copyright (c) 2020 Nanmiao Wu
-//
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2017-2020 Hartmut Kaiser
+
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -50,12 +50,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             execution_tree::primitive_arguments_type const& args,
             execution_tree::eval_context ctx) const override;
 
-        execution_tree::primitive_argument_type identity_helper(
+        execution_tree::primitive_argument_type dist_identity_helper(
             std::size_t const& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type) const;   
 
-        execution_tree::primitive_argument_type identity_nd(
+        execution_tree::primitive_argument_type dist_identity_nd(
             std::size_t const& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type, 

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -51,12 +51,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             execution_tree::eval_context ctx) const override;
 
         execution_tree::primitive_argument_type dist_identity_helper(
-            std::size_t const& sz, std::uint32_t const& tile_idx, 
+            std::int64_t&& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type) const;   
 
         execution_tree::primitive_argument_type dist_identity_nd(
-            std::size_t const& sz, std::uint32_t const& tile_idx, 
+            std::int64_t&& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type, 
             execution_tree::node_data_type dtype) const;

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -50,12 +50,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             execution_tree::primitive_arguments_type const& args,
             execution_tree::eval_context ctx) const override;
 
-        execution_tree::primitive_argument_type dist_identity_helper(
+        execution_tree::primitive_argument_type identity_helper(
             std::size_t const& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type) const;   
 
-        execution_tree::primitive_argument_type dist_identity(
+        execution_tree::primitive_argument_type identity_nd(
             std::size_t const& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type, 

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <random>
 #include <string>
 #include <tuple>
 #include <utility>

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -17,16 +17,12 @@
 
 #include <hpx/lcos/future.hpp>
 
-#include <array>
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <tuple>
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
 
 namespace phylanx { namespace dist_matrixops { namespace primitives {
     class dist_identity

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -53,13 +53,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type dist_identity_helper(
             std::int64_t&& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
-            std::string const& tiling_type) const;   
+            std::string const& tiling_type);   
 
         execution_tree::primitive_argument_type dist_identity(
             std::int64_t&& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type, 
-            execution_tree::node_data_type dtype) const;
+            execution_tree::node_data_type dtype);
 
         
     };

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -15,6 +15,7 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
+
 #include <hpx/lcos/future.hpp>
 
 #include <array>
@@ -29,7 +30,8 @@
 
 #include <blaze/Math.h>
 
-namespace phylanx { namespace dist_matrixops { namespace primitives {
+namespace phylanx { namespace dist_matrixops { namespace primitives
+{
     class dist_identity
       : public execution_tree::primitives::primitive_component_base
       , public std::enable_shared_from_this<dist_identity>
@@ -50,25 +52,26 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
         template <typename T>
         execution_tree::primitive_argument_type dist_identity_helper(
-            std::int64_t&& sz, std::uint32_t const& tile_idx,
-            std::uint32_t const& numtiles, std::string&& given_name,
-            std::string const& tiling_type) const;
+            std::int64_t&& sz, std::uint32_t const& tile_idx, 
+            std::uint32_t const& numtiles, std::string&& given_name, 
+            std::string const& tiling_type) const;   
 
         execution_tree::primitive_argument_type dist_identity_nd(
-            std::int64_t&& sz, std::uint32_t const& tile_idx,
-            std::uint32_t const& numtiles, std::string&& given_name,
-            std::string const& tiling_type,
+            std::int64_t&& sz, std::uint32_t const& tile_idx, 
+            std::uint32_t const& numtiles, std::string&& given_name, 
+            std::string const& tiling_type, 
             execution_tree::node_data_type dtype) const;
+
+        
     };
 
-    inline execution_tree::primitive create_dist_identity(
-        hpx::id_type const& locality,
+    inline execution_tree::primitive create_dist_identity(hpx::id_type const& locality,
         execution_tree::primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(
             locality, "identity_d", std::move(operands), name, codename);
     }
-}}}    // namespace phylanx::dist_matrixops::primitives
+}}}
 
 #endif

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -50,6 +50,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             execution_tree::primitive_arguments_type const& args,
             execution_tree::eval_context ctx) const override;
 
+        template <typename T>
         execution_tree::primitive_argument_type dist_identity_helper(
             std::int64_t&& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -15,7 +15,6 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-
 #include <hpx/lcos/future.hpp>
 
 #include <array>
@@ -30,8 +29,7 @@
 
 #include <blaze/Math.h>
 
-namespace phylanx { namespace dist_matrixops { namespace primitives
-{
+namespace phylanx { namespace dist_matrixops { namespace primitives {
     class dist_identity
       : public execution_tree::primitives::primitive_component_base
       , public std::enable_shared_from_this<dist_identity>
@@ -52,26 +50,25 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
 
         template <typename T>
         execution_tree::primitive_argument_type dist_identity_helper(
-            std::int64_t&& sz, std::uint32_t const& tile_idx, 
-            std::uint32_t const& numtiles, std::string&& given_name, 
-            std::string const& tiling_type) const;   
+            std::int64_t&& sz, std::uint32_t const& tile_idx,
+            std::uint32_t const& numtiles, std::string&& given_name,
+            std::string const& tiling_type) const;
 
         execution_tree::primitive_argument_type dist_identity_nd(
-            std::int64_t&& sz, std::uint32_t const& tile_idx, 
-            std::uint32_t const& numtiles, std::string&& given_name, 
-            std::string const& tiling_type, 
+            std::int64_t&& sz, std::uint32_t const& tile_idx,
+            std::uint32_t const& numtiles, std::string&& given_name,
+            std::string const& tiling_type,
             execution_tree::node_data_type dtype) const;
-
-        
     };
 
-    inline execution_tree::primitive create_dist_identity(hpx::id_type const& locality,
+    inline execution_tree::primitive create_dist_identity(
+        hpx::id_type const& locality,
         execution_tree::primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(
             locality, "identity_d", std::move(operands), name, codename);
     }
-}}}
+}}}    // namespace phylanx::dist_matrixops::primitives
 
 #endif

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -53,13 +53,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type dist_identity_helper(
             std::int64_t&& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
-            std::string const& tiling_type);   
+            std::string const& tiling_type) const;   
 
         execution_tree::primitive_argument_type dist_identity(
             std::int64_t&& sz, std::uint32_t const& tile_idx, 
             std::uint32_t const& numtiles, std::string&& given_name, 
             std::string const& tiling_type, 
-            execution_tree::node_data_type dtype);
+            execution_tree::node_data_type dtype) const;
 
         
     };

--- a/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
@@ -9,8 +9,9 @@
 #include <phylanx/plugins/dist_matrixops/dist_cannon_product.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_constant.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_dot_operation.hpp>
+#include <phylanx/plugins/dist_matrixops/dist_identity.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_random.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_transpose_operation.hpp>
-#include <phylanx/plugins/dist_matrixops/dist_identity.hpp>
+
 
 #endif

--- a/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
@@ -11,5 +11,6 @@
 #include <phylanx/plugins/dist_matrixops/dist_dot_operation.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_random.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_transpose_operation.hpp>
+#include <phylanx/plugins/dist_matrixops/dist_identity.hpp>
 
 #endif

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -239,41 +239,24 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
                     std::int64_t sz = extract_scalar_integer_value_strict(
                         std::move(args[0]), this_->name_, this_->codename_);
-/*                        
-                    std::uint32_t tile_idx =
-                        extract_scalar_nonneg_integer_value_strict(
-                            std::move(args[1]), this_->name_, this_->codename_);
-                    std::uint32_t numtiles =
-                        extract_scalar_positive_integer_value_strict(
-                            std::move(args[2]), this_->name_, this_->codename_);
-                    if (tile_idx >= numtiles)
-                    {
-                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "dist_identity::eval",
-                            this_->generate_error_message(
-                                "invalid tile index. Tile indices start from 0 "
-                                "and should be smaller than number of tiles"));
-                    }
-*/
+
                     std::uint32_t tile_idx;
                     std::uint32_t numtiles;
                     if (valid(args[1]) && valid(args[2]))
                     {
-                        tile_idx =
-                            extract_scalar_nonneg_integer_value_strict(
-                                std::move(args[1]), this_->name_, 
-                                this_->codename_);
-                        numtiles =
-                            extract_scalar_positive_integer_value_strict(
-                                std::move(args[2]), this_->name_, 
-                                this_->codename_);
+                        tile_idx = extract_scalar_nonneg_integer_value_strict(
+                            std::move(args[1]), this_->name_, this_->codename_);
+                        numtiles = extract_scalar_positive_integer_value_strict(
+                            std::move(args[2]), this_->name_, this_->codename_);
                         if (tile_idx >= numtiles)
                         {
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                             "dist_identity::eval",
-                             this_->generate_error_message(
-                                "invalid tile index. Tile indices start from 0 "
-                                "and should be smaller than number of tiles"));
+                                "dist_identity::eval",
+                                this_->generate_error_message(
+                                    "invalid tile index. Tile indices start "
+                                    "from 0 "
+                                    "and should be smaller than number of "
+                                    "tiles"));
                         }
                     }
                     else
@@ -285,7 +268,6 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                                 "generate a distributed identity",
                                 this_->name_, this_->codename_));
                     }
-                   
 
                     std::string given_name = "";
                     if (valid(args[3]))

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -291,7 +291,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             map_dtype(extract_string_value(std::move(args[5]),
                                 this_->name_, this_->codename_));
                     }
-       
+
+                    return this_->dist_identity_nd(std::move(args[0]), 
+                                tile_idx, numtiles, std::move(given_name),
+                                tiling_type, dtype);
+
                 }),
             execution_tree::primitives::detail::map_operands(operands,
                 execution_tree::functional::value_operand{}, args, name_,

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -1,4 +1,3 @@
-// Copyright (c) 2017-2020 Hartmut Kaiser
 // Copyright (c) 2020 Nanmiao Wu
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,8 +10,7 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/tiling_annotations.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/plugins/common/constant_nd.hpp>
-#include <phylanx/plugins/dist_matrixops/dist_constant.hpp>
+#include <phylanx/plugins/dist_matrixops/dist_identity.hpp>
 #include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
 #include <phylanx/execution_tree/localities_annotation.hpp>
 
@@ -90,7 +88,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         {
             if (given_name.empty())
             {
-                return "full_array_" + std::to_string(++const_count);
+                return "identity_array_" + std::to_string(++const_count);
             }
 
             return std::move(given_name);

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -143,8 +143,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         else if (tiling_type == "sym")
         {
             std::int64_t num_band = row_start - column_start;
-            std::int64_t upper_band = static_cast<std::size_t>(column_size - 1);
-            std::int64_t lower_band = static_cast<std::size_t>(1 - row_size);
+            std::int64_t upper_band = column_size - 1;
+            std::int64_t lower_band = 1 - row_size;
 
             if (num_band <= (std::max)(int64_t(0), upper_band) &&
                 num_band >= (std::min)(int64_t(0), lower_band))

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -41,7 +41,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
         hpx::util::make_tuple("identity_d", std::vector<std::string>{R"(
                 identity_d(
-                    _1_size, 
+                    _1_sz, 
                     __arg(_2_tile_index, nil),
                     __arg(_3_numtiles, nil),
                     __arg(_4_name, ""),
@@ -221,12 +221,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                                        "at least 1 and at most 6 operands"));
         }
 
-        if (!valid(operands[0]))
+        if (!valid(operands[1]) || !valid(operands[2]) || !valid(operands[3]))
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_identity::eval",
                 generate_error_message(
-                    "the identity_d primitive requires the first argument"
-                    "given by the operands array is valid"));
+                    "the identity_d primitive requires the arguments"
+                    "given by the operands array are valid"));
         }
 
         auto this_ = this->shared_from_this();

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -223,21 +223,21 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::eval_context ctx) const
     {
         // verify arguments
-        if (operands.size() < 2 || operands.size() > 7)
+        if (operands.size() < 1 || operands.size() > 6)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "dist_constant::eval",
+                "dist_identity::eval",
                 generate_error_message(
-                    "the constant_d primitive requires "
-                        "at least 2 and at most 7 operands"));
+                    "the identity_d primitive requires "
+                        "at least 1 and at most 6 operands"));
         }
 
-        if (!valid(operands[0]) || !valid(operands[1]))
+        if (!valid(operands[0]))
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_constant::eval",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_identity::eval",
                 generate_error_message(
-                    "the constant_d primitive requires the first two arguments "
-                    "given by the operands array are valid"));
+                    "the constant_d primitive requires the first argument"
+                    "given by the operands array is valid"));
         }
 
         auto this_ = this->shared_from_this();
@@ -252,7 +252,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                         extract_numeric_value_dimension(args[0]) != 0)
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "dist_constant::eval",
+                            "dist_identity::eval",
                             this_->generate_error_message(
                                 "the first argument must be a literal "
                                 "scalar value"));

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -104,7 +104,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::int64_t&& sz,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type,
-        std::string const& name, std::string const& codename) const
+        std::string const& name, std::string const& codename) 
     {
         using namespace execution_tree;
         if (sz < 0)

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2020 Nanmiao Wu
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2017-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -239,6 +239,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
                     std::int64_t sz = extract_scalar_integer_value_strict(
                         std::move(args[0]), this_->name_, this_->codename_);
+/*                        
                     std::uint32_t tile_idx =
                         extract_scalar_nonneg_integer_value_strict(
                             std::move(args[1]), this_->name_, this_->codename_);
@@ -253,22 +254,28 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                                 "invalid tile index. Tile indices start from 0 "
                                 "and should be smaller than number of tiles"));
                     }
-/*
+*/
+                    std::uint32_t const& tile_idx = extract_scalar_nonneg_integer_value_strict(
+                                std::move(args[1]));
+                    std::uint32_t const& numtiles= extract_scalar_positive_integer_value_strict(
+                                std::move(args[2]));
                     if (valid(args[1]) && valid(args[2]))
                     {
                         std::uint32_t tile_idx =
                             extract_scalar_nonneg_integer_value_strict(
-                                std::move(args[1]), this_->name_, this_->codename_);
+                                std::move(args[1]), this_->name_, 
+                                this_->codename_);
                         std::uint32_t numtiles =
                             extract_scalar_positive_integer_value_strict(
-                                std::move(args[2]), this_->name_, this_->codename_);
+                                std::move(args[2]), this_->name_, 
+                                this_->codename_);
                         if (tile_idx >= numtiles)
                         {
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "dist_identity::eval",
-                                this_->generate_error_message(
-                                    "invalid tile index. Tile indices start from 0 "
-                                    "and should be smaller than number of tiles"));
+                             "dist_identity::eval",
+                             this_->generate_error_message(
+                                "invalid tile index. Tile indices start from 0 "
+                                "and should be smaller than number of tiles"));
                         }
                     }
                     else
@@ -280,8 +287,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                                 "generate a distributed identity",
                                 this_->name_, this_->codename_));
                     }
+                   
 
-*/
                     std::string given_name = "";
                     if (valid(args[3]))
                     {

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -186,7 +186,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type,
         execution_tree::node_data_type dtype, std::string const& name_,
-        std::string const& codename_) const
+        std::string const& codename_) 
     {
         using namespace execution_tree;
 
@@ -217,7 +217,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    hpx::future<execution_tree::primitive_argument_type> dist_constant::eval(
+    hpx::future<execution_tree::primitive_argument_type> dist_identity::eval(
         execution_tree::primitive_arguments_type const& operands,
         execution_tree::primitive_arguments_type const& args,
         execution_tree::eval_context ctx) const

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -142,7 +142,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             for (std::size_t i = 0; i != row_size; ++i)
             {
                 std::size_t j = i + row_start;
-                m(i, j) = 1;
+                m(i, j) = 1.0;
             }
         }
         else if (tiling_type == "column")
@@ -150,7 +150,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             for (std::size_t i = 0; i != column_size; ++i)
             {
                 std::size_t j = i + column_start;
-                m(j, i) = 1;
+                m(j, i) = 1.0;
             }
         }
         else if (tiling_type == "sym" && numtiles == 4)
@@ -162,7 +162,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                 {
                     break;
                 }
-                m(j, i) = 1;
+                m(j, i) = 1.0;
             }
         }
         else

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -239,19 +239,32 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
                     std::int64_t sz = extract_scalar_integer_value_strict(
                         std::move(args[0]), this_->name_, this_->codename_);
-                    std::uint32_t tile_idx =
-                        extract_scalar_nonneg_integer_value_strict(
-                            std::move(args[1]), this_->name_, this_->codename_);
-                    std::uint32_t numtiles =
-                        extract_scalar_positive_integer_value_strict(
-                            std::move(args[2]), this_->name_, this_->codename_);
-                    if (tile_idx >= numtiles)
+
+                    if (valid(args[1]) && valid(args[2]))
+                    {
+                        std::uint32_t tile_idx =
+                            extract_scalar_nonneg_integer_value_strict(
+                                std::move(args[1]), this_->name_, this_->codename_);
+                        std::uint32_t numtiles =
+                            extract_scalar_positive_integer_value_strict(
+                                std::move(args[2]), this_->name_, this_->codename_);
+                        if (tile_idx >= numtiles)
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "dist_identity::eval",
+                                this_->generate_error_message(
+                                    "invalid tile index. Tile indices start from 0 "
+                                    "and should be smaller than number of tiles"));
+                        }
+                    }
+                    else
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
                             "dist_identity::eval",
-                            this_->generate_error_message(
-                                "invalid tile index. Tile indices start from 0 "
-                                "and should be smaller than number of tiles"));
+                            util::generate_error_message(
+                                "both tile_idx and numtiles should be given to "
+                                "generate a distributed identity",
+                                this_->name_, this_->codename_));
                     }
 
                     std::string given_name = "";

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -38,7 +38,7 @@
 namespace phylanx { namespace dist_matrixops { namespace primitives
 {
     ///////////////////////////////////////////////////////////////////////////
-    execution_tree::match_pattern_type const dist_constant::match_data =
+    execution_tree::match_pattern_type const dist_identity::match_data =
     {
 
         hpx::util::make_tuple("identity_d", std::vector<std::string>{R"(
@@ -76,7 +76,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    dist_constant::dist_identity(
+    dist_identity::dist_identity(
             execution_tree::primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -292,7 +292,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                 this_->name_, this_->codename_));
                     }
 
-                    return this_->dist_identity_nd(std::move(args[0]), 
+                    return this_->dist_identity_nd(sz, 
                                 tile_idx, numtiles, std::move(given_name),
                                 tiling_type, dtype);
 

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -42,8 +42,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         hpx::util::make_tuple("identity_d", std::vector<std::string>{R"(
                 identity_d(
                     _1_sz,
-                    __arg(_2_tile_index, nil),
-                    __arg(_3_numtiles, nil),
+                    __arg(_2_tile_index, find_here()),
+                    __arg(_3_numtiles, num_localities()),
                     __arg(_4_name, ""),
                     __arg(_5_tiling_type, "sym"),
                     __arg(_6_dtype, nil)
@@ -55,9 +55,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             sz, dtype, tile_index, numtiles, name, tiling_type,
             Args:
                 sz (int): the size of a created (n x n) matrix.
-                tile_index (int): the tile index we need to generate the
-                    constant array for. A non-negative integer.
-                numtiles (int): number of tiles of the returned array
+                tile_index (int, optional): the tile index we need to generate
+                    the identity array for. A non-negative integer. If not
+                    given, it sets to current locality.
+                numtiles (int, optional): number of tiles of the returned array.
+                    If not given it sets to the number of localities in the
+                    application.
                 name (string, optional): the array given name. If not given, a
                     globally unique name will be generated.
                 tiling_type (string, optional): defaults to `sym` which is a

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -141,23 +141,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             blaze::band(m, -column_start) = T(1);
         }
         else if (tiling_type == "sym" && numtiles == 4)
-        {   
+        {
             if (column_start - row_start == 0)
             {
                 blaze::band(m, 0) = T(1);
             }
-            
-            /*
-            for (std::size_t i = 0; i != column_size; ++i)
-            {
-                std::int64_t j = i + column_start - row_start;
-                if (j >= row_size || j < 0)
-                {
-                    break;
-                }
-                m(j, i) = 1.0;
-            }
-            */
         }
         else
         {

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -168,7 +168,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         else
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "identity::identity_helper",
+                "dist_identity::dist_identity_helper",
                 generate_error_message("wrong numtiles input when tiling_type is sym"));
         }
         
@@ -204,7 +204,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "dist_matrixops::dist_identity::dist_identity",
+            "dist_matrixops::dist_identity::dist_identity_nd",
             util::generate_error_message(
                 "the constant primitive requires for all arguments to "
                     "be numeric data types"));

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -239,7 +239,21 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
                     std::int64_t sz = extract_scalar_integer_value_strict(
                         std::move(args[0]), this_->name_, this_->codename_);
-
+                    std::uint32_t tile_idx =
+                        extract_scalar_nonneg_integer_value_strict(
+                            std::move(args[1]), this_->name_, this_->codename_);
+                    std::uint32_t numtiles =
+                        extract_scalar_positive_integer_value_strict(
+                            std::move(args[2]), this_->name_, this_->codename_);
+                    if (tile_idx >= numtiles)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "dist_identity::eval",
+                            this_->generate_error_message(
+                                "invalid tile index. Tile indices start from 0 "
+                                "and should be smaller than number of tiles"));
+                    }
+/*
                     if (valid(args[1]) && valid(args[2]))
                     {
                         std::uint32_t tile_idx =
@@ -267,6 +281,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                                 this_->name_, this_->codename_));
                     }
 
+*/
                     std::string given_name = "";
                     if (valid(args[3]))
                     {

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -146,8 +146,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             std::int64_t upper_band = static_cast<std::size_t>(column_size - 1);
             std::int64_t lower_band = static_cast<std::size_t>(1 - row_size);
 
-            if (num_band <= std::max(int64_t(0), upper_band) &&
-                num_band >= std::min(int64_t(0), lower_band))
+            if (num_band <= (std::max)(int64_t(0), upper_band) &&
+                num_band >= (std::min)(int64_t(0), lower_band))
             {
                 blaze::band(m, num_band) = T(1);
             }

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -292,7 +292,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                 this_->name_, this_->codename_));
                     }
 
-                    return this_->dist_identity_nd(sz, 
+                    return this_->dist_identity_nd(std::move(sz), 
                                 tile_idx, numtiles, std::move(given_name),
                                 tiling_type, dtype);
 

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -41,7 +41,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
 
         hpx::util::make_tuple("identity_d", std::vector<std::string>{R"(
                 identity_d(
-                    _1_sz, 
+                    _1_sz,
                     __arg(_2_tile_index, nil),
                     __arg(_3_numtiles, nil),
                     __arg(_4_name, ""),
@@ -52,7 +52,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             )"},
             &create_dist_identity,
             &execution_tree::create_primitive<dist_identity>, R"(
-            sz, dtype, tile_index, numtiles, name, tiling_type, 
+            sz, dtype, tile_index, numtiles, name, tiling_type,
             Args:
                 sz (int): the size of a created (n x n) matrix.
                 tile_index (int): the tile index we need to generate the
@@ -62,10 +62,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                     globally unique name will be generated.
                 tiling_type (string, optional): defaults to `sym` which is a
                     balanced way of tiling among all the numtiles localities.
-                    Other options are `row` or `column` tiling. 
+                    Other options are `row` or `column` tiling.
                 dtype (string, optional): the data-type of the returned array,
                     defaults to 'float'.
-                
 
             Returns:
 

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -100,19 +100,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
    
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    execution_tree::primitive_argument_type dist_identity::identity_helper(
+    execution_tree::primitive_argument_type dist_identity::dist_identity_helper(
         std::int64_t&& sz,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type) const
     {
         using namespace execution_tree;
-        if (sz < 0)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "dist_identity::identity_helper",
-                generate_error_message("input should be greater than zero"));
-        }
-
+        
         std::size_t size = static_cast<std::size_t>(sz);
 
         std::int64_t row_start, column_start;
@@ -182,7 +176,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         return primitive_argument_type(std::move(m), attached_annotation);
     }
 
-    execution_tree::primitive_argument_type dist_identity::identity_nd(
+    execution_tree::primitive_argument_type dist_identity::dist_identity_nd(
         std::int64_t&& sz,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type,
@@ -193,16 +187,16 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         switch (dtype)
         {
         case node_data_type_bool:
-            return identity_helper<std::uint8_t>(std::move(sz), tile_idx, 
+            return dist_identity_helper<std::uint8_t>(std::move(sz), tile_idx, 
             numtiles, std::move(given_name), tiling_type);
 
         case node_data_type_int64:
-            return identity_helper<std::int64_t>(std::move(sz), tile_idx, 
+            return dist_identity_helper<std::int64_t>(std::move(sz), tile_idx, 
             numtiles, std::move(given_name), tiling_type);
 
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
-            return identity_helper<double>(std::move(sz), tile_idx, 
+            return dist_identity_helper<double>(std::move(sz), tile_idx, 
             numtiles, std::move(given_name), tiling_type);
 
         default:
@@ -210,7 +204,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-            "dist_matrixops::dist_identity::identity_nd",
+            "dist_matrixops::dist_identity::dist_identity",
             util::generate_error_message(
                 "the constant primitive requires for all arguments to "
                     "be numeric data types"));

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -258,24 +258,23 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                 "scalar value"));
                     }
 
-
                     std::string given_name = "";
-                    if (valid(args[4]))
+                    if (valid(args[3]))
                     {
-                        given_name = extract_string_value(std::move(args[4]),
+                        given_name = extract_string_value(std::move(args[3]),
                             this_->name_, this_->codename_);
                     }
                     // using balanced symmetric tiles
                     std::string tiling_type = "sym";
-                    if (valid(args[5]))
+                    if (valid(args[4]))
                     {
                         tiling_type = extract_string_value(
-                            std::move(args[5]), this_->name_, this_->codename_);
+                            std::move(args[4]), this_->name_, this_->codename_);
                         if ((tiling_type != "sym" && tiling_type != "row") &&
                             tiling_type != "column")
                         {
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "dist_constant::eval",
+                                "dist_identity::eval",
                                 this_->generate_error_message(
                                     "invalid tling_type. the tiling_type cane "
                                     "one of these: `sym`, `row` or `column`"));
@@ -283,81 +282,53 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     }
 
                     node_data_type dtype = node_data_type_unknown;
-                    if (valid(args[6]))
+                    if (valid(args[5]))
                     {
                         dtype =
-                            map_dtype(extract_string_value(std::move(args[6]),
+                            map_dtype(extract_string_value(std::move(args[5]),
                                 this_->name_, this_->codename_));
                     }
 
-                    if (valid(args[2]) && valid(args[3]))
+                    if (valid(args[1]) && valid(args[2]))
                     {
                         std::uint32_t tile_idx =
                             extract_scalar_nonneg_integer_value_strict(
-                                std::move(args[2]), this_->name_, this_->codename_);
+                                std::move(args[1]), this_->name_, this_->codename_);
                         std::uint32_t numtiles =
                             extract_scalar_positive_integer_value_strict(
-                                std::move(args[3]), this_->name_, this_->codename_);
+                                std::move(args[2]), this_->name_, this_->codename_);
                         if (tile_idx >= numtiles)
                         {
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "dist_constant::eval",
+                                "dist_identity::eval",
                                 this_->generate_error_message(
                                     "invalid tile index. Tile indices start from 0 "
                                     "and should be smaller than number of tiles"));
                         }
 
-                        switch (numdims)
-                        {
-                        case 1:
-                            return this_->constant1d(std::move(args[0]), dims,
-                                tile_idx, numtiles, std::move(given_name),
-                                dtype, this_->name_, this_->codename_);
-
-                        case 2:
-                            return this_->constant2d(std::move(args[0]), dims,
-                                tile_idx, numtiles, std::move(given_name),
-                                tiling_type, dtype, this_->name_, this_->codename_);
+                        
+                        
+                        return this_->constant2d(std::move(args[0]), 
+                            tile_idx, numtiles, std::move(given_name),
+                            tiling_type, dtype, this_->name_, this_->codename_);
 
                         default:
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "dist_constant::eval",
+                                "dist_identity::eval",
                                 util::generate_error_message(
                                     "the given shape is of an unsupported "
                                     "dimensionality",
                                     this_->name_, this_->codename_));
-                        }
+                        
                     }
-                    else if (!valid(args[2]) && !valid(args[3]))
+                    else if (!valid(args[1]) && !valid(args[2]))
                     {
-                        switch (numdims)
-                        {
-                        case 0:
-                            return common::constant0d(std::move(args[0]), dtype,
-                                false, this_->name_, this_->codename_);
-
-                        case 1:
-                            return common::constant1d(std::move(args[0]),
-                                dims[0], dtype, false, this_->name_,
-                                this_->codename_);
-
-                        case 2:
-                            return common::constant2d(std::move(args[0]), dims,
-                                dtype, false, this_->name_, this_->codename_);
-
-                        case 3:
-                            return common::constant3d(std::move(args[0]), dims,
-                                dtype, false, this_->name_, this_->codename_);
-
-                        case 4:
-                            return common::constant4d(std::move(args[0]), dims,
-                                dtype, false, this_->name_, this_->codename_);
-
-                        default:
-                            break;
-                        }
+                                           
+                        return common::constant2d(std::move(args[0]),
+                            dtype, false, this_->name_, this_->codename_);
+                   
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "dist_constant::eval",
+                            "dist_identity::eval",
                             util ::generate_error_message(
                                 "left hand side operand has unsupported "
                                 "number of dimensions"));
@@ -365,7 +336,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     else
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            "dist_constant::eval",
+                            "dist_identity::eval",
                             util::generate_error_message(
                                 "both tile_idx and numtiles should be given to "
                                 "generate a distributed constant",

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -207,7 +207,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                                        "at least 1 and at most 6 operands"));
         }
 
-        if (!valid(operands[1]))
+        if (!valid(operands[0]))
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_identity::eval",
                 generate_error_message(

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -258,35 +258,6 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                 "scalar value"));
                     }
 
-                    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> dims{0};
-                    std::size_t numdims = 0;
-                    if (is_list_operand_strict(args[1]))
-                    {
-                        ir::range&& overall_shape = extract_list_value_strict(
-                            std::move(args[1]), this_->name_, this_->codename_);
-
-                        if (overall_shape.size() > PHYLANX_MAX_DIMENSIONS)
-                        {
-                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                                "dist_constant::eval",
-                                this_->generate_error_message(
-                                    "the given shape has a number of "
-                                    "dimensions that is not supported"));
-                        }
-
-                        dims =
-                            common::extract_dimensions(overall_shape);
-                        numdims = common::extract_num_dimensions(
-                            overall_shape);
-                    }
-                    else if (is_numeric_operand(args[1]))
-                    {
-                        // support constant_d(42, 3, 0, 3), to annotate the
-                        // first tile of [42, 42, 42]
-                        numdims = 1;
-                        dims[0] = extract_scalar_positive_integer_value_strict(
-                            std::move(args[1]), this_->name_, this_->codename_);
-                    }
 
                     std::string given_name = "";
                     if (valid(args[4]))

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -140,11 +140,16 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         {
             blaze::band(m, -column_start) = T(1);
         }
-        else if (tiling_type == "sym" && numtiles == 4)
+        else if (tiling_type == "sym")
         {
-            if (column_start - row_start == 0)
+            std::int64_t num_band = row_start - column_start;
+            std::int64_t upper_band = static_cast<std::size_t>(column_size - 1);
+            std::int64_t lower_band = static_cast<std::size_t>(1 - row_size);
+
+            if (num_band <= std::max(int64_t(0), upper_band) &&
+                num_band >= std::min(int64_t(0), lower_band))
             {
-                blaze::band(m, 0) = T(1);
+                blaze::band(m, num_band) = T(1);
             }
         }
         else

--- a/src/plugins/dist_matrixops/dist_identity.cpp
+++ b/src/plugins/dist_matrixops/dist_identity.cpp
@@ -255,17 +255,15 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                                 "and should be smaller than number of tiles"));
                     }
 */
-                    std::uint32_t const& tile_idx = extract_scalar_nonneg_integer_value_strict(
-                                std::move(args[1]));
-                    std::uint32_t const& numtiles= extract_scalar_positive_integer_value_strict(
-                                std::move(args[2]));
+                    std::uint32_t tile_idx;
+                    std::uint32_t numtiles;
                     if (valid(args[1]) && valid(args[2]))
                     {
-                        std::uint32_t tile_idx =
+                        tile_idx =
                             extract_scalar_nonneg_integer_value_strict(
                                 std::move(args[1]), this_->name_, 
                                 this_->codename_);
-                        std::uint32_t numtiles =
+                        numtiles =
                             extract_scalar_positive_integer_value_strict(
                                 std::move(args[2]), this_->name_, 
                                 this_->codename_);

--- a/src/plugins/dist_matrixops/dist_matrixops.cpp
+++ b/src/plugins/dist_matrixops/dist_matrixops.cpp
@@ -21,3 +21,5 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(dist_random_plugin,
     phylanx::dist_matrixops::primitives::dist_random::match_data)
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_transpose_operation_plugin,
     phylanx::dist_matrixops::primitives::dist_transpose_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(dist_identity_plugin,
+    phylanx::dist_matrixops::primitives::dist_identity::match_data)

--- a/src/plugins/dist_matrixops/dist_matrixops.cpp
+++ b/src/plugins/dist_matrixops/dist_matrixops.cpp
@@ -17,9 +17,10 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(dist_constant_plugin,
     phylanx::dist_matrixops::primitives::dist_constant::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_dot_operation_plugin,
     phylanx::dist_matrixops::primitives::dist_dot_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(dist_identity_plugin,
+    phylanx::dist_matrixops::primitives::dist_identity::match_data)
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_random_plugin,
     phylanx::dist_matrixops::primitives::dist_random::match_data)
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_transpose_operation_plugin,
     phylanx::dist_matrixops::primitives::dist_transpose_operation::match_data);
-PHYLANX_REGISTER_PLUGIN_FACTORY(dist_identity_plugin,
-    phylanx::dist_matrixops::primitives::dist_identity::match_data)
+

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -10,10 +10,11 @@ set(tests
     dist_constant_4_loc
     dist_constant_6_loc
     dist_dot_operation
+    dist_identity_2_loc
     dist_transpose_operation
     dist_random_2_loc
     dist_random_5_loc
-    dist_identity_2_loc
+    
    )
 
 
@@ -23,9 +24,10 @@ set(dist_constant_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_dot_operation_PARAMETERS LOCALITIES 2)
+set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
-set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
+
 
 
 foreach(test ${tests})

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -15,7 +15,6 @@ set(tests
     dist_transpose_operation
     dist_random_2_loc
     dist_random_5_loc
-    
    )
 
 

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
     dist_dot_operation
     dist_identity_2_loc
     dist_identity_4_loc
+    dist_identity_6_loc
     dist_transpose_operation
     dist_random_2_loc
     dist_random_5_loc
@@ -26,6 +27,7 @@ set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_dot_operation_PARAMETERS LOCALITIES 2)
 set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_identity_4_loc_PARAMETERS LOCALITIES 4)
+set(dist_identity_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
 

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -13,6 +13,7 @@ set(tests
     dist_transpose_operation
     dist_random_2_loc
     dist_random_5_loc
+    dist_identity_2_loc
    )
 
 
@@ -24,6 +25,7 @@ set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_dot_operation_PARAMETERS LOCALITIES 2)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
+set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
 
 
 foreach(test ${tests})

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tests
     dist_constant_6_loc
     dist_dot_operation
     dist_identity_2_loc
+    dist_identity_4_loc
     dist_transpose_operation
     dist_random_2_loc
     dist_random_5_loc
@@ -25,6 +26,7 @@ set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_dot_operation_PARAMETERS LOCALITIES 2)
 set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_identity_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -81,6 +81,34 @@ void test_identity_0()
     }
 }
 
+void test_identity_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_2loc_1", R"(
+            identity_d(4, 0, 2, "my_identity_2", "row")
+        )", R"(
+            annotate_d([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], 
+                "my_identity_2",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4), list("rows", 0, 2))))
+        )");
+    }
+    else
+    {
+        test_identity_d_operation("test_identity_2loc_0", R"(
+            identity_d(4, 1, 2, "my_identity_2", "row")
+        )", R"(
+            annotate_d([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], 
+                "my_identity_2",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 4), list("rows", 2, 4))))
+        )");
+    }
+}
+
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -88,6 +116,7 @@ int hpx_main(int argc, char* argv[])
 {
     // only annotations are compared
     test_identity_0();
+    test_identity_1();
     
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -176,7 +176,7 @@ int hpx_main(int argc, char* argv[])
     test_identity_2loc_0();
     test_identity_2loc_1();
     test_identity_2loc_2();
-  //  test_identity_2loc_3();
+    test_identity_2loc_3();
     
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -176,7 +176,7 @@ int hpx_main(int argc, char* argv[])
     test_identity_2loc_0();
     test_identity_2loc_1();
     test_identity_2loc_2();
-    test_identity_2loc_3();
+  //  test_identity_2loc_3();
     
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -16,6 +16,7 @@
 #include <array>
 #include <cstdint>
 #include <string>
+
 #include <utility>
 #include <vector>
 
@@ -55,7 +56,7 @@ void test_identity_0()
     if (hpx::get_locality_id() == 0)
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 0, 2)
+            identity_d(4, 0, 2, "column")
         )", R"(
             annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], 
                 [0.0, 0.0]], 
@@ -68,7 +69,7 @@ void test_identity_0()
     else
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 1, 2)
+            identity_d(4, 1, 2, "column")
         )", R"(
             annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
                 [0.0, 1.0]], 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -56,8 +56,8 @@ void test_identity_2loc_0()
             identity_d(4, 0, 2, "my_identity_1", "column")
         )",
             R"(
-            annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], 
-                [0.0, 0.0]], 
+            annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0],
+                [0.0, 0.0]],
                 "my_identity_1",
                 list("args",
                     list("locality", 0, 2),
@@ -70,8 +70,8 @@ void test_identity_2loc_0()
             identity_d(4, 1, 2, "my_identity_1", "column")
         )",
             R"(
-            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
-                [0.0, 1.0]], 
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0],
+                [0.0, 1.0]],
                 "my_identity_1",
                 list("args",
                     list("locality", 1, 2),
@@ -88,7 +88,7 @@ void test_identity_2loc_1()
             identity_d(4, 0, 2, "my_identity_2", "row")
         )",
             R"(
-            annotate_d([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], 
+            annotate_d([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
                 "my_identity_2",
                 list("args",
                     list("locality", 0, 2),
@@ -101,7 +101,7 @@ void test_identity_2loc_1()
             identity_d(4, 1, 2, "my_identity_2", "row")
         )",
             R"(
-            annotate_d([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], 
+            annotate_d([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]],
                 "my_identity_2",
                 list("args",
                     list("locality", 1, 2),
@@ -118,8 +118,8 @@ void test_identity_2loc_2()
             identity_d(5, 0, 2, "my_identity_3", "column")
         )",
             R"(
-            annotate_d([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], 
-                [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], 
+            annotate_d([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],
                 "my_identity_3",
                 list("args",
                     list("locality", 0, 2),
@@ -132,8 +132,8 @@ void test_identity_2loc_2()
             identity_d(5, 1, 2, "my_identity_3", "column")
         )",
             R"(
-            annotate_d([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
-                [0.0, 1.0]], 
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0],
+                [0.0, 1.0]],
                 "my_identity_3",
                 list("args",
                     list("locality", 1, 2),
@@ -150,8 +150,8 @@ void test_identity_2loc_3()
             identity_d(5, 0, 2, "my_identity_4", "row")
         )",
             R"(
-            annotate_d([[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0], 
-                [0.0, 0.0, 1.0, 0.0, 0.0]], 
+            annotate_d([[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0, 0.0]],
                 "my_identity_4",
                 list("args",
                     list("locality", 0, 2),
@@ -164,7 +164,7 @@ void test_identity_2loc_3()
             identity_d(5, 1, 2, "my_identity_4", "row")
         )",
             R"(
-            annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 1.0]], 
+            annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 1.0]],
                 "my_identity_4",
                 list("args",
                     list("locality", 1, 2),

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -12,15 +12,9 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <array>
-#include <cstdint>
 #include <string>
-
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
-#include <blaze_tensor/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -146,7 +146,7 @@ void test_identity_2loc_3()
         test_identity_d_operation("test_identity_2loc_3", R"(
             identity_d(5, 0, 2, "my_identity_4", "row")
         )", R"(
-            annotate_d([[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0]
+            annotate_d([[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0], 
                 [0.0, 0.0, 1.0, 0.0, 0.0]], 
                 "my_identity_4",
                 list("args",
@@ -159,7 +159,7 @@ void test_identity_2loc_3()
         test_identity_d_operation("test_identity_2loc_3", R"(
             identity_d(5, 1, 2, "my_identity_4", "row")
         )", R"(
-            annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 1.0]], 
+            annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0 0.0, 0.0, 0.0, 1.0]], 
                 "my_identity_4",
                 list("args",
                     list("locality", 1, 2),

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -6,7 +6,6 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
@@ -44,10 +43,9 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
-
-    std::cout << result<<"\n";
+    std::cout << result << "\n";
     // comparing annotations
-    HPX_TEST_EQ(*(result.annotation()),*(comparison.annotation()));
+    HPX_TEST_EQ(*(result.annotation()), *(comparison.annotation()));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -57,7 +55,8 @@ void test_identity_2loc_0()
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
             identity_d(4, 0, 2, "my_identity_1", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], 
                 [0.0, 0.0]], 
                 "my_identity_1",
@@ -70,7 +69,8 @@ void test_identity_2loc_0()
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
             identity_d(4, 1, 2, "my_identity_1", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
                 [0.0, 1.0]], 
                 "my_identity_1",
@@ -87,7 +87,8 @@ void test_identity_2loc_1()
     {
         test_identity_d_operation("test_identity_2loc_1", R"(
             identity_d(4, 0, 2, "my_identity_2", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], 
                 "my_identity_2",
                 list("args",
@@ -99,7 +100,8 @@ void test_identity_2loc_1()
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
             identity_d(4, 1, 2, "my_identity_2", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], 
                 "my_identity_2",
                 list("args",
@@ -115,7 +117,8 @@ void test_identity_2loc_2()
     {
         test_identity_d_operation("test_identity_2loc_2", R"(
             identity_d(5, 0, 2, "my_identity_3", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], 
                 [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], 
                 "my_identity_3",
@@ -128,7 +131,8 @@ void test_identity_2loc_2()
     {
         test_identity_d_operation("test_identity_2loc_2", R"(
             identity_d(5, 1, 2, "my_identity_3", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
                 [0.0, 1.0]], 
                 "my_identity_3",
@@ -145,7 +149,8 @@ void test_identity_2loc_3()
     {
         test_identity_d_operation("test_identity_2loc_3", R"(
             identity_d(5, 0, 2, "my_identity_4", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0], 
                 [0.0, 0.0, 1.0, 0.0, 0.0]], 
                 "my_identity_4",
@@ -158,7 +163,8 @@ void test_identity_2loc_3()
     {
         test_identity_d_operation("test_identity_2loc_3", R"(
             identity_d(5, 1, 2, "my_identity_4", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 1.0]], 
                 "my_identity_4",
                 list("args",
@@ -168,7 +174,6 @@ void test_identity_2loc_3()
     }
 }
 
-
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -177,17 +182,13 @@ int hpx_main(int argc, char* argv[])
     test_identity_2loc_1();
     test_identity_2loc_2();
     test_identity_2loc_3();
-    
 
     hpx::finalize();
     return hpx::util::report_errors();
 }
 int main(int argc, char* argv[])
 {
-    std::vector<std::string> cfg = {
-        "hpx.run_hpx_main!=1"
-    };
+    std::vector<std::string> cfg = {"hpx.run_hpx_main!=1"};
 
     return hpx::init(argc, argv, cfg);
 }
-

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -1,5 +1,5 @@
-// Copyright (c) 2020 Hartmut Kaiser
-// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Nanmiao Wu
+
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -33,7 +33,7 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
     return code.run().arg_;
 }
 
-void test_random_d_operation(std::string const& name, std::string const& code,
+void test_identity_d_operation(std::string const& name, std::string const& code,
     std::string const& expected_str)
 {
     phylanx::execution_tree::primitive_argument_type result =
@@ -46,12 +46,12 @@ void test_random_d_operation(std::string const& name, std::string const& code,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_random_1d_0()
+void test_identity_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_random_d_operation("test_random_2loc1d_0", R"(
-            random_d(list(4), 0, 2)
+        test_random_d_operation("test_identity_2loc_0", R"(
+            identity_d(5, 0, 2)
         )", R"(
             annotate_d([42.0, 42.0], "random_array_1",
                 list("args",

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -139,6 +139,34 @@ void test_identity_2loc_2()
     }
 }
 
+void test_identity_2loc_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_2loc_3", R"(
+            identity_d(5, 0, 2, "my_identity_4", "row")
+        )", R"(
+            annotate_d([[1.0, 0.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0, 0.0]
+                [0.0, 0.0, 1.0, 0.0, 0.0]], 
+                "my_identity_4",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 5), list("rows", 0, 3))))
+        )");
+    }
+    else
+    {
+        test_identity_d_operation("test_identity_2loc_3", R"(
+            identity_d(5, 1, 2, "my_identity_4", "row")
+        )", R"(
+            annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 1.0]], 
+                "my_identity_4",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 5), list("rows", 3, 5))))
+        )");
+    }
+}
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -148,6 +176,7 @@ int hpx_main(int argc, char* argv[])
     test_identity_2loc_0();
     test_identity_2loc_1();
     test_identity_2loc_2();
+    test_identity_2loc_3();
     
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -1,4 +1,6 @@
 // Copyright (c) 2020 Nanmiao Wu
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2017-2020 Hartmut Kaiser
 
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -74,7 +74,7 @@ void test_identity_0()
                 [0.0, 1.0]], 
                 "identity_array_1",
                 list("args",
-                    list("locality", 0, 2),
+                    list("locality", 1, 2),
                     list("tile", list("columns", 2, 4), list("rows", 0, 4))))
         )");
     }

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -1,0 +1,267 @@
+// Copyright (c) 2020 Hartmut Kaiser
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_random_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    // comparing annotations
+    HPX_TEST_EQ(*(result.annotation()),*(comparison.annotation()));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_random_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc1d_0", R"(
+            random_d(list(4), 0, 2)
+        )", R"(
+            annotate_d([42.0, 42.0], "random_array_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc1d_0", R"(
+            random_d(list(4), 1, 2)
+        )", R"(
+            annotate_d([42.0, 42.0], "random_array_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 4))))
+        )");
+    }
+}
+
+void test_random_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc1d_1", R"(
+            random_d(list(5), 0, 2)
+        )", R"(
+            annotate_d([42.0, 42.0, 42.0], "random_array_2",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 3))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc1d_1", R"(
+            random_d(list(5), 1, 2)
+        )", R"(
+            annotate_d([42.0, 42.0], "random_array_2",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 3, 5))))
+        )");
+    }
+}
+
+void test_random_1d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc1d_2", R"(
+            random_d(list(7), 0, 2, "my_rand_13")
+        )", R"(
+            annotate_d([13.0, 13.0, 13.0, 13.0], "my_rand_13",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc1d_2", R"(
+            random_d(list(7), 1, 2, "my_rand_13")
+        )", R"(
+            annotate_d([13.0, 13.0, 13.0], "my_rand_13",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 4, 7))))
+        )");
+    }
+}
+
+void test_random_1d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test1d_3", R"(
+            random_d(list(7), 0, 2, "my_rand_13_2", "sym")
+        )", R"(
+            annotate_d([13, 13, 13, 13], "my_rand_13_2",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test1d_3", R"(
+            random_d(list(7), 1, 2, "my_rand_13_2", "sym")
+        )", R"(
+            annotate_d([13, 13, 13], "my_rand_13_2",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 4, 7))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_random_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc2d_0", R"(
+            random_d(list(4, 6), 0, 2)
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
+                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
+                "random_array_3",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc2d_0", R"(
+            random_d(list(4, 6), 1, 2)
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
+                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
+                "random_array_3",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 3, 6), list("rows", 0, 4))))
+        )");
+    }
+}
+
+void test_random_2d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc2d_1", R"(
+            random_d(list(5, 4), 0, 2, "rand_42", "column")
+        )", R"(
+            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
+                        [42.0, 42.0], [42.0, 42.0]],
+                "rand_42",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 5))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc2d_1", R"(
+            random_d(list(5, 4), 1, 2, "rand_42", "column")
+        )", R"(
+            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
+                        [42.0, 42.0], [42.0, 42.0]],
+                "rand_42",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 5))))
+        )");
+    }
+}
+
+void test_random_2d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_random_d_operation("test_random_2loc2d_2", R"(
+            random_d(list(5, 4), 0, 2, "rand_5_4", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0],
+                [42.0, 42.0, 42.0, 42.0]],
+                "rand_5_4",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4), list("rows", 0, 3))))
+        )");
+    }
+    else
+    {
+        test_random_d_operation("test_random_2loc2d_2", R"(
+            random_d(list(5, 4), 1, 2, "rand_5_4", "row")
+        )", R"(
+            annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0]],
+                "rand_5_4",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 4), list("rows", 3, 5))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    // only annotations are compared
+    test_random_1d_0();
+    test_random_1d_1();
+    test_random_1d_2();
+    test_random_1d_3();
+
+    test_random_2d_0();
+    test_random_2d_1();
+    test_random_2d_2();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -43,8 +43,7 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
-    // comparing annotations
-    HPX_TEST_EQ(*(result.annotation()), *(comparison.annotation()));
+    HPX_TEST_EQ(result, comparison);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -176,7 +175,6 @@ void test_identity_2loc_3()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    // only annotations are compared
     test_identity_2loc_0();
     test_identity_2loc_1();
     test_identity_2loc_2();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -43,7 +43,6 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
-    std::cout << result << "\n";
     // comparing annotations
     HPX_TEST_EQ(*(result.annotation()), *(comparison.annotation()));
 }

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -56,11 +56,11 @@ void test_identity_0()
     if (hpx::get_locality_id() == 0)
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 0, 2, "column")
+            identity_d(4, 0, 2, "my_identity_1", "column")
         )", R"(
             annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], 
                 [0.0, 0.0]], 
-                "identity_array_1",
+                "my_identity_1",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 2), list("rows", 0, 4))))
@@ -69,11 +69,11 @@ void test_identity_0()
     else
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 1, 2, "column")
+            identity_d(4, 1, 2, "my_identity_1", "column")
         )", R"(
             annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
                 [0.0, 1.0]], 
-                "identity_array_1",
+                "my_identity_1",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 2, 4), list("rows", 0, 4))))

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -109,6 +109,36 @@ void test_identity_2loc_1()
     }
 }
 
+void test_identity_2loc_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_2loc_2", R"(
+            identity_d(5, 0, 2, "my_identity_3", "column")
+        )", R"(
+            annotate_d([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], 
+                [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], 
+                "my_identity_3",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 5))))
+        )");
+    }
+    else
+    {
+        test_identity_d_operation("test_identity_2loc_2", R"(
+            identity_d(5, 1, 2, "my_identity_3", "column")
+        )", R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
+                [0.0, 1.0]], 
+                "my_identity_3",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 3, 5), list("rows", 0, 5))))
+        )");
+    }
+}
+
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -117,6 +147,7 @@ int hpx_main(int argc, char* argv[])
     // only annotations are compared
     test_identity_2loc_0();
     test_identity_2loc_1();
+    test_identity_2loc_2();
     
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -159,7 +159,7 @@ void test_identity_2loc_3()
         test_identity_d_operation("test_identity_2loc_3", R"(
             identity_d(5, 1, 2, "my_identity_4", "row")
         )", R"(
-            annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0 0.0, 0.0, 0.0, 1.0]], 
+            annotate_d([[0.0, 0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0, 1.0]], 
                 "my_identity_4",
                 list("args",
                     list("locality", 1, 2),

--- a/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_2_loc.cpp
@@ -41,6 +41,8 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
+
+    std::cout << result<<"\n";
     // comparing annotations
     HPX_TEST_EQ(*(result.annotation()),*(comparison.annotation()));
 }
@@ -50,208 +52,40 @@ void test_identity_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_random_d_operation("test_identity_2loc_0", R"(
-            identity_d(5, 0, 2)
+        test_identity_d_operation("test_identity_2loc_0", R"(
+            identity_d(4, 0, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "random_array_1",
+            annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], 
+                [0.0, 0.0]], 
+                "identity_array_1",
                 list("args",
                     list("locality", 0, 2),
-                    list("tile", list("columns", 0, 2))))
+                    list("tile", list("columns", 0, 2), list("rows", 0, 4))))
         )");
     }
     else
     {
-        test_random_d_operation("test_random_2loc1d_0", R"(
-            random_d(list(4), 1, 2)
+        test_identity_d_operation("test_identity_2loc_0", R"(
+            identity_d(4, 1, 2)
         )", R"(
-            annotate_d([42.0, 42.0], "random_array_1",
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
+                [0.0, 1.0]], 
+                "identity_array_1",
                 list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 2, 4))))
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 4))))
         )");
     }
 }
 
-void test_random_1d_1()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_random_d_operation("test_random_2loc1d_1", R"(
-            random_d(list(5), 0, 2)
-        )", R"(
-            annotate_d([42.0, 42.0, 42.0], "random_array_2",
-                list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 3))))
-        )");
-    }
-    else
-    {
-        test_random_d_operation("test_random_2loc1d_1", R"(
-            random_d(list(5), 1, 2)
-        )", R"(
-            annotate_d([42.0, 42.0], "random_array_2",
-                list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 3, 5))))
-        )");
-    }
-}
 
-void test_random_1d_2()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_random_d_operation("test_random_2loc1d_2", R"(
-            random_d(list(7), 0, 2, "my_rand_13")
-        )", R"(
-            annotate_d([13.0, 13.0, 13.0, 13.0], "my_rand_13",
-                list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 4))))
-        )");
-    }
-    else
-    {
-        test_random_d_operation("test_random_2loc1d_2", R"(
-            random_d(list(7), 1, 2, "my_rand_13")
-        )", R"(
-            annotate_d([13.0, 13.0, 13.0], "my_rand_13",
-                list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 4, 7))))
-        )");
-    }
-}
-
-void test_random_1d_3()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_random_d_operation("test1d_3", R"(
-            random_d(list(7), 0, 2, "my_rand_13_2", "sym")
-        )", R"(
-            annotate_d([13, 13, 13, 13], "my_rand_13_2",
-                list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 4))))
-        )");
-    }
-    else
-    {
-        test_random_d_operation("test1d_3", R"(
-            random_d(list(7), 1, 2, "my_rand_13_2", "sym")
-        )", R"(
-            annotate_d([13, 13, 13], "my_rand_13_2",
-                list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 4, 7))))
-        )");
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////
-void test_random_2d_0()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_random_d_operation("test_random_2loc2d_0", R"(
-            random_d(list(4, 6), 0, 2)
-        )", R"(
-            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
-                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "random_array_3",
-                list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 3), list("rows", 0, 4))))
-        )");
-    }
-    else
-    {
-        test_random_d_operation("test_random_2loc2d_0", R"(
-            random_d(list(4, 6), 1, 2)
-        )", R"(
-            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
-                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-                "random_array_3",
-                list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 3, 6), list("rows", 0, 4))))
-        )");
-    }
-}
-
-void test_random_2d_1()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_random_d_operation("test_random_2loc2d_1", R"(
-            random_d(list(5, 4), 0, 2, "rand_42", "column")
-        )", R"(
-            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
-                        [42.0, 42.0], [42.0, 42.0]],
-                "rand_42",
-                list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 2), list("rows", 0, 5))))
-        )");
-    }
-    else
-    {
-        test_random_d_operation("test_random_2loc2d_1", R"(
-            random_d(list(5, 4), 1, 2, "rand_42", "column")
-        )", R"(
-            annotate_d([[42.0, 42.0], [42.0, 42.0], [42.0, 42.0],
-                        [42.0, 42.0], [42.0, 42.0]],
-                "rand_42",
-                list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 2, 4), list("rows", 0, 5))))
-        )");
-    }
-}
-
-void test_random_2d_2()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_random_d_operation("test_random_2loc2d_2", R"(
-            random_d(list(5, 4), 0, 2, "rand_5_4", "row")
-        )", R"(
-            annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0],
-                [42.0, 42.0, 42.0, 42.0]],
-                "rand_5_4",
-                list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 4), list("rows", 0, 3))))
-        )");
-    }
-    else
-    {
-        test_random_d_operation("test_random_2loc2d_2", R"(
-            random_d(list(5, 4), 1, 2, "rand_5_4", "row")
-        )", R"(
-            annotate_d([[42.0, 42.0, 42.0, 42.0], [42.0, 42.0, 42.0, 42.0]],
-                "rand_5_4",
-                list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 0, 4), list("rows", 3, 5))))
-        )");
-    }
-}
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
     // only annotations are compared
-    test_random_1d_0();
-    test_random_1d_1();
-    test_random_1d_2();
-    test_random_1d_3();
-
-    test_random_2d_0();
-    test_random_2d_1();
-    test_random_2d_2();
+    test_identity_0();
+    
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -6,7 +6,6 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
@@ -44,10 +43,9 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
-
-    std::cout << result<<"\n";
+    std::cout << result << "\n";
     // comparing annotations
-    HPX_TEST_EQ(*(result.annotation()),*(comparison.annotation()));
+    HPX_TEST_EQ(*(result.annotation()), *(comparison.annotation()));
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -57,7 +55,8 @@ void test_identity_4loc_0()
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
             identity_d(4, 0, 4, "", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([1.0, 0.0, 0.0, 0.0], 
                 "identity_array_1",
                 list("args",
@@ -69,7 +68,8 @@ void test_identity_4loc_0()
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
             identity_d(4, 1, 4, "", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 1.0, 0.0, 0.0],  
                 "identity_array_1",
                 list("args",
@@ -81,7 +81,8 @@ void test_identity_4loc_0()
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
             identity_d(4, 2, 4, "", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 1.0, 0.0], 
                 "identity_array_1",
                 list("args",
@@ -93,7 +94,8 @@ void test_identity_4loc_0()
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
             identity_d(4, 3, 4, "", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 0.0, 1.0], 
                 "identity_array_1",
                 list("args",
@@ -109,7 +111,8 @@ void test_identity_4loc_1()
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
             identity_d(4, 0, 4, "my_identity_2", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([1.0, 0.0, 0.0, 0.0], 
                 "my_identity_2",
                 list("args",
@@ -121,7 +124,8 @@ void test_identity_4loc_1()
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
             identity_d(4, 1, 4, "my_identity_2", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 1.0, 0.0, 0.0],  
                 "my_identity_2",
                 list("args",
@@ -133,7 +137,8 @@ void test_identity_4loc_1()
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
             identity_d(4, 2, 4, "my_identity_2", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 1.0, 0.0], 
                 "my_identity_2",
                 list("args",
@@ -145,7 +150,8 @@ void test_identity_4loc_1()
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
             identity_d(4, 3, 4, "my_identity_2", "column")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 0.0, 1.0], 
                 "my_identity_2",
                 list("args",
@@ -161,7 +167,8 @@ void test_identity_4loc_2()
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
             identity_d(4, 0, 4, "my_identity_3", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([1.0, 0.0, 0.0, 0.0], 
                 "my_identity_3",
                 list("args",
@@ -173,7 +180,8 @@ void test_identity_4loc_2()
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
             identity_d(4, 1, 4, "my_identity_3", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 1.0, 0.0, 0.0],  
                 "my_identity_3",
                 list("args",
@@ -185,7 +193,8 @@ void test_identity_4loc_2()
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
             identity_d(4, 2, 4, "my_identity_3", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 1.0, 0.0], 
                 "my_identity_3",
                 list("args",
@@ -197,7 +206,8 @@ void test_identity_4loc_2()
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
             identity_d(4, 3, 4, "my_identity_3", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 0.0, 1.0], 
                 "my_identity_3",
                 list("args",
@@ -213,7 +223,8 @@ void test_identity_4loc_3()
     {
         test_identity_d_operation("test_identity_4loc_3", R"(
             identity_d(4, 0, 4, "", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([1.0, 0.0, 0.0, 0.0], 
                 "identity_array_2",
                 list("args",
@@ -225,7 +236,8 @@ void test_identity_4loc_3()
     {
         test_identity_d_operation("test_identity_4loc_3", R"(
             identity_d(4, 1, 4, "", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 1.0, 0.0, 0.0],  
                 "identity_array_2",
                 list("args",
@@ -237,7 +249,8 @@ void test_identity_4loc_3()
     {
         test_identity_d_operation("test_identity_4loc_3", R"(
             identity_d(4, 2, 4, "", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 1.0, 0.0], 
                 "identity_array_2",
                 list("args",
@@ -249,7 +262,8 @@ void test_identity_4loc_3()
     {
         test_identity_d_operation("test_identity_4loc_3", R"(
             identity_d(4, 3, 4, "", "row")
-        )", R"(
+        )",
+            R"(
             annotate_d([0.0, 0.0, 0.0, 1.0], 
                 "identity_array_2",
                 list("args",
@@ -258,11 +272,6 @@ void test_identity_4loc_3()
         )");
     }
 }
-
-
-
-
-
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
@@ -278,10 +287,7 @@ int hpx_main(int argc, char* argv[])
 }
 int main(int argc, char* argv[])
 {
-    std::vector<std::string> cfg = {
-        "hpx.run_hpx_main!=1"
-    };
+    std::vector<std::string> cfg = {"hpx.run_hpx_main!=1"};
 
     return hpx::init(argc, argv, cfg);
 }
-

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -268,7 +268,7 @@ int hpx_main(int argc, char* argv[])
     // only annotations are compared
     test_identity_4loc_0();
     test_identity_4loc_1();
- //   test_identity_4loc_2();
+    test_identity_4loc_2();
   //  test_identity_4loc_3();
 
     

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -273,9 +273,6 @@ int hpx_main(int argc, char* argv[])
     test_identity_4loc_2();
     test_identity_4loc_3();
 
-
-    
-
     hpx::finalize();
     return hpx::util::report_errors();
 }

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -51,7 +51,7 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_identity_2loc_0()
+void test_identity_4loc_0()
 {
     if (hpx::get_locality_id() == 0)
     {
@@ -66,7 +66,33 @@ void test_identity_2loc_0()
                     list("tile", list("columns", 0, 2), list("rows", 0, 4))))
         )");
     }
-    else
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_2loc_0", R"(
+            identity_d(4, 1, 2, "my_identity_1", "column")
+        )", R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
+                [0.0, 1.0]], 
+                "my_identity_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_2loc_0", R"(
+            identity_d(4, 1, 2, "my_identity_1", "column")
+        )", R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
+                [0.0, 1.0]], 
+                "my_identity_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
     {
         test_identity_d_operation("test_identity_2loc_0", R"(
             identity_d(4, 1, 2, "my_identity_1", "column")
@@ -81,33 +107,6 @@ void test_identity_2loc_0()
     }
 }
 
-void test_identity_2loc_1()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_identity_d_operation("test_identity_2loc_1", R"(
-            identity_d(4, 0, 2, "my_identity_2", "row")
-        )", R"(
-            annotate_d([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], 
-                "my_identity_2",
-                list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 4), list("rows", 0, 2))))
-        )");
-    }
-    else
-    {
-        test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 1, 2, "my_identity_2", "row")
-        )", R"(
-            annotate_d([[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]], 
-                "my_identity_2",
-                list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 0, 4), list("rows", 2, 4))))
-        )");
-    }
-}
 
 
 
@@ -115,8 +114,8 @@ void test_identity_2loc_1()
 int hpx_main(int argc, char* argv[])
 {
     // only annotations are compared
-    test_identity_2loc_0();
-    test_identity_2loc_1();
+    test_identity_0();
+
     
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -259,6 +259,59 @@ void test_identity_4loc_3()
     }
 }
 
+void test_identity_4loc_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 0, 4, "", "sym")
+        )", R"(
+            annotate_d([[1.0, 0.0], [0.0, 1.0]], 
+                "identity_array_3",
+                list("args",
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 0, 4, "", "sym")
+        )", R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0]], 
+                "identity_array_3",
+                list("args",
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 0, 4, "", "sym")
+        )", R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0]], 
+                "identity_array_3",
+                list("args",
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 0, 2), list("rows", 2, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 0, 4, "", "sym")
+        )", R"(
+            annotate_d([[1.0, 0.0], [0.0, 1.0]], 
+                "identity_array_3",
+                list("args",
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 2, 4), list("rows", 2, 4))))
+        )");
+    }
+}
+
+
 
 
 
@@ -270,6 +323,7 @@ int hpx_main(int argc, char* argv[])
     test_identity_4loc_1();
     test_identity_4loc_2();
     test_identity_4loc_3();
+    test_identity_4loc_4();
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -12,15 +12,9 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <array>
-#include <cstdint>
 #include <string>
-
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
-#include <blaze_tensor/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -62,7 +62,7 @@ void test_identity_4loc_0()
                 "my_identity_1",
                 list("args",
                     list("locality", 0, 4),
-                    list("tile", list("columns", 0, 1), list("rows", 0, 3))))
+                    list("tile", list("columns", 0, 1), list("rows", 0, 4))))
         )");
     }
     else if (hpx::get_locality_id() == 1)
@@ -74,7 +74,7 @@ void test_identity_4loc_0()
                 "my_identity_1",
                 list("args",
                     list("locality", 1, 4),
-                    list("tile", list("columns", 1, 2), list("rows", 0, 3))))
+                    list("tile", list("columns", 1, 2), list("rows", 0, 4))))
         )");
     }
     else if (hpx::get_locality_id() == 2)
@@ -86,7 +86,7 @@ void test_identity_4loc_0()
                 "my_identity_1",
                 list("args",
                     list("locality", 2, 4),
-                    list("tile", list("columns", 2, 3), list("rows", 0, 3))))
+                    list("tile", list("columns", 2, 3), list("rows", 0, 4))))
         )");
     }
     else if (hpx::get_locality_id() == 3)
@@ -98,7 +98,59 @@ void test_identity_4loc_0()
                 "my_identity_1",
                 list("args",
                     list("locality", 3, 4),
-                    list("tile", list("columns", 3, 4), list("rows", 0, 3))))
+                    list("tile", list("columns", 3, 4), list("rows", 0, 4))))
+        )");
+    }
+}
+
+void test_identity_4loc_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_4loc_1", R"(
+            identity_d(4, 0, 4, "my_identity_2", "row")
+        )", R"(
+            annotate_d([1.0, 0.0, 0.0, 0.0], 
+                "my_identity_2",
+                list("args",
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 0, 1))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_4loc_1", R"(
+            identity_d(4, 1, 4, "my_identity_2", "row")
+        )", R"(
+            annotate_d([0.0, 1.0, 0.0, 0.0],  
+                "my_identity_2",
+                list("args",
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 1, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_4loc_1", R"(
+            identity_d(4, 2, 4, "my_identity_2", "row")
+        )", R"(
+            annotate_d([0.0, 0.0, 1.0, 0.0], 
+                "my_identity_2",
+                list("args",
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 2, 3))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_4loc_1", R"(
+            identity_d(4, 3, 4, "my_identity_2", "row")
+        )", R"(
+            annotate_d([0.0, 0.0, 0.0, 1.0], 
+                "my_identity_2",
+                list("args",
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 3, 4))))
         )");
     }
 }
@@ -111,6 +163,7 @@ int hpx_main(int argc, char* argv[])
 {
     // only annotations are compared
     test_identity_4loc_0;
+    test_identity_4loc_1;
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -43,8 +43,7 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
-    // comparing annotations
-    HPX_TEST_EQ(*(result.annotation()), *(comparison.annotation()));
+    HPX_TEST_EQ(result, comparison);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -56,7 +55,7 @@ void test_identity_4loc_0()
             identity_d(4, 0, 4, "", "column")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0],
+            annotate_d([[1.0], [0.0], [0.0], [0.0]],
                 "identity_array_1",
                 list("args",
                     list("locality", 0, 4),
@@ -69,7 +68,7 @@ void test_identity_4loc_0()
             identity_d(4, 1, 4, "", "column")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],
+            annotate_d([[0.0], [1.0], [0.0], [0.0]],
                 "identity_array_1",
                 list("args",
                     list("locality", 1, 4),
@@ -82,7 +81,7 @@ void test_identity_4loc_0()
             identity_d(4, 2, 4, "", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0],
+            annotate_d([[0.0], [0.0], [1.0], [0.0]],
                 "identity_array_1",
                 list("args",
                     list("locality", 2, 4),
@@ -95,7 +94,7 @@ void test_identity_4loc_0()
             identity_d(4, 3, 4, "", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0],
+            annotate_d([[0.0], [0.0], [0.0], [1.0]],
                 "identity_array_1",
                 list("args",
                     list("locality", 3, 4),
@@ -109,11 +108,11 @@ void test_identity_4loc_1()
     if (hpx::get_locality_id() == 0)
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 0, 4, "my_identity_2", "column")
+            identity_d(4, 0, 4, "my_identity_1", "column")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0],
-                "my_identity_2",
+            annotate_d([[1.0], [0.0], [0.0], [0.0]],
+                "my_identity_1",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 1), list("rows", 0, 4))))
@@ -122,11 +121,11 @@ void test_identity_4loc_1()
     else if (hpx::get_locality_id() == 1)
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 1, 4, "my_identity_2", "column")
+            identity_d(4, 1, 4, "my_identity_1", "column")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],
-                "my_identity_2",
+            annotate_d([[0.0], [1.0], [0.0], [0.0]],
+                "my_identity_1",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 1, 2), list("rows", 0, 4))))
@@ -135,11 +134,11 @@ void test_identity_4loc_1()
     else if (hpx::get_locality_id() == 2)
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 2, 4, "my_identity_2", "column")
+            identity_d(4, 2, 4, "my_identity_1", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0],
-                "my_identity_2",
+            annotate_d([[0.0], [0.0], [1.0], [0.0]],
+                "my_identity_1",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 2, 3), list("rows", 0, 4))))
@@ -148,11 +147,11 @@ void test_identity_4loc_1()
     else if (hpx::get_locality_id() == 3)
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 3, 4, "my_identity_2", "column")
+            identity_d(4, 3, 4, "my_identity_1", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0],
-                "my_identity_2",
+            annotate_d([[0.0], [0.0], [0.0], [1.0]],
+                "my_identity_1",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 3, 4), list("rows", 0, 4))))
@@ -165,11 +164,11 @@ void test_identity_4loc_2()
     if (hpx::get_locality_id() == 0)
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
-            identity_d(4, 0, 4, "my_identity_3", "row")
+            identity_d(4, 0, 4, "my_identity_2", "row")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0],
-                "my_identity_3",
+            annotate_d([[1.0, 0.0, 0.0, 0.0]],
+                "my_identity_2",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 4), list("rows", 0, 1))))
@@ -178,11 +177,11 @@ void test_identity_4loc_2()
     else if (hpx::get_locality_id() == 1)
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
-            identity_d(4, 1, 4, "my_identity_3", "row")
+            identity_d(4, 1, 4, "my_identity_2", "row")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],
-                "my_identity_3",
+            annotate_d([[0.0, 1.0, 0.0, 0.0]],
+                "my_identity_2",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 0, 4), list("rows", 1, 2))))
@@ -191,11 +190,11 @@ void test_identity_4loc_2()
     else if (hpx::get_locality_id() == 2)
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
-            identity_d(4, 2, 4, "my_identity_3", "row")
+            identity_d(4, 2, 4, "my_identity_2", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0],
-                "my_identity_3",
+            annotate_d([[0.0, 0.0, 1.0, 0.0]],
+                "my_identity_2",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 0, 4), list("rows", 2, 3))))
@@ -204,11 +203,11 @@ void test_identity_4loc_2()
     else if (hpx::get_locality_id() == 3)
     {
         test_identity_d_operation("test_identity_4loc_2", R"(
-            identity_d(4, 3, 4, "my_identity_3", "row")
+            identity_d(4, 3, 4, "my_identity_2", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0],
-                "my_identity_3",
+            annotate_d([[0.0, 0.0, 0.0, 1.0]],
+                "my_identity_2",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 0, 4), list("rows", 3, 4))))
@@ -224,7 +223,7 @@ void test_identity_4loc_3()
             identity_d(4, 0, 4, "", "row")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0],
+            annotate_d([[1.0, 0.0, 0.0, 0.0]],
                 "identity_array_2",
                 list("args",
                     list("locality", 0, 4),
@@ -237,7 +236,7 @@ void test_identity_4loc_3()
             identity_d(4, 1, 4, "", "row")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],
+            annotate_d([[0.0, 1.0, 0.0, 0.0]],
                 "identity_array_2",
                 list("args",
                     list("locality", 1, 4),
@@ -250,7 +249,7 @@ void test_identity_4loc_3()
             identity_d(4, 2, 4, "", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0],
+            annotate_d([[0.0, 0.0, 1.0, 0.0]],
                 "identity_array_2",
                 list("args",
                     list("locality", 2, 4),
@@ -263,7 +262,7 @@ void test_identity_4loc_3()
             identity_d(4, 3, 4, "", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0],
+            annotate_d([[0.0, 0.0, 0.0, 1.0]],
                 "identity_array_2",
                 list("args",
                     list("locality", 3, 4),
@@ -272,14 +271,126 @@ void test_identity_4loc_3()
     }
 }
 
+void test_identity_4loc_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 0, 4, "my_identity_3", "sym")
+        )",
+            R"(
+            annotate_d([[1.0, 0.0], [0.0, 1.0]],
+                "my_identity_3",
+                list("args",
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 1, 4, "my_identity_3", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0]],
+                "my_identity_3",
+                list("args",
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 2, 4, "my_identity_3", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0]],
+                "my_identity_3",
+                list("args",
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 0, 2), list("rows", 2, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_4loc_4", R"(
+            identity_d(4, 3, 4, "my_identity_3", "sym")
+        )",
+            R"(
+            annotate_d([[1.0, 0.0], [0.0, 1.0]],
+                "my_identity_3",
+                list("args",
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 2, 4), list("rows", 2, 4))))
+        )");
+    }
+}
+
+void test_identity_4loc_5()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_4loc_5", R"(
+            identity_d(4, 0, 4, "", "sym")
+        )",
+            R"(
+            annotate_d([[1.0, 0.0], [0.0, 1.0]],
+                "identity_array_3",
+                list("args",
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_4loc_5", R"(
+            identity_d(4, 1, 4, "", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0]],
+                "identity_array_3",
+                list("args",
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_4loc_5", R"(
+            identity_d(4, 2, 4, "", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0]],
+                "identity_array_3",
+                list("args",
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 0, 2), list("rows", 2, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_4loc_5", R"(
+            identity_d(4, 3, 4, "", "sym")
+        )",
+            R"(
+            annotate_d([[1.0, 0.0], [0.0, 1.0]],
+                "identity_array_3",
+                list("args",
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 2, 4), list("rows", 2, 4))))
+        )");
+    }
+}
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    // only annotations are compared
     test_identity_4loc_0();
     test_identity_4loc_1();
     test_identity_4loc_2();
     test_identity_4loc_3();
+    test_identity_4loc_4();
+    test_identity_4loc_5();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -259,57 +259,6 @@ void test_identity_4loc_3()
     }
 }
 
-void test_identity_4loc_4()
-{
-    if (hpx::get_locality_id() == 0)
-    {
-        test_identity_d_operation("test_identity_4loc_4", R"(
-            identity_d(4, 0, 4, "", "sym")
-        )", R"(
-            annotate_d([[1.0, 0.0], [0.0, 1.0]], 
-                "identity_array_3",
-                list("args",
-                    list("locality", 0, 4),
-                    list("tile", list("columns", 0, 2), list("rows", 0, 2))))
-        )");
-    }
-    else if (hpx::get_locality_id() == 1)
-    {
-        test_identity_d_operation("test_identity_4loc_4", R"(
-            identity_d(4, 0, 4, "", "sym")
-        )", R"(
-            annotate_d([[0.0, 0.0], [0.0, 0.0]], 
-                "identity_array_3",
-                list("args",
-                    list("locality", 1, 4),
-                    list("tile", list("columns", 2, 4), list("rows", 0, 2))))
-        )");
-    }
-    else if (hpx::get_locality_id() == 2)
-    {
-        test_identity_d_operation("test_identity_4loc_4", R"(
-            identity_d(4, 0, 4, "", "sym")
-        )", R"(
-            annotate_d([[0.0, 0.0], [0.0, 0.0]], 
-                "identity_array_3",
-                list("args",
-                    list("locality", 2, 4),
-                    list("tile", list("columns", 0, 2), list("rows", 2, 4))))
-        )");
-    }
-    else if (hpx::get_locality_id() == 3)
-    {
-        test_identity_d_operation("test_identity_4loc_4", R"(
-            identity_d(4, 0, 4, "", "sym")
-        )", R"(
-            annotate_d([[1.0, 0.0], [0.0, 1.0]], 
-                "identity_array_3",
-                list("args",
-                    list("locality", 3, 4),
-                    list("tile", list("columns", 2, 4), list("rows", 2, 4))))
-        )");
-    }
-}
 
 
 
@@ -323,7 +272,7 @@ int hpx_main(int argc, char* argv[])
     test_identity_4loc_1();
     test_identity_4loc_2();
     test_identity_4loc_3();
-    test_identity_4loc_4();
+
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -43,7 +43,6 @@ void test_identity_d_operation(std::string const& name, std::string const& code,
     phylanx::execution_tree::primitive_argument_type comparison =
         compile_and_run(name, expected_str);
 
-    std::cout << result << "\n";
     // comparing annotations
     HPX_TEST_EQ(*(result.annotation()), *(comparison.annotation()));
 }

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -56,10 +56,10 @@ void test_identity_4loc_0()
     if (hpx::get_locality_id() == 0)
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
-            identity_d(4, 0, 4, "my_identity_1", "column")
+            identity_d(4, 0, 4, "", "column")
         )", R"(
             annotate_d([1.0, 0.0, 0.0, 0.0], 
-                "my_identity_1",
+                "identity_array_1",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 1), list("rows", 0, 4))))
@@ -68,10 +68,10 @@ void test_identity_4loc_0()
     else if (hpx::get_locality_id() == 1)
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
-            identity_d(4, 1, 4, "my_identity_1", "column")
+            identity_d(4, 1, 4, "", "column")
         )", R"(
             annotate_d([0.0, 1.0, 0.0, 0.0],  
-                "my_identity_1",
+                "identity_array_1",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 1, 2), list("rows", 0, 4))))
@@ -80,10 +80,10 @@ void test_identity_4loc_0()
     else if (hpx::get_locality_id() == 2)
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
-            identity_d(4, 2, 4, "my_identity_1", "column")
+            identity_d(4, 2, 4, "", "column")
         )", R"(
             annotate_d([0.0, 0.0, 1.0, 0.0], 
-                "my_identity_1",
+                "identity_array_1",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 2, 3), list("rows", 0, 4))))
@@ -92,10 +92,10 @@ void test_identity_4loc_0()
     else if (hpx::get_locality_id() == 3)
     {
         test_identity_d_operation("test_identity_4loc_0", R"(
-            identity_d(4, 3, 4, "my_identity_1", "column")
+            identity_d(4, 3, 4, "", "column")
         )", R"(
             annotate_d([0.0, 0.0, 0.0, 1.0], 
-                "my_identity_1",
+                "identity_array_1",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 3, 4), list("rows", 0, 4))))
@@ -162,8 +162,8 @@ void test_identity_4loc_1()
 int hpx_main(int argc, char* argv[])
 {
     // only annotations are compared
-    test_identity_4loc_0;
-    test_identity_4loc_1;
+    test_identity_4loc_0();
+ //   test_identity_4loc_1;
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -55,54 +55,50 @@ void test_identity_4loc_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 0, 2, "my_identity_1", "column")
+        test_identity_d_operation("test_identity_4loc_0", R"(
+            identity_d(4, 0, 4, "my_identity_1", "column")
         )", R"(
-            annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], 
-                [0.0, 0.0]], 
+            annotate_d([1.0, 0.0, 0.0, 0.0], 
                 "my_identity_1",
                 list("args",
-                    list("locality", 0, 2),
-                    list("tile", list("columns", 0, 2), list("rows", 0, 4))))
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 1), list("rows", 0, 3))))
         )");
     }
     else if (hpx::get_locality_id() == 1)
     {
-        test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 1, 2, "my_identity_1", "column")
+        test_identity_d_operation("test_identity_4loc_0", R"(
+            identity_d(4, 1, 4, "my_identity_1", "column")
         )", R"(
-            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
-                [0.0, 1.0]], 
+            annotate_d([0.0, 1.0, 0.0, 0.0],  
                 "my_identity_1",
                 list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 2, 4), list("rows", 0, 4))))
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 1, 2), list("rows", 0, 3))))
         )");
     }
     else if (hpx::get_locality_id() == 2)
     {
-        test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 1, 2, "my_identity_1", "column")
+        test_identity_d_operation("test_identity_4loc_0", R"(
+            identity_d(4, 2, 4, "my_identity_1", "column")
         )", R"(
-            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
-                [0.0, 1.0]], 
+            annotate_d([0.0, 0.0, 1.0, 0.0], 
                 "my_identity_1",
                 list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 2, 4), list("rows", 0, 4))))
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 2, 3), list("rows", 0, 3))))
         )");
     }
     else if (hpx::get_locality_id() == 3)
     {
-        test_identity_d_operation("test_identity_2loc_0", R"(
-            identity_d(4, 1, 2, "my_identity_1", "column")
+        test_identity_d_operation("test_identity_4loc_0", R"(
+            identity_d(4, 3, 4, "my_identity_1", "column")
         )", R"(
-            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], 
-                [0.0, 1.0]], 
+            annotate_d([0.0, 0.0, 0.0, 1.0], 
                 "my_identity_1",
                 list("args",
-                    list("locality", 1, 2),
-                    list("tile", list("columns", 2, 4), list("rows", 0, 4))))
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 3, 4), list("rows", 0, 3))))
         )");
     }
 }
@@ -114,7 +110,7 @@ void test_identity_4loc_0()
 int hpx_main(int argc, char* argv[])
 {
     // only annotations are compared
-    test_identity_0();
+    test_identity_4loc_0;
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -215,7 +215,7 @@ void test_identity_4loc_3()
             identity_d(4, 0, 4, "", "row")
         )", R"(
             annotate_d([1.0, 0.0, 0.0, 0.0], 
-                "identity_array_4",
+                "identity_array_2",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 4), list("rows", 0, 1))))
@@ -227,7 +227,7 @@ void test_identity_4loc_3()
             identity_d(4, 1, 4, "", "row")
         )", R"(
             annotate_d([0.0, 1.0, 0.0, 0.0],  
-                "identity_array_4",
+                "identity_array_2",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 0, 4), list("rows", 1, 2))))
@@ -239,7 +239,7 @@ void test_identity_4loc_3()
             identity_d(4, 2, 4, "", "row")
         )", R"(
             annotate_d([0.0, 0.0, 1.0, 0.0], 
-                "identity_array_4",
+                "identity_array_2",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 0, 4), list("rows", 2, 3))))
@@ -251,7 +251,7 @@ void test_identity_4loc_3()
             identity_d(4, 3, 4, "", "row")
         )", R"(
             annotate_d([0.0, 0.0, 0.0, 1.0], 
-                "identity_array_4",
+                "identity_array_2",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 0, 4), list("rows", 3, 4))))
@@ -269,7 +269,7 @@ int hpx_main(int argc, char* argv[])
     test_identity_4loc_0();
     test_identity_4loc_1();
     test_identity_4loc_2();
-  //  test_identity_4loc_3();
+    test_identity_4loc_3();
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -268,8 +268,8 @@ int hpx_main(int argc, char* argv[])
     // only annotations are compared
     test_identity_4loc_0();
     test_identity_4loc_1();
-    test_identity_4loc_2();
-    test_identity_4loc_3();
+ //   test_identity_4loc_2();
+  //  test_identity_4loc_3();
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -56,7 +56,7 @@ void test_identity_4loc_0()
             identity_d(4, 0, 4, "", "column")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0], 
+            annotate_d([1.0, 0.0, 0.0, 0.0],
                 "identity_array_1",
                 list("args",
                     list("locality", 0, 4),
@@ -69,7 +69,7 @@ void test_identity_4loc_0()
             identity_d(4, 1, 4, "", "column")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],  
+            annotate_d([0.0, 1.0, 0.0, 0.0],
                 "identity_array_1",
                 list("args",
                     list("locality", 1, 4),
@@ -82,7 +82,7 @@ void test_identity_4loc_0()
             identity_d(4, 2, 4, "", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0], 
+            annotate_d([0.0, 0.0, 1.0, 0.0],
                 "identity_array_1",
                 list("args",
                     list("locality", 2, 4),
@@ -95,7 +95,7 @@ void test_identity_4loc_0()
             identity_d(4, 3, 4, "", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0], 
+            annotate_d([0.0, 0.0, 0.0, 1.0],
                 "identity_array_1",
                 list("args",
                     list("locality", 3, 4),
@@ -112,7 +112,7 @@ void test_identity_4loc_1()
             identity_d(4, 0, 4, "my_identity_2", "column")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0], 
+            annotate_d([1.0, 0.0, 0.0, 0.0],
                 "my_identity_2",
                 list("args",
                     list("locality", 0, 4),
@@ -125,7 +125,7 @@ void test_identity_4loc_1()
             identity_d(4, 1, 4, "my_identity_2", "column")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],  
+            annotate_d([0.0, 1.0, 0.0, 0.0],
                 "my_identity_2",
                 list("args",
                     list("locality", 1, 4),
@@ -138,7 +138,7 @@ void test_identity_4loc_1()
             identity_d(4, 2, 4, "my_identity_2", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0], 
+            annotate_d([0.0, 0.0, 1.0, 0.0],
                 "my_identity_2",
                 list("args",
                     list("locality", 2, 4),
@@ -151,7 +151,7 @@ void test_identity_4loc_1()
             identity_d(4, 3, 4, "my_identity_2", "column")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0], 
+            annotate_d([0.0, 0.0, 0.0, 1.0],
                 "my_identity_2",
                 list("args",
                     list("locality", 3, 4),
@@ -168,7 +168,7 @@ void test_identity_4loc_2()
             identity_d(4, 0, 4, "my_identity_3", "row")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0], 
+            annotate_d([1.0, 0.0, 0.0, 0.0],
                 "my_identity_3",
                 list("args",
                     list("locality", 0, 4),
@@ -181,7 +181,7 @@ void test_identity_4loc_2()
             identity_d(4, 1, 4, "my_identity_3", "row")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],  
+            annotate_d([0.0, 1.0, 0.0, 0.0],
                 "my_identity_3",
                 list("args",
                     list("locality", 1, 4),
@@ -194,7 +194,7 @@ void test_identity_4loc_2()
             identity_d(4, 2, 4, "my_identity_3", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0], 
+            annotate_d([0.0, 0.0, 1.0, 0.0],
                 "my_identity_3",
                 list("args",
                     list("locality", 2, 4),
@@ -207,7 +207,7 @@ void test_identity_4loc_2()
             identity_d(4, 3, 4, "my_identity_3", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0], 
+            annotate_d([0.0, 0.0, 0.0, 1.0],
                 "my_identity_3",
                 list("args",
                     list("locality", 3, 4),
@@ -224,7 +224,7 @@ void test_identity_4loc_3()
             identity_d(4, 0, 4, "", "row")
         )",
             R"(
-            annotate_d([1.0, 0.0, 0.0, 0.0], 
+            annotate_d([1.0, 0.0, 0.0, 0.0],
                 "identity_array_2",
                 list("args",
                     list("locality", 0, 4),
@@ -237,7 +237,7 @@ void test_identity_4loc_3()
             identity_d(4, 1, 4, "", "row")
         )",
             R"(
-            annotate_d([0.0, 1.0, 0.0, 0.0],  
+            annotate_d([0.0, 1.0, 0.0, 0.0],
                 "identity_array_2",
                 list("args",
                     list("locality", 1, 4),
@@ -250,7 +250,7 @@ void test_identity_4loc_3()
             identity_d(4, 2, 4, "", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 1.0, 0.0], 
+            annotate_d([0.0, 0.0, 1.0, 0.0],
                 "identity_array_2",
                 list("args",
                     list("locality", 2, 4),
@@ -263,7 +263,7 @@ void test_identity_4loc_3()
             identity_d(4, 3, 4, "", "row")
         )",
             R"(
-            annotate_d([0.0, 0.0, 0.0, 1.0], 
+            annotate_d([0.0, 0.0, 0.0, 1.0],
                 "identity_array_2",
                 list("args",
                     list("locality", 3, 4),

--- a/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_4_loc.cpp
@@ -108,10 +108,62 @@ void test_identity_4loc_1()
     if (hpx::get_locality_id() == 0)
     {
         test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 0, 4, "my_identity_2", "row")
+            identity_d(4, 0, 4, "my_identity_2", "column")
         )", R"(
             annotate_d([1.0, 0.0, 0.0, 0.0], 
                 "my_identity_2",
+                list("args",
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 1), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_4loc_1", R"(
+            identity_d(4, 1, 4, "my_identity_2", "column")
+        )", R"(
+            annotate_d([0.0, 1.0, 0.0, 0.0],  
+                "my_identity_2",
+                list("args",
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 1, 2), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_4loc_1", R"(
+            identity_d(4, 2, 4, "my_identity_2", "column")
+        )", R"(
+            annotate_d([0.0, 0.0, 1.0, 0.0], 
+                "my_identity_2",
+                list("args",
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 2, 3), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_4loc_1", R"(
+            identity_d(4, 3, 4, "my_identity_2", "column")
+        )", R"(
+            annotate_d([0.0, 0.0, 0.0, 1.0], 
+                "my_identity_2",
+                list("args",
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 3, 4), list("rows", 0, 4))))
+        )");
+    }
+}
+
+void test_identity_4loc_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_4loc_2", R"(
+            identity_d(4, 0, 4, "my_identity_3", "row")
+        )", R"(
+            annotate_d([1.0, 0.0, 0.0, 0.0], 
+                "my_identity_3",
                 list("args",
                     list("locality", 0, 4),
                     list("tile", list("columns", 0, 4), list("rows", 0, 1))))
@@ -119,11 +171,11 @@ void test_identity_4loc_1()
     }
     else if (hpx::get_locality_id() == 1)
     {
-        test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 1, 4, "my_identity_2", "row")
+        test_identity_d_operation("test_identity_4loc_2", R"(
+            identity_d(4, 1, 4, "my_identity_3", "row")
         )", R"(
             annotate_d([0.0, 1.0, 0.0, 0.0],  
-                "my_identity_2",
+                "my_identity_3",
                 list("args",
                     list("locality", 1, 4),
                     list("tile", list("columns", 0, 4), list("rows", 1, 2))))
@@ -131,11 +183,11 @@ void test_identity_4loc_1()
     }
     else if (hpx::get_locality_id() == 2)
     {
-        test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 2, 4, "my_identity_2", "row")
+        test_identity_d_operation("test_identity_4loc_2", R"(
+            identity_d(4, 2, 4, "my_identity_3", "row")
         )", R"(
             annotate_d([0.0, 0.0, 1.0, 0.0], 
-                "my_identity_2",
+                "my_identity_3",
                 list("args",
                     list("locality", 2, 4),
                     list("tile", list("columns", 0, 4), list("rows", 2, 3))))
@@ -143,11 +195,63 @@ void test_identity_4loc_1()
     }
     else if (hpx::get_locality_id() == 3)
     {
-        test_identity_d_operation("test_identity_4loc_1", R"(
-            identity_d(4, 3, 4, "my_identity_2", "row")
+        test_identity_d_operation("test_identity_4loc_2", R"(
+            identity_d(4, 3, 4, "my_identity_3", "row")
         )", R"(
             annotate_d([0.0, 0.0, 0.0, 1.0], 
-                "my_identity_2",
+                "my_identity_3",
+                list("args",
+                    list("locality", 3, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 3, 4))))
+        )");
+    }
+}
+
+void test_identity_4loc_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_4loc_3", R"(
+            identity_d(4, 0, 4, "", "row")
+        )", R"(
+            annotate_d([1.0, 0.0, 0.0, 0.0], 
+                "identity_array_4",
+                list("args",
+                    list("locality", 0, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 0, 1))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_4loc_3", R"(
+            identity_d(4, 1, 4, "", "row")
+        )", R"(
+            annotate_d([0.0, 1.0, 0.0, 0.0],  
+                "identity_array_4",
+                list("args",
+                    list("locality", 1, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 1, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_4loc_3", R"(
+            identity_d(4, 2, 4, "", "row")
+        )", R"(
+            annotate_d([0.0, 0.0, 1.0, 0.0], 
+                "identity_array_4",
+                list("args",
+                    list("locality", 2, 4),
+                    list("tile", list("columns", 0, 4), list("rows", 2, 3))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_4loc_3", R"(
+            identity_d(4, 3, 4, "", "row")
+        )", R"(
+            annotate_d([0.0, 0.0, 0.0, 1.0], 
+                "identity_array_4",
                 list("args",
                     list("locality", 3, 4),
                     list("tile", list("columns", 0, 4), list("rows", 3, 4))))
@@ -163,7 +267,9 @@ int hpx_main(int argc, char* argv[])
 {
     // only annotations are compared
     test_identity_4loc_0();
- //   test_identity_4loc_1;
+    test_identity_4loc_1();
+    test_identity_4loc_2();
+    test_identity_4loc_3();
 
     
 

--- a/tests/unit/plugins/dist_matrixops/dist_identity_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_6_loc.cpp
@@ -12,15 +12,9 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <array>
-#include <cstdint>
 #include <string>
-
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
-#include <blaze_tensor/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(

--- a/tests/unit/plugins/dist_matrixops/dist_identity_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_identity_6_loc.cpp
@@ -1,0 +1,325 @@
+// Copyright (c) 2020 Nanmiao Wu
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2017-2020 Hartmut Kaiser
+
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_identity_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_identity_6loc_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_6loc_0", R"(
+            identity_d(7, 0, 6, "", "sym")
+        )",
+            R"(
+            annotate_d([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0], [0.0, 0.0, 0.0]],
+                "identity_array_1",
+                list("args",
+                    list("locality", 0, 6),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_6loc_0", R"(
+            identity_d(7, 1, 6, "", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0],
+                [0.0, 0.0], [1.0, 0.0]],
+                "identity_array_1",
+                list("args",
+                    list("locality", 1, 6),
+                    list("tile", list("columns", 3, 5), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_6loc_0", R"(
+            identity_d(7, 2, 6, "", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0],
+                [0.0, 0.0], [0.0, 0.0]],
+                "identity_array_1",
+                list("args",
+                    list("locality", 2, 6),
+                    list("tile", list("columns", 5, 7), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_6loc_0", R"(
+            identity_d(7, 3, 6, "", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0]],
+                "identity_array_1",
+                list("args",
+                    list("locality", 3, 6),
+                    list("tile", list("columns", 0, 3), list("rows", 4, 7))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_identity_d_operation("test_identity_6loc_0", R"(
+            identity_d(7, 4, 6, "", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 1.0], [0.0, 0.0],
+                [0.0, 0.0]],
+                "identity_array_1",
+                list("args",
+                    list("locality", 4, 6),
+                    list("tile", list("columns", 3, 5), list("rows", 4, 7))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 5)
+    {
+        test_identity_d_operation("test_identity_6loc_0", R"(
+            identity_d(7, 5, 6, "", "sym")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [1.0, 0.0],
+                [0.0, 1.0]],
+                "identity_array_1",
+                list("args",
+                    list("locality", 5, 6),
+                    list("tile", list("columns", 5, 7), list("rows", 4, 7))))
+        )");
+    }
+}
+
+void test_identity_6loc_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_6loc_1", R"(
+            identity_d(8, 0, 6, "my_identity_1", "row")
+        )",
+            R"(
+            annotate_d([[1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]],
+                "my_identity_1",
+                list("args",
+                    list("locality", 0, 6),
+                    list("tile", list("columns", 0, 8), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_6loc_1", R"(
+            identity_d(8, 1, 6, "my_identity_1", "row")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]],
+                "my_identity_1",
+                list("args",
+                    list("locality", 1, 6),
+                    list("tile", list("columns", 0, 8), list("rows", 2, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_6loc_1", R"(
+            identity_d(8, 2, 6, "my_identity_1", "row")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]],
+                "my_identity_1",
+                list("args",
+                    list("locality", 2, 6),
+                    list("tile", list("columns", 0, 8), list("rows", 4, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_6loc_1", R"(
+            identity_d(8, 3, 6, "my_identity_1", "row")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]],
+                "my_identity_1",
+                list("args",
+                    list("locality", 3, 6),
+                    list("tile", list("columns", 0, 8), list("rows", 5, 6))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_identity_d_operation("test_identity_6loc_1", R"(
+            identity_d(8, 4, 6, "my_identity_1", "row")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]],
+                "my_identity_1",
+                list("args",
+                    list("locality", 4, 6),
+                    list("tile", list("columns", 0, 8), list("rows", 6, 7))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 5)
+    {
+        test_identity_d_operation("test_identity_6loc_1", R"(
+            identity_d(8, 5, 6, "my_identity_1", "row")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]],
+                "my_identity_1",
+                list("args",
+                    list("locality", 5, 6),
+                    list("tile", list("columns", 0, 8), list("rows", 7, 8))))
+        )");
+    }
+}
+
+void test_identity_6loc_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_identity_d_operation("test_identity_6loc_2", R"(
+            identity_d(9, 0, 6, "my_identity_2", "column")
+        )",
+            R"(
+            annotate_d([[1.0, 0.0], [0.0, 1.0], [0.0, 0.0], [0.0, 0.0],
+                [0.0, 0.0], [0.0, 0.0],[0.0, 0.0], [0.0, 0.0],[0.0, 0.0]],
+                "my_identity_2",
+                list("args",
+                    list("locality", 0, 6),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 9))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_identity_d_operation("test_identity_6loc_2", R"(
+            identity_d(9, 1, 6, "my_identity_2", "column")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [1.0, 0.0], [0.0, 1.0],
+                [0.0, 0.0], [0.0, 0.0],[0.0, 0.0], [0.0, 0.0],[0.0, 0.0]],
+                "my_identity_2",
+                list("args",
+                    list("locality", 1, 6),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 9))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_identity_d_operation("test_identity_6loc_2", R"(
+            identity_d(9, 2, 6, "my_identity_2", "column")
+        )",
+            R"(
+            annotate_d([[0.0, 0.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0],
+                [1.0, 0.0], [0.0, 1.0],[0.0, 0.0], [0.0, 0.0],[0.0, 0.0]],
+                "my_identity_2",
+                list("args",
+                    list("locality", 2, 6),
+                    list("tile", list("columns", 4, 6), list("rows", 0, 9))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_identity_d_operation("test_identity_6loc_2", R"(
+            identity_d(9, 3, 6, "my_identity_2", "column")
+        )",
+            R"(
+            annotate_d([[0.0], [0.0], [0.0], [0.0], [0.0], [0.0], [1.0],
+                [0.0], [0.0]],
+                "my_identity_2",
+                list("args",
+                    list("locality", 3, 6),
+                    list("tile", list("columns", 6, 7), list("rows", 0, 9))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_identity_d_operation("test_identity_6loc_2", R"(
+            identity_d(9, 4, 6, "my_identity_2", "column")
+        )",
+            R"(
+            annotate_d([[0.0], [0.0], [0.0], [0.0], [0.0], [0.0], [0.0],
+                [1.0], [0.0]],
+                "my_identity_2",
+                list("args",
+                    list("locality", 4, 6),
+                    list("tile", list("columns", 7, 8), list("rows", 0, 9))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 5)
+    {
+        test_identity_d_operation("test_identity_6loc_2", R"(
+            identity_d(9, 5, 6, "my_identity_2", "column")
+        )",
+            R"(
+            annotate_d([[0.0], [0.0], [0.0], [0.0], [0.0], [0.0], [0.0],
+                [0.0], [1.0]],
+                "my_identity_2",
+                list("args",
+                    list("locality", 5, 6),
+                    list("tile", list("columns", 8, 9), list("rows", 0, 9))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_identity_6loc_0();
+    test_identity_6loc_1();
+    test_identity_6loc_2();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {"hpx.run_hpx_main!=1"};
+
+    return hpx::init(argc, argv, cfg);
+}


### PR DESCRIPTION
Consider three cases: row-tiling, column-tiling, and sym-tiling. All of the three cases are able to deal with any number of tiles, which means they are general.