### PR TITLE
Making expand_dims aware of annotations

### DIFF
--- a/phylanx/plugins/matrixops/expand_dims.hpp
+++ b/phylanx/plugins/matrixops/expand_dims.hpp
@@ -1,6 +1,6 @@
 // Copyright (c) 2018 Parsa Amini
-// Copyright (c) 2018 Hartmut Kaiser
-// Copyright (c) 2018 Bita Hasheminezhad
+// Copyright (c) 2018-2020 Hartmut Kaiser
+// Copyright (c) 2018-2020 Bita Hasheminezhad
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -9,6 +9,7 @@
 #define PHYLANX_PRIMITIVES_ADD_DIM
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/localities_annotation.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
@@ -48,26 +49,30 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     private:
         template <typename T>
-        primitive_argument_type add_dim_0d(ir::node_data<T>&& arg) const;
+        primitive_argument_type expand_dims_0d(ir::node_data<T>&& arg) const;
+        primitive_argument_type expand_dims_0d(
+            primitive_arguments_type&& arg) const;
 
         template <typename T>
-        primitive_argument_type add_dim_1d(
+        primitive_argument_type expand_dims_1d(
             ir::node_data<T>&& arg, std::int64_t axis) const;
-
-        primitive_argument_type add_dim_0d(primitive_arguments_type&& arg) const;
-        primitive_argument_type add_dim_1d(primitive_arguments_type&& arg) const;
+        template <typename T>
+        primitive_argument_type expand_dims_1d(ir::node_data<T>&& arg,
+            std::int64_t axis, localities_information&& arr_localities) const;
+        primitive_argument_type expand_dims_1d(
+            primitive_arguments_type&& arg) const;
 
         template <typename T>
-        primitive_argument_type add_dim_2d(
+        primitive_argument_type expand_dims_2d(
             ir::node_data<T>&& arg, std::int64_t axis) const;
-
-        primitive_argument_type add_dim_2d(primitive_arguments_type&& arg) const;
+        primitive_argument_type expand_dims_2d(
+            primitive_arguments_type&& arg) const;
 
         template <typename T>
-        primitive_argument_type add_dim_3d(
+        primitive_argument_type expand_dims_3d(
             ir::node_data<T>&& arg, std::int64_t axis) const;
-
-        primitive_argument_type add_dim_3d(primitive_arguments_type&& arg) const;
+        primitive_argument_type expand_dims_3d(
+            primitive_arguments_type&& arg) const;
     };
 
     inline primitive create_expand_dims(hpx::id_type const& locality,

--- a/src/plugins/matrixops/expand_dims.cpp
+++ b/src/plugins/matrixops/expand_dims.cpp
@@ -80,6 +80,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "either 0 or -1 for scalars."));
         }
 
+        if (args[0].has_annotation())
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::primitives::expand_dims::expand_dims_"
+                "0d",
+                generate_error_message("distributed 0d arrays are not "
+                                       "supported by expand_dims primitive"));
+        }
 
         switch (extract_common_type(args[0]))
         {
@@ -466,6 +474,15 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 std::size_t a_dims = extract_numeric_value_dimension(
                     args[0], this_->name_, this_->codename_);
 
+                if (args[0].has_annotation() && a_dims > 1)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "phylanx::execution_tree::primitives::expand_dims::"
+                        "eval",
+                        this_->generate_error_message(
+                            "distributed arrays with more than two dimensions "
+                            "are not currently supported"));
+                }
                 switch (a_dims)
                 {
                 case 0:

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -11,6 +11,8 @@ set(tests
     dist_constant_4_loc
     dist_constant_6_loc
     dist_dot_operation_2_loc
+    dist_expand_dims_2_loc
+    dist_expand_dims_3_loc
     dist_identity_2_loc
     dist_identity_4_loc
     dist_identity_6_loc
@@ -31,6 +33,8 @@ set(dist_constant_3_loc_PARAMETERS LOCALITIES 3)
 set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
 set(dist_dot_operation_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_expand_dims_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_expand_dims_3_loc_PARAMETERS LOCALITIES 3)
 set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_identity_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_identity_6_loc_PARAMETERS LOCALITIES 6)

--- a/tests/unit/plugins/dist_matrixops/dist_expand_dims_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_expand_dims_2_loc.cpp
@@ -1,0 +1,186 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_expand_dims_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_expand_dims_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_0", R"(
+            expand_dims(
+                annotate_d([1, 2, 3, 4], "array_0",
+                list("tile", list("columns", 2, 6)))
+            , 0)
+        )", R"(
+            annotate_d([[1, 2, 3, 4]], "array_0_expanded/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 2, 6), list("rows", 0, 1))))
+        )");
+    }
+    else
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_0", R"(
+            expand_dims(
+                annotate_d([-1, 0], "array_0",
+                list("tile", list("columns", 0, 2)))
+            , 0)
+        )", R"(
+            annotate_d([[-1, 0]], "array_0_expanded/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 1))))
+        )");
+    }
+}
+
+void test_expand_dims_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_1", R"(
+            expand_dims(
+                annotate_d([1, 2, 3, 4], "array_1",
+                list("tile", list("rows", 3, 7)))
+            , -2)
+        )", R"(
+            annotate_d([[1, 2, 3, 4]], "array_1_expanded/1",
+                    list("tile", list("columns", 3, 7), list("rows", 0, 1)))
+        )");
+    }
+    else
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_1", R"(
+            expand_dims(
+                annotate_d([-2, -1, 0], "array_1",
+                list("tile", list("rows", 0, 3)))
+            , -2)
+        )", R"(
+            annotate_d([[-2, -1, 0]], "array_1_expanded/1",
+                    list("tile", list("columns", 0, 3), list("rows", 0, 1)))
+        )");
+    }
+}
+
+void test_expand_dims_1d_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_2", R"(
+            expand_dims(
+                annotate_d([1., 2., 3., 4.], "array_2",
+                list("tile", list("columns", 0, 4)))
+            , 1)
+        )", R"(
+            annotate_d([[1.], [2.], [3.], [4.]], "array_2_expanded/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 1), list("rows", 0, 4))))
+        )");
+    }
+    else
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_2", R"(
+            expand_dims(
+                annotate_d([5., 6.], "array_2",
+                list("tile", list("columns", 4, 6)))
+            , 1)
+        )", R"(
+            annotate_d([[5.], [6.]], "array_2_expanded/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 1), list("rows", 4, 6))))
+        )");
+    }
+}
+
+void test_expand_dims_1d_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_3", R"(
+            expand_dims(
+                annotate_d([1., 2., 3., 4.], "array_3",
+                list("tile", list("columns", 4, 8)))
+            , -1)
+        )", R"(
+            annotate_d([[1.], [2.], [3.], [4.]], "array_3_expanded/1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 1), list("rows", 4, 8))))
+        )");
+    }
+    else
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_3", R"(
+            expand_dims(
+                annotate_d([-3, -2, -1, 0.], "array_3",
+                list("tile", list("columns", 0, 4)))
+            , -1)
+        )", R"(
+            annotate_d([[-3.], [-2.], [-1.], [0.]], "array_3_expanded/1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 1), list("rows", 0, 4))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_expand_dims_1d_0();
+    test_expand_dims_1d_1();
+    test_expand_dims_1d_2();
+    test_expand_dims_1d_3();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/dist_expand_dims_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_expand_dims_2_loc.cpp
@@ -164,6 +164,26 @@ void test_expand_dims_1d_3()
     }
 }
 
+void test_expand_dims_1d_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_4", R"(
+            expand_dims([1., 2., 3., 4.], 1)
+        )", R"(
+            [[1.], [2.], [3.], [4.]]
+        )");
+    }
+    else
+    {
+        test_expand_dims_operation("test_expand_dims_2loc1d_4", R"(
+            expand_dims([5., 6.], 1)
+        )", R"(
+            [[5.], [6.]]
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -171,6 +191,7 @@ int hpx_main(int argc, char* argv[])
     test_expand_dims_1d_1();
     test_expand_dims_1d_2();
     test_expand_dims_1d_3();
+    test_expand_dims_1d_4();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/dist_expand_dims_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_expand_dims_3_loc.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_expand_dims_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_expand_dims_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_expand_dims_operation("test_expand_dims_3loc1d_0", R"(
+            expand_dims(
+                annotate_d([1, 2, 3, 4], "array_0",
+                list("tile", list("columns", 2, 6)))
+            , 0)
+        )", R"(
+            annotate_d([[1, 2, 3, 4]], "array_0_expanded/1",
+                    list("tile", list("columns", 2, 6), list("rows", 0, 1)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_expand_dims_operation("test_expand_dims_3loc1d_0", R"(
+            expand_dims(
+                annotate_d([-1, 0], "array_0",
+                list("tile", list("columns", 6, 8)))
+            , 0)
+        )", R"(
+            annotate_d([[-1, 0]], "array_0_expanded/1",
+                    list("tile", list("columns", 6, 8), list("rows", 0, 1)))
+        )");
+    }
+    else
+    {
+        test_expand_dims_operation("test_expand_dims_3loc1d_0", R"(
+            expand_dims(
+                annotate_d([5, 42], "array_0",
+                list("tile", list("columns", 0, 2)))
+            , 0)
+        )", R"(
+            annotate_d([[5, 42]], "array_0_expanded/1",
+                    list("tile", list("columns", 0, 2), list("rows", 0, 1)))
+        )");
+    }
+}
+
+void test_expand_dims_1d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_expand_dims_operation("test_expand_dims_3loc1d_1", R"(
+            expand_dims(
+                annotate_d([1, 2, 3, 4], "array_1",
+                list("tile", list("columns", 2, 6)))
+            , 1)
+        )", R"(
+            annotate_d([[1], [2], [3], [4]], "array_1_expanded/1",
+                list("tile", list("columns", 0, 1), list("rows", 2, 6)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_expand_dims_operation("test_expand_dims_3loc1d_1", R"(
+            expand_dims(
+                annotate_d([-1, 0], "array_1",
+                list("tile", list("columns", 6, 8)))
+            , 1)
+        )", R"(
+            annotate_d([[-1], [0]], "array_1_expanded/1",
+                list("tile", list("columns", 0, 1), list("rows", 6, 8)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_expand_dims_operation("test_expand_dims_3loc1d_1", R"(
+            expand_dims(
+                annotate_d([5, 42], "array_1",
+                list("tile", list("columns", 0, 2)))
+            , 1)
+        )", R"(
+            annotate_d([[5], [42]], "array_1_expanded/1",
+                list("tile", list("columns", 0, 1), list("rows", 0, 2)))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_expand_dims_1d_0();
+    test_expand_dims_1d_1();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+


### PR DESCRIPTION
This PR adds an expand_dims_1d function that can accept a distributed array.
Working towards #1162.