### PR TITLE
Adding 3D kmeans

### DIFF
--- a/examples/algorithms/kmeans/CMakeLists.txt
+++ b/examples/algorithms/kmeans/CMakeLists.txt
@@ -5,6 +5,7 @@
 
 set(example_programs
     kmeans
+    kmeans_fix_points_3d
     kmeans_fix_points
    )
 

--- a/examples/algorithms/kmeans/kmeans_fix_points.cpp
+++ b/examples/algorithms/kmeans/kmeans_fix_points.cpp
@@ -55,13 +55,13 @@ char const* const kmeans_code = R"(
             store(count, 0),
             for(define(i, 0), i < num_points, store(i, i + 1),block(
                 if(slice(closest, i) == k, block(
-                    store(slice(result, k, list(0, 2)),
+                    store(slice_row(result, k),
                         slice_row(result, k) + slice_row(points, i)),
                     store(count, count + 1)
                 ))
             )),
             if(count,
-                store(slice(result, k, list(0, 2)), slice_row(result, k)/count)
+                store(slice_row(result, k), slice_row(result, k)/count)
             ))
         ), result
     ))

--- a/examples/algorithms/kmeans/kmeans_fix_points_3d.cpp
+++ b/examples/algorithms/kmeans/kmeans_fix_points_3d.cpp
@@ -25,64 +25,40 @@
 
 ///////////////////////////////////////////////////////////////////////////////
 char const* const kmeans_code = R"(
-    define(closest_centroids, points, centroids,
-        block(
-            define(points_x,
-                expand_dims(slice_column(points, 0), -1)
-            ),
-            define(points_y,
-                expand_dims(slice_column(points, 1), -1)
-            ),
-            define(centroids_x,
-                slice_column(centroids, 0)
-            ),
-            define(centroids_y,
-                slice_column(centroids, 1)
-            ),
-            argmin(sqrt(
-                        square(points_x - centroids_x)
-                        + square(points_y - centroids_y)
-                ), 1
-            )
-        )
-    )
+    define(closest_centroids, points, centroids, block(
+        define(expanded_centroids,
+            reshape(centroids, list(shape(centroids, 0), 1, 2))
+        ),
+        define(distances,
+            sqrt(sum(square(points - expanded_centroids), 2))
+        ),
+        argmin(distances, 0)
+    ))
 
-    define(move_centroids, points, closest, centroids, num_points, num_centroids,
-        block(
-        define(result, constant(0.0, list(num_centroids, 2))),
-        define(count, 0),
-        for(define(k, 0), k < num_centroids, store(k, k + 1), block(
-            store(count, 0),
-            for(define(i, 0), i < num_points, store(i, i + 1),block(
-                if(slice(closest, i) == k, block(
-                    store(slice(result, k, list(0, 2)),
-                        slice_row(result, k) + slice_row(points, i)),
-                    store(count, count + 1)
-                ))
+    define(move_centroids, points, closest, centroids, block(
+        fmap(lambda(k, block(
+                    define(x, closest == k),
+                    define(count, sum(x * constant(1, shape(x, 0)))),
+                    define(sum_, sum(points * expand_dims(x, -1), 0)),
+                    sum_/count
             )),
-            if(count,
-                store(slice(result, k, list(0, 2)), slice_row(result, k)/count)
-            ))
-        ), result
+            range(shape(centroids, 0))
+        )
     ))
 
     define(kmeans, points, iterations, initial_centroids, enable_output,
         block(
             define(centroids, initial_centroids),
-            define(num_centroids, shape(centroids, 0)),
-            define(num_points, shape(points, 0)),
             for(define(i, 0), i < iterations, store(i, i + 1),
                 block(
                     if(enable_output, block(
                         cout("centroids in iteration ", i,": ", centroids)
                     )),
                     store(centroids,
-                          move_centroids(points,
-                                        closest_centroids(points,
-                                                         centroids),
-                                        centroids,
-                                        num_points,
-                                        num_centroids))
+                          apply(vstack,
+                                list(move_centroids(points,
+                                        closest_centroids(points, centroids),
+                                        centroids))))
                 )
             ), centroids
         )

--- a/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
@@ -696,14 +696,9 @@ namespace phylanx { namespace execution_tree
 
         auto row = blaze::row(
             m, detail::check_index(rows[0], m.rows(), name, codename));
-        if (!explicit_nil)
-        {
-            return f.vector(m, std::move(row));
-        }
 
-        typename ir::node_data<T>::storage2d_type result(1, m.columns());
-        blaze::row(result, 0) = row;
-        return f.matrix(m, std::move(result));
+        return f.vector(m, std::move(row));
+
     }
 
     template <typename T, typename Data, typename F>

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -1403,7 +1403,8 @@ namespace phylanx { namespace execution_tree { namespace compiler
                     }
 
                     // Handle slice(_1, __2)
-                    if (function_name == "slice")
+                    if (function_name == "slice" ||
+                        function_name == "slice_row")
                     {
                         placeholder_map_type placeholders;
                         if (ast::match_ast(expr, cit->second.pattern_ast_,

--- a/tests/unit/execution_tree/primitives/advanced_integer_slicing.cpp
+++ b/tests/unit/execution_tree/primitives/advanced_integer_slicing.cpp
@@ -227,11 +227,11 @@ void test_integer_slicing_2d_0d()
     test_integer_slicing("slice([[42], [43]], 0)", "[42]");
     test_integer_slicing("slice([[42, 43]], 0)", "[42, 43]");
 
-    test_integer_slicing("slice([[42], [43]], 0, nil)", "[[42]]");
-    test_integer_slicing("slice([[42, 43]], 0, nil)", "[[42, 43]]");
+    test_integer_slicing("slice([[42], [43]], 0, nil)", "[42]");
+    test_integer_slicing("slice([[42, 43]], 0, nil)", "[42, 43]");
 
-    test_integer_slicing("slice([[42], [43]], nil, 0)", "[[42]]");
-    test_integer_slicing("slice([[42, 43]], nil, 0)", "[[42, 43]]");
+    test_integer_slicing("slice([[42], [43]], nil, 0)", "[42]");
+    test_integer_slicing("slice([[42, 43]], nil, 0)", "[42, 43]");
 
     test_integer_slicing("slice([[42], [43]], 0, 0)", "42");
     test_integer_slicing("slice([[42, 43]], 0, 1)", "43");

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -10,7 +10,8 @@ set(tests
     dist_constant_3_loc
     dist_constant_4_loc
     dist_constant_6_loc
-    dist_dot_operation_2_loc    dist_expand_dims_2_loc
+    dist_dot_operation_2_loc
+    dist_expand_dims_2_loc
     dist_expand_dims_3_loc
     dist_generic_operation_2_loc
     dist_identity_2_loc
@@ -33,7 +34,8 @@ set(dist_constant_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_constant_3_loc_PARAMETERS LOCALITIES 3)
 set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
-set(dist_dot_operation_2_loc_PARAMETERS LOCALITIES 2)set(dist_expand_dims_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_dot_operation_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_expand_dims_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_expand_dims_3_loc_PARAMETERS LOCALITIES 3)
 set(dist_generic_operation_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -10,17 +10,17 @@ set(tests
     dist_constant_3_loc
     dist_constant_4_loc
     dist_constant_6_loc
-    dist_dot_operation_2_loc
-    dist_expand_dims_2_loc
+    dist_dot_operation_2_loc    dist_expand_dims_2_loc
     dist_expand_dims_3_loc
+    dist_generic_operation_2_loc
     dist_identity_2_loc
     dist_identity_4_loc
     dist_identity_6_loc
-    dist_transpose_operation
     dist_random_2_loc
     dist_random_4_loc
     dist_random_5_loc
     dist_shape_2_loc
+    dist_transpose_operation
     retile_2_loc
     retile_3_loc
     retile_6_loc
@@ -33,9 +33,9 @@ set(dist_constant_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_constant_3_loc_PARAMETERS LOCALITIES 3)
 set(dist_constant_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_constant_6_loc_PARAMETERS LOCALITIES 6)
-set(dist_dot_operation_2_loc_PARAMETERS LOCALITIES 2)
-set(dist_expand_dims_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_dot_operation_2_loc_PARAMETERS LOCALITIES 2)set(dist_expand_dims_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_expand_dims_3_loc_PARAMETERS LOCALITIES 3)
+set(dist_generic_operation_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_identity_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_identity_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_identity_6_loc_PARAMETERS LOCALITIES 6)

--- a/tests/unit/plugins/dist_matrixops/dist_generic_operation_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_generic_operation_2_loc.cpp
@@ -48,7 +48,7 @@ void test_sqrt_1d_0()
             sqrt(annotate_d([0, 1764, 1, 169], "array_1",
                 list("tile", list("columns", 2, 6))))
         )", R"(
-            annotate_d([0., 42., 1., 13.], "array_1/0",
+            annotate_d([0., 42., 1., 13.], "array_1/1",
                 list("tile", list("columns", 2, 6)))
         )");
     }
@@ -58,7 +58,7 @@ void test_sqrt_1d_0()
             sqrt(annotate_d([16, 4], "array_1",
                 list("tile", list("columns", 0, 2))))
         )", R"(
-            annotate_d([4., 2.], "array_1/0",
+            annotate_d([4., 2.], "array_1/1",
                 list("tile", list("columns", 0, 2)))
         )");
     }
@@ -72,7 +72,7 @@ void test_square_1d_0()
             square(annotate_d([4., 2.], "array_2",
                 list("tile", list("rows", 0, 2))))
         )", R"(
-            annotate_d([16., 4.], "array_2/0",
+            annotate_d([16., 4.], "array_2/1",
                 list("tile", list("rows", 0, 2)))
         )");
     }
@@ -82,7 +82,7 @@ void test_square_1d_0()
             square(annotate_d([0., 42., 1., 13.], "array_2",
                 list("tile", list("rows", 2, 6))))
         )", R"(
-            annotate_d([0., 1764., 1., 169.], "array_2/0",
+            annotate_d([0., 1764., 1., 169.], "array_2/1",
                 list("tile", list("rows", 2, 6)))
         )");
     }
@@ -97,7 +97,7 @@ void test_sqrt_2d_0()
             sqrt(annotate_d([[0, 1764], [1, 169]], "array_3",
                 list("tile", list("columns", 0, 2), list("rows", 0, 2))))
         )", R"(
-            annotate_d([[0., 42.], [1., 13.]], "array_3/0",
+            annotate_d([[0., 42.], [1., 13.]], "array_3/1",
                 list("tile", list("columns", 0, 2), list("rows", 0, 2)))
         )");
     }
@@ -107,7 +107,7 @@ void test_sqrt_2d_0()
             sqrt(annotate_d([[16], [4]], "array_3",
                 list("tile", list("columns", 2, 3), list("rows", 0, 2))))
         )", R"(
-            annotate_d([[4.], [2.]], "array_3/0",
+            annotate_d([[4.], [2.]], "array_3/1",
                 list("tile", list("columns", 2, 3), list("rows", 0, 2)))
         )");
     }
@@ -121,7 +121,7 @@ void test_square_2d_0()
             square(annotate_d([[1, 2], [4, 5]], "array_4",
                 list("tile", list("columns", 1, 3), list("rows", 0, 2))))
         )", R"(
-            annotate_d([[1, 4], [16, 25]], "array_4/0",
+            annotate_d([[1, 4], [16, 25]], "array_4/1",
                 list("tile", list("columns", 1, 3), list("rows", 0, 2)))
         )");
     }
@@ -131,7 +131,7 @@ void test_square_2d_0()
             square(annotate_d([[0], [3]], "array_4",
                 list("tile", list("columns", 0, 1), list("rows", 0, 2))))
         )", R"(
-            annotate_d([[0], [9]], "array_4/0",
+            annotate_d([[0], [9]], "array_4/1",
                 list("tile", list("columns", 0, 1), list("rows", 0, 2)))
         )");
     }

--- a/tests/unit/plugins/dist_matrixops/dist_generic_operation_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_generic_operation_2_loc.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2020 Hartmut Kaiser
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_generic_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_sqrt_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_generic_d_operation("test_sqrt_2loc1d_0", R"(
+            sqrt(annotate_d([0, 1764, 1, 169], "array_1",
+                list("tile", list("columns", 2, 6))))
+        )", R"(
+            annotate_d([0., 42., 1., 13.], "array_1/0",
+                list("tile", list("columns", 2, 6)))
+        )");
+    }
+    else
+    {
+        test_generic_d_operation("test_sqrt_2loc1d_0", R"(
+            sqrt(annotate_d([16, 4], "array_1",
+                list("tile", list("columns", 0, 2))))
+        )", R"(
+            annotate_d([4., 2.], "array_1/0",
+                list("tile", list("columns", 0, 2)))
+        )");
+    }
+}
+
+void test_square_1d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_generic_d_operation("test_square_2loc1d_0", R"(
+            square(annotate_d([4., 2.], "array_2",
+                list("tile", list("rows", 0, 2))))
+        )", R"(
+            annotate_d([16., 4.], "array_2/0",
+                list("tile", list("rows", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_generic_d_operation("test_square_2loc1d_0", R"(
+            square(annotate_d([0., 42., 1., 13.], "array_2",
+                list("tile", list("rows", 2, 6))))
+        )", R"(
+            annotate_d([0., 1764., 1., 169.], "array_2/0",
+                list("tile", list("rows", 2, 6)))
+        )");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+void test_sqrt_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_generic_d_operation("test_sqrt_2loc2d_0", R"(
+            sqrt(annotate_d([[0, 1764], [1, 169]], "array_3",
+                list("tile", list("columns", 0, 2), list("rows", 0, 2))))
+        )", R"(
+            annotate_d([[0., 42.], [1., 13.]], "array_3/0",
+                list("tile", list("columns", 0, 2), list("rows", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_generic_d_operation("test_sqrt_2loc2d_0", R"(
+            sqrt(annotate_d([[16], [4]], "array_3",
+                list("tile", list("columns", 2, 3), list("rows", 0, 2))))
+        )", R"(
+            annotate_d([[4.], [2.]], "array_3/0",
+                list("tile", list("columns", 2, 3), list("rows", 0, 2)))
+        )");
+    }
+}
+
+void test_square_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_generic_d_operation("test_square_2loc2d_0", R"(
+            square(annotate_d([[1, 2], [4, 5]], "array_4",
+                list("tile", list("columns", 1, 3), list("rows", 0, 2))))
+        )", R"(
+            annotate_d([[1, 4], [16, 25]], "array_4/0",
+                list("tile", list("columns", 1, 3), list("rows", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_generic_d_operation("test_square_2loc2d_0", R"(
+            square(annotate_d([[0], [3]], "array_4",
+                list("tile", list("columns", 0, 1), list("rows", 0, 2))))
+        )", R"(
+            annotate_d([[0], [9]], "array_4/0",
+                list("tile", list("columns", 0, 1), list("rows", 0, 2)))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_sqrt_1d_0();
+    test_square_1d_0();
+
+    test_sqrt_2d_0();
+    test_square_2d_0();
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+


### PR DESCRIPTION
This PR:
- adds a 3d version of kmeans algorithm (only `closest_centroid` function is different)
- simplifies kmeans_fix_point to be more compatible with its primitive version; it does not require `apply`, `fmap`, `lambda`, `range` or `vstack`, however, it uses `slice_assign`.
- adds a test on 2 localities for distributed generic operations, on sqrt and square. (#1162)