### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -70,7 +70,7 @@ include_directories(${pybind11_INCLUDE_DIR})
 # this makes sure CMake uses the proper HPX library dependencies
 target_link_libraries(phylanx_py
   ${HPX_TLL_PRIVATE}
-    HPX::hpx_init
+    HPX::hpx
     HPX::iostreams_component
     phylanx_component
     blaze::blaze


### PR DESCRIPTION
Changing HPX::hpx_init to HPX::hpx to fix buildbot failures

see: http://omega.nic.uoregon.edu:8020/#/builders/5/builds/161