### PR TITLE
Making sure all_of() always returns boolean values

### DIFF
--- a/phylanx/ast/node.hpp
+++ b/phylanx/ast/node.hpp
@@ -253,6 +253,7 @@ namespace phylanx { namespace ast
           , phylanx::util::recursive_wrapper<expression>
           , phylanx::util::recursive_wrapper<function_call>
           , phylanx::util::recursive_wrapper<std::vector<ast::expression>>
+          , phylanx::ir::node_data<std::uint8_t>
         >;
 
     struct primary_expr : expr_node_type, tagged
@@ -828,6 +829,7 @@ namespace phylanx { namespace ast
           , phylanx::ir::node_data<double>
           , phylanx::util::recursive_wrapper<std::vector<literal_argument_type>>
           , phylanx::ir::node_data<std::int64_t>
+          , phylanx::ir::node_data<std::uint8_t>
         >;
 
     struct literal_argument_type : literal_value_type

--- a/phylanx/ast/parser/expression.hpp
+++ b/phylanx/ast/parser/expression.hpp
@@ -54,6 +54,10 @@ namespace phylanx { namespace ast { namespace parser
             std::vector<std::vector<std::vector<std::vector<std::int64_t>>>>(),
             skipper<Iterator>>
             int64_quatern;
+        qi::rule<Iterator,
+            std::vector<std::vector<std::vector<std::vector<std::uint8_t>>>>(),
+            skipper<Iterator>>
+            bool_quatern;
 
         qi::rule<Iterator, std::vector<std::vector<std::vector<double>>>(),
             skipper<Iterator>>
@@ -61,6 +65,9 @@ namespace phylanx { namespace ast { namespace parser
         qi::rule<Iterator, std::vector<std::vector<std::vector<std::int64_t>>>(),
             skipper<Iterator>>
             int64_tensor;
+        qi::rule<Iterator, std::vector<std::vector<std::vector<std::uint8_t>>>(),
+            skipper<Iterator>>
+            bool_tensor;
 
         qi::rule<Iterator, std::vector<std::vector<double>>(),
             skipper<Iterator>>
@@ -68,11 +75,16 @@ namespace phylanx { namespace ast { namespace parser
         qi::rule<Iterator, std::vector<std::vector<std::int64_t>>(),
             skipper<Iterator>>
             int64_matrix;
+        qi::rule<Iterator, std::vector<std::vector<std::uint8_t>>(),
+            skipper<Iterator>>
+            bool_matrix;
 
         qi::rule<Iterator, std::vector<double>(), skipper<Iterator>>
             double_vector;
         qi::rule<Iterator, std::vector<std::int64_t>(), skipper<Iterator>>
             int64_vector;
+        qi::rule<Iterator, std::vector<std::uint8_t>(), skipper<Iterator>>
+            bool_vector;
 
         qi::rule<Iterator, ast::function_call(), skipper<Iterator>>
             function_call;

--- a/phylanx/ast/parser/expression_def.hpp
+++ b/phylanx/ast/parser/expression_def.hpp
@@ -122,6 +122,10 @@ namespace phylanx { namespace ast { namespace parser
             |   bool_
             |   long_long
             |   string
+            |   bool_quatern
+            |   bool_tensor
+            |   bool_matrix
+            |   bool_vector
             |   int64_quatern
             |   int64_tensor
             |   int64_matrix
@@ -133,18 +137,19 @@ namespace phylanx { namespace ast { namespace parser
             |   '(' > expr > ')'
             ;
 
+        bool_quatern %= '[' >> (bool_tensor % ',') >> ']';
+        bool_tensor  %= '[' >> (bool_matrix % ',') >> ']';
+        bool_matrix %= '[' >> (bool_vector % ',') >> ']';
+        bool_vector %= '[' >> -(bool_ % ',') >> ']';
+
         int64_quatern %= '[' >> (int64_tensor % ',') >> ']';
         int64_tensor  %= '[' >> (int64_matrix % ',') >> ']';
-
         int64_matrix %= '[' >> (int64_vector % ',') >> ']';
-
         int64_vector %= '[' >> -(long_long % ',') >> ']';
 
         double_quatern %= '[' >> (double_tensor % ',') > ']';
         double_tensor  %= '[' >> (double_matrix % ',') > ']';
-
         double_matrix %= '[' >> (double_vector % ',') > ']';
-
         double_vector %= '[' > -(double_ % ',') > ']';
 
         function_call %=
@@ -192,8 +197,12 @@ namespace phylanx { namespace ast { namespace parser
             (unary_expr)
             (primary_expr)
             (list)
+            (int64_quatern)
+            (int64_tensor)
             (int64_matrix)
             (int64_vector)
+            (double_quatern)
+            (double_tensor)
             (double_matrix)
             (double_vector)
             (function_call)

--- a/phylanx/plugins/statistics/statistics_base_impl.hpp
+++ b/phylanx/plugins/statistics/statistics_base_impl.hpp
@@ -65,9 +65,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
-        return primitive_argument_type{
-            op(extract_scalar_data<T>(std::move(arg), name_, codename_),
-                initial_value)};
+        using result_type = typename Op<T>::result_type;
+
+        return primitive_argument_type{op(
+            extract_scalar_data<result_type>(std::move(arg), name_, codename_),
+            initial_value)};
     }
 
     template <template <class T> class Op, typename Derived>
@@ -85,7 +87,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "to be either 0 or -1 for vectors."));
         }
 
-
         Op<T> op{name_, codename_};
 
         Init initial_value = Op<T>::initial();
@@ -99,7 +100,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (keepdims)
         {
-            return primitive_argument_type{blaze::DynamicVector<T>(
+            using result_type = typename Op<T>::result_type;
+
+            return primitive_argument_type{blaze::DynamicVector<result_type>(
                 1, op.finalize(result, v.size()))};
         }
 
@@ -133,7 +136,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (keepdims)
         {
-            return primitive_argument_type{blaze::DynamicMatrix<T>(
+            using result_type = typename Op<T>::result_type;
+
+            return primitive_argument_type{blaze::DynamicMatrix<result_type>(
                 1, 1, op.finalize(result, size))};
         }
 
@@ -154,9 +159,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicMatrix<T> result(1, m.columns());
+            blaze::DynamicMatrix<result_type> result(1, m.columns());
             for (std::size_t i = 0; i != m.columns(); ++i)
             {
                 Op<T> op{name_, codename_};
@@ -167,7 +174,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(m.columns());
+        blaze::DynamicVector<result_type> result(m.columns());
         for (std::size_t i = 0; i != m.columns(); ++i)
         {
             Op<T> op{name_, codename_};
@@ -192,9 +199,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicMatrix<T> result(m.rows(), 1);
+            blaze::DynamicMatrix<result_type> result(m.rows(), 1);
             for (std::size_t i = 0; i != m.rows(); ++i)
             {
                 Op<T> op{name_, codename_};
@@ -205,7 +214,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(m.rows());
+        blaze::DynamicVector<result_type> result(m.rows());
         for (std::size_t i = 0; i != m.rows(); ++i)
         {
             Op<T> op{name_, codename_};
@@ -277,7 +286,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (keepdims)
         {
-            return primitive_argument_type{blaze::DynamicTensor<T>(
+            using result_type = typename Op<T>::result_type;
+
+            return primitive_argument_type{blaze::DynamicTensor<result_type>(
                 1, 1, 1, op.finalize(result, size))};
         }
 
@@ -298,9 +309,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicTensor<T> result(1, t.rows(), t.columns());
+            blaze::DynamicTensor<result_type> result(1, t.rows(), t.columns());
             for (std::size_t i = 0; i != t.rows(); ++i)
             {
                 auto slice = blaze::rowslice(t, i);
@@ -316,7 +329,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(t.rows(), t.columns());
+        blaze::DynamicMatrix<result_type> result(t.rows(), t.columns());
         for (std::size_t i = 0; i != t.rows(); ++i)
         {
             auto slice = blaze::rowslice(t, i);
@@ -345,9 +358,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicTensor<T> result(t.pages(), 1, t.columns());
+            blaze::DynamicTensor<result_type> result(t.pages(), 1, t.columns());
             for (std::size_t k = 0; k != t.pages(); ++k)
             {
                 auto slice = blaze::pageslice(t, k);
@@ -363,7 +378,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(t.pages(), t.columns());
+        blaze::DynamicMatrix<result_type> result(t.pages(), t.columns());
         for (std::size_t k = 0; k != t.pages(); ++k)
         {
             auto slice = blaze::pageslice(t, k);
@@ -392,9 +407,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicTensor<T> result(t.pages(), t.rows(), 1);
+            blaze::DynamicTensor<result_type> result(t.pages(), t.rows(), 1);
             for (std::size_t k = 0; k != t.pages(); ++k)
             {
                 auto slice = blaze::pageslice(t, k);
@@ -410,7 +427,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(t.pages(), t.rows());
+        blaze::DynamicMatrix<result_type> result(t.pages(), t.rows());
         for (std::size_t k = 0; k != t.pages(); ++k)
         {
             auto slice = blaze::pageslice(t, k);
@@ -473,9 +490,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicTensor<T> result(1, 1, t.columns());
+            blaze::DynamicTensor<result_type> result(1, 1, t.columns());
             for (std::size_t k = 0; k != t.columns(); ++k)
             {
                 Op<T> op{name_, codename_};
@@ -487,7 +506,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(t.columns());
+        blaze::DynamicVector<result_type> result(t.columns());
         for (std::size_t k = 0; k != t.columns(); ++k)
         {
             Op<T> op{name_, codename_};
@@ -512,9 +531,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicTensor<T> result(1, t.rows(), 1);
+            blaze::DynamicTensor<result_type> result(1, t.rows(), 1);
             for (std::size_t k = 0; k != t.rows(); ++k)
             {
                 Op<T> op{name_, codename_};
@@ -526,7 +547,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(t.rows());
+        blaze::DynamicVector<result_type> result(t.rows());
         for (std::size_t k = 0; k != t.rows(); ++k)
         {
             Op<T> op{name_, codename_};
@@ -551,9 +572,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicTensor<T> result(t.pages(), 1, 1);
+            blaze::DynamicTensor<result_type> result(t.pages(), 1, 1);
             for (std::size_t k = 0; k != t.pages(); ++k)
             {
                 Op<T> op{name_, codename_};
@@ -565,7 +588,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(t.pages());
+        blaze::DynamicVector<result_type> result(t.pages());
         for (std::size_t k = 0; k != t.pages(); ++k)
         {
             Op<T> op{name_, codename_};
@@ -582,12 +605,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         arg_type<T>&& arg, std::int64_t axis0, std::int64_t axis1,
         bool keepdims, primitive_argument_type&& initial) const
     {
-        using initial_type = typename Op<T>::result_type;
+        using result_type = typename Op<T>::result_type;
 
-        hpx::util::optional<initial_type> initial_value;
+        hpx::util::optional<result_type> initial_value;
         if (valid(initial))
         {
-            initial_value = extract_scalar_data<initial_type>(
+            initial_value = extract_scalar_data<result_type>(
                 std::move(initial), name_, codename_);
         }
 
@@ -669,9 +692,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(1, 1, q.rows(), q.columns());
+            blaze::DynamicArray<4UL, result_type> result(
+                1, 1, q.rows(), q.columns());
             for (std::size_t l = 0; l != q.rows(); ++l)
             {
                 auto tensor =
@@ -688,7 +714,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(q.rows(), q.columns());
+        blaze::DynamicMatrix<result_type> result(q.rows(), q.columns());
         for (std::size_t l = 0; l != q.rows(); ++l)
         {
             auto tensor = blaze::quatslice(blaze::trans(q, {2, 0, 1, 3}), l);
@@ -718,9 +744,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(1, q.pages(), 1, q.columns());
+            blaze::DynamicArray<4UL, result_type> result(
+                1, q.pages(), 1, q.columns());
             for (std::size_t l = 0; l != q.pages(); ++l)
             {
                 auto tensor =
@@ -737,7 +766,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(q.pages(), q.columns());
+        blaze::DynamicMatrix<result_type> result(q.pages(), q.columns());
         for (std::size_t l = 0; l != q.pages(); ++l)
         {
             auto tensor = blaze::quatslice(blaze::trans(q, {1, 0, 2, 3}), l);
@@ -767,9 +796,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(1, q.pages(), q.rows(), 1);
+            blaze::DynamicArray<4UL, result_type> result(
+                1, q.pages(), q.rows(), 1);
             for (std::size_t l = 0; l != q.pages(); ++l)
             {
                 auto tensor =
@@ -786,7 +818,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(q.pages(), q.rows());
+        blaze::DynamicMatrix<result_type> result(q.pages(), q.rows());
         for (std::size_t l = 0; l != q.pages(); ++l)
         {
             auto tensor = blaze::quatslice(blaze::trans(q, {1, 0, 2, 3}), l);
@@ -816,9 +848,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(q.quats(), 1, 1, q.columns());
+            blaze::DynamicArray<4UL, result_type> result(
+                q.quats(), 1, 1, q.columns());
             for (std::size_t l = 0; l != q.quats(); ++l)
             {
                 auto tensor = blaze::quatslice(q, l);
@@ -834,7 +869,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(q.quats(), q.columns());
+        blaze::DynamicMatrix<result_type> result(q.quats(), q.columns());
         for (std::size_t l = 0; l != q.quats(); ++l)
         {
             auto tensor = blaze::quatslice(q, l);
@@ -864,9 +899,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(q.quats(), 1, q.rows(), 1);
+            blaze::DynamicArray<4UL, result_type> result(
+                q.quats(), 1, q.rows(), 1);
             for (std::size_t l = 0; l != q.quats(); ++l)
             {
                 auto tensor = blaze::quatslice(q, l);
@@ -882,7 +920,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(q.quats(), q.rows());
+        blaze::DynamicMatrix<result_type> result(q.quats(), q.rows());
         for (std::size_t l = 0; l != q.quats(); ++l)
         {
             auto tensor = blaze::quatslice(q, l);
@@ -912,9 +950,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(q.quats(), q.pages(), 1, 1);
+            blaze::DynamicArray<4UL, result_type> result(
+                q.quats(), q.pages(), 1, 1);
             for (std::size_t l = 0; l != q.quats(); ++l)
             {
                 auto tensor = blaze::quatslice(q, l);
@@ -930,7 +971,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicMatrix<T> result(q.quats(), q.pages());
+        blaze::DynamicMatrix<result_type> result(q.quats(), q.pages());
         for (std::size_t l = 0; l != q.quats(); ++l)
         {
             auto tensor = blaze::quatslice(q, l);
@@ -952,12 +993,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         arg_type<T>&& arg, std::int64_t axis0, std::int64_t axis1,
         bool keepdims, primitive_argument_type&& initial) const
     {
-        using initial_type = typename Op<T>::result_type;
+        using result_type = typename Op<T>::result_type;
 
-        hpx::util::optional<initial_type> initial_value;
+        hpx::util::optional<result_type> initial_value;
         if (valid(initial))
         {
-            initial_value = extract_scalar_data<initial_type>(
+            initial_value = extract_scalar_data<result_type>(
                 std::move(initial), name_, codename_);
         }
 
@@ -1056,9 +1097,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(1, 1, 1, q.columns());
+            blaze::DynamicArray<4UL, result_type> result(1, 1, 1, q.columns());
             for (std::size_t l = 0; l != q.columns(); ++l)
             {
                 Op<T> op{ name_, codename_ };
@@ -1071,7 +1114,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(q.columns());
+        blaze::DynamicVector<result_type> result(q.columns());
         for (std::size_t l = 0; l != q.columns(); ++l)
         {
             Op<T> op{name_, codename_};
@@ -1096,9 +1139,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(1, 1, q.rows(), 1);
+            blaze::DynamicArray<4UL, result_type> result(1, 1, q.rows(), 1);
             for (std::size_t l = 0; l != q.rows(); ++l)
             {
                 Op<T> op{ name_, codename_ };
@@ -1111,7 +1156,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(q.rows());
+        blaze::DynamicVector<result_type> result(q.rows());
         for (std::size_t l = 0; l != q.rows(); ++l)
         {
             Op<T> op{name_, codename_};
@@ -1136,9 +1181,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(1, q.pages(), 1, 1);
+            blaze::DynamicArray<4UL, result_type> result(1, q.pages(), 1, 1);
             for (std::size_t l = 0; l != q.pages(); ++l)
             {
                 Op<T> op{ name_, codename_ };
@@ -1151,7 +1198,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(q.pages());
+        blaze::DynamicVector<result_type> result(q.pages());
         for (std::size_t l = 0; l != q.pages(); ++l)
         {
             Op<T> op{name_, codename_};
@@ -1176,9 +1223,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(q.quats(), 1, 1, 1);
+            blaze::DynamicArray<4UL, result_type> result(q.quats(), 1, 1, 1);
             for (std::size_t l = 0; l != q.quats(); ++l)
             {
                 Op<T> op{ name_, codename_ };
@@ -1190,7 +1239,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicVector<T> result(q.quats());
+        blaze::DynamicVector<result_type> result(q.quats());
         for (std::size_t l = 0; l != q.quats(); ++l)
         {
             Op<T> op{name_, codename_};
@@ -1207,12 +1256,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::int64_t axis2, bool keepdims,
         primitive_argument_type&& initial) const
     {
-        using initial_type = typename Op<T>::result_type;
+        using result_type = typename Op<T>::result_type;
 
-        hpx::util::optional<initial_type> initial_value;
+        hpx::util::optional<result_type> initial_value;
         if (valid(initial))
         {
-            initial_value = extract_scalar_data<initial_type>(
+            initial_value = extract_scalar_data<result_type>(
                 std::move(initial), name_, codename_);
         }
 
@@ -1322,8 +1371,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (keepdims)
         {
+            using result_type = typename Op<T>::result_type;
+
             return primitive_argument_type{
-                blaze::DynamicArray<4UL, T>(blaze::init_from_value,
+                blaze::DynamicArray<4UL, result_type>(blaze::init_from_value,
                     op.finalize(result, size), 1, 1, 1, 1)};
         }
 
@@ -1344,9 +1395,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(
+            blaze::DynamicArray<4UL, result_type> result(
                 1, q.pages(), q.rows(), q.columns());
             for (std::size_t k = 0; k != q.pages(); ++k)
             {
@@ -1368,7 +1421,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicTensor<T> result(q.pages(), q.rows(), q.columns());
+        blaze::DynamicTensor<result_type> result(
+            q.pages(), q.rows(), q.columns());
         for (std::size_t k = 0; k != q.pages(); ++k)
         {
             auto tensor = blaze::quatslice(blaze::trans(q, {1, 0, 2, 3}), k);
@@ -1402,9 +1456,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(
+            blaze::DynamicArray<4UL, result_type> result(
                 q.quats(), 1, q.rows(), q.columns());
             for (std::size_t k = 0; k != q.quats(); ++k)
             {
@@ -1425,7 +1481,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicTensor<T> result(q.quats(), q.rows(), q.columns());
+        blaze::DynamicTensor<result_type> result(
+            q.quats(), q.rows(), q.columns());
         for (std::size_t k = 0; k != q.quats(); ++k)
         {
             auto tensor = blaze::quatslice(q, k);
@@ -1459,9 +1516,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(
+            blaze::DynamicArray<4UL, result_type> result(
                 q.quats(), q.pages(), 1, q.columns());
             for (std::size_t k = 0; k != q.quats(); ++k)
             {
@@ -1482,7 +1541,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicTensor<T> result(q.quats(), q.pages(), q.columns());
+        blaze::DynamicTensor<result_type> result(
+            q.quats(), q.pages(), q.columns());
         for (std::size_t k = 0; k != q.quats(); ++k)
         {
             auto tensor = blaze::quatslice(q, k);
@@ -1516,9 +1576,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             initial_value = *initial;
         }
 
+        using result_type = typename Op<T>::result_type;
+
         if (keepdims)
         {
-            blaze::DynamicArray<4UL, T> result(
+            blaze::DynamicArray<4UL, result_type> result(
                 q.quats(), q.pages(), q.rows(), 1);
             for (std::size_t k = 0; k != q.quats(); ++k)
             {
@@ -1539,7 +1601,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
             return primitive_argument_type{std::move(result)};
         }
 
-        blaze::DynamicTensor<T> result(q.quats(), q.pages(), q.rows());
+        blaze::DynamicTensor<result_type> result(
+            q.quats(), q.pages(), q.rows());
         for (std::size_t k = 0; k != q.quats(); ++k)
         {
             auto tensor = blaze::quatslice(q, k);
@@ -1603,12 +1666,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         arg_type<T>&& arg, hpx::util::optional<std::int64_t> const& axis,
         bool keepdims, primitive_argument_type&& initial) const
     {
-        using initial_type = typename Op<T>::result_type;
+        using result_type = typename Op<T>::result_type;
 
-        hpx::util::optional<initial_type> initial_value;
+        hpx::util::optional<result_type> initial_value;
         if (valid(initial))
         {
-            initial_value = extract_scalar_data<initial_type>(
+            initial_value = extract_scalar_data<result_type>(
                 std::move(initial), name_, codename_);
         }
 
@@ -1687,12 +1750,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
         arg_type<T>&& arg, bool keepdims,
         primitive_argument_type&& initial) const
     {
-        using initial_type = typename Op<T>::result_type;
+        using result_type = typename Op<T>::result_type;
 
-        hpx::util::optional<initial_type> initial_value;
+        hpx::util::optional<result_type> initial_value;
         if (valid(initial))
         {
-            initial_value = extract_scalar_data<initial_type>(
+            initial_value = extract_scalar_data<result_type>(
                 std::move(initial), name_, codename_);
         }
 

--- a/src/ast/detail/is_literal_value.cpp
+++ b/src/ast/detail/is_literal_value.cpp
@@ -31,7 +31,8 @@ namespace phylanx { namespace ast { namespace detail
         case 1: HPX_FALLTHROUGH;    // bool
         case 2: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
         case 4: HPX_FALLTHROUGH;    // std::string
-        case 5:                     // phylanx::ir::node_data<std::int64_t>
+        case 5: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::int64_t>
+        case 9:                     // phylanx::ir::node_data<std::uint8_t>
             return true;
 
         // phylanx::util::recursive_wrapper<expression>
@@ -83,6 +84,9 @@ namespace phylanx { namespace ast { namespace detail
         case 5:     // phylanx::ir::node_data<std::int64_t>
             return util::get<5>(pe.get());
 
+        case 9:     // phylanx::ir::node_data<std::uint8_t>
+            return util::get<9>(pe.get());
+
         // phylanx::util::recursive_wrapper<expression>
         case 6:
             return literal_value(util::get<6>(pe.get()).get());
@@ -122,6 +126,9 @@ namespace phylanx { namespace ast { namespace detail
 
         case 6:     // phylanx::ir::node_data<std::int64_t>
             return ir::node_data<double>{util::get<6>(val)};
+
+        case 7:     // phylanx::ir::node_data<std::uint8_t>
+            return ir::node_data<double>{util::get<7>(val)};
 
         case 3: HPX_FALLTHROUGH;    // std::string
         // phylanx::util::recursive_wrapper<std::vector<literal_argument_type>>

--- a/src/ast/generate_ast.cpp
+++ b/src/ast/generate_ast.cpp
@@ -148,6 +148,7 @@ namespace phylanx { namespace ast
             case 2: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
             case 4: HPX_FALLTHROUGH;    // std::string
             case 5: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::int64_t>
+            case 9: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
             default:
                 break;
             }

--- a/src/ast/transform_ast.cpp
+++ b/src/ast/transform_ast.cpp
@@ -128,6 +128,7 @@ namespace phylanx { namespace ast
             case 2: HPX_FALLTHROUGH;    // phylanx::ir::node_data<double>
             case 4: HPX_FALLTHROUGH;    // std::string
             case 5: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::int64_t>
+            case 9: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
             default:
                 return pe;
             }
@@ -269,6 +270,7 @@ namespace phylanx { namespace ast
             case 3: HPX_FALLTHROUGH;    // identifier
             case 4: HPX_FALLTHROUGH;    // std::string
             case 5: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::int64_t>
+            case 9: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
             default:
                 return pe;
             }
@@ -407,6 +409,7 @@ namespace phylanx { namespace ast
             case 3: HPX_FALLTHROUGH;    // identifier
             case 4: HPX_FALLTHROUGH;    // std::string
             case 5: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::int64_t>
+            case 9: HPX_FALLTHROUGH;    // phylanx::ir::node_data<std::uint8_t>
             default:
                 return pe;
             }

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -4025,6 +4025,9 @@ namespace phylanx { namespace execution_tree
         case 6:
             return primitive_argument_type{util::get<6>(std::move(val))};
 
+        case 7:
+            return primitive_argument_type{util::get<7>(std::move(val))};
+
         default:
             break;
         }
@@ -4051,6 +4054,9 @@ namespace phylanx { namespace execution_tree
 
         case 6:
             return ir::node_data<double>{util::get<6>(std::move(val))};
+
+        case 7:
+            return ir::node_data<double>{util::get<7>(std::move(val))};
 
         case 0: HPX_FALLTHROUGH;    // ast::nil
         case 3: HPX_FALLTHROUGH;
@@ -4079,6 +4085,7 @@ namespace phylanx { namespace execution_tree
         // phylanx::util::recursive_wrapper<std::vector<literal_argument_type>>
         case 5: HPX_FALLTHROUGH;
         case 6: HPX_FALLTHROUGH;
+        case 7: HPX_FALLTHROUGH;
         default:
             break;
         }
@@ -4104,6 +4111,9 @@ namespace phylanx { namespace execution_tree
 
         case 6:
             return util::get<6>(std::move(val));
+
+        case 7:
+            return ir::node_data<std::int64_t>{util::get<7>(std::move(val))};
 
         case 0: HPX_FALLTHROUGH;    // ast::nil
         case 3: HPX_FALLTHROUGH;
@@ -4138,6 +4148,9 @@ namespace phylanx { namespace execution_tree
 
         case 6:
             return ir::node_data<std::uint8_t>{util::get<6>(std::move(val))};
+
+        case 7:
+            return util::get<7>(std::move(val));
 
         case 0: HPX_FALLTHROUGH;    // ast::nil
         case 3: HPX_FALLTHROUGH;

--- a/src/ir/node_data.cpp
+++ b/src/ir/node_data.cpp
@@ -2918,19 +2918,18 @@ namespace phylanx { namespace ir
         {
             switch (nd.index())
             {
-            case node_data<std::uint8_t>::storage0d:
+            case node_data<std::uint8_t>::storage0d:          HPX_FALLTHROUGH;
             case node_data<std::uint8_t>::custom_storage0d:
-                out << std::boolalpha
-                    << std::to_string(bool{nd.scalar() != 0});
+                out << std::boolalpha << bool{nd.scalar() != 0};
                 break;
 
-            case node_data<std::uint8_t>::storage1d:
+            case node_data<std::uint8_t>::storage1d:          HPX_FALLTHROUGH;
             case node_data<std::uint8_t>::custom_storage1d:
                 out << std::boolalpha;
                 detail::print_vector<bool>(out, nd.vector(), nd.size());
                 break;
 
-            case node_data<std::uint8_t>::storage2d:
+            case node_data<std::uint8_t>::storage2d:          HPX_FALLTHROUGH;
             case node_data<std::uint8_t>::custom_storage2d:
                 {
                     auto m = nd.matrix();

--- a/src/plugins/matrixops/astype.cpp
+++ b/src/plugins/matrixops/astype.cpp
@@ -104,6 +104,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "arguments given by the operands array are valid"));
         }
 
+        auto op1 = value_operand(operands[0], args, name_, codename_, ctx);
+
         auto this_ = this->shared_from_this();
         return hpx::dataflow(hpx::launch::sync,
             hpx::util::unwrapping(
@@ -113,7 +115,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     return this_->astype_nd(std::move(op0), map_dtype(dtype_op));
                 }),
-            value_operand(operands[0], args, name_, codename_, std::move(ctx)),
+            std::move(op1),
             string_operand(
                 operands[1], args, name_, codename_, std::move(ctx)));
     }

--- a/src/plugins/matrixops/gauss_inverse.cpp
+++ b/src/plugins/matrixops/gauss_inverse.cpp
@@ -16,9 +16,6 @@
 #include <hpx/include/util.hpp>
 #include <hpx/lcos/future.hpp>
 
-#include <hpx/parallel/algorithms/for_each.hpp>
-#include <hpx/parallel/execution_policy.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <cstddef>

--- a/src/plugins/statistics/all_operation.cpp
+++ b/src/plugins/statistics/all_operation.cpp
@@ -35,32 +35,35 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::string const& codename)
             {}
 
-            static constexpr bool initial()
+            static constexpr std::uint8_t initial()
             {
-                return true;
+                return 1;
             }
 
             template <typename Scalar>
-            typename std::enable_if<traits::is_scalar<Scalar>::value, bool>::type
-            operator()(Scalar s, bool initial) const
+            typename std::enable_if<traits::is_scalar<Scalar>::value,
+                std::uint8_t>::type
+            operator()(Scalar s, std::uint8_t initial) const
             {
-                return s && initial;
+                return (s && initial) ? 1 : 0;
             }
 
             template <typename Vector>
-            typename std::enable_if<!traits::is_scalar<Vector>::value, T>::type
-            operator()(Vector& v, bool initial) const
+            typename std::enable_if<!traits::is_scalar<Vector>::value,
+                std::uint8_t>::type
+            operator()(Vector& v, std::uint8_t initial) const
             {
                 return initial && std::all_of(v.begin(), v.end(),
-                    [](T val) -> bool
+                    [](T val) -> std::uint8_t
                     {
-                        return val != 0;
+                        return (val != 0) ? 1 : 0;
                     });
             }
 
-            static constexpr bool finalize(bool value, std::size_t size)
+            static constexpr std::uint8_t finalize(
+                std::uint8_t value, std::size_t size)
             {
-                return value;
+                return value ? 1 : 0;
             }
         };
     }

--- a/tests/regressions/plugins/CMakeLists.txt
+++ b/tests/regressions/plugins/CMakeLists.txt
@@ -1,18 +1,16 @@
-# Copyright (c) 2017-2018 Hartmut Kaiser
+# Copyright (c) 2020 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(subdirs
-    ast
-    execution_tree
-    plugins
-    python
+    matrixops
    )
 
 foreach(subdir ${subdirs})
-  add_phylanx_pseudo_target(tests.regressions.${subdir}_dir)
+  add_phylanx_pseudo_target(tests.regressions.plugins_dir.${subdir}_dir)
   add_subdirectory(${subdir})
-  add_phylanx_pseudo_dependencies(tests.regressions tests.regressions.${subdir}_dir)
+  add_phylanx_pseudo_dependencies(tests.regressions.plugins_dir
+    tests.regressions.plugins_dir.${subdir}_dir)
 endforeach()
 

--- a/tests/regressions/plugins/matrixops/1157_astype_bool.cpp
+++ b/tests/regressions/plugins/matrixops/1157_astype_bool.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/testing.hpp>
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_operation(char const* code, char const* expectedstr)
+{
+    auto result = compile_and_run(code);
+    auto expected = compile_and_run(expectedstr);
+
+    HPX_TEST_EQ(result, expected);
+}
+
+int main(int argc, char* argv[])
+{
+    test_operation(R"(astype([1, 0, 1], "bool"))", "[true, false, true]");
+
+    test_operation(R"(block(
+            define(a, [1, 0, 1]),
+            astype(a, "bool")
+        ))",
+        "[true, false, true]");
+
+    return hpx::util::report_errors();
+}

--- a/tests/regressions/plugins/matrixops/1157_astype_bool_axis.cpp
+++ b/tests/regressions/plugins/matrixops/1157_astype_bool_axis.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_main.hpp>
+#include <hpx/testing.hpp>
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code = phylanx::execution_tree::compile(codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_operation(char const* code, char const* expectedstr)
+{
+    auto result = compile_and_run(code);
+    auto expected = compile_and_run(expectedstr);
+
+    HPX_TEST_EQ(result, expected);
+}
+
+int main(int argc, char* argv[])
+{
+    test_operation(R"(all([[1, 0, -1], [1, 2, 0]]))", "false");
+    test_operation(
+        R"(all([[1, 0, -1], [1, 2, 0]], 0))", "[true, false, false]");
+
+    return hpx::util::report_errors();
+}

--- a/tests/regressions/plugins/matrixops/CMakeLists.txt
+++ b/tests/regressions/plugins/matrixops/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2020 Hartmut Kaiser
+#
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests
+    1157_astype_bool
+    1157_astype_bool_axis
+   )
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add executable
+  add_phylanx_executable(${test}_test
+    SOURCES ${sources}
+    ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    FOLDER "Tests/Regression/Plugins/MatrixOps")
+
+  add_phylanx_regression_test("plugins.matrixops" ${test} ${${test}_PARAMETERS})
+
+  add_phylanx_pseudo_target(tests.regressions.plugins_dir.matrixops_dir.${test})
+  add_phylanx_pseudo_dependencies(tests.regressions.plugins_dir.matrixops_dir
+    tests.regressions.plugins_dir.matrixops_dir.${test})
+  add_phylanx_pseudo_dependencies(
+    tests.regressions.plugins_dir.matrixops_dir.${test}
+    ${test}_test_exe)
+
+endforeach()
+


### PR DESCRIPTION
- fixing astype() to properly support variables
- flyby: add support for constant boolean arrays to PhySL parser

Fixes: #1157