### PR TITLE
Printing out seed in case of error in remote_add test

### DIFF
--- a/tests/unit/distributed/remote_add.cpp
+++ b/tests/unit/distributed/remote_add.cpp
@@ -7,6 +7,7 @@
 #include <phylanx/execution_tree/primitives/generic_function.hpp>
 #include <phylanx/phylanx.hpp>
 #include <phylanx/plugins/plugin_factory.hpp>
+#include <phylanx/util/random.hpp>
 
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/iostreams.hpp>
@@ -14,6 +15,7 @@
 #include <hpx/testing.hpp>
 
 #include <cstdint>
+#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -49,6 +51,8 @@ phylanx::execution_tree::compiler::function compile_and_run(
 
 void test_remote_add(hpx::id_type const& here, hpx::id_type const& there)
 {
+    std::uint32_t seed = phylanx::util::get_seed();
+
     // generate two random matrices
     auto load_data = compile_and_run(load_data_str, here);
     auto m1 = load_data(std::int64_t(4), std::int64_t(4));
@@ -81,6 +85,7 @@ void test_remote_add(hpx::id_type const& here, hpx::id_type const& there)
     auto result = columnwise_merge(primitive_argument_type{
         primitive_arguments_type{result1.get(), result2.get()}});
 
+    std::cout << "using seed: " << seed << "\n";
     HPX_TEST_EQ(expected, result);
 }
 


### PR DESCRIPTION
For some seeds, `remote_add_test` has failed: [1](https://circleci.com/gh/STEllAR-GROUP/phylanx/36175) and [2](https://circleci.com/gh/STEllAR-GROUP/phylanx/36376)
This PR adds printing the seed to the test to investigate the problem in case it happens again.