### PR TITLE
Second attempt at allowing raw physl code to be passed to a Python

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -460,7 +460,7 @@ class PhySL:
         self.__ast__ = None
         self.ir = None
         self.python_tree = tree
-        if 'doc_src' in kwargs and kwargs['doc_src'] == True:
+        if 'doc_src' in kwargs and kwargs['doc_src']:
             self.doc_src = func.__doc__
         else:
             self.doc_src = None

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -382,8 +382,9 @@ class PhySL:
                 self.ir = self._apply_rule(self.python_tree.body[0])
                 check_return(self.ir)
 
-                self.__src__ = self._generate_physl(self.ir)
-                if self.doc_src is not None:
+                if self.doc_src is None:
+                    self.__src__ = self._generate_physl(self.ir)
+                else:
                     self.__src__ = self.doc_src
                 self.__ast__ = phylanx.ast.generate_ast(self.__src__)
 

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -383,11 +383,16 @@ class PhySL:
                 check_return(self.ir)
 
                 self.__src__ = self._generate_physl(self.ir)
+                if self.doc_src is not None:
+                    self.__src__ = self.doc_src
                 self.__ast__ = phylanx.ast.generate_ast(self.__src__)
 
                 # now store the PhySL string and AST for this function
                 physl_db.insert(
                     self.wrapped_function.__name__, self.__src__, self.__ast__)
+
+            if self.doc_src is not None:
+                self.__src__ = self.doc_src
 
             physl_db.close()
 
@@ -398,6 +403,9 @@ class PhySL:
             check_return(self.ir)
             self.__src__ = self._generate_physl(self.ir)
             self.__ast__ = phylanx.ast.generate_ast(self.__src__)
+
+            if self.doc_src is not None:
+                self.__src__ = self.doc_src
 
             # close database, if needed
             if physl_db is not None:
@@ -451,6 +459,10 @@ class PhySL:
         self.__ast__ = None
         self.ir = None
         self.python_tree = tree
+        if 'doc_src' in kwargs and kwargs['doc_src'] == True:
+            self.doc_src = func.__doc__
+        else:
+            self.doc_src = None
 
         if self.kwargs.get('fglobals'):
             self.fglobals = self.kwargs['fglobals']

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -39,6 +39,7 @@ def Phylanx(__phylanx_arg=None, **kwargs):
                 'debug',
                 'target',
                 'compiler_state',
+                'doc_src',
                 'performance',
                 'localities'
             ]

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -112,7 +112,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         eval_context ctx) const
     {
         if ((ctx.mode_ & eval_dont_evaluate_partials) &&
-            primitive_->operands_.empty())
+            primitive_->no_operands())
         {
             // return a client referring to this component as the evaluation
             // result
@@ -127,7 +127,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type && param, eval_context ctx) const
     {
         if ((ctx.mode_ & eval_dont_evaluate_partials) &&
-            primitive_->operands_.empty())
+            primitive_->no_operands())
         {
             // return a client referring to this component as the evaluation
             // result

--- a/tests/regressions/python/1170_no_error.py
+++ b/tests/regressions/python/1170_no_error.py
@@ -1,0 +1,32 @@
+#  Copyright (c) 2020 Steven R. Brandt
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #1170: Error messages for bad PhySL code not shown
+
+from phylanx import Phylanx, PhylanxSession
+
+
+@Phylanx(doc_src=True)
+def foo():
+    """
+    define(foo, lambda(cout("Worked!"))
+    """
+    pass
+
+
+def main():
+    caught_exception = False
+    try:
+        foo()
+
+    except Exception as e:
+        caught_exception = True
+        assert(type(e) == RuntimeError and "Incomplete parse" in str(e))
+
+    assert(caught_exception)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -51,6 +51,7 @@ set(tests
     1054_variable_shape
     1056_client_base
     1104_no_arg_lambda
+    1170_no_error
     array_len_494
     array_shape_486
     array_subscript_403


### PR DESCRIPTION
This pull request allows users to create Python functions from raw PhySL code using the doc string as follows:
```
@Phylanx(doc_src=True)
def addme(a,b):
    """
    define(addme,a,b,a+b)
    """

print(addme(3,4))
```
By circumventing the Python to PhySL translation, this PR allows users to test new features more quickly and workaround bugs in the translator code.