### PR TITLE
Making slice aware of annotations 

### DIFF
--- a/phylanx/execution_tree/primitives/slice_node_data.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data.hpp
@@ -24,6 +24,14 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>");
 
     template <typename T>
+    PHYLANX_EXPORT execution_tree::primitive_argument_type slice_extract(
+        ir::node_data<T> const& data,
+        execution_tree::primitive_argument_type const& indices,
+        execution_tree::localities_information&& arr_localities,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <typename T>
     PHYLANX_EXPORT ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,

--- a/phylanx/execution_tree/primitives/slice_node_data.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data.hpp
@@ -64,6 +64,16 @@ namespace phylanx { namespace execution_tree
         std::string const& codename = "<unknown>");
 
     template <typename T>
+    PHYLANX_EXPORT execution_tree::primitive_argument_type slice_assign(
+        ir::node_data<T>&& data,
+        execution_tree::primitive_argument_type const& indices,
+        ir::node_data<T>&& value,
+        execution_tree::localities_information&& arr_localities,
+        execution_tree::localities_information&& val_localities,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <typename T>
     PHYLANX_EXPORT ir::node_data<T> slice_assign(ir::node_data<T>&& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,

--- a/phylanx/execution_tree/primitives/slice_node_data.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data.hpp
@@ -7,6 +7,7 @@
 #define PHYLANX_IR_NODE_DATA_SLICING_JUL_19_2018_1248PM
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/localities_annotation.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/ir/node_data.hpp>
 
@@ -26,6 +27,15 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
+        std::string const& name = "",
+        std::string const& codename = "<unknown>");
+
+    template <typename T>
+    PHYLANX_EXPORT execution_tree::primitive_argument_type slice_extract(
+        ir::node_data<T> const& data,
+        execution_tree::primitive_argument_type const& rows,
+        execution_tree::primitive_argument_type const& columns,
+        execution_tree::localities_information&& arr_localities,
         std::string const& name = "",
         std::string const& codename = "<unknown>");
 

--- a/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
@@ -20,7 +20,6 @@
 #include <phylanx/util/slicing_helpers.hpp>
 
 #include <hpx/assertion.hpp>
-#include <hpx/collectives/all_reduce.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/phylanx/plugins/dist_matrixops/idx_tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/idx_tile_calculation_helper.hpp
@@ -13,7 +13,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
-#include <tuple>
 
 #include <blaze/Math.h>
 

--- a/phylanx/util/index_calculation_helper.hpp
+++ b/phylanx/util/index_calculation_helper.hpp
@@ -5,8 +5,8 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_DIST_MATRIXOPS_IDX_TILE_CALCULATION_HELPER)
-#define PHYLANX_DIST_MATRIXOPS_IDX_TILE_CALCULATION_HELPER
+#if !defined(PHYLANX_UTIL_INDEX_CALCULATION_HELPER)
+#define PHYLANX_UTIL_INDEX_CALCULATION_HELPER
 
 #include <hpx/assertion.hpp>
 
@@ -17,7 +17,7 @@
 #include <blaze/Math.h>
 
 
-namespace phylanx { namespace dist_matrixops { namespace calculation_detail
+namespace phylanx { namespace util
 {
     struct indices_pack
     {
@@ -54,7 +54,7 @@ namespace phylanx { namespace dist_matrixops { namespace calculation_detail
         }
         return indices_pack{0, 0, 0};
     }
-}}}
+}}
 
 #endif
 

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -1402,7 +1402,7 @@ namespace phylanx { namespace execution_tree { namespace compiler
                         }
                     }
 
-                    // Handle slice(_1, __2)
+                    // Handle slice(_1, __2) and slice_row(_1, _2)
                     if (function_name == "slice" ||
                         function_name == "slice_row")
                     {

--- a/src/execution_tree/localities_annotation.cpp
+++ b/src/execution_tree/localities_annotation.cpp
@@ -100,17 +100,29 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
-        std::size_t dim = tiles_[0].dimension();
+        std::size_t dim = 0;
         for (std::size_t i = 0; i != tiles_.size(); ++i)
         {
             // make sure that all tiles have the same dimensionality
-            if (tiles_[i].dimension() != dim)
+            if (dim)
             {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "localities_information::localities_information",
-                    util::generate_error_message(
-                        "inconsistent dimensionalities in tiles",
-                        name, codename));
+                if (tiles_[i].spans_[0].is_valid())
+                {
+                    if (tiles_[i].dimension() != dim)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "localities_information::localities_information",
+                            util::generate_error_message(
+                                "inconsistent dimensionalities in tiles", name,
+                                codename));
+                    }
+                }
+            }
+
+            if (tiles_[i].spans_[0].is_valid() ||
+                tiles_[i].spans_[1].is_valid())
+            {
+                dim = tiles_[i].dimension();
             }
         }
 

--- a/src/execution_tree/primitives/slice.cpp
+++ b/src/execution_tree/primitives/slice.cpp
@@ -30,6 +30,37 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type const& indices, std::string const& name,
         std::string const& codename)
     {
+        if (data.has_annotation())
+        {
+            localities_information arr_localities =
+                extract_localities_information(data, name, codename);
+
+            if (is_integer_operand_strict(data))
+            {
+                return slice_extract(
+                    extract_integer_value_strict(data, name, codename), indices,
+                    std::move(arr_localities), name, codename);
+            }
+            if (is_numeric_operand_strict(data))
+            {
+                return slice_extract(
+                    extract_numeric_value_strict(data, name, codename), indices,
+                    std::move(arr_localities), name, codename);
+            }
+            if (is_boolean_operand_strict(data))
+            {
+                return slice_extract(
+                    extract_boolean_value_strict(data, name, codename), indices,
+                    std::move(arr_localities), name, codename);
+            }
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::execution_tree::slice",
+                util::generate_error_message("distributed target object does "
+                                             "not hold a numeric type and as "
+                                             "such does not support slicing",
+                    name, codename));
+        }
+
         if (is_integer_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
@@ -75,6 +106,7 @@ namespace phylanx { namespace execution_tree
         {
             localities_information arr_localities =
                 extract_localities_information(data, name, codename);
+
             if (is_integer_operand_strict(data))
             {
                 return slice_extract(

--- a/src/execution_tree/primitives/slice.cpp
+++ b/src/execution_tree/primitives/slice.cpp
@@ -198,6 +198,93 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type const& indices, primitive_argument_type&& value,
         std::string const& name, std::string const& codename)
     {
+        if (data.has_annotation() && value.has_annotation())
+        {
+            localities_information arr_localities =
+                extract_localities_information(data, name, codename);
+
+            localities_information val_localities =
+                extract_localities_information(value, name, codename);
+
+            if (is_integer_operand_strict(data))
+            {
+                if (is_integer_operand_strict(value))
+                {
+                    return slice_assign(extract_integer_value_strict(
+                                            std::move(data), name, codename),
+                        indices,
+                        extract_integer_value_strict(
+                            std::move(value), name, codename),
+                        std::move(arr_localities), std::move(val_localities),
+                        name, codename);
+                }
+
+                return slice_assign(extract_integer_value_strict(
+                                        std::move(data), name, codename),
+                    indices,
+                    extract_integer_value(std::move(value), name, codename),
+                    std::move(arr_localities), std::move(val_localities), name,
+                    codename);
+            }
+            else if (is_numeric_operand_strict(data))
+            {
+                if (is_numeric_operand_strict(value))
+                {
+                    return slice_assign(extract_numeric_value_strict(
+                                            std::move(data), name, codename),
+                        indices,
+                        extract_numeric_value_strict(
+                            std::move(value), name, codename),
+                        std::move(arr_localities), std::move(val_localities),
+                        name, codename);
+                }
+
+                return slice_assign(extract_numeric_value_strict(
+                                        std::move(data), name, codename),
+                    indices,
+                    extract_numeric_value(std::move(value), name, codename),
+                    std::move(arr_localities), std::move(val_localities), name,
+                    codename);
+            }
+            else if (is_boolean_operand_strict(data))
+            {
+                if (is_boolean_operand_strict(value))
+                {
+                    return slice_assign(extract_boolean_value_strict(
+                                            std::move(data), name, codename),
+                        indices,
+                        extract_boolean_value_strict(
+                            std::move(value), name, codename),
+                        std::move(arr_localities), std::move(val_localities),
+                        name, codename);
+                }
+
+                return slice_assign(extract_boolean_value_strict(
+                                        std::move(data), name, codename),
+                    indices,
+                    extract_boolean_value(std::move(value), name, codename),
+                    std::move(arr_localities), std::move(val_localities), name,
+                    codename);
+            }
+
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::execution_tree::slice",
+                util::generate_error_message(
+                    "distributed target object does not hold a numeric type "
+                    "and as such does not support slicing",
+                    name, codename));
+        }
+
+        if (data.has_annotation() || value.has_annotation())
+        {
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::execution_tree::slice",
+                util::generate_error_message(
+                    "cannot remote assign value to data when only one of them "
+                    "is distributed",
+                    name, codename));
+        }
+
         if (is_list_operand_strict(data))
         {
             return primitive_argument_type{slice_list(

--- a/src/execution_tree/primitives/slice.cpp
+++ b/src/execution_tree/primitives/slice.cpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/localities_annotation.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/slice.hpp>
 #include <phylanx/execution_tree/primitives/slice_node_data.hpp>
@@ -70,6 +71,37 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type const& columns, std::string const& name,
         std::string const& codename)
     {
+        if (data.has_annotation())
+        {
+            localities_information arr_localities =
+                extract_localities_information(data, name, codename);
+            if (is_integer_operand_strict(data))
+            {
+                return slice_extract(
+                    extract_integer_value_strict(data, name, codename), rows,
+                    columns, std::move(arr_localities), name, codename);
+            }
+            if (is_numeric_operand_strict(data))
+            {
+                return slice_extract(
+                    extract_numeric_value_strict(data, name, codename), rows,
+                    columns, std::move(arr_localities), name, codename);
+            }
+            if (is_boolean_operand_strict(data))
+            {
+                return slice_extract(
+                    extract_boolean_value_strict(data, name, codename), rows,
+                    columns, std::move(arr_localities), name, codename);
+            }
+
+            HPX_THROW_EXCEPTION(hpx::invalid_status,
+                "phylanx::execution_tree::slice",
+                util::generate_error_message(
+                    "target object does not hold a numeric data type and "
+                    "as such does not support slicing",
+                    name, codename));
+        }
+
         if (is_integer_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(

--- a/src/execution_tree/primitives/slice_node_data.cpp
+++ b/src/execution_tree/primitives/slice_node_data.cpp
@@ -103,6 +103,32 @@ namespace phylanx { namespace execution_tree
     }
 
     template <typename T>
+    execution_tree::primitive_argument_type slice_extract(
+        ir::node_data<T> const& data,
+        execution_tree::primitive_argument_type const& rows,
+        execution_tree::primitive_argument_type const& columns,
+        execution_tree::localities_information&& arr_localities,
+        std::string const& name, std::string const& codename)
+    {
+        switch (data.num_dimensions())
+        {
+        case 2:
+            return slice2d_extract2d(
+                data, rows, columns, std::move(arr_localities), name, codename);
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::execution_tree::slice_extract",
+            util::generate_error_message(
+                "distributed target ir::node_data object has an unsupported "
+                "number of dimensions",
+                name, codename));
+    }
+
+    template <typename T>
     ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& pages,
         execution_tree::primitive_argument_type const& rows,
@@ -162,6 +188,27 @@ namespace phylanx { namespace execution_tree
     slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_extract<std::uint8_t>(ir::node_data<std::uint8_t> const& data,
+        execution_tree::primitive_argument_type const& rows,
+        execution_tree::primitive_argument_type const& columns,
+        execution_tree::localities_information&& arr_localities,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_extract<double>(ir::node_data<double> const& data,
+        execution_tree::primitive_argument_type const& rows,
+        execution_tree::primitive_argument_type const& columns,
+        execution_tree::localities_information&& arr_localities,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
+        execution_tree::primitive_argument_type const& rows,
+        execution_tree::primitive_argument_type const& columns,
+        execution_tree::localities_information&& arr_localities,
         std::string const& name, std::string const& codename);
 
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>

--- a/src/execution_tree/primitives/slice_node_data.cpp
+++ b/src/execution_tree/primitives/slice_node_data.cpp
@@ -60,6 +60,31 @@ namespace phylanx { namespace execution_tree
     }
 
     template <typename T>
+    execution_tree::primitive_argument_type slice_extract(
+        ir::node_data<T> const& data,
+        execution_tree::primitive_argument_type const& indices,
+        execution_tree::localities_information&& arr_localities,
+        std::string const& name, std::string const& codename)
+    {
+        switch (data.num_dimensions())
+        {
+        case 2:
+            return slice1d_extract2d(
+                data, indices, std::move(arr_localities), name, codename);
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::execution_tree::slice_extract",
+            util::generate_error_message(
+                "distributed target ir::node_data object has an unsupported "
+                "number of dimensions",
+                name, codename));
+    }
+
+    template <typename T>
     ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
@@ -170,6 +195,24 @@ namespace phylanx { namespace execution_tree
     template PHYLANX_EXPORT ir::node_data<std::int64_t>
     slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
         execution_tree::primitive_argument_type const& indices,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_extract<std::uint8_t>(ir::node_data<std::uint8_t> const& data,
+        execution_tree::primitive_argument_type const& indices,
+        execution_tree::localities_information&& arr_localities,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_extract<double>(ir::node_data<double> const& data,
+        execution_tree::primitive_argument_type const& indices,
+        execution_tree::localities_information&& arr_localities,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
+        execution_tree::primitive_argument_type const& indices,
+        execution_tree::localities_information&& arr_localities,
         std::string const& name, std::string const& codename);
 
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>

--- a/src/execution_tree/primitives/slice_node_data.cpp
+++ b/src/execution_tree/primitives/slice_node_data.cpp
@@ -313,6 +313,34 @@ namespace phylanx { namespace execution_tree
     }
 
     template <typename T>
+    execution_tree::primitive_argument_type slice_assign(
+        ir::node_data<T>&& data,
+        execution_tree::primitive_argument_type const& indices,
+        ir::node_data<T>&& value,
+        execution_tree::localities_information&& arr_localities,
+        execution_tree::localities_information&& val_localities,
+        std::string const& name, std::string const& codename)
+    {
+        switch (data.num_dimensions())
+        {
+        case 2:
+            return slice1d_assign2d(std::move(data), indices, std::move(value),
+                std::move(arr_localities), std::move(val_localities), name,
+                codename);
+
+        default:
+            break;
+        }
+
+        HPX_THROW_EXCEPTION(hpx::invalid_status,
+            "phylanx::execution_tree::slice_assign",
+            util::generate_error_message(
+                "distributed target ir::node_data object has an "
+                "unsupported number of dimensions",
+                name, codename));
+    }
+
+    template <typename T>
     ir::node_data<T> slice_assign(ir::node_data<T>&& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
@@ -381,6 +409,30 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<std::int64_t>&& value, std::string const& name,
         std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_assign<std::uint8_t>(ir::node_data<std::uint8_t>&& data,
+        execution_tree::primitive_argument_type const& indices,
+        ir::node_data<std::uint8_t>&& value,
+        execution_tree::localities_information&& arr_localities,
+        execution_tree::localities_information&& val_localities,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_assign<double>(ir::node_data<double>&& data,
+        execution_tree::primitive_argument_type const& indices,
+        ir::node_data<double>&& value,
+        execution_tree::localities_information&& arr_localities,
+        execution_tree::localities_information&& val_localities,
+        std::string const& name, std::string const& codename);
+
+    template PHYLANX_EXPORT execution_tree::primitive_argument_type
+    slice_assign<std::int64_t>(ir::node_data<std::int64_t>&& data,
+        execution_tree::primitive_argument_type const& indices,
+        ir::node_data<std::int64_t>&& value,
+        execution_tree::localities_information&& arr_localities,
+        execution_tree::localities_information&& val_localities,
+        std::string const& name, std::string const& codename);
 
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>
     slice_assign<std::uint8_t>(ir::node_data<std::uint8_t>&& data,

--- a/src/plugins/dist_matrixops/dist_diag.cpp
+++ b/src/plugins/dist_matrixops/dist_diag.cpp
@@ -15,11 +15,11 @@
 #include <phylanx/execution_tree/tiling_annotations.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/dist_matrixops/dist_diag.hpp>
-#include <phylanx/plugins/dist_matrixops/idx_tile_calculation_helper.hpp>
 #include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
 #include <phylanx/util/distributed_matrix.hpp>
 #include <phylanx/util/distributed_vector.hpp>
 #include <phylanx/util/generate_error_message.hpp>
+#include <phylanx/util/index_calculation_helper.hpp>
 
 #include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
@@ -126,10 +126,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                     // copying the local part
                     if (des_start < cur_stop && des_stop > cur_start)
                     {
-                        auto indices =
-                            calculation_detail::index_calculation_1d(
-                                des_start, des_stop,
-                                cur_start, cur_stop);
+                        auto indices = util::index_calculation_1d(
+                            des_start, des_stop, cur_start, cur_stop);
                         blaze::subvector(res_arr,
                             indices.projected_start_,
                             indices.intersection_size_)
@@ -149,8 +147,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                         tiling_span loc_span =
                             arr_localities.tiles_[loc]
                                 .spans_[span_index];
-                        auto indices =
-                            calculation_detail::retile_calculation_1d(
+                        auto indices = util::retile_calculation_1d(
                             loc_span, des_start, des_stop);
                         if (indices.intersection_size_ > 0)
                         {
@@ -194,15 +191,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                     // copying the local part
                     if (des_start < cur_stop && des_stop > cur_start)
                     {
-                        auto indices =
-                            calculation_detail::index_calculation_1d(
+                        auto indices = util::index_calculation_1d(
                             des_start, des_stop, cur_start, cur_stop);
-                        blaze::subvector(res_arr,
-                            indices.projected_start_,
-                            indices.intersection_size_)
-                                = blaze::subvector(v,
-                                    indices.local_start_,
-                                    indices.intersection_size_);
+                        blaze::subvector(res_arr, indices.projected_start_,
+                            indices.intersection_size_) = blaze::subvector(v,
+                            indices.local_start_, indices.intersection_size_);
                     }
                     // collecting other parts from remote localities
                     for (std::uint32_t loc = 0; loc != num_localities;
@@ -216,8 +209,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                         tiling_span loc_span =
                             arr_localities.tiles_[loc]
                             .spans_[span_index];
-                        auto indices =
-                            calculation_detail::retile_calculation_1d(
+                        auto indices = util::retile_calculation_1d(
                             loc_span, des_start, des_stop);
                         if (indices.intersection_size_ > 0)
                         {
@@ -262,15 +254,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                     // copying the local part
                     if (des_start < cur_stop && des_stop > cur_start)
                     {
-                        auto indices =
-                            calculation_detail::index_calculation_1d(
+                        auto indices = util::index_calculation_1d(
                             des_start, des_stop, cur_start, cur_stop);
-                        blaze::subvector(res_arr,
-                            indices.projected_start_,
-                            indices.intersection_size_)
-                                = blaze::subvector(v,
-                                indices.local_start_,
-                                indices.intersection_size_);
+                        blaze::subvector(res_arr, indices.projected_start_,
+                            indices.intersection_size_) = blaze::subvector(v,
+                            indices.local_start_, indices.intersection_size_);
                     }
                     // collecting other parts from remote localities
                     for (std::uint32_t loc = 0; loc != num_localities;
@@ -284,8 +272,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                         tiling_span loc_span =
                             arr_localities.tiles_[loc]
                             .spans_[span_index];
-                        auto indices =
-                            calculation_detail::retile_calculation_1d(
+                        auto indices = util::retile_calculation_1d(
                             loc_span, des_start, des_stop);
                         if (indices.intersection_size_ > 0)
                         {

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -13,12 +13,12 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/tiling_annotations.hpp>
 #include <phylanx/ir/node_data.hpp>
-#include <phylanx/plugins/dist_matrixops/idx_tile_calculation_helper.hpp>
 #include <phylanx/plugins/dist_matrixops/retile_annotations.hpp>
 #include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
 #include <phylanx/util/detail/range_dimension.hpp>
 #include <phylanx/util/distributed_matrix.hpp>
 #include <phylanx/util/distributed_vector.hpp>
+#include <phylanx/util/index_calculation_helper.hpp>
 
 #include <hpx/assertion.hpp>
 #include <hpx/include/lcos.hpp>
@@ -313,7 +313,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             // copying the local part
             if (des_start < cur_stop && des_stop > cur_start)
             {
-                auto indices = calculation_detail::index_calculation_1d(
+                auto indices = util::index_calculation_1d(
                     des_start, des_stop, cur_start, cur_stop);
                 blaze::subvector(result, indices.projected_start_,
                     indices.intersection_size_) = blaze::subvector(v,
@@ -332,8 +332,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                 tiling_span loc_span =
                     arr_localities.tiles_[loc].spans_[span_index];
 
-                auto indices = calculation_detail::retile_calculation_1d(
-                    loc_span, des_start, des_stop);
+                auto indices =
+                    util::retile_calculation_1d(loc_span, des_start, des_stop);
                 if (indices.intersection_size_ > 0)
                 {
                     // loc_span has the part of result that we need
@@ -514,9 +514,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     des_row_stop > cur_row_start) &&
                 (des_col_start < cur_col_stop && des_col_stop > cur_col_start))
             {
-                auto row_indices = calculation_detail::index_calculation_1d(
+                auto row_indices = util::index_calculation_1d(
                     des_row_start, des_row_stop, cur_row_start, cur_row_stop);
-                auto col_indices = calculation_detail::index_calculation_1d(
+                auto col_indices = util::index_calculation_1d(
                     des_col_start, des_col_stop, cur_col_start, cur_col_stop);
 
                 blaze::submatrix(result, row_indices.projected_start_,
@@ -539,9 +539,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                 tiling_span loc_row_span = arr_localities.tiles_[loc].spans_[0];
                 tiling_span loc_col_span = arr_localities.tiles_[loc].spans_[1];
 
-                auto row_indices = calculation_detail::retile_calculation_1d(
+                auto row_indices = util::retile_calculation_1d(
                     loc_row_span, des_row_start, des_row_stop);
-                auto col_indices = calculation_detail::retile_calculation_1d(
+                auto col_indices = util::retile_calculation_1d(
                     loc_col_span, des_col_start, des_col_stop);
                 if (row_indices.intersection_size_ > 0 &&
                     col_indices.intersection_size_ > 0)

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -24,6 +24,8 @@ set(tests
     dist_random_4_loc
     dist_random_5_loc
     dist_shape_2_loc
+    dist_slice_2_loc
+    dist_slice_3_loc
     dist_transpose_operation
     retile_2_loc
     retile_3_loc
@@ -51,6 +53,8 @@ set(dist_random_2_loc_PARAMETERS LOCALITIES 2)
 set(dist_random_4_loc_PARAMETERS LOCALITIES 4)
 set(dist_random_5_loc_PARAMETERS LOCALITIES 5)
 set(dist_shape_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_slice_2_loc_PARAMETERS LOCALITIES 2)
+set(dist_slice_3_loc_PARAMETERS LOCALITIES 3)
 set(retile_2_loc_PARAMETERS LOCALITIES 2)
 set(retile_3_loc_PARAMETERS LOCALITIES 3)
 set(retile_6_loc_PARAMETERS LOCALITIES 6)

--- a/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
@@ -161,12 +161,13 @@ void test_slice_row_assign_2()
 {
     if (hpx::get_locality_id() == 0)
     {
-        R"(define(a, annotate_d([[1, 2], [4, 5], [7, 8]], "array_4",
-            list("tile", list("columns", 0, 2), list("rows", 0, 3)))))";
         test_slice_d_operation("test_slice_row_2loc_2", R"(
-            store(slice_row(a, 1),
-                annotate_d([-4, -5], "value_0", list("tile", ("columns", 0, 2)))
-            )
+            define(a, annotate_d([[1, 2], [4, 5], [7, 8]], "array_4",
+                list("tile", list("columns", 0, 2), list("rows", 0, 3))))
+            define(v, annotate_d([-4, -5], "value_0",
+                list("tile", list("columns", 0, 2))))
+            store(slice_row(a, 1), v)
+            a
         )", R"(
             annotate_d([[1, 2], [-4, -5], [7, 8]], "array_4/1",
                 list("tile", list("rows", 0, 3), list("columns", 0, 2)))
@@ -174,12 +175,13 @@ void test_slice_row_assign_2()
     }
     else
     {
-        R"(define(a, annotate_d([[3], [6], [9]], "array_4",
-            list("tile", list("columns", 2, 3), list("rows", 0, 3)))))";
         test_slice_d_operation("test_slice_row_2loc_2", R"(
-            store(slice_row(a, 1),
-                annotate_d([-6], "value_0", list("tile", ("columns", 2, 3)))
-            )
+            define(a, annotate_d([[3], [6], [9]], "array_4",
+                list("tile", list("columns", 2, 3), list("rows", 0, 3))))
+            define(v, annotate_d([-6], "value_0",
+                list("tile", list("columns", 2, 3))))
+            store(slice_row(a, 1), v)
+            a
         )", R"(
             annotate_d([[3], [-6], [9]], "array_4/1",
                 list("tile", list("rows", 0, 3), list("columns", 2, 3)))
@@ -187,6 +189,69 @@ void test_slice_row_assign_2()
     }
 }
 
+void test_slice_row_assign_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_3", R"(
+            define(a, annotate_d([[1, 2, 3]], "array_5",
+                list("tile", list("columns", 0, 3), list("rows", 0, 1))))
+            define(v, annotate_d([-9], "value_1",
+                list("tile", list("columns", 2, 3))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[1, 2, 3]], "array_5/1",
+                list("tile", list("rows", 0, 1), list("columns", 0, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_3", R"(
+            define(a, annotate_d([[4, 5, 6], [7, 8, 9]], "array_5",
+                list("tile", list("columns", 0, 3), list("rows", 1, 3))))
+            define(v, annotate_d([-7, -8], "value_1",
+                list("tile", list("columns", 0, 2))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[4, 5, 6], [-7, -8, -9]], "array_5/1",
+                list("tile", list("rows", 1, 3), list("columns", 0, 3)))
+        )");
+    }
+}
+
+void test_slice_row_assign_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_4", R"(
+            define(a, annotate_d([[4, 5, 6], [7, 8, 9]], "array_6",
+                list("tile", list("columns", 0, 3), list("rows", 1, 3))))
+            define(v, annotate_d([-9], "value_2",
+                list("tile", list("columns", 2, 3))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[4, 5, 6], [-7, -8, -9]], "array_6/1",
+                list("tile", list("rows", 1, 3), list("columns", 0, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_4", R"(
+            define(a, annotate_d([[1, 2, 3]], "array_6",
+                list("tile", list("columns", 0, 3), list("rows", 0, 1))))
+            define(v, annotate_d([-7, -8], "value_2",
+                list("tile", list("columns", 0, 2))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[1, 2, 3]], "array_6/1",
+                list("tile", list("rows", 0, 1), list("columns", 0, 3)))
+        )");
+    }
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
@@ -196,7 +261,9 @@ int hpx_main(int argc, char* argv[])
 
     test_slice_row_0();
     test_slice_row_1();
-    //test_slice_row_assign_2();
+    test_slice_row_assign_2();
+    test_slice_row_assign_3();
+    test_slice_row_assign_4();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
@@ -157,6 +157,37 @@ void test_slice_row_1()
     }
 }
 
+void test_slice_row_assign_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        R"(define(a, annotate_d([[1, 2], [4, 5], [7, 8]], "array_4",
+            list("tile", list("columns", 0, 2), list("rows", 0, 3)))))";
+        test_slice_d_operation("test_slice_row_2loc_2", R"(
+            store(slice_row(a, 1),
+                annotate_d([-4, -5], "value_0", list("tile", ("columns", 0, 2)))
+            )
+        )", R"(
+            annotate_d([[1, 2], [-4, -5], [7, 8]], "array_4/1",
+                list("tile", list("rows", 0, 3), list("columns", 0, 2)))
+        )");
+    }
+    else
+    {
+        R"(define(a, annotate_d([[3], [6], [9]], "array_4",
+            list("tile", list("columns", 2, 3), list("rows", 0, 3)))))";
+        test_slice_d_operation("test_slice_row_2loc_2", R"(
+            store(slice_row(a, 1),
+                annotate_d([-6], "value_0", list("tile", ("columns", 2, 3)))
+            )
+        )", R"(
+            annotate_d([[3], [-6], [9]], "array_4/1",
+                list("tile", list("rows", 0, 3), list("columns", 2, 3)))
+        )");
+    }
+}
+
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -165,6 +196,7 @@ int hpx_main(int argc, char* argv[])
 
     test_slice_row_0();
     test_slice_row_1();
+    //test_slice_row_assign_2();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
@@ -1,0 +1,181 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_slice_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(hpx::cout, result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_slice_column_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_column_2loc_0", R"(
+            slice_column(annotate_d([[1, 2, 3]], "array_0",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 1)))),
+            1)
+        )", R"(
+            annotate_d([2], "array_0_sliced/1",
+                list("tile", list("columns", 0, 1)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_column_2loc_0", R"(
+            slice_column(annotate_d([[4, 5, 6], [7, 8, 9]], "array_0",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 3), list("rows", 1, 3)))),
+            1)
+        )", R"(
+            annotate_d([5, 8], "array_0_sliced/1",
+                list("tile", list("columns", 1, 3)))
+        )");
+    }
+}
+
+void test_slice_column_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_column_2loc_1", R"(
+            slice_column(annotate_d([[1, 2], [4, 5], [7, 8]], "array_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 3)))),
+            1)
+        )", R"(
+            annotate_d([2, 5, 8], "array_1_sliced/1",
+                list("tile", list("columns", 0, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_column_2loc_1", R"(
+            slice_column(annotate_d([[3], [6], [9]], "array_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 3), list("rows", 0, 3)))),
+            1)
+        )", R"(
+            annotate_d(nil, "array_1_sliced/1",
+                list("tile", list("columns", 0, 0)))
+        )");
+    }
+}
+
+void test_slice_row_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_0", R"(
+            slice_row(annotate_d([[1, 2], [4, 5], [7, 8]], "array_2",
+                    list("tile", list("columns", 0, 2), list("rows", 0, 3))),
+            1)
+        )", R"(
+            annotate_d([4, 5], "array_2_sliced/1",
+                list("tile", list("rows", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_0", R"(
+            slice_row(annotate_d([[3], [6], [9]], "array_2",
+                    list("tile", list("columns", 2, 3), list("rows", 0, 3))),
+            1)
+        )", R"(
+            annotate_d([6], "array_2_sliced/1",
+                list("tile", list("rows", 2, 3)))
+        )");
+    }
+}
+
+void test_slice_row_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_1", R"(
+            slice_row(annotate_d([[1, 2, 3]], "array_3",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 1)))),
+            2)
+        )", R"(
+            annotate_d(nil, "array_3_sliced/1",
+                list("tile", list("rows", 0, 0)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_1", R"(
+            slice_row(annotate_d([[4, 5, 6], [7, 8, 9]], "array_3",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 3), list("rows", 1, 3)))),
+            2)
+        )", R"(
+            annotate_d([7, 8, 9], "array_3_sliced/1",
+                list("tile", list("rows", 0, 3)))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_slice_column_0();
+    test_slice_column_1();
+
+    test_slice_row_0();
+    test_slice_row_1();
+
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
@@ -1,0 +1,234 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/testing.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_slice_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(hpx::cout, result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_slice_column_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_column_3loc_0", R"(
+            slice_column(annotate_d([[1, 2, 3]], "array_0",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 0, 3), list("rows", 3, 4)))),
+            0)
+        )", R"(
+            annotate_d([1], "array_0_sliced/1",
+                list("tile", list("columns", 3, 4)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_column_3loc_0", R"(
+            slice_column(annotate_d([[4, 5, 6], [7, 8, 9]], "array_0",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 0, 3), list("rows", 1, 3)))),
+            0)
+        )", R"(
+            annotate_d([4, 7], "array_0_sliced/1",
+                list("tile", list("columns", 1, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_column_3loc_0", R"(
+            slice_column(annotate_d([[-1, -2, -3]], "array_0",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 0, 3), list("rows", 0, 1)))),
+            0)
+        )", R"(
+            annotate_d([-1], "array_0_sliced/1",
+                list("tile", list("columns", 0, 1)))
+        )");
+    }
+}
+
+void test_slice_column_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_column_3loc_1", R"(
+            slice_column(annotate_d([[3, 4], [13, 14], [-3, -4], [-13, -14]],
+                "array_1",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 4)))),
+            1)
+        )", R"(
+            annotate_d(nil, "array_1_sliced/1",
+                list("tile", list("columns", 0, 0)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_column_3loc_1", R"(
+            slice_column(annotate_d([[1, 2], [11, 12]], "array_1",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 2)))),
+            1)
+        )", R"(
+            annotate_d([2, 12], "array_1_sliced/1",
+                list("tile", list("columns", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_column_3loc_1", R"(
+            slice_column(annotate_d([[-1, -2], [-11, -12]], "array_1",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 0, 2), list("rows", 2, 4)))),
+            1)
+        )", R"(
+            annotate_d([-2, -12], "array_1_sliced/1",
+                list("tile", list("columns", 2, 4)))
+        )");
+    }
+}
+
+void test_slice_row_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_3loc_0", R"(
+            slice_row(annotate_d([[1, 2], [11, 12], [-1, -2], [-11, -12]],
+                "array_2",
+                list("tile", list("columns", 0, 2), list("rows", 0, 4))),
+            3)
+        )", R"(
+            annotate_d([-11, -12], "array_2_sliced/1",
+                list("tile", list("rows", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_row_3loc_0", R"(
+            slice_row(annotate_d([[3], [13], [-3], [-13]], "array_2",
+                    list("tile", list("columns", 2, 3), list("rows", 0, 4))),
+            3)
+        )", R"(
+            annotate_d([-13], "array_2_sliced/1",
+                list("tile", list("rows", 2, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_3loc_0", R"(
+            slice_row(annotate_d([[4], [14], [-4], [-14]], "array_2",
+                    list("tile", list("columns", 3, 4), list("rows", 0, 4))),
+            3)
+        )", R"(
+            annotate_d([-14], "array_2_sliced/1",
+                list("tile", list("rows", 3, 4)))
+        )");
+    }
+}
+
+void test_slice_row_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_3loc_1", R"(
+            slice_row(annotate_d([[3, 4], [13, 14], [-3, -4], [-13, -14]],
+                "array_3",
+                list("args",
+                    list("locality", 0, 3),
+                    list("tile", list("columns", 2, 4), list("rows", 0, 4)))),
+            1)
+        )", R"(
+            annotate_d([13, 14], "array_3_sliced/1",
+                list("tile", list("rows", 2, 4)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_row_3loc_1", R"(
+            slice_row(annotate_d([[1, 2], [11, 12]], "array_3",
+                list("args",
+                    list("locality", 1, 3),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 2)))),
+            1)
+        )", R"(
+            annotate_d([11, 12], "array_3_sliced/1",
+                list("tile", list("rows", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_3loc_1", R"(
+            slice_row(annotate_d([[-1, -2], [-11, -12]], "array_3",
+                list("args",
+                    list("locality", 2, 3),
+                    list("tile", list("columns", 0, 2), list("rows", 2, 4)))),
+            1)
+        )", R"(
+            annotate_d(nil, "array_3_sliced/1",
+                list("tile", list("rows", 0, 0)))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    test_slice_column_0();
+    test_slice_column_1();
+
+    test_slice_row_0();
+    test_slice_row_1();
+
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+

--- a/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
@@ -210,6 +210,98 @@ void test_slice_row_1()
     }
 }
 
+void test_slice_row_assign_2()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_2", R"(
+            define(a, annotate_d([[1, 2], [4, 5], [7, 8]], "array_4",
+                list("tile", list("columns", 0, 2), list("rows", 0, 3))))
+            define(v, annotate_d([-7], "value_0",
+                list("tile", list("columns", 0, 1))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[1, 2], [4, 5], [-7, -8]], "array_4/1",
+                list("tile", list("rows", 0, 3), list("columns", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_row_2loc_2", R"(
+            define(a, annotate_d([[3], [6], [9]], "array_4",
+                list("tile", list("columns", 2, 3), list("rows", 0, 3))))
+            define(v, annotate_d([-8], "value_0",
+                list("tile", list("columns", 1, 2))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[3], [6], [-9]], "array_4/1",
+                list("tile", list("rows", 0, 3), list("columns", 2, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_2", R"(
+            define(a, annotate_d([[10, 11, 12]], "array_4",
+                list("tile", list("columns", 0, 3), list("rows", 3, 4))))
+            define(v, annotate_d([-9], "value_0",
+                list("tile", list("columns", 2, 3))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[10, 11, 12]], "array_4/1",
+                list("tile", list("rows", 3, 4), list("columns", 0, 3)))
+        )");
+    }
+}
+
+void test_slice_row_assign_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_3", R"(
+            define(a, annotate_d([[1, 2], [5, 6]], "array_5",
+                list("tile", list("columns", 0, 2), list("rows", 0, 2))))
+            define(v, annotate_d([5], "value_1",
+                list("tile", list("rows", 0, 1))))
+            store(slice_row(a, 3), v)
+            a
+        )", R"(
+            annotate_d([[1, 2], [5, 6]], "array_5/1",
+                list("tile", list("rows", 0, 2), list("columns", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_row_2loc_3", R"(
+            define(a, annotate_d([[-1, -2], [-5, -6]], "array_5",
+                list("tile", list("columns", 0, 2), list("rows", 2, 4))))
+            define(v, annotate_d([6, 7], "value_1",
+                list("tile", list("rows", 1, 3))))
+            store(slice_row(a, 3), v)
+            a
+        )", R"(
+            annotate_d([[-1, -2], [5, 6]], "array_5/1",
+                list("tile", list("rows", 2, 4), list("columns", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_3", R"(
+            define(a, annotate_d([[3, 4], [7, 8], [-3, -4], [-7, -8]], "array_5",
+                list("tile", list("columns", 2, 4), list("rows", 0, 4))))
+            define(v, annotate_d([8], "value_1",
+                list("tile", list("rows", 3, 4))))
+            store(slice_row(a, 3), v)
+            a
+        )", R"(
+            annotate_d([[3, 4], [7, 8], [-3, -4], [7, 8]], "array_5/1",
+                list("tile", list("rows", 0, 4), list("columns", 2, 4)))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -218,6 +310,8 @@ int hpx_main(int argc, char* argv[])
 
     test_slice_row_0();
     test_slice_row_1();
+    test_slice_row_assign_2();
+    test_slice_row_assign_3();
 
 
     hpx::finalize();


### PR DESCRIPTION
This PR makes it possible to pass a distributed array to slice (assign or extract) functions that are used in kmeans algorithm (slice1d_extract2d, slice2d_extract2d and slice1d_assign2d).
Working towards #1162.