### PR TITLE
Modifying dist_matrix fetch function and cannon_product name

### DIFF
--- a/phylanx/plugins/dist_matrixops/dist_cannon_product.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product.hpp
@@ -70,7 +70,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         std::string const& name = "", std::string const& codename = "")
     {
         return execution_tree::create_primitive_component(
-            locality, "cannon_product", std::move(operands), name, codename);
+            locality, "cannon_product_d", std::move(operands), name, codename);
     }
 }}}
 #endif

--- a/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
@@ -37,7 +37,6 @@
 #include <vector>
 
 #include <blaze/Math.h>
-#include <blaze/math/DynamicMatrix.h>
 #include <blaze_tensor/Math.h>
 
 using std_int64_t = std::int64_t;

--- a/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
@@ -18,10 +18,8 @@
 #include <phylanx/plugins/common/dot_operation_nd.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_cannon_product.hpp>
 #include <phylanx/util/distributed_matrix.hpp>
-#include <phylanx/util/distributed_vector.hpp>
 
 #include <hpx/assertion.hpp>
-#include <hpx/collectives/all_reduce.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
@@ -37,27 +35,14 @@
 #include <vector>
 
 #include <blaze/Math.h>
-#include <blaze_tensor/Math.h>
 
 using std_int64_t = std::int64_t;
 using std_uint8_t = std::uint8_t;
 
 ////////////////////////////////////////////////////////////////////////////////
-REGISTER_DISTRIBUTED_VECTOR_DECLARATION(double);
-REGISTER_DISTRIBUTED_VECTOR_DECLARATION(std_int64_t);
-REGISTER_DISTRIBUTED_VECTOR_DECLARATION(std_uint8_t);
-
-HPX_REGISTER_ALLREDUCE_DECLARATION(double);
-HPX_REGISTER_ALLREDUCE_DECLARATION(std_int64_t);
-HPX_REGISTER_ALLREDUCE_DECLARATION(std_uint8_t);
-
-using blaze_vector_double = blaze::DynamicVector<double>;
-using blaze_vector_std_int64_t = blaze::DynamicVector<std_int64_t>;
-using blaze_vector_std_uint8_t = blaze::DynamicVector<std_uint8_t>;
-
-HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_vector_double);
-HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_vector_std_int64_t);
-HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_vector_std_uint8_t);
+REGISTER_DISTRIBUTED_MATRIX_DECLARATION(double);
+REGISTER_DISTRIBUTED_MATRIX_DECLARATION(std_int64_t);
+REGISTER_DISTRIBUTED_MATRIX_DECLARATION(std_uint8_t);
 
 ////////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace dist_matrixops { namespace primitives {

--- a/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
@@ -37,7 +37,6 @@
 #include <vector>
 
 #include <blaze/Math.h>
-#include <blaze/math/DynamicMatrix.h>
 #include <blaze_tensor/Math.h>
 
 using std_int64_t = std::int64_t;
@@ -48,6 +47,10 @@ REGISTER_DISTRIBUTED_VECTOR_DECLARATION(double);
 REGISTER_DISTRIBUTED_VECTOR_DECLARATION(std_int64_t);
 REGISTER_DISTRIBUTED_VECTOR_DECLARATION(std_uint8_t);
 
+REGISTER_DISTRIBUTED_MATRIX_DECLARATION(double);
+REGISTER_DISTRIBUTED_MATRIX_DECLARATION(std_int64_t);
+REGISTER_DISTRIBUTED_MATRIX_DECLARATION(std_uint8_t);
+
 HPX_REGISTER_ALLREDUCE_DECLARATION(double);
 HPX_REGISTER_ALLREDUCE_DECLARATION(std_int64_t);
 HPX_REGISTER_ALLREDUCE_DECLARATION(std_uint8_t);
@@ -56,9 +59,17 @@ using blaze_vector_double = blaze::DynamicVector<double>;
 using blaze_vector_std_int64_t = blaze::DynamicVector<std::int64_t>;
 using blaze_vector_std_uint8_t = blaze::DynamicVector<std::uint8_t>;
 
+using blaze_matrix_double = blaze::DynamicMatrix<double>;
+using blaze_matrix_std_int64_t = blaze::DynamicMatrix<std::int64_t>;
+using blaze_matrix_std_uint8_t = blaze::DynamicMatrix<std::uint8_t>;
+
 HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_vector_double);
 HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_vector_std_int64_t);
 HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_vector_std_uint8_t);
+
+HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_matrix_double);
+HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_matrix_std_int64_t);
+HPX_REGISTER_ALLREDUCE_DECLARATION(blaze_matrix_std_uint8_t);
 
 ////////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace dist_matrixops { namespace primitives {
@@ -297,8 +308,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                     dot_result, rhs_column_start, rhs_column_size) +=
                     blaze::trans(
                         rhs_data
-                            .fetch(loc, rhs_intersection.start_,
-                                rhs_intersection.stop_, 0, rhs_column_size)
+                            .fetch(loc, rhs_intersection.start_, 0,
+                                rhs_intersection.stop_, rhs_column_size)
                             .get()) *
                     blaze::subvector(lhs.vector(), lhs_intersection.start_,
                         lhs_intersection.size());
@@ -654,8 +665,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                     blaze::submatrix(lhs.matrix(), 0, lhs_intersection.start_,
                         lhs.dimension(0), lhs_intersection.size()) *
                     rhs_data
-                        .fetch(loc, rhs_intersection.start_,
-                            rhs_intersection.stop_, 0, rhs_column_size)
+                        .fetch(loc, rhs_intersection.start_, 0,
+                            rhs_intersection.stop_, rhs_column_size)
                         .get();
             }
             ++loc;

--- a/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
@@ -23,8 +23,7 @@ namespace tile_calculation
 {
     ///////////////////////////////////////////////////////////////////////////
     inline std::tuple<std::int64_t, std::size_t> tile_calculation_1d(
-        std::uint32_t const& tile_idx, std::size_t const& dim,
-        std::uint32_t const& numtiles)
+        std::uint32_t tile_idx, std::size_t dim, std::uint32_t numtiles)
     {
         if (dim < numtiles)
         {
@@ -76,9 +75,8 @@ namespace tile_calculation
     }
 
     inline std::tuple<std::int64_t, std::int64_t, std::size_t, std::size_t>
-    tile_calculation_2d(std::uint32_t const& tile_idx,
-        std::size_t const& row_dim, std::size_t const& column_dim,
-        std::uint32_t const& numtiles, std::string const& tiling_type)
+    tile_calculation_2d(std::uint32_t tile_idx, std::size_t row_dim,
+        std::size_t column_dim, std::uint32_t numtiles, std::string tiling_type)
     {
         std::int64_t row_start, column_start;
         std::size_t row_size, column_size;

--- a/phylanx/util/distributed_matrix.hpp
+++ b/phylanx/util/distributed_matrix.hpp
@@ -86,8 +86,8 @@ namespace phylanx { namespace util { namespace server
 
         HPX_DEFINE_COMPONENT_ACTION(distributed_matrix_part, fetch);
 
-        data_type fetch_part(std::size_t start_row, std::size_t stop_row,
-            std::size_t start_column, std::size_t stop_column) const
+        data_type fetch_part(std::size_t start_row, std::size_t start_column,
+            std::size_t stop_row, std::size_t stop_column) const
         {
             return data_type{
                 blaze::submatrix(data_, start_row, start_column,
@@ -283,7 +283,7 @@ namespace phylanx { namespace util
         /// local data copy.
         /// It is suggested to use star operator to access local data.
         hpx::future<data_type> fetch(std::size_t idx, std::size_t start_row,
-            std::size_t stop_row, std::size_t start_column,
+            std::size_t start_column, std::size_t stop_row,
             std::size_t stop_column) const
         {
             /// \cond NOINTERNAL
@@ -292,7 +292,7 @@ namespace phylanx { namespace util
                 typename server::distributed_matrix_part<T>::fetch_part_action;
 
             return hpx::async<action_type>(get_part_id(idx), start_row,
-                stop_row, start_column, stop_column);
+                start_column, stop_row, stop_column);
             /// \endcond
         }
 

--- a/src/plugins/dist_matrixops/dist_cannon_product.cpp
+++ b/src/plugins/dist_matrixops/dist_cannon_product.cpp
@@ -32,14 +32,15 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
      execution_tree::match_pattern_type const dist_cannon_product::match_data =
      {
          execution_tree::match_pattern_type{
-             "cannon_product", std::vector<std::string>{"cannon_product(_1, _2)"},
+             "cannon_product_d",
+             std::vector<std::string>{"cannon_product_d(_1, _2)"},
              &create_dist_cannon_product,
              &execution_tree::create_primitive<dist_cannon_product>,
              R"(a, b
              Args:
 
-                 a (array) : a scalar, vector, matrix or a tensor
-                 b (array) : a scalar, vector, matrix or a tensor
+                 a (array) : a matrix
+                 b (array) : a matrix
 
              Returns:
 

--- a/tests/performance/dist_cannon.cpp
+++ b/tests/performance/dist_cannon.cpp
@@ -26,7 +26,7 @@ char const* const cannon_product_code = R"(block(
                 random_d(list(dim_size, dim_size), find_here(), num_localities())),
             define(array2,
                 random_d(list(dim_size, dim_size), find_here(), num_localities())),
-            cannon_product(array1, array2)
+            cannon_product_d(array1, array2)
         )
     ),
     cannon
@@ -45,7 +45,9 @@ int hpx_main(int argc, char* argv[])
     std::vector<std::int64_t> dim_sizes = {
         12, 120, 240, 480, 960, 4800, 9600, 96000, 960000};
 
-    std::cout << "Having " << hpx::get_num_localities().get() << " localities:\n";
+    std::cout << "Having "
+        << hpx::get_num_localities(hpx::launch::sync)
+        << " localities:\n";
 
     for (std::int64_t const& dim_size : dim_sizes)
     {

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -10,7 +10,7 @@ set(tests
     dist_constant_3_loc
     dist_constant_4_loc
     dist_constant_6_loc
-    dist_dot_operation
+    dist_dot_operation_2_loc
     dist_identity_2_loc
     dist_identity_4_loc
     dist_identity_6_loc
@@ -27,14 +27,13 @@ set(dist_constant_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_constant_3_loc_PARAMETERS LOCALITIES 3)
 set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
-set(dist_dot_operation_PARAMETERS LOCALITIES 2)
+set(dist_dot_operation_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_identity_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_identity_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
-
 
 
 foreach(test ${tests})

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -4,7 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
-    dist_cannon_product
+    dist_cannon_product_4_loc
     dist_cannon_product_9_loc
     dist_constant_2_loc
     dist_constant_3_loc
@@ -21,7 +21,7 @@ set(tests
    )
 
 
-set(dist_cannon_product_PARAMETERS LOCALITIES 4)
+set(dist_cannon_product_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_cannon_product_9_loc_PARAMETERS LOCALITIES 9)
 set(dist_constant_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_constant_3_loc_PARAMETERS LOCALITIES 3)

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product_4_loc.cpp
@@ -50,7 +50,7 @@ void test_cannon_product_0()
     if (hpx::get_locality_id() == 0)
     {
         test_cannon_product("test2d2d_0", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[1], [2], [3]], "test2d2d_0_1",
                     list("args",
                         list("locality", 0, 4),
@@ -72,7 +72,7 @@ void test_cannon_product_0()
     else if (hpx::get_locality_id() == 1)
     {
         test_cannon_product("test2d2d_0", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[0], [2], [3]], "test2d2d_0_1",
                     list("args",
                         list("locality", 1, 4),
@@ -94,7 +94,7 @@ void test_cannon_product_0()
     else if (hpx::get_locality_id() == 2)
     {
         test_cannon_product("test2d2d_0", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[4], [5], [6]], "test2d2d_0_1",
                     list("args",
                         list("locality", 2, 4),
@@ -116,7 +116,7 @@ void test_cannon_product_0()
     else
     {
         test_cannon_product("test2d2d_0", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[4], [5], [0]], "test2d2d_0_1",
                     list("args",
                         list("locality", 3, 4),
@@ -142,7 +142,7 @@ void test_cannon_product_1()
     if (hpx::get_locality_id() == 0)
     {
         test_cannon_product("test2d2d_1", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[1, 1], [2, 2], [3, 3]], "test2d2d_1_1",
                     list("args",
                         list("locality", 0, 4),
@@ -164,7 +164,7 @@ void test_cannon_product_1()
     else if (hpx::get_locality_id() == 1)
     {
         test_cannon_product("test2d2d_1", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[1, 0], [2, 0], [3, 0]], "test2d2d_1_1",
                     list("args",
                         list("locality", 1, 4),
@@ -186,7 +186,7 @@ void test_cannon_product_1()
     else if (hpx::get_locality_id() == 2)
     {
         test_cannon_product("test2d2d_1", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[4, 4], [5, 5], [6, 6]], "test2d2d_1_1",
                     list("args",
                         list("locality", 2, 4),
@@ -208,7 +208,7 @@ void test_cannon_product_1()
     else
     {
         test_cannon_product("test2d2d_1", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[0, 1], [0, 2], [0, 3]], "test2d2d_1_1",
                     list("args",
                         list("locality", 3, 4),

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product_4_loc.cpp
@@ -12,7 +12,6 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
@@ -49,7 +49,7 @@ void test_cannon_product_2()
     {
     case 0: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[1, 1], [2, 2], [3, 3]], "test2d2d_2_1",
                     list("args",
                         list("locality", 0, 9),
@@ -71,7 +71,7 @@ void test_cannon_product_2()
     }
     case 1: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[1, 0], [2, 0], [3, 0]], "test2d2d_2_1",
                     list("args",
                         list("locality", 1, 9),
@@ -93,7 +93,7 @@ void test_cannon_product_2()
     }
     case 2: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[1, 1], [2, 2], [3, 3]], "test2d2d_2_1",
                     list("args",
                         list("locality", 2, 9),
@@ -115,7 +115,7 @@ void test_cannon_product_2()
     }
     case 3: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[4, 4], [5, 5], [6, 6]], "test2d2d_2_1",
                     list("args",
                         list("locality", 3, 9),
@@ -137,7 +137,7 @@ void test_cannon_product_2()
     }
     case 4: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[0, 1], [0, 2], [0, 3]], "test2d2d_2_1",
                     list("args",
                         list("locality", 4, 9),
@@ -159,7 +159,7 @@ void test_cannon_product_2()
     }
     case 5: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[4, 4], [5, 5], [6, 6]], "test2d2d_2_1",
                     list("args",
                         list("locality", 5, 9),
@@ -181,7 +181,7 @@ void test_cannon_product_2()
     }
     case 6: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[7, 0], [8, 8], [9, 0]], "test2d2d_2_1",
                     list("args",
                         list("locality", 6, 9),
@@ -203,7 +203,7 @@ void test_cannon_product_2()
     }
     case 7: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[7, 0], [0, 0], [0, 0]], "test2d2d_2_1",
                     list("args",
                         list("locality", 7, 9),
@@ -225,7 +225,7 @@ void test_cannon_product_2()
     }
     case 8: {
         test_cannon_product("test2d2d_2", R"(
-            cannon_product(
+            cannon_product_d(
                 annotate_d([[7, 0], [8, 8], [0, 9]], "test2d2d_2_1",
                     list("args",
                         list("locality", 8, 9),

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
@@ -12,7 +12,6 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/tests/unit/plugins/dist_matrixops/dist_dot_operation_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_dot_operation_2_loc.cpp
@@ -12,7 +12,6 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>


### PR DESCRIPTION
In this PR:
- `cannon_product` is replaced with `cannon_product_d` as it is a distributed operation (All other distributed primitives end with `_d`).
- The argument order for distributed matrix' `fetch` is modified to be compatible with Blaze conventions. E.g. for a `submatrix` the order is: row_start, column_start, row_size, column_size.