### PR TITLE
Modifying shape and adding shape_d

### DIFF
--- a/phylanx/plugins/matrixops/extract_shape.hpp
+++ b/phylanx/plugins/matrixops/extract_shape.hpp
@@ -25,6 +25,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : public primitive_component_base
       , public std::enable_shared_from_this<extract_shape>
     {
+    public:
+        enum shape_mode
+        {
+            local_mode,
+            len_mode,
+            dist_mode    // shape_d
+        };
+
     protected:
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
@@ -60,7 +68,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type shape4d(
             primitive_argument_type&& arg, std::int64_t index) const;
 
-        bool len_mode_;
+    private:
+        shape_mode mode_;
     };
 
     inline primitive create_extract_shape(hpx::id_type const& locality,
@@ -69,6 +78,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         return create_primitive_component(
             locality, "shape", std::move(operands), name, codename);
+    }
+
+    inline primitive create_extract_dist_shape(hpx::id_type const& locality,
+        primitive_arguments_type&& operands,
+        std::string const& name = "", std::string const& codename = "")
+    {
+        return create_primitive_component(
+            locality, "shape_d", std::move(operands), name, codename);
     }
 }}}
 

--- a/src/plugins/matrixops/extract_shape.cpp
+++ b/src/plugins/matrixops/extract_shape.cpp
@@ -39,8 +39,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             Without the optional argument, it returns a list of integers
             corresponding to the size of each dimension of the array `a`. If the
-            optional `dim` argument is supplied, then the
-            size for that dimension is returned as an integer.)"},
+            optional `dim` argument is supplied, then the size for that
+            dimension is returned as an integer. If the supplied array is
+            distributed, the shape is calculated on the current locality.)"},
 
         match_pattern_type{"__len",
             std::vector<std::string>{"__len(_1)"},
@@ -53,15 +54,41 @@ namespace phylanx { namespace execution_tree { namespace primitives
             Returns:
 
             This returns the number of elements of the given array along its
-            outermost (leftmost) dimension.)"}
+            outermost (leftmost) dimension.)"},
+
+        match_pattern_type{"shape_d",
+            std::vector<std::string>{"shape_d(_1, _2)", "shape_d(_1)"},
+            &create_extract_shape, &create_primitive<extract_shape>, R"(
+            a, dim
+            Args:
+
+                a (object): a distributed array of arbitrary dimensions
+                dim (optional, int): the dimension to get the size of
+
+            Returns:
+
+            Without the optional argument, it returns a list of integers
+            corresponding to the size of each dimension of the array `a` on all
+            localities. If the optional `dim` argument is supplied, then the
+            size for that dimension of the whole array is returned as an
+            integer.)"}
     };
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        bool extract_shape_mode(std::string const& name)
+        extract_shape::shape_mode extract_shape_mode(std::string const& name)
         {
-            return name.find("__len") != std::string::npos;
+            extract_shape::shape_mode result = extract_shape::local_mode;
+            if (name.find("__len") != std::string::npos)
+            {
+                result = extract_shape::len_mode;
+            }
+            else if (name.find("shape_d") != std::string::npos)
+            {
+                result = extract_shape::dist_mode;
+            }
+            return result;
         }
     }
 
@@ -69,7 +96,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type && operands,
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
-      , len_mode_(detail::extract_shape_mode(name_))
+      , mode_(detail::extract_shape_mode(name_))
     {}
 
     ///////////////////////////////////////////////////////////////////////////
@@ -92,7 +119,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type&& arg) const
     {
         std::int64_t size = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -117,7 +144,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         std::int64_t size = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -137,7 +164,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // return a list of numbers representing the dimensions of the argument
         std::int64_t rows = 0;
         std::int64_t columns = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -170,7 +197,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             index += 2;
 
         std::int64_t size = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -192,7 +219,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::int64_t pages = 0;
         std::int64_t rows = 0;
         std::int64_t columns = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -227,7 +254,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             index += 3;
 
         std::int64_t size = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -250,7 +277,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::int64_t pages = 0;
         std::int64_t rows = 0;
         std::int64_t columns = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -288,7 +315,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             index += 4;
 
         std::int64_t size = 0;
-        if (arg.has_annotation())
+        if (mode_ == dist_mode)
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -307,7 +334,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
     {
-        if (operands.empty() || operands.size() > 2)
+        if (operands.empty() || ((operands.size() > 1 && mode_ == len_mode)) ||
+            (operands.size() > 2 && mode_ != len_mode))
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "extract_shape::eval",
@@ -336,33 +364,53 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 {
                     auto&& arg = farg.get();
 
-                    switch (extract_numeric_value_dimension(
-                        arg, this_->name_, this_->codename_))
+                    std::size_t numdims = extract_numeric_value_dimension(
+                        arg, this_->name_, this_->codename_);
+                    if (this_->mode_ == len_mode)
+                    {
+                        switch (numdims)
+                        {
+                        case 0:
+                            return this_->shape0d(std::move(arg), 0);
+
+                        case 1:
+                            return this_->shape1d(std::move(arg), 0);
+
+                        case 2:
+                            return this_->shape2d(std::move(arg), 0);
+
+                        case 3:
+                            return this_->shape3d(std::move(arg), 0);
+
+                        case 4:
+                            return this_->shape4d(std::move(arg), 0);
+
+                        default:
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "extract_shape::eval",
+                                this_->generate_error_message(
+                                    "first operand has unsupported "
+                                    "number of dimensions"));
+                        }
+                    }
+
+                    // local or distributed shape is asked, no dim
+                    switch (numdims)
                     {
                     case 0:
-                        return this_->len_mode_ ?
-                            this_->shape0d(std::move(arg), 0) :
-                            this_->shape0d(std::move(arg));
+                        return this_->shape0d(std::move(arg));
 
                     case 1:
-                        return this_->len_mode_ ?
-                            this_->shape1d(std::move(arg), 0) :
-                            this_->shape1d(std::move(arg));
+                        return this_->shape1d(std::move(arg));
 
                     case 2:
-                        return this_->len_mode_ ?
-                            this_->shape2d(std::move(arg), 0) :
-                            this_->shape2d(std::move(arg));
+                        return this_->shape2d(std::move(arg));
 
                     case 3:
-                        return this_->len_mode_ ?
-                            this_->shape3d(std::move(arg), 0) :
-                            this_->shape3d(std::move(arg));
+                        return this_->shape3d(std::move(arg));
 
                     case 4:
-                        return this_->len_mode_ ?
-                            this_->shape4d(std::move(arg), 0) :
-                            this_->shape4d(std::move(arg));
+                        return this_->shape4d(std::move(arg));
 
                     default:
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
@@ -376,6 +424,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     name_, codename_, std::move(ctx)));
         }
 
+        // cannot be on len_mode
+        // local or distributed shape is asked on a dimension
         return hpx::dataflow(hpx::launch::sync,
             [this_ = std::move(this_)](
                     hpx::future<primitive_argument_type>&& farg,

--- a/src/plugins/matrixops/extract_shape.cpp
+++ b/src/plugins/matrixops/extract_shape.cpp
@@ -91,7 +91,17 @@ namespace phylanx { namespace execution_tree { namespace primitives
     primitive_argument_type extract_shape::shape1d(
         primitive_argument_type&& arg) const
     {
-        std::int64_t size = extract_numeric_value_size(arg, name_, codename_);
+        std::int64_t size = 0;
+        if (arg.has_annotation())
+        {
+            localities_information localities =
+                extract_localities_information(arg, name_, codename_);
+            size = localities.size();
+        }
+        else
+        {
+            size = extract_numeric_value_size(arg, name_, codename_);
+        }
         primitive_arguments_type result{primitive_argument_type{size}};
         return primitive_argument_type{std::move(result)};
     }
@@ -115,7 +125,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
         else
         {
-            size = extract_numeric_value_size(arg,name_,codename_);
+            size = extract_numeric_value_size(arg, name_, codename_);
         }
         return primitive_argument_type{size};
     }

--- a/src/plugins/matrixops/extract_shape.cpp
+++ b/src/plugins/matrixops/extract_shape.cpp
@@ -119,7 +119,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type&& arg) const
     {
         std::int64_t size = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -144,7 +144,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         std::int64_t size = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -164,7 +164,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         // return a list of numbers representing the dimensions of the argument
         std::int64_t rows = 0;
         std::int64_t columns = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -197,7 +197,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             index += 2;
 
         std::int64_t size = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -219,7 +219,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::int64_t pages = 0;
         std::int64_t rows = 0;
         std::int64_t columns = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -254,7 +254,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             index += 3;
 
         std::int64_t size = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -277,7 +277,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::int64_t pages = 0;
         std::int64_t rows = 0;
         std::int64_t columns = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);
@@ -315,7 +315,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             index += 4;
 
         std::int64_t size = 0;
-        if (mode_ == dist_mode)
+        if (mode_ == dist_mode && arg.has_annotation())
         {
             localities_information localities =
                 extract_localities_information(arg, name_, codename_);

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -54,6 +54,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(extract_shape_plugin,
     phylanx::execution_tree::primitives::extract_shape::match_data[0]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(extract_len_plugin,
     phylanx::execution_tree::primitives::extract_shape::match_data[1]);
+PHYLANX_REGISTER_PLUGIN_FACTORY(extract_dist_shape_plugin,
+    phylanx::execution_tree::primitives::extract_shape::match_data[2]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(eye_operation_plugin,
     phylanx::execution_tree::primitives::eye_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(flatten_operation_plugin,

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     dist_random_2_loc
     dist_random_4_loc
     dist_random_5_loc
+    dist_shape_2_loc
     retile_2_loc
     retile_3_loc
     retile_6_loc
@@ -37,6 +38,7 @@ set(dist_identity_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
+set(dist_shape_2_loc_PARAMETERS LOCALITIES 2)
 set(retile_2_loc_PARAMETERS LOCALITIES 2)
 set(retile_3_loc_PARAMETERS LOCALITIES 3)
 set(retile_6_loc_PARAMETERS LOCALITIES 6)

--- a/tests/unit/plugins/dist_matrixops/dist_shape_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_shape_2_loc.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_shape_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_shape_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_shape_d_operation("test_shape_2loc1d_0", R"(
+            shape(annotate_d([42.0, 13.0], "full_array_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2)))))
+        )", "list(5)");
+    }
+    else
+    {
+        test_shape_d_operation("test_shape_2loc1d_0", R"(
+            shape(annotate_d([33.0, 42.0, 43.0], "full_array_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 5)))))
+        )", "list(5)");
+    }
+}
+
+void test_shape_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_shape_d_operation("test_shape_2loc1d_1", R"(
+            shape(annotate_d([1, 2, 3], "array",
+                list("tile", list("rows", 2, 5))))
+        )", "list(5)");
+    }
+    else
+    {
+        test_shape_d_operation("test_shape_2loc1d_1", R"(
+            shape(annotate_d([1, 2], "array",
+                list("tile", list("rows", 0, 2))))
+        )", "list(5)");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_shape_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_shape_d_operation("test_shape_2loc2d_0", R"(
+            shape(annotate_d([[-1,-2,-3], [1, 2, 3]], "array",
+                list("tile", list("rows", 1, 3), list("columns", 0, 3))))
+        )", "list(3, 3)");
+    }
+    else
+    {
+        test_shape_d_operation("test_shape_2loc2d_0", R"(
+            shape(annotate_d([[11, 12, 33]], "array",
+                list("tile", list("rows", 0, 1), list("columns", 0, 3))))
+        )", "list(3, 3)");
+    }
+}
+
+void test_shape_2d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_shape_d_operation("test_shape_2loc2d_1", R"(
+            shape(annotate_d([[-1,-2], [-3, 1], [2, 3]], "array",
+                list("tile", list("rows", 0, 3), list("columns", 3, 5))))
+        )", "list(3, 5)");
+    }
+    else
+    {
+        test_shape_d_operation("test_shape_2loc2d_1", R"(
+            shape(annotate_d([[1, 2, 3], [4, 5, 6], [7, 8, 9]], "array",
+                list("tile", list("rows", 0, 3), list("columns", 0, 3))))
+        )", "list(3, 5)");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_shape_1d_0();
+    //test_shape_1d_1();
+
+    //test_shape_2d_0();
+    //test_shape_2d_1();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/dist_shape_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_shape_2_loc.cpp
@@ -40,12 +40,12 @@ void test_shape_d_operation(std::string const& name, std::string const& code,
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_shape_1d_0()
+void test_shape_d_1d_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_shape_d_operation("test_shape_2loc1d_0", R"(
-            shape(annotate_d([42.0, 13.0], "full_array_1",
+        test_shape_d_operation("test_shape_d_2loc1d_0", R"(
+            shape_d(annotate_d([42.0, 13.0], "full_array_1",
                 list("args",
                     list("locality", 0, 2),
                     list("tile", list("columns", 0, 2)))))
@@ -53,8 +53,8 @@ void test_shape_1d_0()
     }
     else
     {
-        test_shape_d_operation("test_shape_2loc1d_0", R"(
-            shape(annotate_d([33.0, 42.0, 43.0], "full_array_1",
+        test_shape_d_operation("test_shape_d_2loc1d_0", R"(
+            shape_d(annotate_d([33.0, 42.0, 43.0], "full_array_1",
                 list("args",
                     list("locality", 1, 2),
                     list("tile", list("columns", 2, 5)))))
@@ -62,56 +62,96 @@ void test_shape_1d_0()
     }
 }
 
-void test_shape_1d_1()
+void test_shape_1d_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_shape_d_operation("test_shape_2loc1d_1", R"(
-            shape(annotate_d([1, 2, 3], "array",
+        test_shape_d_operation("test_shape_2loc1d_0", R"(
+            shape(annotate_d([42.0, 13.0], "array_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2)))))
+        )", "list(2)");
+    }
+    else
+    {
+        test_shape_d_operation("test_shape_2loc1d_0", R"(
+            shape(annotate_d([33.0, 42.0, 43.0], "array_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 5)))))
+        )", "list(3)");
+    }
+}
+
+void test_shape_d_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_shape_d_operation("test_shape_d_2loc1d_1", R"(
+            shape_d(annotate_d([1, 2, 3], "array",
                 list("tile", list("rows", 2, 5))))
         )", "list(5)");
     }
     else
     {
-        test_shape_d_operation("test_shape_2loc1d_1", R"(
-            shape(annotate_d([1, 2], "array",
+        test_shape_d_operation("test_shape_d_2loc1d_1", R"(
+            shape_d(annotate_d([1, 2], "array",
                 list("tile", list("rows", 0, 2))))
         )", "list(5)");
     }
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-void test_shape_2d_0()
+void test_shape_d_2d_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_shape_d_operation("test_shape_2loc2d_0", R"(
-            shape(annotate_d([[-1,-2,-3], [1, 2, 3]], "array",
+        test_shape_d_operation("test_shape_d_2loc2d_0", R"(
+            shape_d(annotate_d([[-1,-2,-3], [1, 2, 3]], "array",
                 list("tile", list("rows", 1, 3), list("columns", 0, 3))))
         )", "list(3, 3)");
     }
     else
     {
-        test_shape_d_operation("test_shape_2loc2d_0", R"(
-            shape(annotate_d([[11, 12, 33]], "array",
+        test_shape_d_operation("test_shape_d_2loc2d_0", R"(
+            shape_d(annotate_d([[11, 12, 33]], "array",
                 list("tile", list("rows", 0, 1), list("columns", 0, 3))))
         )", "list(3, 3)");
     }
 }
 
-void test_shape_2d_1()
+void test_shape_2d_0()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_shape_d_operation("test_shape_2loc2d_1", R"(
-            shape(annotate_d([[-1,-2], [-3, 1], [2, 3]], "array",
+        test_shape_d_operation("test_shape_2loc2d_0", R"(
+            shape(annotate_d([[-1,-2,-3], [1, 2, 3]], "array2d_0",
+                list("tile", list("rows", 1, 3), list("columns", 0, 3))))
+        )", "list(2, 3)");
+    }
+    else
+    {
+        test_shape_d_operation("test_shape_2loc2d_0", R"(
+            shape(annotate_d([[11, 12, 33]], "array2d_0",
+                list("tile", list("rows", 0, 1), list("columns", 0, 3))))
+        )", "list(1, 3)");
+    }
+}
+
+void test_shape_d_2d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_shape_d_operation("test_shape_d_2loc2d_1", R"(
+            shape_d(annotate_d([[-1,-2], [-3, 1], [2, 3]], "array",
                 list("tile", list("rows", 0, 3), list("columns", 3, 5))))
         )", "list(3, 5)");
     }
     else
     {
-        test_shape_d_operation("test_shape_2loc2d_1", R"(
-            shape(annotate_d([[1, 2, 3], [4, 5, 6], [7, 8, 9]], "array",
+        test_shape_d_operation("test_shape_d_2loc2d_1", R"(
+            shape_d(annotate_d([[1, 2, 3], [4, 5, 6], [7, 8, 9]], "array",
                 list("tile", list("rows", 0, 3), list("columns", 0, 3))))
         )", "list(3, 5)");
     }
@@ -120,11 +160,13 @@ void test_shape_2d_1()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
+    test_shape_d_1d_0();
     test_shape_1d_0();
-    //test_shape_1d_1();
+    test_shape_d_1d_1();
 
-    //test_shape_2d_0();
-    //test_shape_2d_1();
+    test_shape_d_2d_0();
+    test_shape_2d_0();
+    test_shape_d_2d_1();
 
     hpx::finalize();
     return hpx::util::report_errors();


### PR DESCRIPTION
This PR modifies the `extract_shape` primitive to always return the local shape, whether it is given a local array or a distributed one.
It also adds `shape_d` to calculate the whole shape of the given distributed array.
Having the following:
```c++
constant_d(0.0, shape_d(x, 0))
```
we expect the overall shape of the array.