### PR TITLE
Adding Retile for distributed arrays

### DIFF
--- a/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_matrixops.hpp
@@ -12,6 +12,7 @@
 #include <phylanx/plugins/dist_matrixops/dist_identity.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_random.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_transpose_operation.hpp>
+#include <phylanx/plugins/dist_matrixops/retile_annotations.hpp>
 
 
 #endif

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -14,7 +14,6 @@
 
 #include <hpx/lcos/future.hpp>
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -53,11 +52,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type retile1d(ir::node_data<T>&& arr,
             ir::range&& new_tiling,
             execution_tree::localities_information&& arr_localities) const;
-        //execution_tree::primitive_argument_type retile2d(
-        //    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
-        //    std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-        //    std::string&& given_name, std::string const& tiling_type,
-        //    double const& mean, double const& std) const;
+
+        execution_tree::primitive_argument_type retile2d(
+            execution_tree::primitive_argument_type&& arr,
+            ir::range&& new_tiling) const;
+        template <typename T>
+        execution_tree::primitive_argument_type retile2d(ir::node_data<T>&& arr,
+            ir::range&& new_tiling,
+            execution_tree::localities_information&& arr_localities) const;
     };
 
     inline execution_tree::primitive create_retile_annotations(

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -9,7 +9,6 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
-//#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/lcos/future.hpp>
@@ -21,8 +20,6 @@
 #include <tuple>
 #include <utility>
 #include <vector>
-
-//#include <blaze/Math.h>
 
 namespace phylanx { namespace dist_matrixops { namespace primitives
 {

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -19,7 +19,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -9,10 +9,12 @@
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/lcos/future.hpp>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -44,22 +46,25 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     private:
         execution_tree::primitive_argument_type retile1d(
             execution_tree::primitive_argument_type&& arr,
-            std::string const& tiling_type, std::uint32_t numtiles,
-            ir::range&& new_tiling, std::size_t intersection) const;
+            std::string const& tiling_type, std::size_t intersection,
+            std::uint32_t numtiles, ir::range&& new_tiling) const;
         template <typename T>
         execution_tree::primitive_argument_type retile1d(ir::node_data<T>&& arr,
-            std::string const& tiling_type, std::uint32_t numtiles,
-            ir::range&& new_tiling,
-            execution_tree::localities_information&& arr_localities,
-            std::size_t intersection) const;
+            std::string const& tiling_type, std::size_t intersection,
+            std::uint32_t numtiles, ir::range&& new_tiling,
+            execution_tree::localities_information&& arr_localities) const;
 
-        //execution_tree::primitive_argument_type retile2d(
-        //    execution_tree::primitive_argument_type&& arr,
-        //    ir::range&& new_tiling) const;
-        //template <typename T>
-        //execution_tree::primitive_argument_type retile2d(ir::node_data<T>&& arr,
-        //    ir::range&& new_tiling,
-        //    execution_tree::localities_information&& arr_localities) const;
+        execution_tree::primitive_argument_type retile2d(
+            execution_tree::primitive_argument_type&& arr,
+            std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersection,
+            std::uint32_t numtiles, ir::range&& new_tiling) const;
+        template <typename T>
+        execution_tree::primitive_argument_type retile2d(ir::node_data<T>&& arr,
+            std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersection,
+            std::uint32_t numtiles, ir::range&& new_tiling,
+            execution_tree::localities_information&& arr_localities) const;
     };
 
     inline execution_tree::primitive create_retile_annotations(

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -45,12 +45,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type retile1d(
             execution_tree::primitive_argument_type&& arr,
             std::string const& tiling_type, std::uint32_t numtiles,
-            ir::range&& new_tiling) const;
+            ir::range&& new_tiling, std::size_t intersection) const;
         template <typename T>
         execution_tree::primitive_argument_type retile1d(ir::node_data<T>&& arr,
             std::string const& tiling_type, std::uint32_t numtiles,
             ir::range&& new_tiling,
-            execution_tree::localities_information&& arr_localities) const;
+            execution_tree::localities_information&& arr_localities,
+            std::size_t intersection) const;
 
         //execution_tree::primitive_argument_type retile2d(
         //    execution_tree::primitive_argument_type&& arr,

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_EXECUTION_TREE_PRIMITIVES_RETILE_ANNOTATIONS)
+#define PHYLANX_EXECUTION_TREE_PRIMITIVES_RETILE_ANNOTATIONS
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+//#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/lcos/future.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+//#include <blaze/Math.h>
+
+namespace phylanx { namespace dist_matrixops { namespace primitives
+{
+    class retile_annotations
+      : public execution_tree::primitives::primitive_component_base
+      , public std::enable_shared_from_this<retile_annotations>
+    {
+    public:
+        static execution_tree::match_pattern_type const match_data;
+
+        retile_annotations() = default;
+
+        retile_annotations(execution_tree::primitive_arguments_type&& operands,
+            std::string const& name, std::string const& codename);
+
+    protected:
+        hpx::future<execution_tree::primitive_argument_type> eval(
+            execution_tree::primitive_arguments_type const& operands,
+            execution_tree::primitive_arguments_type const& args,
+            execution_tree::eval_context ctx) const override;
+
+    private:
+        execution_tree::primitive_argument_type retile1d(
+            execution_tree::primitive_argument_type&& arr,
+            ir::range&& new_tiling) const;
+        template <typename T>
+        execution_tree::primitive_argument_type retile1d(ir::node_data<T>&& arr,
+            ir::range&& new_tiling,
+            execution_tree::localities_information&& arr_localities) const;
+        //execution_tree::primitive_argument_type retile2d(
+        //    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
+        //    std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
+        //    std::string&& given_name, std::string const& tiling_type,
+        //    double const& mean, double const& std) const;
+    };
+
+    inline execution_tree::primitive create_retile_annotations(
+        hpx::id_type const& locality,
+        execution_tree::primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "retile_d", std::move(operands), name, codename);
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -44,19 +44,21 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     private:
         execution_tree::primitive_argument_type retile1d(
             execution_tree::primitive_argument_type&& arr,
+            std::string const& tiling_type, std::uint32_t numtiles,
             ir::range&& new_tiling) const;
         template <typename T>
         execution_tree::primitive_argument_type retile1d(ir::node_data<T>&& arr,
+            std::string const& tiling_type, std::uint32_t numtiles,
             ir::range&& new_tiling,
             execution_tree::localities_information&& arr_localities) const;
 
-        execution_tree::primitive_argument_type retile2d(
-            execution_tree::primitive_argument_type&& arr,
-            ir::range&& new_tiling) const;
-        template <typename T>
-        execution_tree::primitive_argument_type retile2d(ir::node_data<T>&& arr,
-            ir::range&& new_tiling,
-            execution_tree::localities_information&& arr_localities) const;
+        //execution_tree::primitive_argument_type retile2d(
+        //    execution_tree::primitive_argument_type&& arr,
+        //    ir::range&& new_tiling) const;
+        //template <typename T>
+        //execution_tree::primitive_argument_type retile2d(ir::node_data<T>&& arr,
+        //    ir::range&& new_tiling,
+        //    execution_tree::localities_information&& arr_localities) const;
     };
 
     inline execution_tree::primitive create_retile_annotations(

--- a/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
@@ -55,6 +55,41 @@ namespace tile_calculation
         return std::make_tuple(start, size);
     }
 
+    inline std::tuple<std::int64_t, std::size_t> tile_calculation_overlap_1d(
+        std::int64_t start, std::size_t size, std::size_t dim,
+        std::size_t intersection)
+    {
+        if (start == 0)
+        {
+        }
+        else if (start + size == dim)
+        {
+            start -= intersection;
+        }
+        else
+        {
+            start -= static_cast<std::size_t>(intersection / 2);
+        }
+        size += intersection;
+
+        if (start < 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "tile_calculation::tile_calculation_overlap_1d",
+                phylanx::util::generate_error_message(
+                    "the given intersection produces negative start for the "
+                    "array"));
+        }
+        if (start + size > dim)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "tile_calculation::tile_calculation_overlap_1d",
+                phylanx::util::generate_error_message(
+                    "the given intersection need an end point larger than the "
+                    "array size"));
+        }
+        return std::make_tuple(start, size);
+    }
     ///////////////////////////////////////////////////////////////////////////
     inline std::tuple<std::size_t, std::size_t> middle_divisors(std::size_t num)
     {

--- a/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
@@ -90,6 +90,7 @@ namespace tile_calculation
         }
         return std::make_tuple(start, size);
     }
+
     ///////////////////////////////////////////////////////////////////////////
     inline std::tuple<std::size_t, std::size_t> middle_divisors(std::size_t num)
     {
@@ -221,6 +222,51 @@ namespace tile_calculation
                     extract_scalar_positive_integer_value_strict(*++elem_1);
                 result[3] =
                     extract_scalar_positive_integer_value_strict(*++elem_1);
+            }
+        }
+        return result;
+    }
+
+    inline std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
+    extract_nonneg_dimensions(phylanx::ir::range const& shape)
+    {
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
+        if (!shape.empty())
+        {
+            if (shape.size() == 1)
+            {
+                result[0] = extract_scalar_nonneg_integer_value_strict(
+                    *shape.begin());
+            }
+            else if (shape.size() == 2)
+            {
+                auto elem_1 = shape.begin();
+                result[0] =
+                    extract_scalar_nonneg_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+            }
+            else if (shape.size() == 3)
+            {
+                auto elem_1 = shape.begin();
+                result[0] =
+                    extract_scalar_nonneg_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[2] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+            }
+            else if (shape.size() == 4)
+            {
+                auto elem_1 = shape.begin();
+                result[0] =
+                    extract_scalar_nonneg_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[2] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[3] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
             }
         }
         return result;

--- a/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
@@ -58,14 +58,11 @@ namespace tile_calculation
         std::int64_t start, std::size_t size, std::size_t dim,
         std::size_t intersection)
     {
-        if (start == 0)
-        {
-        }
-        else if (start + size == dim)
+        if (start + size == dim)
         {
             start -= intersection;
         }
-        else
+        else if (start != 0)
         {
             start -= static_cast<std::size_t>(intersection / 2);
         }

--- a/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
@@ -11,7 +11,6 @@
 
 #include <hpx/errors/throw_exception.hpp>
 
-#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -174,102 +173,6 @@ namespace tile_calculation
                     "`sym`, `row` or `column` for a matrix"));
         }
         return std::make_tuple(row_start, column_start, row_size, column_size);
-    }
-
-    ///////////////////////////////////////////////////////////////////////////
-    inline std::size_t extract_num_dimensions(phylanx::ir::range const& shape)
-    {
-        return shape.size();
-    }
-
-    inline std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> extract_dimensions(
-        phylanx::ir::range const& shape)
-    {
-        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
-        if (!shape.empty())
-        {
-            if (shape.size() == 1)
-            {
-                result[0] = extract_scalar_positive_integer_value_strict(
-                    *shape.begin());
-            }
-            else if (shape.size() == 2)
-            {
-                auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_positive_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-            }
-            else if (shape.size() == 3)
-            {
-                auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_positive_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-            }
-            else if (shape.size() == 4)
-            {
-                auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_positive_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-                result[3] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-            }
-        }
-        return result;
-    }
-
-    inline std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
-    extract_nonneg_dimensions(phylanx::ir::range const& shape)
-    {
-        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
-        if (!shape.empty())
-        {
-            if (shape.size() == 1)
-            {
-                result[0] = extract_scalar_nonneg_integer_value_strict(
-                    *shape.begin());
-            }
-            else if (shape.size() == 2)
-            {
-                auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_nonneg_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-            }
-            else if (shape.size() == 3)
-            {
-                auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_nonneg_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-            }
-            else if (shape.size() == 4)
-            {
-                auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_nonneg_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                result[3] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-            }
-        }
-        return result;
     }
 }
 #endif

--- a/phylanx/util/detail/range_dimension.hpp
+++ b/phylanx/util/detail/range_dimension.hpp
@@ -20,7 +20,8 @@ namespace phylanx { namespace util { namespace detail {
     }
 
     inline std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
-    extract_positive_range_dimensions(phylanx::ir::range const& shape)
+    extract_positive_range_dimensions(phylanx::ir::range const& shape,
+        std::string const& name, std::string const& codename)
     {
         std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
         if (!shape.empty())
@@ -28,79 +29,83 @@ namespace phylanx { namespace util { namespace detail {
             if (shape.size() == 1)
             {
                 result[0] = extract_scalar_positive_integer_value_strict(
-                    *shape.begin());
+                    *shape.begin(), name, codename);
             }
             else if (shape.size() == 2)
             {
                 auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_positive_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
+                result[0] = extract_scalar_positive_integer_value_strict(
+                    *elem_1, name, codename);
+                result[1] = extract_scalar_positive_integer_value_strict(
+                    *++elem_1, name, codename);
             }
             else if (shape.size() == 3)
             {
                 auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_positive_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
+                result[0] = extract_scalar_positive_integer_value_strict(
+                    *elem_1, name, codename);
+                result[1] = extract_scalar_positive_integer_value_strict(
+                    *++elem_1, name, codename);
+                result[2] = extract_scalar_positive_integer_value_strict(
+                    *++elem_1, name, codename);
             }
             else if (shape.size() == 4)
             {
                 auto elem_1 = shape.begin();
-                result[0] =
-                    extract_scalar_positive_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
-                result[3] =
-                    extract_scalar_positive_integer_value_strict(*++elem_1);
+                result[0] = extract_scalar_positive_integer_value_strict(
+                    *elem_1, name, codename);
+                result[1] = extract_scalar_positive_integer_value_strict(
+                    *++elem_1, name, codename);
+                result[2] = extract_scalar_positive_integer_value_strict(
+                    *++elem_1, name, codename);
+                result[3] = extract_scalar_positive_integer_value_strict(
+                    *++elem_1, name, codename);
             }
         }
         return result;
     }
 
     inline std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
-    extract_nonneg_range_dimensions(phylanx::ir::range const& shape)
+    extract_nonneg_range_dimensions(phylanx::ir::range const& shape,
+        std::string const& name, std::string const& codename)
     {
         std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
         if (!shape.empty())
         {
             if (shape.size() == 1)
             {
-                result[0] =
-                    extract_scalar_nonneg_integer_value_strict(*shape.begin());
+                result[0] = extract_scalar_nonneg_integer_value_strict(
+                    *shape.begin(), name, codename);
             }
             else if (shape.size() == 2)
             {
                 auto elem_1 = shape.begin();
-                result[0] = extract_scalar_nonneg_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[0] = extract_scalar_nonneg_integer_value_strict(
+                    *elem_1, name, codename);
+                result[1] = extract_scalar_nonneg_integer_value_strict(
+                    *++elem_1, name, codename);
             }
             else if (shape.size() == 3)
             {
                 auto elem_1 = shape.begin();
-                result[0] = extract_scalar_nonneg_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[0] = extract_scalar_nonneg_integer_value_strict(
+                    *elem_1, name, codename);
+                result[1] = extract_scalar_nonneg_integer_value_strict(
+                    *++elem_1, name, codename);
+                result[2] = extract_scalar_nonneg_integer_value_strict(
+                    *++elem_1, name, codename);
             }
             else if (shape.size() == 4)
             {
                 auto elem_1 = shape.begin();
-                result[0] = extract_scalar_nonneg_integer_value_strict(*elem_1);
-                result[1] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                result[2] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                result[3] =
-                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[0] = extract_scalar_nonneg_integer_value_strict(
+                    *elem_1, name, codename);
+                result[1] = extract_scalar_nonneg_integer_value_strict(
+                    *++elem_1, name, codename);
+                result[2] = extract_scalar_nonneg_integer_value_strict(
+                    *++elem_1, name, codename);
+                result[3] = extract_scalar_nonneg_integer_value_strict(
+                    *++elem_1, name, codename);
             }
         }
         return result;

--- a/phylanx/util/detail/range_dimension.hpp
+++ b/phylanx/util/detail/range_dimension.hpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_UTIL_DETAIL_RANGE_DIMENSION)
+#define PHYLANX_UTIL_DETAIL_RANGE_DIMENSION
+
+#include <array>
+#include <cstddef>
+#include <string>
+
+namespace phylanx { namespace util { namespace detail {
+
+    inline std::size_t extract_range_num_dimensions(
+        phylanx::ir::range const& shape)
+    {
+        return shape.size();
+    }
+
+    inline std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
+    extract_positive_range_dimensions(phylanx::ir::range const& shape)
+    {
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
+        if (!shape.empty())
+        {
+            if (shape.size() == 1)
+            {
+                result[0] = extract_scalar_positive_integer_value_strict(
+                    *shape.begin());
+            }
+            else if (shape.size() == 2)
+            {
+                auto elem_1 = shape.begin();
+                result[0] =
+                    extract_scalar_positive_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_positive_integer_value_strict(*++elem_1);
+            }
+            else if (shape.size() == 3)
+            {
+                auto elem_1 = shape.begin();
+                result[0] =
+                    extract_scalar_positive_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_positive_integer_value_strict(*++elem_1);
+                result[2] =
+                    extract_scalar_positive_integer_value_strict(*++elem_1);
+            }
+            else if (shape.size() == 4)
+            {
+                auto elem_1 = shape.begin();
+                result[0] =
+                    extract_scalar_positive_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_positive_integer_value_strict(*++elem_1);
+                result[2] =
+                    extract_scalar_positive_integer_value_strict(*++elem_1);
+                result[3] =
+                    extract_scalar_positive_integer_value_strict(*++elem_1);
+            }
+        }
+        return result;
+    }
+
+    inline std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
+    extract_nonneg_range_dimensions(phylanx::ir::range const& shape)
+    {
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0};
+        if (!shape.empty())
+        {
+            if (shape.size() == 1)
+            {
+                result[0] =
+                    extract_scalar_nonneg_integer_value_strict(*shape.begin());
+            }
+            else if (shape.size() == 2)
+            {
+                auto elem_1 = shape.begin();
+                result[0] = extract_scalar_nonneg_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+            }
+            else if (shape.size() == 3)
+            {
+                auto elem_1 = shape.begin();
+                result[0] = extract_scalar_nonneg_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[2] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+            }
+            else if (shape.size() == 4)
+            {
+                auto elem_1 = shape.begin();
+                result[0] = extract_scalar_nonneg_integer_value_strict(*elem_1);
+                result[1] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[2] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+                result[3] =
+                    extract_scalar_nonneg_integer_value_strict(*++elem_1);
+            }
+        }
+        return result;
+    }
+}}}
+#endif

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -366,8 +366,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                                 "dist_constant::eval",
                                 this_->generate_error_message(
-                                    "invalid tling_type. the tiling_type can be "
-                                    "one of these: `sym`, `row` or `column`"));
+                                    "invalid tiling_type. The tiling_type can "
+                                    "be one of these: `sym`, `row` or "
+                                    "`column`"));
                         }
                     }
 

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -314,7 +314,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                         }
 
                         dims = util::detail::extract_positive_range_dimensions(
-                            overall_shape);
+                            overall_shape, this_->name_, this_->codename_);
                         numdims = util::detail::extract_range_num_dimensions(
                             overall_shape);
                     }

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -14,6 +14,7 @@
 #include <phylanx/plugins/dist_matrixops/dist_constant.hpp>
 #include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
 #include <phylanx/execution_tree/localities_annotation.hpp>
+#include <phylanx/util/detail/range_dimension.hpp>
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
@@ -312,9 +313,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                     "dimensions that is not supported"));
                         }
 
-                        dims =
-                            tile_calculation::extract_dimensions(overall_shape);
-                        numdims = tile_calculation::extract_num_dimensions(
+                        dims = util::detail::extract_positive_range_dimensions(
+                            overall_shape);
+                        numdims = util::detail::extract_range_num_dimensions(
                             overall_shape);
                     }
                     else if (is_numeric_operand(args[1]))

--- a/src/plugins/dist_matrixops/dist_matrixops.cpp
+++ b/src/plugins/dist_matrixops/dist_matrixops.cpp
@@ -22,5 +22,6 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(dist_identity_plugin,
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_random_plugin,
     phylanx::dist_matrixops::primitives::dist_random::match_data)
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_transpose_operation_plugin,
-    phylanx::dist_matrixops::primitives::dist_transpose_operation::match_data);PHYLANX_REGISTER_PLUGIN_FACTORY(retile_annotations_plugin,
+    phylanx::dist_matrixops::primitives::dist_transpose_operation::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(retile_annotations_plugin,
     phylanx::dist_matrixops::primitives::retile_annotations::match_data);

--- a/src/plugins/dist_matrixops/dist_matrixops.cpp
+++ b/src/plugins/dist_matrixops/dist_matrixops.cpp
@@ -22,5 +22,5 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(dist_identity_plugin,
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_random_plugin,
     phylanx::dist_matrixops::primitives::dist_random::match_data)
 PHYLANX_REGISTER_PLUGIN_FACTORY(dist_transpose_operation_plugin,
-    phylanx::dist_matrixops::primitives::dist_transpose_operation::match_data);
-
+    phylanx::dist_matrixops::primitives::dist_transpose_operation::match_data);PHYLANX_REGISTER_PLUGIN_FACTORY(retile_annotations_plugin,
+    phylanx::dist_matrixops::primitives::retile_annotations::match_data);

--- a/src/plugins/dist_matrixops/dist_random.cpp
+++ b/src/plugins/dist_matrixops/dist_random.cpp
@@ -240,7 +240,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                         }
 
                         dims = util::detail::extract_positive_range_dimensions(
-                            shape);
+                            shape, this_->name_, this_->codename_);
                         numdims =
                             util::detail::extract_range_num_dimensions(shape);
                     }

--- a/src/plugins/dist_matrixops/dist_random.cpp
+++ b/src/plugins/dist_matrixops/dist_random.cpp
@@ -14,6 +14,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_random.hpp>
 #include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
+#include <phylanx/util/detail/range_dimension.hpp>
 #include <phylanx/util/random.hpp>
 
 #include <hpx/include/lcos.hpp>
@@ -238,9 +239,10 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                     "dimensions that is not supported"));
                         }
 
-                        dims = tile_calculation::extract_dimensions(shape);
+                        dims = util::detail::extract_positive_range_dimensions(
+                            shape);
                         numdims =
-                            tile_calculation::extract_num_dimensions(shape);
+                            util::detail::extract_range_num_dimensions(shape);
                     }
                     else if (is_numeric_operand(args[0]))
                     {

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -56,17 +56,6 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     only contains positive integers.
                 new_tiling (a list): the tile index we need to generate the
                     random array for. A non-negative integer.
-                numtiles (int): number of tiles of the returned array
-                name (string, optional): the array given name. If not given, a
-                    globally unique name will be generated.
-                tiling_type (string, optional): defaults to `sym` which is a
-                    balanced way of tiling among all the numtiles localities.
-                    Other options are `row` or `column` tiling. For a vector
-                    all these three tiling_types are the same.
-                mean (float, optional): the mean value of the distribution. It
-                    sets to 0.0 by default.
-                std (float, optional): the standard deviation of the normal
-                    distribution. It sets to 1.0 by default.
 
             Returns:
 
@@ -240,6 +229,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             (std::min)(cur_start, des_stop));
                     if (res_size > 0)
                     {
+                        // loc_span has the part of result that we need
                         blaze::subvector(result, res_start, res_size) =
                             v_data
                                 .fetch(loc, rel_loc_start,
@@ -255,6 +245,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             (std::max)(cur_stop, des_start), des_start);
                     if (res_size > 0)
                     {
+                        // loc_span has the part of result that we need
                         blaze::subvector(result, res_start, res_size) =
                             v_data
                                 .fetch(loc, rel_loc_start,
@@ -378,7 +369,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     }
                     ir::range&& new_tiling = extract_list_value_strict(
                         std::move(args[1]), this_->name_, this_->codename_);
-                    auto label = extract_string_value_strict(*new_tiling.begin());
+                    auto label =
+                        extract_string_value_strict(*new_tiling.begin());
                     if (label != "args" && label != "tile")
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter, "retile::eval",
@@ -386,43 +378,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                 "the given shape is of an unsupported "
                                 "dimensionality"));
                     }
-                    //annotation_information ann_info{std::move(ann_name), 0ll};
-                    //annotation localities;
-                    //if (phylanx::execution_tree::extract_string_value(*args.begin()) ==
-                    //    "args")
-                    //{
-                    //    annotation tmp(args);
-                    //    annotation locality_ann;
-                    //    annotation tiles_ann;
-                    //    if (tmp.find("locality", locality_ann) &&
-                    //        tmp.find("tile", tiles_ann))
-                    //    {
-                    //        ir::range tmp = tiles_ann.get_range();
-                    //        localities = localities_annotation(locality_ann,
-                    //            annotation{std::move(tmp)}, ann_info, name_, codename_);
-                    //    }
-                    //    else
-                    //    {
-                    //        HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    //            "annotate_primitive::annotate_d",
-                    //            generate_error_message(
-                    //                "locality and/or tile annotation not found"));
-                    //    }
-                    //}
-                    //else if (phylanx::execution_tree::extract_string_value(*args.begin()) ==
-                    //    "tile")
-                    //{
-                    //    annotation locality_ann;
-                    //    localities = localities_annotation(locality_ann,
-                    //        annotation{std::move(args)}, ann_info, name_, codename_);
-                    //}
-                    //else
-                    //{
-                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    //        "annotate_primitive::annotate_d",
-                    //        generate_error_message(
-                    //            "no args annotation and tiles annotation not first"));
-                    //}
+
 
                     switch (numdims)
                     {
@@ -431,8 +387,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             std::move(new_tiling));
 
                         //case 2:
-                        //    return this_->retile2d(dims, tile_idx, numtiles,
-                        //        std::move(given_name), tiling_type, mean, std);
+                        //    return this_->retile2d();
 
                     default:
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -56,20 +56,19 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             a, tiling_type, intersection, numtiles, new_tiling
             Args:
 
-                a (array): and array (local or distributed). A vector or a
-                    matrix.
+                a (array): a distributed array. A vector or a matrix.
                 tiling_type (string, optional): defaults to `sym` which is a
                     balanced way of tiling among all localities. Other options
                     are `row`, `column` or `user` tiling types. If an
-                    intersection is given, retile produces overlapped parts of
-                    arrays. In the `user` mode, using new_tiling, tiles are
-                    specified with their spans.
+                    intersection is given, retile produces tiles that have
+                    overlapped parts. In the `user` mode, using new_tiling,
+                    tiles are specified with their spans.
                 intersection (int or tuple of ints, optional): the size of
                     overlapped part on each dimension. If an integer is given,
                     that would be the intersection length on all dimensions
                     that are tiled. If the given intersection is odd, the extra
                     overlapped vector will be at the end of the part.
-                    In the `user` mode, intersection cannot be used.
+                    In the `user` mode, `intersection` cannot be used.
                 numtiles (int, optional): number of tiles of the returned array
                     If not given it sets to the number of localities in the
                     application.
@@ -565,9 +564,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                         col_indices.intersection_size_) =
                         m_data
                             .fetch(loc, row_indices.local_start_,
+                                col_indices.local_start_,
                                 row_indices.local_start_ +
                                     row_indices.intersection_size_,
-                                col_indices.local_start_,
                                 col_indices.local_start_ +
                                     col_indices.intersection_size_)
                             .get();

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -15,6 +15,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/dist_matrixops/retile_annotations.hpp>
 #include <phylanx/util/distributed_vector.hpp>
+#include <phylanx/util/distributed_matrix.hpp>
 
 #include <hpx/assertion.hpp>
 #include <hpx/include/lcos.hpp>
@@ -22,7 +23,6 @@
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
-#include <algorithm>
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -107,39 +107,100 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             return tile_extraction_1d_helper(std::move(it));
         }
 
-        std::tuple<std::size_t, std::size_t, std::size_t> retile_calculation_1d(
-            execution_tree::tiling_span const& loc_span,
-            std::int64_t const& des_start, std::int64_t const& cur_start)
+        struct indices_pack
         {
-            execution_tree::tiling_span pre_span(des_start, cur_start);
-            execution_tree::tiling_span intersection;
-            if (intersect(pre_span, loc_span, intersection))
-            {
-                std::int64_t rel_loc_start =
-                    intersection.start_ - loc_span.start_;
-                HPX_ASSERT(rel_loc_start >= 0);
-                return std::make_tuple(intersection.start_ - des_start,
-                    intersection.size(), rel_loc_start);
-            }
-            return std::make_tuple(0, 0, 0);
+            std::int64_t intersection_size_;
+            std::int64_t projected_start_;
+            std::int64_t local_start_;
+        };
+
+        indices_pack index_calculation_1d(std::int64_t des_start,
+            std::int64_t des_stop, std::int64_t cur_start,
+            std::int64_t cur_stop)
+        {
+            std::int64_t local_intersection_size =
+                (std::min)(des_stop, cur_stop) -
+                (std::max)(des_start, cur_start);
+            std::int64_t rel_start = des_start - cur_start;
+
+            return indices_pack{local_intersection_size,
+                rel_start < 0 ? -rel_start : 0, rel_start > 0 ? rel_start : 0};
         }
 
-        std::tuple<std::size_t, std::size_t, std::size_t> retile_calculation_1d(
+        indices_pack retile_calculation_1d(
             execution_tree::tiling_span const& loc_span,
-            std::int64_t const& des_stop, std::int64_t const& cur_stop,
-            std::int64_t const& des_start)
+            std::int64_t des_start, std::int64_t cur_start)
         {
-            execution_tree::tiling_span post_span(cur_stop, des_stop);
+            execution_tree::tiling_span span(des_start, cur_start);
             execution_tree::tiling_span intersection;
-            if (intersect(post_span, loc_span, intersection))
+            if (intersect(span, loc_span, intersection))
             {
                 std::int64_t rel_loc_start =
                     intersection.start_ - loc_span.start_;
                 HPX_ASSERT(rel_loc_start >= 0);
-                return std::make_tuple(intersection.start_ - des_start,
-                    intersection.size(), rel_loc_start);
+                return indices_pack{intersection.size(),
+                    intersection.start_ - des_start, rel_loc_start};
             }
-            return std::make_tuple(0, 0, 0);
+            return indices_pack{0, 0, 0};
+        }
+
+        ///////////////////////////////////////////////////////////////////////
+        std::tuple<std::int64_t, std::int64_t, std::int64_t, std::int64_t>
+        tile_extraction_2d_helper(ir::range_iterator&& it)
+        {
+            ir::range tile_data1 = extract_list_value_strict(*++it);
+            ir::range tile_data2 = extract_list_value_strict(*++it);
+            ir::range_iterator inner_it1 = tile_data1.begin();
+            ir::range_iterator inner_it2 = tile_data2.begin();
+
+
+            if (extract_string_value_strict(*inner_it1) == "rows" &&
+                extract_string_value_strict(*inner_it2) == "columns")
+            {
+            }
+            else if (extract_string_value_strict(*inner_it2) == "rows" &&
+                extract_string_value_strict(*inner_it1) == "columns")
+            {
+                std::swap(inner_it1, inner_it2);
+            }
+            else
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "dist_matrixops::primitives::retile_annotations::detail::"
+                    "tile_extraction_2d_helper",
+                    util::generate_error_message(
+                        "the new_tiling for a matrix should have two tile "
+                        "tags: `rows` and `columns`"));
+            }
+
+            std::int64_t row_start =
+                extract_scalar_nonneg_integer_value_strict(*++inner_it1);
+            std::int64_t row_stop =
+                extract_scalar_nonneg_integer_value_strict(*++inner_it1);
+            std::int64_t col_start =
+                extract_scalar_nonneg_integer_value_strict(*++inner_it2);
+            std::int64_t col_stop =
+                extract_scalar_nonneg_integer_value_strict(*++inner_it2);
+
+            return std::move(std::make_tuple(
+                row_start, col_start, row_stop, col_stop));
+        }
+
+        std::tuple<std::int64_t, std::int64_t, std::int64_t, std::int64_t>
+        tile_extraction_2d(ir::range&& new_tiling)
+        {
+            ir::range_iterator it = new_tiling.begin();
+            std::string label = extract_string_value_strict(*it);
+            if (label == "args")
+            {
+                // extracting the "tile" tag
+                ++it; // passing the "locality" tag
+                return tile_extraction_2d_helper(
+                    extract_list_value_strict(*++it).begin());
+            }
+
+            // label is "tile"
+            return tile_extraction_2d_helper(std::move(it));
         }
     }    // namespace detail
 
@@ -153,6 +214,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
 
         // current annotation information
         std::uint32_t const loc_id = arr_localities.locality_.locality_id_;
+        std::uint32_t const num_localities =
+            arr_localities.locality_.num_localities_;
         tiling_information_1d tile_info(
             arr_localities.tiles_[loc_id], name_, codename_);
 
@@ -188,8 +251,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         // updating the array
         auto v = arr.vector();
         blaze::DynamicVector<T> result(des_size);
-        util::distributed_vector<T> v_data(arr_localities.annotation_.name_, v,
-            arr_localities.locality_.num_localities_, loc_id);
+        util::distributed_vector<T> v_data(
+            arr_localities.annotation_.name_, v, num_localities, loc_id);
 
         std::int64_t rel_start = des_start - cur_start;
         if (rel_start < 0 || des_stop > cur_stop)
@@ -197,65 +260,40 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             // copying the local part
             if (des_start < cur_stop && des_stop > cur_start)
             {
-                std::int64_t local_intersection_size =
-                    (std::min)(des_stop, cur_stop) -
-                    (std::max)(des_start, cur_start);
-                std::int64_t res_intersection_start =
-                    rel_start < 0 ? -rel_start : 0;
-                std::int64_t v_intersection_start =
-                    rel_start > 0 ? rel_start : 0;
-                blaze::subvector(result, res_intersection_start,
-                    local_intersection_size) = blaze::subvector(v,
-                    v_intersection_start, local_intersection_size);
+                auto indices = detail::index_calculation_1d(
+                    des_start, des_stop, cur_start, cur_stop);
+                blaze::subvector(result, indices.projected_start_,
+                    indices.intersection_size_) = blaze::subvector(v,
+                    indices.local_start_, indices.intersection_size_);
             }
 
-            for (std::uint32_t loc = 0;
-                 loc != arr_localities.locality_.num_localities_; ++loc)
+            for (std::uint32_t loc = 0; loc != num_localities; ++loc)
             {
                 if (loc == loc_id)
                 {
                     continue;
                 }
 
-                // the array span in locality loc
+                // the array span in for loc-th locality
                 tiling_span loc_span =
                     arr_localities.tiles_[loc].spans_[span_index];
-                std::size_t res_start, res_size, rel_loc_start;
 
-                if (rel_start < 0)
+                auto indices = detail::retile_calculation_1d(
+                    loc_span, des_start, des_stop);
+                if (indices.intersection_size_ > 0)
                 {
-                    std::tie(res_start, res_size, rel_loc_start) =
-                        detail::retile_calculation_1d(loc_span, des_start,
-                            (std::min)(cur_start, des_stop));
-                    if (res_size > 0)
-                    {
-                        // loc_span has the part of result that we need
-                        blaze::subvector(result, res_start, res_size) =
-                            v_data
-                                .fetch(loc, rel_loc_start,
-                                    rel_loc_start + res_size)
-                                .get();
-                    }
-                }
-
-                if (des_stop > cur_stop)
-                {
-                    std::tie(res_start, res_size, rel_loc_start) =
-                        detail::retile_calculation_1d(loc_span, des_stop,
-                            (std::max)(cur_stop, des_start), des_start);
-                    if (res_size > 0)
-                    {
-                        // loc_span has the part of result that we need
-                        blaze::subvector(result, res_start, res_size) =
-                            v_data
-                                .fetch(loc, rel_loc_start,
-                                    rel_loc_start + res_size)
-                                .get();
-                    }
+                    // loc_span has the part of result that we need
+                    blaze::subvector(result, indices.projected_start_,
+                        indices.intersection_size_) =
+                        v_data
+                            .fetch(loc, indices.local_start_,
+                                indices.local_start_ +
+                                    indices.intersection_size_)
+                            .get();
                 }
             }
         }
-        else // the new array is a subset of the origina array
+        else // the new array is a subset of the original array
         {
             result = blaze::subvector(v, rel_start, des_size);
         }
@@ -325,6 +363,174 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    execution_tree::primitive_argument_type retile_annotations::retile2d(
+        ir::node_data<T>&& arr, ir::range&& new_tiling,
+        execution_tree::localities_information&& arr_localities) const
+    {
+        using namespace execution_tree;
+
+        // current annotation information
+        std::uint32_t const loc_id = arr_localities.locality_.locality_id_;
+        std::uint32_t const num_localities =
+            arr_localities.locality_.num_localities_;
+        tiling_information_2d tile_info(
+            arr_localities.tiles_[loc_id], name_, codename_);
+
+        std::int64_t cur_row_start = tile_info.spans_[0].start_;
+        std::int64_t cur_row_stop = tile_info.spans_[0].stop_;
+        std::int64_t cur_col_start = tile_info.spans_[1].start_;
+        std::int64_t cur_col_stop = tile_info.spans_[1].stop_;
+
+        // updating the annotation_ part of localities annotation
+        arr_localities.annotation_.name_ += "_retiled";
+        ++arr_localities.annotation_.generation_;
+
+        // desired annotation information
+        std::int64_t des_row_start, des_row_stop, des_col_start,
+            des_col_stop;
+        std::tie(des_row_start, des_col_start, des_row_stop,
+            des_col_stop) =
+            detail::tile_extraction_2d(std::move(new_tiling));
+
+        std::int64_t des_row_size = des_row_stop - des_row_start;
+        std::int64_t des_col_size = des_col_stop - des_col_start;
+        if (des_row_size <= 0 || des_col_size <= 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "dist_matrixops::primitives::retile_annotations::retile2d",
+                generate_error_message(
+                    "the given start point of the new_tiling should be less "
+                    "than its stop point on each dimension"));
+        }
+
+        // updating the array
+        auto m = arr.matrix();
+        blaze::DynamicMatrix<T> result(des_row_size, des_col_size);
+        util::distributed_matrix<T> m_data(
+            arr_localities.annotation_.name_, m, num_localities, loc_id);
+
+        // relative starts
+        std::int64_t rel_row_start = des_row_start - cur_row_start;
+        std::int64_t rel_col_start = des_col_start - cur_col_start;
+        if ((rel_row_start < 0 || des_row_stop > cur_row_stop) ||
+            (rel_col_start < 0 || des_col_stop > cur_col_stop))
+        {
+            // copying the local part
+            if ((des_row_start < cur_row_stop &&
+                    des_row_stop > cur_row_start) &&
+                (des_col_start < cur_col_stop && des_row_stop > cur_row_start))
+            {
+                auto row_indices = detail::index_calculation_1d(
+                    des_row_start, des_row_stop, cur_row_start, cur_row_stop);
+                auto col_indices = detail::index_calculation_1d(
+                    des_col_start, des_col_stop, cur_col_start, cur_col_stop);
+
+                blaze::submatrix(result, row_indices.projected_start_,
+                    col_indices.projected_start_,
+                    row_indices.intersection_size_,
+                    col_indices.intersection_size_) = blaze::submatrix(m,
+                    row_indices.local_start_, col_indices.local_start_,
+                    row_indices.intersection_size_,
+                    col_indices.intersection_size_);
+            }
+
+            for (std::uint32_t loc = 0; loc != num_localities; ++loc)
+            {
+                if (loc == loc_id)
+                {
+                    continue;
+                }
+
+                // the array span in locality loc
+                tiling_span loc_row_span = arr_localities.tiles_[loc].spans_[0];
+                tiling_span loc_col_span = arr_localities.tiles_[loc].spans_[1];
+
+                auto row_indices = detail::retile_calculation_1d(
+                    loc_row_span, des_row_start, des_row_stop);
+                auto col_indices = detail::retile_calculation_1d(
+                    loc_col_span, des_col_start, des_col_stop);
+                if (row_indices.intersection_size_ > 0 &&
+                    col_indices.intersection_size_)
+                {
+                    // loc_span has the block of result that we need
+                    blaze::submatrix(result, row_indices.projected_start_,
+                        col_indices.projected_start_,
+                        row_indices.intersection_size_,
+                        col_indices.intersection_size_) =
+                        m_data
+                            .fetch(loc, row_indices.local_start_,
+                                row_indices.local_start_ +
+                                    row_indices.intersection_size_,
+                                col_indices.local_start_,
+                                col_indices.local_start_ +
+                                    col_indices.intersection_size_)
+                            .get();
+                }
+            }
+        }
+        else // the new array is a subset of the origina array
+        {
+            result = blaze::submatrix(
+                m, rel_row_start, rel_col_start, des_row_size, des_col_size);
+        }
+
+        // updating the tile information
+        tile_info =
+            tiling_information_2d(tiling_span(des_row_start, des_row_stop),
+                tiling_span(des_col_start, des_col_stop));
+
+        auto locality_ann = arr_localities.locality_.as_annotation();
+        auto attached_annotation =
+            std::make_shared<annotation>(localities_annotation(locality_ann,
+                tile_info.as_annotation(name_, codename_),
+                arr_localities.annotation_, name_, codename_));
+
+        return primitive_argument_type(result, attached_annotation);
+    }
+
+    execution_tree::primitive_argument_type retile_annotations::retile2d(
+        execution_tree::primitive_argument_type&& arr,
+        ir::range&& new_tiling) const
+    {
+        using namespace execution_tree;
+        execution_tree::localities_information arr_localities =
+            extract_localities_information(arr, name_, codename_);
+
+        switch (extract_common_type(arr))
+        {
+        case node_data_type_bool:
+            return retile2d(
+                extract_boolean_value_strict(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        case node_data_type_int64:
+            return retile2d(
+                extract_integer_value_strict(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        case node_data_type_double:
+            return retile2d(
+                extract_numeric_value_strict(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        case node_data_type_unknown:
+            return retile2d(
+                extract_numeric_value(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "dist_matrixops::primitives::retile_annotations::retile2d",
+            generate_error_message(
+                "the retile_d primitive requires for all arguments to "
+                "be numeric data types"));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<execution_tree::primitive_argument_type>
     retile_annotations::eval(
         execution_tree::primitive_arguments_type const& operands,
@@ -369,8 +575,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     }
                     ir::range&& new_tiling = extract_list_value_strict(
                         std::move(args[1]), this_->name_, this_->codename_);
-                    auto label =
-                        extract_string_value_strict(*new_tiling.begin());
+                    auto label = extract_string_value_strict(*new_tiling.begin());
                     if (label != "args" && label != "tile")
                     {
                         HPX_THROW_EXCEPTION(hpx::bad_parameter, "retile::eval",
@@ -379,15 +584,15 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                 "dimensionality"));
                     }
 
-
                     switch (numdims)
                     {
                     case 1:
                         return this_->retile1d(std::move(args[0]),
                             std::move(new_tiling));
 
-                        //case 2:
-                        //    return this_->retile2d();
+                        case 2:
+                            return this_->retile2d(
+                                std::move(args[0]), std::move(new_tiling));
 
                     default:
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -15,8 +15,9 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/dist_matrixops/retile_annotations.hpp>
 #include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
-#include <phylanx/util/distributed_vector.hpp>
+#include <phylanx/util/detail/range_dimension.hpp>
 #include <phylanx/util/distributed_matrix.hpp>
+#include <phylanx/util/distributed_vector.hpp>
 
 #include <hpx/assertion.hpp>
 #include <hpx/include/lcos.hpp>
@@ -55,14 +56,15 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             a, tiling_type, intersection, numtiles, new_tiling
             Args:
 
-                a (array): a distributed array. A vector or a matrix
+                a (array): and array (local or distributed). A vector or a
+                    matrix.
                 tiling_type (string, optional): defaults to `sym` which is a
                     balanced way of tiling among all localities. Other options
                     are `row`, `column` or `user` tiling types. If an
                     intersection is given, retile produces overlapped parts of
                     arrays. In the `user` mode, using new_tiling, tiles are
                     specified with their spans.
-                intersection (int or list of ints, optional): the size of
+                intersection (int or tuple of ints, optional): the size of
                     overlapped part on each dimension. If an integer is given,
                     that would be the intersection length on all dimensions
                     that are tiled. If the given intersection is odd, the extra
@@ -730,7 +732,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                                         "all dimensions"));
                             }
                             intersections =
-                                tile_calculation::extract_nonneg_dimensions(
+                                util::detail::extract_nonneg_range_dimensions(
                                     intersection_list);
                         }
                         else if (is_numeric_operand(args[2]))

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -1,0 +1,421 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/annotation.hpp>
+#include <phylanx/execution_tree/locality_annotation.hpp>
+#include <phylanx/execution_tree/localities_annotation.hpp>
+#include <phylanx/execution_tree/meta_annotation.hpp>
+#include <phylanx/execution_tree/primitives/annotate_primitive.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/tiling_annotations.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/dist_matrixops/retile_annotations.hpp>
+#include <phylanx/util/distributed_vector.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/errors/throw_exception.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+//#include <blaze/Math.h>
+//#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace dist_matrixops { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    execution_tree::match_pattern_type const retile_annotations::match_data =
+    {
+        hpx::util::make_tuple("retile_d", std::vector<std::string>{R"(
+                retile_d(
+                    _1_a,
+                    _2_new_tiling
+                )
+            )"},
+            &create_retile_annotations,
+            &execution_tree::create_primitive<retile_annotations>, R"(
+            a, new_tiling
+            Args:
+
+                a (array): overall shape of the array. It
+                    only contains positive integers.
+                new_tiling (a list): the tile index we need to generate the
+                    random array for. A non-negative integer.
+                numtiles (int): number of tiles of the returned array
+                name (string, optional): the array given name. If not given, a
+                    globally unique name will be generated.
+                tiling_type (string, optional): defaults to `sym` which is a
+                    balanced way of tiling among all the numtiles localities.
+                    Other options are `row` or `column` tiling. For a vector
+                    all these three tiling_types are the same.
+                mean (float, optional): the mean value of the distribution. It
+                    sets to 0.0 by default.
+                std (float, optional): the standard deviation of the normal
+                    distribution. It sets to 1.0 by default.
+
+            Returns:
+
+            A part of an array of random numbers on tile_index-th tile out of
+            numtiles using the nrmal distribution)")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        //static std::atomic<std::size_t> rand_count(0);
+        //std::string generate_random_name(std::string&& given_name)
+        //{
+        //    if (given_name.empty())
+        //    {
+        //        return "random_array_" + std::to_string(++rand_count);
+        //    }
+
+        //    return std::move(given_name);
+        //}
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    retile_annotations::retile_annotations(
+        execution_tree::primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        std::tuple<bool, std::int64_t, std::int64_t> tile_extraction_1d_helper(
+            ir::range_iterator&& it)
+        {
+            ir::range tile_data = extract_list_value_strict(*++it);
+            ir::range_iterator inner_it = tile_data.begin();
+
+            // type_: columns = 0, rows = 1
+            bool type_ =
+                extract_string_value_strict(*inner_it) == "rows" ? 1 : 0;
+            std::int64_t start =
+                extract_scalar_nonneg_integer_value_strict(*++inner_it);
+            std::int64_t stop =
+                extract_scalar_nonneg_integer_value_strict(*++inner_it);
+
+            return std::move(std::make_tuple(type_, start, stop));
+        }
+
+        std::tuple<bool, std::int64_t, std::int64_t> tile_extraction_1d(
+            ir::range&& new_tiling)
+        {
+            ir::range_iterator it = new_tiling.begin();
+            std::string label = extract_string_value_strict(*it);
+            if (label == "args")
+            {
+                // extracting the "tile" tag
+                ++it; // passing the "locality" tag
+                return tile_extraction_1d_helper(
+                    extract_list_value_strict(*++it).begin());
+            }
+
+            // label is "tile"
+            return tile_extraction_1d_helper(std::move(it));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    execution_tree::primitive_argument_type retile_annotations::retile1d(
+        ir::node_data<T>&& arr, ir::range&& new_tiling,
+        execution_tree::localities_information&& arr_localities) const
+    {
+        using namespace execution_tree;
+
+        // current annotation information
+        std::uint32_t const loc_id = arr_localities.locality_.locality_id_;
+        tiling_information_1d tile_info(
+            arr_localities.tiles_[loc_id], name_, codename_);
+
+        std::int64_t cur_start = tile_info.span_.start_;
+        std::int64_t cur_stop = tile_info.span_.stop_;
+
+        // updating the annotation_ part of localities annotation
+        arr_localities.annotation_.name_ += "_retiled";
+        ++arr_localities.annotation_.generation_;
+
+        // desired annotation information
+        std::int64_t des_start, des_stop;
+        bool type_;
+        std::tie(type_, des_start, des_stop) =
+            detail::tile_extraction_1d(std::move(new_tiling));
+        std::int64_t des_size = des_stop - des_start;
+        if (des_size <= 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "dist_matrixops::primitives::retile_annotations::retile1d",
+                generate_error_message(
+                    "the given start point of the new_tiling should be less "
+                    "than its stop point"));
+        }
+
+        // updating the tile information
+        if (type_)    // rows
+        {
+            tile_info =
+                tiling_information_1d(tiling_information_1d::tile1d_type::rows,
+                    tiling_span(des_start, des_stop));
+        }
+        else    // columns
+        {
+            tile_info = tiling_information_1d(
+                tiling_information_1d::tile1d_type::columns,
+                tiling_span(des_start, des_stop));
+        }
+
+        std::size_t span_index = 0;
+        if (!arr_localities.has_span(0))
+        {
+            HPX_ASSERT(arr_localities.has_span(1));
+            span_index = 1;
+        }
+
+        // updating the array
+        auto v = arr.vector();
+        blaze::DynamicVector<T> result(des_size);
+        util::distributed_vector<T> v_data(arr_localities.annotation_.name_, v,
+            arr_localities.locality_.num_localities_, loc_id);
+
+        if (des_start < cur_start || des_stop > cur_stop)
+        {
+            blaze::subvector(result, cur_start - des_start, v.size()) = v;
+            for (std::uint32_t loc = 0;
+                 loc != arr_localities.locality_.num_localities_; ++loc)
+            {
+                if (loc == loc_id)
+                {
+                    continue;
+                }
+
+                // the array span in locality loc
+                tiling_span loc_span =
+                    arr_localities.tiles_[loc].spans_[span_index];
+                if (des_start < cur_start)
+                {
+                    tiling_span pre_span(des_start, cur_start);
+                    tiling_span intersection;
+                    if (intersect(pre_span, loc_span, intersection))
+                    {
+                        tiling_span outersection =
+                            arr_localities.project_coords(
+                                loc_id, span_index, intersection);
+                        blaze::subvector(result,
+                            des_start - intersection.start_,
+                            intersection.size()) =
+                            v_data
+                                .fetch(loc,
+                                    loc_span.stop_ + outersection.start_,
+                                    loc_span.stop_)
+                                .get();
+                    }
+
+                }
+
+                if (des_stop > cur_stop)
+                {
+                    tiling_span post_span(cur_stop, des_stop);
+                    tiling_span intersection;
+                    if (intersect(post_span, loc_span, intersection))
+                    {
+                        blaze::subvector(
+                            result, intersection.start_, intersection.size()) =
+                            v_data
+                                .fetch(loc,
+                                    loc_span.start_ - intersection.start_,
+                                    loc_span.start_ - intersection.start_ +
+                                        intersection.size())
+                                .get();
+                    }
+                }
+            }
+        }
+        else // the new array is a subset of the origina array
+        {
+            result = blaze::subvector(v, des_start - cur_start, des_size);
+        }
+
+        auto locality_ann = arr_localities.locality_.as_annotation();
+        auto attached_annotation =
+            std::make_shared<annotation>(localities_annotation(locality_ann,
+                tile_info.as_annotation(name_, codename_),
+                arr_localities.annotation_, name_, codename_));
+
+        return primitive_argument_type(result, attached_annotation);
+    }
+
+    execution_tree::primitive_argument_type retile_annotations::retile1d(
+        execution_tree::primitive_argument_type&& arr,
+        ir::range&& new_tiling) const
+    {
+        using namespace execution_tree;
+        execution_tree::localities_information arr_localities =
+            extract_localities_information(arr, name_, codename_);
+
+        switch (extract_common_type(arr))
+        {
+        case node_data_type_bool:
+            return retile1d(
+                extract_boolean_value_strict(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        case node_data_type_int64:
+            return retile1d(
+                extract_integer_value_strict(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        case node_data_type_double:
+            return retile1d(
+                extract_numeric_value_strict(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        case node_data_type_unknown:
+            return retile1d(
+                extract_numeric_value(std::move(arr), name_, codename_),
+                std::move(new_tiling), std::move(arr_localities));
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+            "dist_matrixops::primitives::retile_annotations::retile1d",
+            generate_error_message(
+                "the retile_d primitive requires for all arguments to "
+                "be numeric data types"));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<execution_tree::primitive_argument_type>
+    retile_annotations::eval(
+        execution_tree::primitive_arguments_type const& operands,
+        execution_tree::primitive_arguments_type const& args,
+        execution_tree::eval_context ctx) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "retile::eval",
+                generate_error_message(
+                    "the retile_d primitive requires two operands"));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "retile::eval",
+                generate_error_message(
+                    "the retile_d primitive requires that the arguments "
+                        "given by the operands array are valid"));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+                [this_ = std::move(this_)](
+                        execution_tree::primitive_arguments_type&& args)
+                ->  execution_tree::primitive_argument_type
+                {
+                    using namespace execution_tree;
+
+                    std::size_t numdims = extract_numeric_value_dimension(
+                        args[0], this_->name_, this_->codename_);
+
+                    if (!is_list_operand_strict(args[1]))
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "retile_d::eval",
+                            this_->generate_error_message(
+                                "the new tiling should be a list containing "
+                                "`tile` or `args`"));
+                    }
+                    ir::range&& new_tiling = extract_list_value_strict(
+                        std::move(args[1]), this_->name_, this_->codename_);
+                    auto label = extract_string_value_strict(*new_tiling.begin());
+                    if (label != "args" && label != "tile")
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter, "retile::eval",
+                            this_->generate_error_message(
+                                "the given shape is of an unsupported "
+                                "dimensionality"));
+                    }
+                    //annotation_information ann_info{std::move(ann_name), 0ll};
+                    //annotation localities;
+                    //if (phylanx::execution_tree::extract_string_value(*args.begin()) ==
+                    //    "args")
+                    //{
+                    //    annotation tmp(args);
+                    //    annotation locality_ann;
+                    //    annotation tiles_ann;
+                    //    if (tmp.find("locality", locality_ann) &&
+                    //        tmp.find("tile", tiles_ann))
+                    //    {
+                    //        ir::range tmp = tiles_ann.get_range();
+                    //        localities = localities_annotation(locality_ann,
+                    //            annotation{std::move(tmp)}, ann_info, name_, codename_);
+                    //    }
+                    //    else
+                    //    {
+                    //        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    //            "annotate_primitive::annotate_d",
+                    //            generate_error_message(
+                    //                "locality and/or tile annotation not found"));
+                    //    }
+                    //}
+                    //else if (phylanx::execution_tree::extract_string_value(*args.begin()) ==
+                    //    "tile")
+                    //{
+                    //    annotation locality_ann;
+                    //    localities = localities_annotation(locality_ann,
+                    //        annotation{std::move(args)}, ann_info, name_, codename_);
+                    //}
+                    //else
+                    //{
+                    //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    //        "annotate_primitive::annotate_d",
+                    //        generate_error_message(
+                    //            "no args annotation and tiles annotation not first"));
+                    //}
+
+                    switch (numdims)
+                    {
+                    case 1:
+                        return this_->retile1d(std::move(args[0]),
+                            std::move(new_tiling));
+
+                        //case 2:
+                        //    return this_->retile2d(dims, tile_idx, numtiles,
+                        //        std::move(given_name), tiling_type, mean, std);
+
+                    default:
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "retile::eval",
+                            this_->generate_error_message(
+                                "the given shape is of an unsupported "
+                                "dimensionality"));
+                    }
+                }),
+            execution_tree::primitives::detail::map_operands(operands,
+                execution_tree::functional::value_operand{}, args, name_,
+                codename_, std::move(ctx)));
+    }
+
+
+}}}
+

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -759,7 +759,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                             }
                             intersections =
                                 util::detail::extract_nonneg_range_dimensions(
-                                    intersection_list);
+                                    intersection_list, this_->name_,
+                                    this_->codename_);
                         }
                         else if (is_numeric_operand(args[2]))
                         {

--- a/src/plugins/matrixops/constant.cpp
+++ b/src/plugins/matrixops/constant.cpp
@@ -525,7 +525,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "4 entries"));
                     }
 
-                    dims = util::detail::extract_nonneg_range_dimensions(r);
+                    dims = util::detail::extract_nonneg_range_dimensions(
+                        r, this_->name_, this_->codename_);
                     numdims = util::detail::extract_range_num_dimensions(r);
                 }
                 else if (is_numeric_operand(op1))
@@ -660,7 +661,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "to have more than 4 entries"));
                     }
 
-                    dims = util::detail::extract_nonneg_range_dimensions(r);
+                    dims = util::detail::extract_nonneg_range_dimensions(
+                        r, this_->name_, this_->codename_);
                     numdims = util::detail::extract_range_num_dimensions(r);
                 }
                 else if (is_numeric_operand(shape))

--- a/src/plugins/matrixops/constant.cpp
+++ b/src/plugins/matrixops/constant.cpp
@@ -7,6 +7,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/ir/ranges.hpp>
 #include <phylanx/plugins/matrixops/constant.hpp>
+#include <phylanx/util/detail/range_dimension.hpp>
 
 #include <hpx/assertion.hpp>
 #include <hpx/include/lcos.hpp>
@@ -133,56 +134,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        std::size_t extract_num_dimensions(ir::range const& shape)
-        {
-            return shape.size();
-        }
-
-        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> extract_dimensions(
-            ir::range const& shape)
-        {
-            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> result = {0, 0};
-            if (!shape.empty())
-            {
-                if (shape.size() == 1)
-                {
-                    result[0] = extract_scalar_nonneg_integer_value_strict(
-                        *shape.begin());
-                }
-                else if (shape.size() == 2)
-                {
-                    auto elem_1 = shape.begin();
-                    result[0] =
-                        extract_scalar_nonneg_integer_value_strict(*elem_1);
-                    result[1] =
-                        extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                }
-                else if (shape.size() == 3)
-                {
-                    auto elem_1 = shape.begin();
-                    result[0] =
-                        extract_scalar_nonneg_integer_value_strict(*elem_1);
-                    result[1] =
-                        extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                    result[2] =
-                        extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                }
-                else if (shape.size() == 4)
-                {
-                    auto elem_1 = shape.begin();
-                    result[0] =
-                        extract_scalar_nonneg_integer_value_strict(*elem_1);
-                    result[1] =
-                        extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                    result[2] =
-                        extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                    result[3] =
-                        extract_scalar_nonneg_integer_value_strict(*++elem_1);
-                }
-            }
-            return result;
-        }
-
         constant::operation extract_operation_helper(std::string const& name)
         {
             if (name.find("constant_like") == 0)
@@ -574,8 +525,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "4 entries"));
                     }
 
-                    dims = detail::extract_dimensions(r);
-                    numdims = detail::extract_num_dimensions(r);
+                    dims = util::detail::extract_nonneg_range_dimensions(r);
+                    numdims = util::detail::extract_range_num_dimensions(r);
                 }
                 else if (is_numeric_operand(op1))
                 {
@@ -709,8 +660,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                                 "to have more than 4 entries"));
                     }
 
-                    dims = detail::extract_dimensions(r);
-                    numdims = detail::extract_num_dimensions(r);
+                    dims = util::detail::extract_nonneg_range_dimensions(r);
+                    numdims = util::detail::extract_range_num_dimensions(r);
                 }
                 else if (is_numeric_operand(shape))
                 {

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -19,6 +19,8 @@ set(tests
     dist_random_4_loc
     dist_random_5_loc
     retile_2_loc
+    retile_3_loc
+    retile_6_loc
    )
 
 
@@ -36,6 +38,8 @@ set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
 set(retile_2_loc_PARAMETERS LOCALITIES 2)
+set(retile_3_loc_PARAMETERS LOCALITIES 3)
+set(retile_6_loc_PARAMETERS LOCALITIES 6)
 
 
 foreach(test ${tests})

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     dist_random_2_loc
     dist_random_4_loc
     dist_random_5_loc
+    retile_2_loc
    )
 
 
@@ -34,6 +35,7 @@ set(dist_identity_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
+set(retile_2_loc_PARAMETERS LOCALITIES 2)
 
 
 foreach(test ${tests})

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -199,6 +199,78 @@ void test_retile_1d_3()
     }
 }
 
+void test_retile_1d_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_4", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_4",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 2, 6))
+            )
+        )", R"(
+            annotate_d([3, 4, 5, 6], "tiled_array_1d_4_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 2, 6))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_4", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_4",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 0, 2))
+            )
+        )", R"(
+            annotate_d([1, 2], "tiled_array_1d_4_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 2))))
+        )");
+    }
+}
+
+void test_retile_1d_5()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_5", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_5",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 4, 6))
+            )
+        )", R"(
+            annotate_d([5, 6], "tiled_array_1d_5_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 4, 6))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_5", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_5",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 0, 4))
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4], "tiled_array_1d_5_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //void test_retile_2d_0()
 //{
@@ -237,6 +309,8 @@ int hpx_main(int argc, char* argv[])
     test_retile_1d_1();
     test_retile_1d_2();
     test_retile_1d_3();
+    test_retile_1d_4();
+    test_retile_1d_5();
 
     //test_retile_2d_0();
     //test_retile_2d_1();

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -1,0 +1,255 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_retile_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    std::cout << "result:" << result << "\n";
+    std::cout << "comparison:" << comparison << "\n";
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_retile_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_0", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_0",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("rows", 0, 4))
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("rows", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_0", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_0",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("rows", 4, 6))
+            )
+        )", R"(
+            annotate_d([5, 6], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("rows", 4, 6))))
+        )");
+    }
+}
+
+void test_retile_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_1", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_1",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 0, 2))
+            )
+        )", R"(
+            annotate_d([1, 2], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_1", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_1",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 2, 6))
+            )
+        )", R"(
+            annotate_d([3, 4, 5, 6], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 6))))
+        )");
+    }
+}
+
+void test_retile_1d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_2", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_2",
+                    list("args",
+                        list("locality", 0, 2),
+                        list("tile", list("rows", 0, 3)))
+                ),
+                list("tile", list("columns", 0, 1))
+            )
+        )", R"(
+            annotate_d([1], "tiled_array_1d_2_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 1))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_2", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_2",
+                    list("args",
+                        list("locality", 1, 2),
+                        list("tile", list("rows", 3, 6)))
+                ),
+                list("tile", list("columns", 1, 6))
+            )
+        )", R"(
+            annotate_d([2, 3, 4, 5, 6], "tiled_array_1d_2_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 1, 6))))
+        )");
+    }
+}
+
+void test_retile_1d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_3", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_3",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2)))
+            )
+        )", R"(
+            annotate_d([1, 2], "tiled_array_1d_3_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_3", R"(
+            retile_d(
+                annotate_d([4, 5, 6, 7], "tiled_array_1d_3",
+                    list("tile", list("columns", 3, 7))
+                ),
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 7)))
+            )
+        )", R"(
+            annotate_d([3, 4, 5, 6, 7], "tiled_array_1d_3_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 7))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//void test_retile_2d_0()
+//{
+//    if (hpx::get_locality_id() == 0)
+//    {
+//        test_retile_d_operation("test_retile_2loc2d_0", R"(
+//            retile_d(42, list(4, 6), 0, 2)
+//        )", R"(
+//            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
+//                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
+//                "full_array_3",
+//                list("args",
+//                    list("locality", 0, 2),
+//                    list("tile", list("columns", 0, 3), list("rows", 0, 4))))
+//        )");
+//    }
+//    else
+//    {
+//        test_retile_d_operation("test_retile_2loc2d_0", R"(
+//            retile_d(42, list(4, 6), 1, 2)
+//        )", R"(
+//            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
+//                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
+//                "full_array_3",
+//                list("args",
+//                    list("locality", 1, 2),
+//                    list("tile", list("columns", 3, 6), list("rows", 0, 4))))
+//        )");
+//    }
+//}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_retile_1d_0();
+    test_retile_1d_1();
+    test_retile_1d_2();
+    test_retile_1d_3();
+
+    //test_retile_2d_0();
+    //test_retile_2d_1();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -49,7 +49,7 @@ void test_retile_2loc_1d_0()
                 annotate_d([1, 2, 3], "tiled_array_1d_0",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", 2, list("tile", list("rows", 0, 4))
+                "user", nil, 2, list("tile", list("rows", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_0_retiled/1",
@@ -65,7 +65,7 @@ void test_retile_2loc_1d_0()
                 annotate_d([4, 5, 6], "tiled_array_1d_0",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", 2, list("tile", list("rows", 4, 6))
+                "user", nil, 2, list("tile", list("rows", 4, 6))
             )
         )", R"(
             annotate_d([5, 6], "tiled_array_1d_0_retiled/1",
@@ -85,7 +85,7 @@ void test_retile_2loc_1d_1()
                 annotate_d([1, 2, 3], "tiled_array_1d_1",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("columns", 0, 2))
+                "user", nil, nil, list("tile", list("columns", 0, 2))
             )
         )", R"(
             annotate_d([1, 2], "tiled_array_1d_1_retiled/1",
@@ -101,7 +101,7 @@ void test_retile_2loc_1d_1()
                 annotate_d([4, 5, 6], "tiled_array_1d_1",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("columns", 2, 6))
+                "user", nil, nil, list("tile", list("columns", 2, 6))
             )
         )", R"(
             annotate_d([3, 4, 5, 6], "tiled_array_1d_1_retiled/1",
@@ -123,7 +123,7 @@ void test_retile_2loc_1d_2()
                         list("locality", 0, 2),
                         list("tile", list("rows", 0, 3)))
                 ),
-                "user", nil, list("tile", list("columns", 0, 1))
+                "user", nil, nil, list("tile", list("columns", 0, 1))
             )
         )", R"(
             annotate_d([1], "tiled_array_1d_2_retiled/1",
@@ -141,7 +141,7 @@ void test_retile_2loc_1d_2()
                         list("locality", 1, 2),
                         list("tile", list("rows", 3, 6)))
                 ),
-                "user", nil, list("tile", list("columns", 1, 6))
+                "user", nil, nil, list("tile", list("columns", 1, 6))
             )
         )", R"(
             annotate_d([2, 3, 4, 5, 6], "tiled_array_1d_2_retiled/1",
@@ -161,7 +161,7 @@ void test_retile_2loc_1d_3()
                 annotate_d([1, 2, 3], "tiled_array_1d_3",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil,
+                "user", nil, nil,
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 2)))
@@ -180,7 +180,7 @@ void test_retile_2loc_1d_3()
                 annotate_d([4, 5, 6, 7], "tiled_array_1d_3",
                     list("tile", list("columns", 3, 7))
                 ),
-                "user", nil,
+                "user", nil, nil,
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 2, 7)))
@@ -203,7 +203,7 @@ void test_retile_2loc_1d_4()
                 annotate_d([1, 2, 3], "tiled_array_1d_4",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil,
+                "user", nil, nil,
                 list("tile", list("columns", 2, 6))
             )
         )", R"(
@@ -220,7 +220,7 @@ void test_retile_2loc_1d_4()
                 annotate_d([4, 5, 6], "tiled_array_1d_4",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil,
+                "user", nil, nil,
                 list("tile", list("columns", 0, 2))
             )
         )", R"(
@@ -241,7 +241,7 @@ void test_retile_2loc_1d_5()
                 annotate_d([1, 2, 3], "tiled_array_1d_5",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("columns", 4, 6))
+                "user", nil, nil, list("tile", list("columns", 4, 6))
             )
         )", R"(
             annotate_d([5, 6], "tiled_array_1d_5_retiled/1",
@@ -257,7 +257,7 @@ void test_retile_2loc_1d_5()
                 annotate_d([4, 5, 6], "tiled_array_1d_5",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("columns", 0, 4))
+                "user", nil, nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_5_retiled/1",
@@ -332,6 +332,40 @@ void test_retile_2loc_1d_7()
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("rows", 4, 7))))
+        )");
+    }
+}
+
+void test_retile_2loc_1d_8()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_8", R"(
+            retile_d(
+                annotate_d([1, 2], "tiled_array_1d_8",
+                    list("tile", list("columns", 0, 2))
+                ), "sym", 2
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4, 5, 6], "tiled_array_1d_8_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 6))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_8", R"(
+            retile_d(
+                annotate_d([3, 4, 5, 6, 7], "tiled_array_1d_8",
+                    list("tile", list("columns", 2, 7))
+                ), "sym", 2
+            )
+        )", R"(
+            annotate_d([3, 4, 5, 6, 7], "tiled_array_1d_8_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 7))))
         )");
     }
 }
@@ -416,14 +450,15 @@ void test_retile_2loc_2d_1()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    //test_retile_2loc_1d_0();
-    //test_retile_2loc_1d_1();
-    //test_retile_2loc_1d_2();
-    //test_retile_2loc_1d_3();
-    //test_retile_2loc_1d_4();
-    //test_retile_2loc_1d_5();
+    test_retile_2loc_1d_0();
+    test_retile_2loc_1d_1();
+    test_retile_2loc_1d_2();
+    test_retile_2loc_1d_3();
+    test_retile_2loc_1d_4();
+    test_retile_2loc_1d_5();
     test_retile_2loc_1d_6();
     test_retile_2loc_1d_7();
+    test_retile_2loc_1d_8();
 
     //test_retile_2loc_2d_0();
     //test_retile_2loc_2d_1();

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -380,6 +380,7 @@ void test_retile_2loc_2d_0()
                 annotate_d([[1, 2, 3], [-1, -2, -3]], "tiled_array_2d_0",
                     list("tile", list("columns", 0, 3), list("rows", 0, 2))
                 ),
+                "user", nil, nil,
                 list("tile", list("rows", 0, 2), list("columns", 0, 5))
             )
         )", R"(
@@ -397,6 +398,7 @@ void test_retile_2loc_2d_0()
                 annotate_d([[4, 5, 6], [-4, -5, -6]], "tiled_array_2d_0",
                     list("tile", list("rows", 0, 2), list("columns", 3, 6))
                 ),
+                "user", nil, nil,
                 list("tile", list("rows", 0, 2), list("columns", 5, 6))
             )
         )", R"(
@@ -418,6 +420,7 @@ void test_retile_2loc_2d_1()
                     "tiled_array_2d_1",
                     list("tile", list("columns", 0, 6), list("rows", 0, 2))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 0, 2), list("rows", 0, 3))
             )
         )", R"(
@@ -435,6 +438,7 @@ void test_retile_2loc_2d_1()
                 annotate_d([[-1, -2, -3, -4, -5, -6]], "tiled_array_2d_1",
                     list("tile", list("rows", 2, 3), list("columns", 0, 6))
                 ),
+                "user", nil, nil,
                 list("tile", list("rows", 0, 3), list("columns", 2, 6))
             )
         )", R"(
@@ -443,6 +447,85 @@ void test_retile_2loc_2d_1()
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("rows", 0, 3), list("columns", 2, 6))))
+        )");
+    }
+}
+
+void test_retile_2loc_2d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc2d_2", R"(
+            retile_d(
+                annotate_d([[1, 2, 3, 4, 5], [-1, -2, -3, -4, -5]],
+                    "tiled_array_2d_2",
+                    list("tile", list("columns", 0, 5), list("rows", 0, 2))
+                )
+            )
+        )", R"(
+            annotate_d([[1, 2, 3], [-1, -2, -3], [11, 12, 13]],
+                "tiled_array_2d_2_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("rows", 0, 3), list("columns", 0, 3))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc2d_2", R"(
+            retile_d(
+                annotate_d([[11, 12, 13, 14, 15]], "tiled_array_2d_2",
+                    list("tile", list("rows", 2, 3), list("columns", 0, 5))
+                )
+            )
+        )", R"(
+            annotate_d([[4, 5], [-4, -5], [14, 15]],
+                "tiled_array_2d_2_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("rows", 0, 3), list("columns", 3, 5))))
+        )");
+    }
+}
+
+void test_retile_2loc_2d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc2d_3", R"(
+            retile_d(
+                annotate_d([[1, 2, 3, 4, 5], [-1, -2, -3, -4, -5]],
+                    "tiled_array_2d_3",
+                    list("tile", list("columns", 0, 5), list("rows", 0, 2))
+                ),
+                "row", 2
+            )
+        )", R"(
+            annotate_d([[1, 2, 3, 4, 5], [-1, -2, -3, -4, -5],
+                        [11, 12, 13, 14, 15], [-11, -12, -13, -14, -15]],
+                "tiled_array_2d_3_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("rows", 0, 4), list("columns", 0, 5))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc2d_3", R"(
+            retile_d(
+                annotate_d([[11, 12, 13, 14, 15], [-11, -12, -13, -14, -15]],
+                    "tiled_array_2d_3",
+                    list("tile", list("rows", 2, 4), list("columns", 0, 5))
+                ),
+                "row", 2
+            )
+        )", R"(
+            annotate_d([[1, 2, 3, 4, 5], [-1, -2, -3, -4, -5],
+                        [11, 12, 13, 14, 15], [-11, -12, -13, -14, -15]],
+                "tiled_array_2d_3_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("rows", 0, 4), list("columns", 0, 5))))
         )");
     }
 }
@@ -460,8 +543,10 @@ int hpx_main(int argc, char* argv[])
     test_retile_2loc_1d_7();
     test_retile_2loc_1d_8();
 
-    //test_retile_2loc_2d_0();
-    //test_retile_2loc_2d_1();
+    test_retile_2loc_2d_0();
+    test_retile_2loc_2d_1();
+    test_retile_2loc_2d_2();
+    test_retile_2loc_2d_3();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -13,6 +13,7 @@
 
 #include <array>
 #include <cstdint>
+#include <iosteram>
 #include <string>
 #include <utility>
 #include <vector>
@@ -47,7 +48,7 @@ void test_retile_d_operation(std::string const& name, std::string const& code,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_retile_1d_0()
+void test_retile_2loc_1d_0()
 {
     if (hpx::get_locality_id() == 0)
     {
@@ -83,7 +84,7 @@ void test_retile_1d_0()
     }
 }
 
-void test_retile_1d_1()
+void test_retile_2loc_1d_1()
 {
     if (hpx::get_locality_id() == 0)
     {
@@ -119,7 +120,7 @@ void test_retile_1d_1()
     }
 }
 
-void test_retile_1d_2()
+void test_retile_2loc_1d_2()
 {
     if (hpx::get_locality_id() == 0)
     {
@@ -159,7 +160,7 @@ void test_retile_1d_2()
     }
 }
 
-void test_retile_1d_3()
+void test_retile_2loc_1d_3()
 {
     if (hpx::get_locality_id() == 0)
     {
@@ -199,7 +200,7 @@ void test_retile_1d_3()
     }
 }
 
-void test_retile_1d_4()
+void test_retile_2loc_1d_4()
 {
     if (hpx::get_locality_id() == 0)
     {
@@ -235,7 +236,7 @@ void test_retile_1d_4()
     }
 }
 
-void test_retile_1d_5()
+void test_retile_2loc_1d_5()
 {
     if (hpx::get_locality_id() == 0)
     {
@@ -305,12 +306,12 @@ void test_retile_1d_5()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    test_retile_1d_0();
-    test_retile_1d_1();
-    test_retile_1d_2();
-    test_retile_1d_3();
-    test_retile_1d_4();
-    test_retile_1d_5();
+    test_retile_2loc_1d_0();
+    test_retile_2loc_1d_1();
+    test_retile_2loc_1d_2();
+    test_retile_2loc_1d_3();
+    test_retile_2loc_1d_4();
+    test_retile_2loc_1d_5();
 
     //test_retile_2d_0();
     //test_retile_2d_1();

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -13,7 +13,7 @@
 
 #include <array>
 #include <cstdint>
-#include <iosteram>
+#include <iostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -273,35 +273,42 @@ void test_retile_2loc_1d_5()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-//void test_retile_2d_0()
-//{
-//    if (hpx::get_locality_id() == 0)
-//    {
-//        test_retile_d_operation("test_retile_2loc2d_0", R"(
-//            retile_d(42, list(4, 6), 0, 2)
-//        )", R"(
-//            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
-//                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-//                "full_array_3",
-//                list("args",
-//                    list("locality", 0, 2),
-//                    list("tile", list("columns", 0, 3), list("rows", 0, 4))))
-//        )");
-//    }
-//    else
-//    {
-//        test_retile_d_operation("test_retile_2loc2d_0", R"(
-//            retile_d(42, list(4, 6), 1, 2)
-//        )", R"(
-//            annotate_d([[42.0, 42.0, 42.0], [42.0, 42.0, 42.0],
-//                        [42.0, 42.0, 42.0], [42.0, 42.0, 42.0]],
-//                "full_array_3",
-//                list("args",
-//                    list("locality", 1, 2),
-//                    list("tile", list("columns", 3, 6), list("rows", 0, 4))))
-//        )");
-//    }
-//}
+void test_retile_2loc_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc2d_0", R"(
+            retile_d(
+                annotate_d([[1, 2, 3], [-1, -2, -3]], "tiled_array_2d_0",
+                    list("tile", list("columns", 0, 3), list("rows", 0, 2))
+                ),
+                list("tile", list("rows", 0, 2), list("columns", 0, 5))
+            )
+        )", R"(
+            annotate_d([[1, 2, 3, 4, 5], [-1, -2, -3, -4, -5]],
+                "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("rows", 0, 2), list("columns", 0, 5))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc2d_0", R"(
+            retile_d(
+                annotate_d([[4, 5, 6], [-4, -5, -6]], "tiled_array_2d_0",
+                    list("tile", list("rows", 0, 2), list("columns", 3, 6))
+                ),
+                list("tile", list("rows", 0, 2), list("columns", 5, 6))
+            )
+        )", R"(
+            annotate_d([[6], [-6]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("rows", 0, 2), list("columns", 5, 6))))
+        )");
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
@@ -313,8 +320,8 @@ int hpx_main(int argc, char* argv[])
     test_retile_2loc_1d_4();
     test_retile_2loc_1d_5();
 
-    //test_retile_2d_0();
-    //test_retile_2d_1();
+    test_retile_2loc_2d_0();
+    //test_retile_2loc_2d_1();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -49,7 +49,7 @@ void test_retile_2loc_1d_0()
                 annotate_d([1, 2, 3], "tiled_array_1d_0",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("rows", 0, 4))
+                "user", 2, list("tile", list("rows", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_0_retiled/1",
@@ -65,7 +65,7 @@ void test_retile_2loc_1d_0()
                 annotate_d([4, 5, 6], "tiled_array_1d_0",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("rows", 4, 6))
+                "user", 2, list("tile", list("rows", 4, 6))
             )
         )", R"(
             annotate_d([5, 6], "tiled_array_1d_0_retiled/1",
@@ -85,7 +85,7 @@ void test_retile_2loc_1d_1()
                 annotate_d([1, 2, 3], "tiled_array_1d_1",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("columns", 0, 2))
+                "user", nil, list("tile", list("columns", 0, 2))
             )
         )", R"(
             annotate_d([1, 2], "tiled_array_1d_1_retiled/1",
@@ -101,7 +101,7 @@ void test_retile_2loc_1d_1()
                 annotate_d([4, 5, 6], "tiled_array_1d_1",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("columns", 2, 6))
+                "user", nil, list("tile", list("columns", 2, 6))
             )
         )", R"(
             annotate_d([3, 4, 5, 6], "tiled_array_1d_1_retiled/1",
@@ -123,7 +123,7 @@ void test_retile_2loc_1d_2()
                         list("locality", 0, 2),
                         list("tile", list("rows", 0, 3)))
                 ),
-                list("tile", list("columns", 0, 1))
+                "user", nil, list("tile", list("columns", 0, 1))
             )
         )", R"(
             annotate_d([1], "tiled_array_1d_2_retiled/1",
@@ -141,7 +141,7 @@ void test_retile_2loc_1d_2()
                         list("locality", 1, 2),
                         list("tile", list("rows", 3, 6)))
                 ),
-                list("tile", list("columns", 1, 6))
+                "user", nil, list("tile", list("columns", 1, 6))
             )
         )", R"(
             annotate_d([2, 3, 4, 5, 6], "tiled_array_1d_2_retiled/1",
@@ -161,6 +161,7 @@ void test_retile_2loc_1d_3()
                 annotate_d([1, 2, 3], "tiled_array_1d_3",
                     list("tile", list("columns", 0, 3))
                 ),
+                "user", nil,
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 2)))
@@ -179,6 +180,7 @@ void test_retile_2loc_1d_3()
                 annotate_d([4, 5, 6, 7], "tiled_array_1d_3",
                     list("tile", list("columns", 3, 7))
                 ),
+                "user", nil,
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 2, 7)))
@@ -201,6 +203,7 @@ void test_retile_2loc_1d_4()
                 annotate_d([1, 2, 3], "tiled_array_1d_4",
                     list("tile", list("columns", 0, 3))
                 ),
+                "user", nil,
                 list("tile", list("columns", 2, 6))
             )
         )", R"(
@@ -217,6 +220,7 @@ void test_retile_2loc_1d_4()
                 annotate_d([4, 5, 6], "tiled_array_1d_4",
                     list("tile", list("columns", 3, 6))
                 ),
+                "user", nil,
                 list("tile", list("columns", 0, 2))
             )
         )", R"(
@@ -237,7 +241,7 @@ void test_retile_2loc_1d_5()
                 annotate_d([1, 2, 3], "tiled_array_1d_5",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("columns", 4, 6))
+                "user", nil, list("tile", list("columns", 4, 6))
             )
         )", R"(
             annotate_d([5, 6], "tiled_array_1d_5_retiled/1",
@@ -253,13 +257,81 @@ void test_retile_2loc_1d_5()
                 annotate_d([4, 5, 6], "tiled_array_1d_5",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("columns", 0, 4))
+                "user", nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_5_retiled/1",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 0, 4))))
+        )");
+    }
+}
+
+void test_retile_2loc_1d_6()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_6", R"(
+            retile_d(
+                annotate_d([6, 7], "tiled_array_1d_6",
+                    list("tile", list("columns", 5, 7))
+                )
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4], "tiled_array_1d_6_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_6", R"(
+            retile_d(
+                annotate_d([1, 2, 3, 4, 5], "tiled_array_1d_6",
+                    list("tile", list("columns", 0, 5))
+                )
+            )
+        )", R"(
+            annotate_d([5, 6, 7], "tiled_array_1d_6_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 4, 7))))
+        )");
+    }
+}
+
+void test_retile_2loc_1d_7()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_2loc1d_7", R"(
+            retile_d(
+                annotate_d([6, 7], "tiled_array_1d_7",
+                    list("tile", list("columns", 5, 7))
+                ), "row"
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4], "tiled_array_1d_7_retiled/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("rows", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_2loc1d_7", R"(
+            retile_d(
+                annotate_d([1, 2, 3, 4, 5], "tiled_array_1d_7",
+                    list("tile", list("columns", 0, 5))
+                ), "row"
+            )
+        )", R"(
+            annotate_d([5, 6, 7], "tiled_array_1d_7_retiled/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("rows", 4, 7))))
         )");
     }
 }
@@ -344,15 +416,17 @@ void test_retile_2loc_2d_1()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
-    test_retile_2loc_1d_0();
-    test_retile_2loc_1d_1();
-    test_retile_2loc_1d_2();
-    test_retile_2loc_1d_3();
-    test_retile_2loc_1d_4();
-    test_retile_2loc_1d_5();
+    //test_retile_2loc_1d_0();
+    //test_retile_2loc_1d_1();
+    //test_retile_2loc_1d_2();
+    //test_retile_2loc_1d_3();
+    //test_retile_2loc_1d_4();
+    //test_retile_2loc_1d_5();
+    test_retile_2loc_1d_6();
+    test_retile_2loc_1d_7();
 
-    test_retile_2loc_2d_0();
-    test_retile_2loc_2d_1();
+    //test_retile_2loc_2d_0();
+    //test_retile_2loc_2d_1();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
@@ -417,6 +417,7 @@ void test_retile_3loc_2d_0()
                 annotate_d([[1, 2, 3], [-1, -2, -3]], "tiled_array_2d_0",
                     list("tile", list("columns", 0, 3), list("rows", 0, 2))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 0, 2), list("rows", 0, 4))
             )
         )", R"(
@@ -437,6 +438,7 @@ void test_retile_3loc_2d_0()
                     "tiled_array_2d_0",
                     list("tile", list("columns", 3, 5), list("rows", 0, 4))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 2, 4), list("rows", 0, 4))
             )
         )", R"(
@@ -453,6 +455,7 @@ void test_retile_3loc_2d_0()
                 annotate_d([[11, 12, 13], [-11, -12, -13]], "tiled_array_2d_0",
                     list("tile", list("columns", 0, 3), list("rows", 2, 4))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 4, 5), list("rows", 0, 4))
             )
         )", R"(
@@ -474,6 +477,7 @@ void test_retile_3loc_2d_1()
                     "tiled_array_2d_1",
                     list("tile", list("columns", 3, 5), list("rows", 0, 4))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 0, 3), list("rows", 0, 4))
             )
         )", R"(
@@ -492,6 +496,7 @@ void test_retile_3loc_2d_1()
                     "tiled_array_2d_1",
                     list("tile", list("columns", 2, 3), list("rows", 0, 4))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 3, 4), list("rows", 0, 4))
             )
         )", R"(
@@ -510,6 +515,7 @@ void test_retile_3loc_2d_1()
                     "tiled_array_2d_1",
                     list("tile", list("columns", 0, 2), list("rows", 0, 4))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 4, 5), list("rows", 0, 4))
             )
         )", R"(
@@ -532,6 +538,7 @@ void test_retile_3loc_2d_2()
                     "tiled_array_2d_2",
                     list("tile", list("columns", 4, 6), list("rows", 0, 2))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 0, 2), list("rows", 0, 2))
             )
         )", R"(
@@ -548,6 +555,7 @@ void test_retile_3loc_2d_2()
                 annotate_d([[1], [-1]], "tiled_array_2d_2",
                     list("tile", list("columns", 0, 1), list("rows", 0, 2))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 2, 4), list("rows", 0, 2))
             )
         )", R"(
@@ -564,6 +572,7 @@ void test_retile_3loc_2d_2()
                 annotate_d([[2, 3, 4], [-2, -3, -4]], "tiled_array_2d_2",
                     list("tile", list("columns", 1, 4), list("rows", 0, 2))
                 ),
+                "user", nil, nil,
                 list("tile", list("columns", 4, 6), list("rows", 0, 2))
             )
         )", R"(
@@ -571,6 +580,62 @@ void test_retile_3loc_2d_2()
                 list("args",
                     list("locality", 2, 3),
                     list("tile", list("columns", 4, 6), list("rows", 0, 2))))
+        )");
+    }
+}
+
+void test_retile_3loc_2d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc2d_3", R"(
+            retile_d(
+                annotate_d([[1, 2, 3, 4, 5]],
+                    "tiled_array_2d_3",
+                    list("tile", list("columns", 0, 5), list("rows", 0, 1))
+                ),
+                "sym", 1
+            )
+        )", R"(
+            annotate_d([[1, 2, 3], [-1, -2, -3], [11, 12, 13]],
+                "tiled_array_2d_3_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 3))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc2d_3", R"(
+            retile_d(
+                annotate_d([[-1, -2, -3, -4, -5]], "tiled_array_2d_3",
+                    list("tile", list("columns", 0, 5), list("rows", 1, 2))
+                ),
+                "sym", 1
+            )
+        )", R"(
+            annotate_d([[3, 4, 5], [-3, -4, -5], [13, 14, 15]],
+                "tiled_array_2d_3_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 2, 5), list("rows", 0, 3))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc2d_3", R"(
+            retile_d(
+                annotate_d([[11, 12, 13, 14, 15]], "tiled_array_2d_3",
+                    list("tile", list("columns", 0, 5), list("rows", 2, 3))
+                ),
+                "sym", 1
+            )
+        )", R"(
+            annotate_d([[4, 5], [-4, -5], [14, 15]],
+                "tiled_array_2d_3_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 3, 5), list("rows", 0, 3))))
         )");
     }
 }
@@ -586,9 +651,10 @@ int hpx_main(int argc, char* argv[])
     test_retile_3loc_1d_5();
     test_retile_3loc_1d_6();
 
-    //test_retile_3loc_2d_0();
-    //test_retile_3loc_2d_1();
-    //test_retile_3loc_2d_2();
+    test_retile_3loc_2d_0();
+    test_retile_3loc_2d_1();
+    test_retile_3loc_2d_2();
+    test_retile_3loc_2d_3();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
@@ -11,14 +11,9 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <array>
-#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
-#include <blaze_tensor/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(
@@ -358,8 +353,174 @@ void test_retile_3loc_1d_5()
         )");
     }
 }
-///////////////////////////////////////////////////////////////////////////////
 
+///////////////////////////////////////////////////////////////////////////////
+void test_retile_3loc_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc2d_0", R"(
+            retile_d(
+                annotate_d([[1, 2, 3], [-1, -2, -3]], "tiled_array_2d_0",
+                    list("tile", list("columns", 0, 3), list("rows", 0, 2))
+                ),
+                list("tile", list("columns", 0, 2), list("rows", 0, 4))
+            )
+        )", R"(
+            annotate_d([[1, 2], [-1, -2], [11, 12], [-11, -12]],
+                "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 4))))
+        )");
+
+
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc2d_0", R"(
+            retile_d(
+                annotate_d([[4, 5], [-4, -5], [14, 15], [-14, -15]],
+                    "tiled_array_2d_0",
+                    list("tile", list("columns", 3, 5), list("rows", 0, 4))
+                ),
+                list("tile", list("columns", 2, 4), list("rows", 0, 4))
+            )
+        )", R"(
+            annotate_d([[3, 4], [-3, -4], [13, 14], [-13, -14]],
+                "tiled_array_2d_0_retiled/1",
+                list("tile", list("columns", 2, 4), list("rows", 0, 4)))
+        )");
+
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc2d_0", R"(
+            retile_d(
+                annotate_d([[11, 12, 13], [-11, -12, -13]], "tiled_array_2d_0",
+                    list("tile", list("columns", 0, 3), list("rows", 2, 4))
+                ),
+                list("tile", list("columns", 4, 5), list("rows", 0, 4))
+            )
+        )", R"(
+            annotate_d([[5], [-5], [15], [-15]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 4, 5), list("rows", 0, 4))))
+        )");
+    }
+}
+
+void test_retile_3loc_2d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc2d_1", R"(
+            retile_d(
+                annotate_d([[4, 5], [-4, -5], [14, 15], [-14, -15]],
+                    "tiled_array_2d_1",
+                    list("tile", list("columns", 3, 5), list("rows", 0, 4))
+                ),
+                list("tile", list("columns", 0, 3), list("rows", 0, 4))
+            )
+        )", R"(
+            annotate_d([[1, 2, 3], [-1, -2, -3], [11, 12, 13], [-11, -12, -13]],
+                "tiled_array_2d_1_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc2d_1", R"(
+            retile_d(
+                annotate_d([[3], [-3], [13], [-13]],
+                    "tiled_array_2d_1",
+                    list("tile", list("columns", 2, 3), list("rows", 0, 4))
+                ),
+                list("tile", list("columns", 3, 4), list("rows", 0, 4))
+            )
+        )", R"(
+            annotate_d([[4], [-4], [14], [-14]],
+                "tiled_array_2d_1_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 3, 4), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_retile_d_operation("test_retile_3loc2d_1", R"(
+            retile_d(
+                annotate_d([[1, 2], [-1, -2], [11, 12], [-11, -12]],
+                    "tiled_array_2d_1",
+                    list("tile", list("columns", 0, 2), list("rows", 0, 4))
+                ),
+                list("tile", list("columns", 4, 5), list("rows", 0, 4))
+            )
+        )", R"(
+            annotate_d([[5], [-5], [15], [-15]],
+                "tiled_array_2d_1_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 4, 5), list("rows", 0, 4))))
+        )");
+    }
+}
+
+void test_retile_3loc_2d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc2d_2", R"(
+            retile_d(
+                annotate_d([[5, 6], [-5, -6]],
+                    "tiled_array_2d_2",
+                    list("tile", list("columns", 4, 6), list("rows", 0, 2))
+                ),
+                list("tile", list("columns", 0, 2), list("rows", 0, 2))
+            )
+        )", R"(
+            annotate_d([[1, 2], [-1, -2]], "tiled_array_2d_2_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc2d_2", R"(
+            retile_d(
+                annotate_d([[1], [-1]], "tiled_array_2d_2",
+                    list("tile", list("columns", 0, 1), list("rows", 0, 2))
+                ),
+                list("tile", list("columns", 2, 4), list("rows", 0, 2))
+            )
+        )", R"(
+            annotate_d([[3, 4], [-3, -4]], "tiled_array_2d_2_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 2))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc2d_2", R"(
+            retile_d(
+                annotate_d([[2, 3, 4], [-2, -3, -4]], "tiled_array_2d_2",
+                    list("tile", list("columns", 1, 4), list("rows", 0, 2))
+                ),
+                list("tile", list("columns", 4, 6), list("rows", 0, 2))
+            )
+        )", R"(
+            annotate_d([[5, 6], [-5, -6]], "tiled_array_2d_2_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 4, 6), list("rows", 0, 2))))
+        )");
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
@@ -370,6 +531,10 @@ int hpx_main(int argc, char* argv[])
     test_retile_3loc_1d_3();
     test_retile_3loc_1d_4();
     test_retile_3loc_1d_5();
+
+    test_retile_3loc_2d_0();
+    test_retile_3loc_2d_1();
+    test_retile_3loc_2d_2();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
@@ -49,7 +49,7 @@ void test_retile_3loc_1d_0()
                 annotate_d([1, 2, 3], "tiled_array_1d_0",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("rows", 0, 2))
+                "user", nil, list("tile", list("rows", 0, 2))
             )
         )", R"(
             annotate_d([1, 2], "tiled_array_1d_0_retiled/1",
@@ -65,7 +65,7 @@ void test_retile_3loc_1d_0()
                 annotate_d([4, 5, 6], "tiled_array_1d_0",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("rows", 2, 7))
+                "user", nil, list("tile", list("rows", 2, 7))
             )
         )", R"(
             annotate_d([3, 4, 5, 6, 7], "tiled_array_1d_0_retiled/1",
@@ -81,7 +81,7 @@ void test_retile_3loc_1d_0()
                 annotate_d([7, 8, 9], "tiled_array_1d_0",
                     list("tile", list("columns", 6, 9))
                 ),
-                list("tile", list("rows", 7, 9))
+                "user", nil, list("tile", list("rows", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_0_retiled/1",
@@ -101,7 +101,7 @@ void test_retile_3loc_1d_1()
                 annotate_d([1, 2, 3], "tiled_array_1d_1",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("columns", 0, 4))
+                "user", nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_1_retiled/1",
@@ -117,7 +117,7 @@ void test_retile_3loc_1d_1()
                 annotate_d([4, 5, 6], "tiled_array_1d_1",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("columns", 4, 7))
+                "user", nil, list("tile", list("columns", 4, 7))
             )
         )", R"(
             annotate_d([5, 6, 7], "tiled_array_1d_1_retiled/1",
@@ -133,7 +133,7 @@ void test_retile_3loc_1d_1()
                 annotate_d([7, 8, 9], "tiled_array_1d_1",
                     list("tile", list("columns", 6, 9))
                 ),
-                list("tile", list("columns", 7, 9))
+                "user", nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_1_retiled/1",
@@ -153,7 +153,7 @@ void test_retile_3loc_1d_2()
                 annotate_d([1, 2, 3], "tiled_array_1d_2",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("columns", 0, 2))
+                "user", nil, list("tile", list("columns", 0, 2))
             )
         )", R"(
             annotate_d([1, 2], "tiled_array_1d_2_retiled/1",
@@ -169,7 +169,7 @@ void test_retile_3loc_1d_2()
                 annotate_d([4, 5, 6], "tiled_array_1d_2",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("columns", 2, 5))
+                "user", nil, list("tile", list("columns", 2, 5))
             )
         )", R"(
             annotate_d([3, 4, 5], "tiled_array_1d_2_retiled/1",
@@ -185,7 +185,7 @@ void test_retile_3loc_1d_2()
                 annotate_d([7, 8, 9], "tiled_array_1d_2",
                     list("tile", list("columns", 6, 9))
                 ),
-                list("tile", list("columns", 5, 9))
+                "user", nil, list("tile", list("columns", 5, 9))
             )
         )", R"(
             annotate_d([6, 7, 8, 9], "tiled_array_1d_2_retiled/1",
@@ -205,7 +205,7 @@ void test_retile_3loc_1d_3()
                 annotate_d([1, 2, 3], "tiled_array_1d_3",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("columns", 3, 7))
+                "user", nil, list("tile", list("columns", 3, 7))
             )
         )", R"(
             annotate_d([4, 5, 6, 7], "tiled_array_1d_3_retiled/1",
@@ -221,7 +221,7 @@ void test_retile_3loc_1d_3()
                 annotate_d([4, 5, 6], "tiled_array_1d_3",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("columns", 7, 9))
+                "user", nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_3_retiled/1",
@@ -237,7 +237,7 @@ void test_retile_3loc_1d_3()
                 annotate_d([7, 8, 9], "tiled_array_1d_3",
                     list("tile", list("columns", 6, 9))
                 ),
-                list("tile", list("columns", 0, 3))
+                "user", nil, list("tile", list("columns", 0, 3))
             )
         )", R"(
             annotate_d([1, 2, 3], "tiled_array_1d_3_retiled/1",
@@ -257,7 +257,7 @@ void test_retile_3loc_1d_4()
                 annotate_d([1, 2, 3], "tiled_array_1d_4",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("columns", 4, 7))
+                "user", nil, list("tile", list("columns", 4, 7))
             )
         )", R"(
             annotate_d([5, 6, 7], "tiled_array_1d_4_retiled/1",
@@ -274,7 +274,7 @@ void test_retile_3loc_1d_4()
                 annotate_d([4, 5, 6], "tiled_array_1d_4",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("columns", 0, 4))
+                "user", nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_4_retiled/1",
@@ -290,7 +290,7 @@ void test_retile_3loc_1d_4()
                 annotate_d([7, 8, 9], "tiled_array_1d_4",
                     list("tile", list("columns", 6, 9))
                 ),
-                list("tile", list("columns", 7, 9))
+                "user", nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_4_retiled/1",
@@ -310,7 +310,7 @@ void test_retile_3loc_1d_5()
                 annotate_d([1, 2, 3], "tiled_array_1d_5",
                     list("tile", list("columns", 0, 3))
                 ),
-                list("tile", list("columns", 4, 7))
+                "user", nil, list("tile", list("columns", 4, 7))
             )
         )", R"(
             annotate_d([5, 6, 7], "tiled_array_1d_5_retiled/1",
@@ -328,7 +328,7 @@ void test_retile_3loc_1d_5()
                 annotate_d([4, 5, 6], "tiled_array_1d_5",
                     list("tile", list("columns", 3, 6))
                 ),
-                list("tile", list("columns", 7, 9))
+                "user", nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_5_retiled/1",
@@ -343,7 +343,7 @@ void test_retile_3loc_1d_5()
                 annotate_d([7, 8, 9], "tiled_array_1d_5",
                     list("tile", list("columns", 6, 9))
                 ),
-                list("tile", list("columns", 0, 4))
+                "user", nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_5_retiled/1",
@@ -532,9 +532,9 @@ int hpx_main(int argc, char* argv[])
     test_retile_3loc_1d_4();
     test_retile_3loc_1d_5();
 
-    test_retile_3loc_2d_0();
-    test_retile_3loc_2d_1();
-    test_retile_3loc_2d_2();
+    //test_retile_3loc_2d_0();
+    //test_retile_3loc_2d_1();
+    //test_retile_3loc_2d_2();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
@@ -49,7 +49,7 @@ void test_retile_3loc_1d_0()
                 annotate_d([1, 2, 3], "tiled_array_1d_0",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("rows", 0, 2))
+                "user", nil, nil, list("tile", list("rows", 0, 2))
             )
         )", R"(
             annotate_d([1, 2], "tiled_array_1d_0_retiled/1",
@@ -65,7 +65,7 @@ void test_retile_3loc_1d_0()
                 annotate_d([4, 5, 6], "tiled_array_1d_0",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("rows", 2, 7))
+                "user", nil, nil, list("tile", list("rows", 2, 7))
             )
         )", R"(
             annotate_d([3, 4, 5, 6, 7], "tiled_array_1d_0_retiled/1",
@@ -81,7 +81,7 @@ void test_retile_3loc_1d_0()
                 annotate_d([7, 8, 9], "tiled_array_1d_0",
                     list("tile", list("columns", 6, 9))
                 ),
-                "user", nil, list("tile", list("rows", 7, 9))
+                "user", nil, nil, list("tile", list("rows", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_0_retiled/1",
@@ -101,7 +101,7 @@ void test_retile_3loc_1d_1()
                 annotate_d([1, 2, 3], "tiled_array_1d_1",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("columns", 0, 4))
+                "user", nil, nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_1_retiled/1",
@@ -117,7 +117,7 @@ void test_retile_3loc_1d_1()
                 annotate_d([4, 5, 6], "tiled_array_1d_1",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("columns", 4, 7))
+                "user", nil, nil, list("tile", list("columns", 4, 7))
             )
         )", R"(
             annotate_d([5, 6, 7], "tiled_array_1d_1_retiled/1",
@@ -133,7 +133,7 @@ void test_retile_3loc_1d_1()
                 annotate_d([7, 8, 9], "tiled_array_1d_1",
                     list("tile", list("columns", 6, 9))
                 ),
-                "user", nil, list("tile", list("columns", 7, 9))
+                "user", nil, nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_1_retiled/1",
@@ -153,7 +153,7 @@ void test_retile_3loc_1d_2()
                 annotate_d([1, 2, 3], "tiled_array_1d_2",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("columns", 0, 2))
+                "user", nil, nil, list("tile", list("columns", 0, 2))
             )
         )", R"(
             annotate_d([1, 2], "tiled_array_1d_2_retiled/1",
@@ -169,7 +169,7 @@ void test_retile_3loc_1d_2()
                 annotate_d([4, 5, 6], "tiled_array_1d_2",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("columns", 2, 5))
+                "user", nil, nil, list("tile", list("columns", 2, 5))
             )
         )", R"(
             annotate_d([3, 4, 5], "tiled_array_1d_2_retiled/1",
@@ -185,7 +185,7 @@ void test_retile_3loc_1d_2()
                 annotate_d([7, 8, 9], "tiled_array_1d_2",
                     list("tile", list("columns", 6, 9))
                 ),
-                "user", nil, list("tile", list("columns", 5, 9))
+                "user", nil, nil, list("tile", list("columns", 5, 9))
             )
         )", R"(
             annotate_d([6, 7, 8, 9], "tiled_array_1d_2_retiled/1",
@@ -205,7 +205,7 @@ void test_retile_3loc_1d_3()
                 annotate_d([1, 2, 3], "tiled_array_1d_3",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("columns", 3, 7))
+                "user", nil, nil, list("tile", list("columns", 3, 7))
             )
         )", R"(
             annotate_d([4, 5, 6, 7], "tiled_array_1d_3_retiled/1",
@@ -221,7 +221,7 @@ void test_retile_3loc_1d_3()
                 annotate_d([4, 5, 6], "tiled_array_1d_3",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("columns", 7, 9))
+                "user", nil, nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_3_retiled/1",
@@ -237,7 +237,7 @@ void test_retile_3loc_1d_3()
                 annotate_d([7, 8, 9], "tiled_array_1d_3",
                     list("tile", list("columns", 6, 9))
                 ),
-                "user", nil, list("tile", list("columns", 0, 3))
+                "user", nil, nil, list("tile", list("columns", 0, 3))
             )
         )", R"(
             annotate_d([1, 2, 3], "tiled_array_1d_3_retiled/1",
@@ -257,7 +257,7 @@ void test_retile_3loc_1d_4()
                 annotate_d([1, 2, 3], "tiled_array_1d_4",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("columns", 4, 7))
+                "user", nil, nil, list("tile", list("columns", 4, 7))
             )
         )", R"(
             annotate_d([5, 6, 7], "tiled_array_1d_4_retiled/1",
@@ -274,7 +274,7 @@ void test_retile_3loc_1d_4()
                 annotate_d([4, 5, 6], "tiled_array_1d_4",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("columns", 0, 4))
+                "user", nil, nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_4_retiled/1",
@@ -290,7 +290,7 @@ void test_retile_3loc_1d_4()
                 annotate_d([7, 8, 9], "tiled_array_1d_4",
                     list("tile", list("columns", 6, 9))
                 ),
-                "user", nil, list("tile", list("columns", 7, 9))
+                "user", nil, nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_4_retiled/1",
@@ -310,7 +310,7 @@ void test_retile_3loc_1d_5()
                 annotate_d([1, 2, 3], "tiled_array_1d_5",
                     list("tile", list("columns", 0, 3))
                 ),
-                "user", nil, list("tile", list("columns", 4, 7))
+                "user", nil, nil, list("tile", list("columns", 4, 7))
             )
         )", R"(
             annotate_d([5, 6, 7], "tiled_array_1d_5_retiled/1",
@@ -328,7 +328,7 @@ void test_retile_3loc_1d_5()
                 annotate_d([4, 5, 6], "tiled_array_1d_5",
                     list("tile", list("columns", 3, 6))
                 ),
-                "user", nil, list("tile", list("columns", 7, 9))
+                "user", nil, nil, list("tile", list("columns", 7, 9))
             )
         )", R"(
             annotate_d([8, 9], "tiled_array_1d_5_retiled/1",
@@ -343,13 +343,66 @@ void test_retile_3loc_1d_5()
                 annotate_d([7, 8, 9], "tiled_array_1d_5",
                     list("tile", list("columns", 6, 9))
                 ),
-                "user", nil, list("tile", list("columns", 0, 4))
+                "user", nil, nil, list("tile", list("columns", 0, 4))
             )
         )", R"(
             annotate_d([1, 2, 3, 4], "tiled_array_1d_5_retiled/1",
                 list("args",
                     list("locality", 2, 3),
                     list("tile", list("columns", 0, 4))))
+        )");
+    }
+}
+
+void test_retile_3loc_1d_6()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc1d_6", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_6",
+                    list("tile", list("columns", 0, 3))
+                ),
+                "row", list(2), 3
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4, 5, 6, 7], "tiled_array_1d_6_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("rows", 0, 7))))
+        )");
+
+
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc1d_6", R"(
+            retile_d(
+                annotate_d([4, 5, 6, 7, 8, 9, 10, 11], "tiled_array_1d_6",
+                    list("tile", list("columns", 3, 11))
+                ),
+                "row", list(2), 3
+            )
+        )", R"(
+            annotate_d([5, 6, 7, 8, 9, 10], "tiled_array_1d_6_retiled/1",
+                list("tile", list("rows", 4, 10)))
+        )");
+
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc1d_6", R"(
+            retile_d(
+                annotate_d([12, 13], "tiled_array_1d_6",
+                    list("tile", list("columns", 11, 13))
+                ),
+                "row", list(2), 3
+            )
+        )", R"(
+            annotate_d([8, 9, 10, 11, 12, 13], "tiled_array_1d_6_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("rows", 7, 13))))
         )");
     }
 }
@@ -531,6 +584,7 @@ int hpx_main(int argc, char* argv[])
     test_retile_3loc_1d_3();
     test_retile_3loc_1d_4();
     test_retile_3loc_1d_5();
+    test_retile_3loc_1d_6();
 
     //test_retile_3loc_2d_0();
     //test_retile_3loc_2d_1();

--- a/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
@@ -1,0 +1,386 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_retile_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_retile_3loc_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc1d_0", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_0",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("rows", 0, 2))
+            )
+        )", R"(
+            annotate_d([1, 2], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("rows", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc1d_0", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_0",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("rows", 2, 7))
+            )
+        )", R"(
+            annotate_d([3, 4, 5, 6, 7], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("rows", 2, 7))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc1d_0", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_0",
+                    list("tile", list("columns", 6, 9))
+                ),
+                list("tile", list("rows", 7, 9))
+            )
+        )", R"(
+            annotate_d([8, 9], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("rows", 7, 9))))
+        )");
+    }
+}
+
+void test_retile_3loc_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc1d_1", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_1",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 0, 4))
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc1d_1", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_1",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 4, 7))
+            )
+        )", R"(
+            annotate_d([5, 6, 7], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 4, 7))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc1d_1", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_1",
+                    list("tile", list("columns", 6, 9))
+                ),
+                list("tile", list("columns", 7, 9))
+            )
+        )", R"(
+            annotate_d([8, 9], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 7, 9))))
+        )");
+    }
+}
+
+void test_retile_3loc_1d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc1d_2", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_2",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 0, 2))
+            )
+        )", R"(
+            annotate_d([1, 2], "tiled_array_1d_2_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc1d_2", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_2",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 2, 5))
+            )
+        )", R"(
+            annotate_d([3, 4, 5], "tiled_array_1d_2_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 2, 5))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc1d_2", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_2",
+                    list("tile", list("columns", 6, 9))
+                ),
+                list("tile", list("columns", 5, 9))
+            )
+        )", R"(
+            annotate_d([6, 7, 8, 9], "tiled_array_1d_2_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 5, 9))))
+        )");
+    }
+}
+
+void test_retile_3loc_1d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc1d_3", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_3",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 3, 7))
+            )
+        )", R"(
+            annotate_d([4, 5, 6, 7], "tiled_array_1d_3_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 3, 7))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc1d_3", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_3",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 7, 9))
+            )
+        )", R"(
+            annotate_d([8, 9], "tiled_array_1d_3_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 7, 9))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc1d_3", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_3",
+                    list("tile", list("columns", 6, 9))
+                ),
+                list("tile", list("columns", 0, 3))
+            )
+        )", R"(
+            annotate_d([1, 2, 3], "tiled_array_1d_3_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 0, 3))))
+        )");
+    }
+}
+
+void test_retile_3loc_1d_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc1d_4", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_4",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 4, 7))
+            )
+        )", R"(
+            annotate_d([5, 6, 7], "tiled_array_1d_4_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 4, 7))))
+        )");
+
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc1d_4", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_4",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 0, 4))
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4], "tiled_array_1d_4_retiled/1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc1d_4", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_4",
+                    list("tile", list("columns", 6, 9))
+                ),
+                list("tile", list("columns", 7, 9))
+            )
+        )", R"(
+            annotate_d([8, 9], "tiled_array_1d_4_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 7, 9))))
+        )");
+    }
+}
+
+void test_retile_3loc_1d_5()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_3loc1d_5", R"(
+            retile_d(
+                annotate_d([1, 2, 3], "tiled_array_1d_5",
+                    list("tile", list("columns", 0, 3))
+                ),
+                list("tile", list("columns", 4, 7))
+            )
+        )", R"(
+            annotate_d([5, 6, 7], "tiled_array_1d_5_retiled/1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 4, 7))))
+        )");
+
+
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_3loc1d_5", R"(
+            retile_d(
+                annotate_d([4, 5, 6], "tiled_array_1d_5",
+                    list("tile", list("columns", 3, 6))
+                ),
+                list("tile", list("columns", 7, 9))
+            )
+        )", R"(
+            annotate_d([8, 9], "tiled_array_1d_5_retiled/1",
+                list("tile", list("columns", 7, 9)))
+        )");
+
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_3loc1d_5", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_5",
+                    list("tile", list("columns", 6, 9))
+                ),
+                list("tile", list("columns", 0, 4))
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4], "tiled_array_1d_5_retiled/1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 0, 4))))
+        )");
+    }
+}
+///////////////////////////////////////////////////////////////////////////////
+
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_retile_3loc_1d_0();
+    test_retile_3loc_1d_1();
+    test_retile_3loc_1d_2();
+    test_retile_3loc_1d_3();
+    test_retile_3loc_1d_4();
+    test_retile_3loc_1d_5();
+
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -11,14 +11,9 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 
-#include <array>
-#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
-#include <blaze_tensor/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(
@@ -146,12 +141,113 @@ void test_retile_6loc_1d_0()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-
+void test_retile_6loc_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_6loc2d_0", R"(
+            retile_d(
+                annotate_d([[-6], [16], [-16]], "tiled_array_2d_0",
+                    list("tile", list("columns", 5, 6), list("rows", 1, 4))
+                ),
+                list("tile", list("rows", 0, 2), list("columns", 0, 2))
+            )
+        )", R"(
+            annotate_d([[1, 2], [-1, -2]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 0, 6),
+                    list("tile", list("rows", 0, 2), list("columns", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_6loc2d_0", R"(
+            retile_d(
+                annotate_d([[1]], "tiled_array_2d_0",
+                    list("tile", list("columns", 0, 1), list("rows", 0, 1))
+                ),
+                list("tile", list("rows", 0, 2), list("columns", 2, 4))
+            )
+        )", R"(
+            annotate_d([[3, 4], [-3, -4]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 1, 6),
+                    list("tile", list("rows", 0, 2), list("columns", 2, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_retile_d_operation("test_retile_6loc2d_0", R"(
+            retile_d(
+                annotate_d([[2, 3, 4, 5]], "tiled_array_2d_0",
+                    list("tile", list("columns", 1, 5), list("rows", 0, 1))
+                ),
+                list("tile", list("rows", 0, 2), list("columns", 4, 6))
+            )
+        )", R"(
+            annotate_d([[5, 6], [-5, -6]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 2, 6),
+                    list("tile", list("rows", 0, 2), list("columns", 4, 6))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_retile_d_operation("test_retile_6loc2d_0", R"(
+            retile_d(
+                annotate_d([[6]], "tiled_array_2d_0",
+                    list("tile", list("columns", 5, 6), list("rows", 0, 1))
+                ),
+                list("tile", list("rows", 2, 4), list("columns", 0, 2))
+            )
+        )", R"(
+            annotate_d([[11, 12], [-11, -12]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 3, 6),
+                    list("tile", list("rows", 2, 4), list("columns", 0, 2))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_retile_d_operation("test_retile_6loc2d_0", R"(
+            retile_d(
+                annotate_d([[-1], [11], [-11]], "tiled_array_2d_0",
+                    list("tile", list("columns", 0, 1), list("rows", 1, 4))
+                ),
+                list("tile", list("rows", 2, 4), list("columns", 2, 4))
+            )
+        )", R"(
+            annotate_d([[13, 14], [-13, -14]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 4, 6),
+                    list("tile", list("rows", 2, 4), list("columns", 2, 4))))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_6loc2d_0", R"(
+            retile_d(
+                annotate_d([[-2, -3, -4, -5], [12, 13, 14, 15],
+                        [-12, -13, -14, -15]],
+                    "tiled_array_2d_0",
+                    list("tile", list("columns", 1, 5), list("rows", 1, 4))
+                ),
+                list("tile", list("rows", 2, 4), list("columns", 4, 6))
+            )
+        )", R"(
+            annotate_d([[15, 16], [-15, -16]], "tiled_array_2d_0_retiled/1",
+                list("args",
+                    list("locality", 5, 6),
+                    list("tile", list("rows", 2, 4), list("columns", 4, 6))))
+        )");
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
     test_retile_6loc_1d_0();
+    test_retile_6loc_2d_0();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -250,6 +250,7 @@ void test_retile_6loc_2d_0()
                 annotate_d([[-6], [16], [-16]], "tiled_array_2d_0",
                     list("tile", list("columns", 5, 6), list("rows", 1, 4))
                 ),
+                "user", nil, 6,
                 list("tile", list("rows", 0, 2), list("columns", 0, 2))
             )
         )", R"(
@@ -266,6 +267,7 @@ void test_retile_6loc_2d_0()
                 annotate_d([[1]], "tiled_array_2d_0",
                     list("tile", list("columns", 0, 1), list("rows", 0, 1))
                 ),
+                "user", nil, 6,
                 list("tile", list("rows", 0, 2), list("columns", 2, 4))
             )
         )", R"(
@@ -282,6 +284,7 @@ void test_retile_6loc_2d_0()
                 annotate_d([[2, 3, 4, 5]], "tiled_array_2d_0",
                     list("tile", list("columns", 1, 5), list("rows", 0, 1))
                 ),
+                "user", nil, 6,
                 list("tile", list("rows", 0, 2), list("columns", 4, 6))
             )
         )", R"(
@@ -298,6 +301,7 @@ void test_retile_6loc_2d_0()
                 annotate_d([[6]], "tiled_array_2d_0",
                     list("tile", list("columns", 5, 6), list("rows", 0, 1))
                 ),
+                "user", nil, 6,
                 list("tile", list("rows", 2, 4), list("columns", 0, 2))
             )
         )", R"(
@@ -314,6 +318,7 @@ void test_retile_6loc_2d_0()
                 annotate_d([[-1], [11], [-11]], "tiled_array_2d_0",
                     list("tile", list("columns", 0, 1), list("rows", 1, 4))
                 ),
+                "user", nil, 6,
                 list("tile", list("rows", 2, 4), list("columns", 2, 4))
             )
         )", R"(
@@ -332,6 +337,7 @@ void test_retile_6loc_2d_0()
                     "tiled_array_2d_0",
                     list("tile", list("columns", 1, 5), list("rows", 1, 4))
                 ),
+                "user", nil, 6,
                 list("tile", list("rows", 2, 4), list("columns", 4, 6))
             )
         )", R"(
@@ -343,13 +349,105 @@ void test_retile_6loc_2d_0()
     }
 }
 
+void test_retile_6loc_2d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_6loc2d_1", R"(
+            retile_d(
+                annotate_d([[1, 2]], "tiled_array_2d_1",
+                    list("tile", list("columns", 0, 2), list("rows", 0, 1))
+                ),
+                "sym", list(1, 0)
+            )
+        )", R"(
+            annotate_d([[1, 2], [-1, -2], [11, 12]],
+                "tiled_array_2d_1_retiled/1",
+                list("tile", list("rows", 0, 3), list("columns", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_6loc2d_1", R"(
+            retile_d(
+                annotate_d([[-1, -2], [11, 12]], "tiled_array_2d_1",
+                    list("tile", list("columns", 0, 2), list("rows", 1, 3))
+                ),
+                "sym", list(1, 0)
+            )
+        )", R"(
+            annotate_d([[3, 4], [-3, -4], [13, 14]],
+                "tiled_array_2d_1_retiled/1",
+                list("tile", list("rows", 0, 3), list("columns", 2, 4)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_retile_d_operation("test_retile_6loc2d_1", R"(
+            retile_d(
+                annotate_d([[-11, -12]], "tiled_array_2d_1",
+                    list("tile", list("columns", 0, 2), list("rows", 3, 4))
+                ),
+                "sym", list(1, 0)
+            )
+        )", R"(
+            annotate_d([[5], [-5], [15]], "tiled_array_2d_1_retiled/1",
+                list("tile", list("rows", 0, 3), list("columns", 4, 5)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_retile_d_operation("test_retile_6loc2d_1", R"(
+            retile_d(
+                annotate_d([[3, 4, 5]], "tiled_array_2d_1",
+                    list("tile", list("columns", 2, 5), list("rows", 0, 1))
+                ),
+                "sym", list(1, 0)
+            )
+        )", R"(
+            annotate_d([[-1, -2], [11, 12], [-11, -12]],
+                "tiled_array_2d_1_retiled/1",
+                list("tile", list("rows", 1, 4), list("columns", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_retile_d_operation("test_retile_6loc2d_1", R"(
+            retile_d(
+                annotate_d([[-3, -4, -5], [13, 14, 15]], "tiled_array_2d_1",
+                    list("tile", list("columns", 2, 5), list("rows", 1, 3))
+                ),
+                "sym", list(1, 0)
+            )
+        )", R"(
+            annotate_d([[-3, -4], [13, 14], [-13, -14]],
+                "tiled_array_2d_1_retiled/1",
+                list("tile", list("rows", 1, 4), list("columns", 2, 4)))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_6loc2d_1", R"(
+            retile_d(
+                annotate_d([[-13, -14, -15]], "tiled_array_2d_1",
+                    list("tile", list("columns", 2, 5), list("rows", 3, 4))
+                ),
+                "sym", list(1, 0)
+            )
+        )", R"(
+            annotate_d([[-5], [15], [-15]], "tiled_array_2d_1_retiled/1",
+                list("tile", list("rows", 1, 4), list("columns", 4, 5)))
+        )");
+    }
+}
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
     test_retile_6loc_1d_0();
     test_retile_6loc_1d_1();
 
-    //test_retile_6loc_2d_0();
+    test_retile_6loc_2d_0();
+    test_retile_6loc_2d_1();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -440,6 +440,95 @@ void test_retile_6loc_2d_1()
         )");
     }
 }
+
+void test_retile_6loc_2d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_6loc2d_2", R"(
+            retile_d(
+                annotate_d([[1, 2]], "tiled_array_2d_2",
+                    list("tile", list("columns", 0, 2), list("rows", 0, 1))
+                ),
+                "column", 1
+            )
+        )", R"(
+            annotate_d([[1, 2], [-1, -2]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_6loc2d_2", R"(
+            retile_d(
+                annotate_d([[-1, -2]], "tiled_array_2d_2",
+                    list("tile", list("columns", 0, 2), list("rows", 1, 2))
+                ),
+                "column", 1
+            )
+        )", R"(
+            annotate_d([[2, 3], [-2, -3]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 1, 3)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_retile_d_operation("test_retile_6loc2d_2", R"(
+            retile_d(
+                annotate_d([[3, 4]], "tiled_array_2d_2",
+                    list("tile", list("columns", 2, 4), list("rows", 0, 1))
+                ),
+                "column", 1
+            )
+        )", R"(
+            annotate_d([[3, 4], [-3, -4]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 2, 4)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_retile_d_operation("test_retile_6loc2d_2", R"(
+            retile_d(
+                annotate_d([[-3, -4]], "tiled_array_2d_2",
+                    list("tile", list("columns", 2, 4), list("rows", 1, 2))
+                ),
+                "column", 1
+            )
+        )", R"(
+            annotate_d([[4, 5], [-4, -5]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 3, 5)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_retile_d_operation("test_retile_6loc2d_2", R"(
+            retile_d(
+                annotate_d([[5, 6]], "tiled_array_2d_2",
+                    list("tile", list("columns", 4, 6), list("rows", 0, 1))
+                ),
+                "column", 1
+            )
+        )", R"(
+            annotate_d([[5, 6], [-5, -6]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 4, 6)))
+        )");
+    }
+    else
+    {
+        test_retile_d_operation("test_retile_6loc2d_2", R"(
+            retile_d(
+                annotate_d([[-5, -6]], "tiled_array_2d_2",
+                    list("tile", list("columns", 4, 6), list("rows", 1, 2))
+                ),
+                "column", 1
+            )
+        )", R"(
+            annotate_d([[5, 6], [-5, -6]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 4, 6)))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -448,6 +537,7 @@ int hpx_main(int argc, char* argv[])
 
     test_retile_6loc_2d_0();
     test_retile_6loc_2d_1();
+    test_retile_6loc_2d_2();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -49,7 +49,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([1, 2, 3, 4], "tiled_array_1d_0",
                     list("tile", list("columns", 0, 4))
                 ),
-                "user", nil, list("tile", list("rows", 15, 17))
+                "user", nil, nil, list("tile", list("rows", 15, 17))
             )
         )", R"(
             annotate_d([16, 17], "tiled_array_1d_0_retiled/1",
@@ -65,7 +65,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([5, 6], "tiled_array_1d_0",
                     list("tile", list("columns", 4, 6))
                 ),
-                "user", nil, list("tile", list("rows", 13, 15))
+                "user", nil, nil, list("tile", list("rows", 13, 15))
             )
         )", R"(
             annotate_d([14, 15], "tiled_array_1d_0_retiled/1",
@@ -81,7 +81,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([7, 8, 9], "tiled_array_1d_0",
                     list("tile", list("columns", 6, 9))
                 ),
-                "user", nil, list("tile", list("rows", 0, 5))
+                "user", nil, nil, list("tile", list("rows", 0, 5))
             )
         )", R"(
             annotate_d([1, 2, 3, 4, 5], "tiled_array_1d_0_retiled/1",
@@ -97,7 +97,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([10], "tiled_array_1d_0",
                     list("tile", list("columns", 9, 10))
                 ),
-                "user", nil, list("tile", list("rows", 10, 13))
+                "user", nil, nil, list("tile", list("rows", 10, 13))
             )
         )", R"(
             annotate_d([11, 12, 13], "tiled_array_1d_0_retiled/1",
@@ -113,7 +113,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([11, 12, 13, 14], "tiled_array_1d_0",
                     list("tile", list("columns", 10, 14))
                 ),
-                "user", nil, list("tile", list("rows", 17, 20))
+                "user", nil, nil, list("tile", list("rows", 17, 20))
             )
         )", R"(
             annotate_d([18, 19, 20], "tiled_array_1d_0_retiled/1",
@@ -129,13 +129,113 @@ void test_retile_6loc_1d_0()
                 annotate_d([15, 16, 17, 18, 19, 20], "tiled_array_1d_0",
                     list("tile", list("columns", 14, 20))
                 ),
-                "user", nil, list("tile", list("rows", 5, 10))
+                "user", nil, nil, list("tile", list("rows", 5, 10))
             )
         )", R"(
             annotate_d([6, 7, 8, 9, 10], "tiled_array_1d_0_retiled/1",
                 list("args",
                     list("locality", 5, 6),
                     list("tile", list("rows", 5, 10))))
+        )");
+    }
+}
+
+void test_retile_6loc_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_6loc1d_1", R"(
+            retile_d(
+                annotate_d([1, 2, 3, 4], "tiled_array_1d_1",
+                    list("tile", list("columns", 0, 4))
+                ),
+                "sym", 1, 6
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4, 5], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 0, 6),
+                    list("tile", list("columns", 0, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_6loc1d_1", R"(
+            retile_d(
+                annotate_d([5, 6], "tiled_array_1d_1",
+                    list("tile", list("columns", 4, 6))
+                ),
+                "sym", 1, 6
+            )
+        )", R"(
+            annotate_d([5, 6, 7, 8, 9], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 1, 6),
+                    list("tile", list("columns", 4, 9))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_retile_d_operation("test_retile_6loc1d_1", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_1",
+                    list("tile", list("columns", 6, 9))
+                ),
+                "sym", 1, 6
+            )
+        )", R"(
+            annotate_d([9, 10, 11, 12], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 2, 6),
+                    list("tile", list("columns", 8, 12))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_retile_d_operation("test_retile_6loc1d_1", R"(
+            retile_d(
+                annotate_d([10], "tiled_array_1d_1",
+                    list("tile", list("columns", 9, 10))
+                ),
+                "sym", 1, 6
+            )
+        )", R"(
+            annotate_d([12, 13, 14, 15], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 3, 6),
+                    list("tile", list("columns", 11, 15))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_retile_d_operation("test_retile_6loc1d_1", R"(
+            retile_d(
+                annotate_d([11, 12, 13, 14], "tiled_array_1d_1",
+                    list("tile", list("columns", 10, 14))
+                ),
+                "sym", 1, 6
+            )
+        )", R"(
+            annotate_d([15, 16, 17, 18], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 4, 6),
+                    list("tile", list("columns", 14, 18))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 5)
+    {
+        test_retile_d_operation("test_retile_6loc1d_1", R"(
+            retile_d(
+                annotate_d([15, 16, 17, 18, 19, 20], "tiled_array_1d_1",
+                    list("tile", list("columns", 14, 20))
+                ),
+                "sym", 1, 6
+            )
+        )", R"(
+            annotate_d([17, 18, 19, 20], "tiled_array_1d_1_retiled/1",
+                list("args",
+                    list("locality", 5, 6),
+                    list("tile", list("columns", 16, 20))))
         )");
     }
 }
@@ -247,6 +347,8 @@ void test_retile_6loc_2d_0()
 int hpx_main(int argc, char* argv[])
 {
     test_retile_6loc_1d_0();
+    test_retile_6loc_1d_1();
+
     //test_retile_6loc_2d_0();
 
 

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -49,7 +49,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([1, 2, 3, 4], "tiled_array_1d_0",
                     list("tile", list("columns", 0, 4))
                 ),
-                list("tile", list("rows", 15, 17))
+                "user", nil, list("tile", list("rows", 15, 17))
             )
         )", R"(
             annotate_d([16, 17], "tiled_array_1d_0_retiled/1",
@@ -65,7 +65,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([5, 6], "tiled_array_1d_0",
                     list("tile", list("columns", 4, 6))
                 ),
-                list("tile", list("rows", 13, 15))
+                "user", nil, list("tile", list("rows", 13, 15))
             )
         )", R"(
             annotate_d([14, 15], "tiled_array_1d_0_retiled/1",
@@ -81,7 +81,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([7, 8, 9], "tiled_array_1d_0",
                     list("tile", list("columns", 6, 9))
                 ),
-                list("tile", list("rows", 0, 5))
+                "user", nil, list("tile", list("rows", 0, 5))
             )
         )", R"(
             annotate_d([1, 2, 3, 4, 5], "tiled_array_1d_0_retiled/1",
@@ -97,7 +97,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([10], "tiled_array_1d_0",
                     list("tile", list("columns", 9, 10))
                 ),
-                list("tile", list("rows", 10, 13))
+                "user", nil, list("tile", list("rows", 10, 13))
             )
         )", R"(
             annotate_d([11, 12, 13], "tiled_array_1d_0_retiled/1",
@@ -113,7 +113,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([11, 12, 13, 14], "tiled_array_1d_0",
                     list("tile", list("columns", 10, 14))
                 ),
-                list("tile", list("rows", 17, 20))
+                "user", nil, list("tile", list("rows", 17, 20))
             )
         )", R"(
             annotate_d([18, 19, 20], "tiled_array_1d_0_retiled/1",
@@ -129,7 +129,7 @@ void test_retile_6loc_1d_0()
                 annotate_d([15, 16, 17, 18, 19, 20], "tiled_array_1d_0",
                     list("tile", list("columns", 14, 20))
                 ),
-                list("tile", list("rows", 5, 10))
+                "user", nil, list("tile", list("rows", 5, 10))
             )
         )", R"(
             annotate_d([6, 7, 8, 9, 10], "tiled_array_1d_0_retiled/1",
@@ -247,7 +247,7 @@ void test_retile_6loc_2d_0()
 int hpx_main(int argc, char* argv[])
 {
     test_retile_6loc_1d_0();
-    test_retile_6loc_2d_0();
+    //test_retile_6loc_2d_0();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -1,0 +1,168 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_retile_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_retile_6loc_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_retile_d_operation("test_retile_6loc1d_0", R"(
+            retile_d(
+                annotate_d([1, 2, 3, 4], "tiled_array_1d_0",
+                    list("tile", list("columns", 0, 4))
+                ),
+                list("tile", list("rows", 15, 17))
+            )
+        )", R"(
+            annotate_d([16, 17], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 0, 6),
+                    list("tile", list("rows", 15, 17))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_retile_d_operation("test_retile_6loc1d_0", R"(
+            retile_d(
+                annotate_d([5, 6], "tiled_array_1d_0",
+                    list("tile", list("columns", 4, 6))
+                ),
+                list("tile", list("rows", 13, 15))
+            )
+        )", R"(
+            annotate_d([14, 15], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 1, 6),
+                    list("tile", list("rows", 13, 15))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_retile_d_operation("test_retile_6loc1d_0", R"(
+            retile_d(
+                annotate_d([7, 8, 9], "tiled_array_1d_0",
+                    list("tile", list("columns", 6, 9))
+                ),
+                list("tile", list("rows", 0, 5))
+            )
+        )", R"(
+            annotate_d([1, 2, 3, 4, 5], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 2, 6),
+                    list("tile", list("rows", 0, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_retile_d_operation("test_retile_6loc1d_0", R"(
+            retile_d(
+                annotate_d([10], "tiled_array_1d_0",
+                    list("tile", list("columns", 9, 10))
+                ),
+                list("tile", list("rows", 10, 13))
+            )
+        )", R"(
+            annotate_d([11, 12, 13], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 3, 6),
+                    list("tile", list("rows", 10, 13))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_retile_d_operation("test_retile_6loc1d_0", R"(
+            retile_d(
+                annotate_d([11, 12, 13, 14], "tiled_array_1d_0",
+                    list("tile", list("columns", 10, 14))
+                ),
+                list("tile", list("rows", 17, 20))
+            )
+        )", R"(
+            annotate_d([18, 19, 20], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 4, 6),
+                    list("tile", list("rows", 17, 20))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 5)
+    {
+        test_retile_d_operation("test_retile_6loc1d_0", R"(
+            retile_d(
+                annotate_d([15, 16, 17, 18, 19, 20], "tiled_array_1d_0",
+                    list("tile", list("columns", 14, 20))
+                ),
+                list("tile", list("rows", 5, 10))
+            )
+        )", R"(
+            annotate_d([6, 7, 8, 9, 10], "tiled_array_1d_0_retiled/1",
+                list("args",
+                    list("locality", 5, 6),
+                    list("tile", list("rows", 5, 10))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_retile_6loc_1d_0();
+
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+


### PR DESCRIPTION
This PR adds `retile` for distributed arrays in 4 tiling types: `sym`, `row`, ` column` and `user`.
In any of the `sym`, `row`, and ` column` tilings, if an intersection is given, retile will produce tiles that have overlapped parts (with the length of the given intersection on that dimension).
`user` tiling type uses the `new_tiling` argument which specifies the spans for each dimension.
A change in the number of tiles is not possible in this PR.

