### PR TITLE
Restricting annotate_d

### DIFF
--- a/phylanx/execution_tree/meta_annotation.hpp
+++ b/phylanx/execution_tree/meta_annotation.hpp
@@ -28,6 +28,11 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT annotation localities_annotation(annotation& locality_ann,
         annotation&& ann, annotation_information const& ann_info,
         std::string const& name, std::string const& codename);
+
+    PHYLANX_EXPORT annotation localities_annotation(
+        primitive_argument_type const& arg, annotation& locality_ann,
+        annotation&& ann, annotation_information const& ann_info,
+        std::string const& name, std::string const& codename);
 }}
 
 #endif

--- a/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
@@ -1227,7 +1227,8 @@ namespace phylanx { namespace execution_tree
                     arr_localities.annotation_, name, codename));
 
             // return an empty array
-            return primitive_argument_type(ast::nil{true}, attached_annotation);
+            return primitive_argument_type(
+                blaze::DynamicVector<std::uint8_t>(0), attached_annotation);
         }
 
         auto m = data.matrix();
@@ -1305,7 +1306,8 @@ namespace phylanx { namespace execution_tree
                     arr_localities.annotation_, name, codename));
 
             // return an empty array
-            return primitive_argument_type(ast::nil{true}, attached_annotation);
+            return primitive_argument_type(
+                blaze::DynamicVector<std::uint8_t>(0), attached_annotation);
         }
 
         auto m = data.matrix();

--- a/phylanx/execution_tree/tiling_annotations.hpp
+++ b/phylanx/execution_tree/tiling_annotations.hpp
@@ -56,11 +56,8 @@ namespace phylanx { namespace execution_tree
         return false;
     }
 
-    namespace detail
-    {
-        tiling_span extract_span(annotation const& ann, char const* key,
-            std::string const& name, std::string const& codename);
-    }
+    inline tiling_span extract_span(annotation const& ann, char const* key,
+        std::string const& name, std::string const& codename);
 
     ////////////////////////////////////////////////////////////////////////////
     struct tiling_information

--- a/src/execution_tree/localities_annotation.cpp
+++ b/src/execution_tree/localities_annotation.cpp
@@ -273,7 +273,8 @@ namespace phylanx { namespace execution_tree
                     return false;
                 });
 
-            return it_max->spans_[N].stop_ - it_min->spans_[N].start_;
+            HPX_ASSERT(it_min->spans_[N].start_ == 0);
+            return it_max->spans_[N].stop_;
         }
     }
 

--- a/src/execution_tree/localities_annotation.cpp
+++ b/src/execution_tree/localities_annotation.cpp
@@ -120,7 +120,7 @@ namespace phylanx { namespace execution_tree
             }
 
             if (tiles_[i].spans_[0].is_valid() ||
-                tiles_[i].spans_[1].is_valid())
+                (tiles_[i].spans_.size() > 1 && tiles_[i].spans_[1].is_valid()))
             {
                 dim = tiles_[i].dimension();
             }
@@ -196,7 +196,7 @@ namespace phylanx { namespace execution_tree
         switch (local_tile.dimension())
         {
         case 0:
-            result[0] = 1;
+            result[0] = 0;
             break;
 
         case 1:
@@ -254,19 +254,23 @@ namespace phylanx { namespace execution_tree
         {
             HPX_ASSERT(!tiles.empty());
             auto it_min = std::min_element(tiles.begin(), tiles.end(),
-                [&](tiling_information const& v, tiling_information const& smallest)
+                [&](tiling_information const& v,
+                    tiling_information const& smallest)
                 {
-                    HPX_ASSERT(N < v.spans_.size());
-                    HPX_ASSERT(v.spans_[N].is_valid());
-                    return v.spans_[N].start_ < smallest.spans_[N].start_;
+                    if ((N < v.spans_.size() && v.spans_[N].is_valid()))
+                        return v.spans_[N].start_ < smallest.spans_[N].start_;
+
+                    return false;
                 });
 
             auto it_max = std::max_element(tiles.begin(), tiles.end(),
-                [&](tiling_information const& largest, tiling_information const& v)
+                [&](tiling_information const& largest,
+                    tiling_information const& v)
                 {
-                    HPX_ASSERT(N < v.spans_.size());
-                    HPX_ASSERT(v.spans_[N].is_valid());
-                    return largest.spans_[N].stop_ < v.spans_[N].stop_;
+                    if (N < v.spans_.size() && v.spans_[N].is_valid())
+                        return largest.spans_[N].stop_ < v.spans_[N].stop_;
+
+                    return false;
                 });
 
             return it_max->spans_[N].stop_ - it_min->spans_[N].start_;
@@ -276,10 +280,22 @@ namespace phylanx { namespace execution_tree
     // Is this helpful? It may only introduce confusion
     std::size_t localities_information::size() const
     {
-        if (tiles_[0].spans_[0].is_valid())
-            return detail::dimension<0>(tiles_);
-
-        return detail::dimension<1>(tiles_);
+        for (std::size_t i = 0; i != tiles_.size(); ++i)
+        {
+            if (tiles_[i].spans_[0].is_valid())
+            {
+                return detail::dimension<0>(tiles_);
+            }
+            else if (tiles_[i].spans_.size() > 1 &&
+                tiles_[i].spans_[1].is_valid())
+            {
+                // a row-wise vector
+                return detail::dimension<1>(tiles_);
+            }
+        }
+        HPX_THROW_EXCEPTION(hpx::bad_parameter, "localities_information::size",
+            util::generate_error_message("the given array does not have a "
+                                         "valid span on any of localities"));
     }
 
     // we assume that all tiles have the same number of dimension
@@ -362,17 +378,26 @@ namespace phylanx { namespace execution_tree
     bool localities_information::has_span(std::size_t dim) const
     {
         HPX_ASSERT(locality_.locality_id_ < tiles_.size());
-        HPX_ASSERT(
-            dim < num_dimensions() || (dim == 1 && dim == num_dimensions()));
+        if (num_dimensions() != 0)
+        {
+            HPX_ASSERT(dim < num_dimensions() ||
+                (dim == 1 && dim == num_dimensions()));
+        }
 
-        return tiles_[locality_.locality_id_].spans_[dim].is_valid();
+        return std::any_of(
+            tiles_.begin(), tiles_.end(), [dim](tiling_information tile) {
+                return tile.spans_[dim].is_valid();
+            });
     }
 
     tiling_span localities_information::get_span(std::size_t dim) const
     {
         HPX_ASSERT(locality_.locality_id_ < tiles_.size());
-        HPX_ASSERT(
-            dim < num_dimensions() || (dim == 1 && dim == num_dimensions()));
+        if (num_dimensions() != 0)
+        {
+            HPX_ASSERT(dim < num_dimensions() ||
+                (dim == 1 && dim == num_dimensions()));
+        }
 
         return tiles_[locality_.locality_id_].spans_[dim];
     }
@@ -382,8 +407,11 @@ namespace phylanx { namespace execution_tree
         std::uint32_t loc, std::size_t dim, tiling_span const& span) const
     {
         HPX_ASSERT(loc < tiles_.size());
-        HPX_ASSERT(
-            dim < num_dimensions() || (dim == 1 && dim == num_dimensions()));
+        if (num_dimensions() != 0)
+        {
+            HPX_ASSERT(dim < num_dimensions() ||
+                (dim == 1 && dim == num_dimensions()));
+        }
 
         auto const& gspan = tiles_[loc].spans_[dim];
         tiling_span result{

--- a/src/execution_tree/locality_annotation.cpp
+++ b/src/execution_tree/locality_annotation.cpp
@@ -39,9 +39,10 @@ namespace phylanx { namespace execution_tree
 
         auto it = data.begin();
         locality_id_ = static_cast<std::uint32_t>(
-            extract_scalar_integer_value(*it, name, codename));
+            extract_scalar_nonneg_integer_value_strict(*it, name, codename));
         num_localities_ = static_cast<std::uint32_t>(
-            extract_scalar_integer_value(*++it, name, codename));
+            extract_scalar_positive_integer_value_strict(
+                *++it, name, codename));
     }
 
     execution_tree::annotation locality_information::as_annotation() const

--- a/src/execution_tree/meta_annotation.cpp
+++ b/src/execution_tree/meta_annotation.cpp
@@ -7,6 +7,7 @@
 #include <phylanx/execution_tree/annotation.hpp>
 #include <phylanx/execution_tree/locality_annotation.hpp>
 #include <phylanx/execution_tree/meta_annotation.hpp>
+#include <phylanx/execution_tree/tiling_annotations.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/util/generate_error_message.hpp>
 
@@ -117,6 +118,140 @@ namespace phylanx { namespace execution_tree
             locality_ann = annotation{"locality",
                 static_cast<std::int64_t>(loc.locality_id_),
                 static_cast<std::int64_t>(loc.num_localities_)};
+        }
+
+        // wrap the user-supplied annotation into a meta-tag
+        auto meta_locality_ann =
+            annotation{
+                hpx::util::format("meta_{}", loc.locality_id_),
+                std::move(ann)
+            };
+
+        // communicate with all other localities to generate set of all meta
+        // entries
+        auto localities_ann = meta_annotation(hpx::launch::sync, locality_ann,
+            std::move(meta_locality_ann), ann_info.generate_name(), name,
+            codename);
+
+        // now generate the overall annotation
+        localities_ann.add_annotation(std::move(locality_ann), name, codename);
+
+        // attach globally unique name to returned annotation
+        localities_ann.add_annotation(ann_info.as_annotation(), name, codename);
+
+        return localities_ann;
+    }
+
+    annotation localities_annotation(primitive_argument_type const& arg,
+        annotation& locality_ann, annotation&& ann,
+        annotation_information const& ann_info, std::string const& name,
+        std::string const& codename)
+    {
+        // defaults to locality_id and num_localities
+        execution_tree::locality_information loc;
+
+        // If the annotation contains information related to the
+        // locality of the data we should perform an all_to_all
+        // operation to collect the information about all connected
+        // objects.
+        if (locality_ann.get_type() == "locality")
+        {
+            std::size_t default_loc = loc.locality_id_;
+            loc = execution_tree::extract_locality_information(
+                locality_ann, name, codename);
+            if (default_loc != loc.locality_id_)
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::localities_annotation",
+                    "supplied locality differs from default");
+            }
+
+        }
+        else
+        {
+            locality_ann = annotation{"locality",
+                static_cast<std::int64_t>(loc.locality_id_),
+                static_cast<std::int64_t>(loc.num_localities_)};
+        }
+
+        // annotation should have the same dimension as array
+        std::size_t ann_ndim = ann.get_data().size();
+        if (ann_ndim != extract_numeric_value_dimension(arg, name, codename))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::localities_annotation",
+                "dimension of supplied annotation is not the same as array's "
+                "number of dimensions");
+        }
+
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> target_dims =
+            extract_numeric_value_dimensions(arg, name, codename);
+        switch (ann_ndim)
+        {
+        case 1:
+        {
+            char const* key = "columns";
+            annotation vector_span;
+            if (!ann.find("columns", vector_span, name, codename))
+            {
+                key = "rows";
+                if (!ann.find("rows", vector_span, name, codename))
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "phylanx::execution_tree::localities_annotation",
+                        "a vector can be either a row-vector or a "
+                        "column-vector");
+                }
+            }
+
+            std::size_t span_size =
+                extract_span(ann, key, name, codename).size();
+            if (span_size != target_dims[0])
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::localities_annotation",
+                    "the annotation span size differs from the vector's size");
+            }
+            break;
+        }
+
+        case 2:
+        {
+            std::size_t row_span_size =
+                extract_span(ann, "rows", name, codename).size();
+            std::size_t col_span_size =
+                extract_span(ann, "columns", name, codename).size();
+            if (target_dims[1] == 0)
+            {
+                // shape of [[]] is (1, 0) while it is shown with ("rows", 0, 0)
+                // and ("columns", 0, 0) spans
+                if (row_span_size != 0 || col_span_size != 0)
+                {
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "phylanx::execution_tree::localities_annotation",
+                        "annotations do not represent an ampty matrix");
+                }
+            }
+            else if (row_span_size != target_dims[0] ||
+                col_span_size != target_dims[1])
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::localities_annotation",
+                    "at least in one of the row or column dimension, the "
+                    "dimension does not comply with its corresponding in the "
+                    "given matrix");
+            }
+            break;
+        }
+
+        case 0: HPX_FALLTHROUGH;
+        case 3: HPX_FALLTHROUGH;
+        case 4: HPX_FALLTHROUGH;
+        default:
+
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "phylanx::execution_tree::localities_annotation",
+                "array's number of dimension is not supported");
         }
 
         // wrap the user-supplied annotation into a meta-tag

--- a/src/execution_tree/primitives/annotate_primitive.cpp
+++ b/src/execution_tree/primitives/annotate_primitive.cpp
@@ -112,7 +112,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                 tmp.find("tile", tiles_ann))
             {
                 ir::range tmp = tiles_ann.get_range();
-                localities = localities_annotation(locality_ann,
+                localities = localities_annotation(target, locality_ann,
                     annotation{std::move(tmp)}, ann_info, name_, codename_);
             }
             else
@@ -127,7 +127,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
             "tile")
         {
             annotation locality_ann;
-            localities = localities_annotation(locality_ann,
+            localities = localities_annotation(target, locality_ann,
                 annotation{std::move(args)}, ann_info, name_, codename_);
         }
         else

--- a/src/execution_tree/primitives/annotate_primitive.cpp
+++ b/src/execution_tree/primitives/annotate_primitive.cpp
@@ -137,6 +137,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                 generate_error_message(
                     "no args annotation and tiles annotation not first"));
         }
+
         target.set_annotation(std::move(localities), name_, codename_);
         return std::move(target);
     }

--- a/src/execution_tree/tiling_annotations.cpp
+++ b/src/execution_tree/tiling_annotations.cpp
@@ -78,7 +78,7 @@ namespace phylanx { namespace execution_tree
         if (!ann.find(get_span_name(0), temp_tile_ann, name, codename))
         {
             // having a row vector, the first span should be empty
-            // so, a row vectoe has a spans size of 2
+            // so, a row vector has a spans size of 2
             spans_.emplace_back();
         }
 
@@ -139,11 +139,11 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
-        if (tile.spans_[0].is_valid())
+        if (tile.spans_.size() == 1)
         {
             span_ = tile.spans_[0];    // column vector
         }
-        else if (tile.spans_.size() == 2 && tile.spans_[1].is_valid())
+        else if (tile.spans_.size() == 2 && !tile.spans_[0].is_valid())
         {
             type_ = rows;
             span_ = tile.spans_[1];    //row vector

--- a/src/execution_tree/tiling_annotations.cpp
+++ b/src/execution_tree/tiling_annotations.cpp
@@ -39,24 +39,20 @@ namespace phylanx { namespace execution_tree
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    namespace detail
+    inline tiling_span extract_span(annotation const& ann, char const* key,
+        std::string const& name, std::string const& codename)
     {
-        tiling_span extract_span(annotation const& ann, char const* key,
-            std::string const& name, std::string const& codename)
+        annotation key_ann;
+        if (!ann.get_if(key, key_ann, name, codename) &&
+            !ann.find(key, key_ann, name, codename))
         {
-            annotation key_ann;
-            if (!ann.get_if(key, key_ann, name, codename) &&
-                !ann.find(key, key_ann, name, codename))
-            {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                    "tiling_annotations_1d::tiling_annotations_1d",
-                    util::generate_error_message(
-                        hpx::util::format(
-                            "annotation type not given '{}'", key),
-                        name, codename));
-            }
-            return tiling_span(key_ann.get_data(), name, codename);
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "tiling_annotations::extract_span",
+                util::generate_error_message(
+                    hpx::util::format("annotation type not given '{}'", key),
+                    name, codename));
         }
+        return tiling_span(key_ann.get_data(), name, codename);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -87,7 +83,7 @@ namespace phylanx { namespace execution_tree
             annotation tile_ann;
             if (ann.find(get_span_name(i - 1), tile_ann, name, codename))
             {
-                spans_.push_back(detail::extract_span(
+                spans_.push_back(extract_span(
                     tile_ann, get_span_name(i - 1), name, codename));
             }
         }
@@ -122,7 +118,7 @@ namespace phylanx { namespace execution_tree
                     hpx::util::format("unexpected annotation type ({})", key),
                     name, codename));
         }
-        span_ = detail::extract_span(ann, tile1d_typename(type_), name, codename);
+        span_ = extract_span(ann, tile1d_typename(type_), name, codename);
     }
 
     tiling_information_1d::tiling_information_1d(
@@ -184,8 +180,8 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
-        spans_[0] = detail::extract_span(ann, "rows", name, codename);
-        spans_[1] = detail::extract_span(ann, "columns", name, codename);
+        spans_[0] = extract_span(ann, "rows", name, codename);
+        spans_[1] = extract_span(ann, "columns", name, codename);
     }
 
     tiling_information_2d::tiling_information_2d(tiling_information const& tile,
@@ -231,9 +227,9 @@ namespace phylanx { namespace execution_tree
                     name, codename));
         }
 
-        spans_[0] = detail::extract_span(ann, "pages", name, codename);
-        spans_[1] = detail::extract_span(ann, "rows", name, codename);
-        spans_[2] = detail::extract_span(ann, "columns", name, codename);
+        spans_[0] = extract_span(ann, "pages", name, codename);
+        spans_[1] = extract_span(ann, "rows", name, codename);
+        spans_[2] = extract_span(ann, "columns", name, codename);
     }
 
     tiling_information_3d::tiling_information_3d(tiling_information const& tile,

--- a/tests/unit/execution_tree/annotation.cpp
+++ b/tests/unit/execution_tree/annotation.cpp
@@ -71,17 +71,32 @@ void test_annotation_equality_2()
         compile_and_run("annotation_1", annotation_1));
 }
 
-void test_annotation_equality_3()
+void test_annotation_non_equality_3()
 {
     std::string annotation_0 = R"(
             annotate_d([[91, 91]], "test2d2d_3_1/1",
-                list("tile", list("columns", 0, 2), list("rows", 2, 4)))
+                list("tile", list("columns", 0, 2), list("rows", 0, 1)))
         )";
     std::string annotation_1 = R"(
-            annotate_d([[91, 91]], "test2d2d_3_1/1",
+            annotate_d([91, 91], "test2d2d_3_1/1",
                 list("args",
                     list("locality", 0, 1),
-                    list("tile", list("rows", 0, 2), list("columns", 0, 2))))
+                    list("tile", list("columns", 0, 2))))
+        )";
+
+    HPX_TEST_NEQ(compile_and_run("annotation_0", annotation_0),
+        compile_and_run("annotation_1", annotation_1));
+}
+
+void test_annotation_non_equality_4()
+{
+    std::string annotation_0 = R"(
+            annotate_d([[]], "empty_array",
+                list("tile", list("columns", 0, 0), list("rows", 0, 0)))
+        )";
+    std::string annotation_1 = R"(
+            annotate_d([], "empty_array",
+                list("tile", list("columns", 0, 0)))
         )";
 
     HPX_TEST_NEQ(compile_and_run("annotation_0", annotation_0),
@@ -93,7 +108,8 @@ int main(int argc, char* argv[])
     test_annotation_equality_0();
     test_annotation_equality_1();
     test_annotation_equality_2();
-    test_annotation_equality_3();
+    test_annotation_non_equality_3();
+    test_annotation_non_equality_4();
 
     return hpx::util::report_errors();
 }

--- a/tests/unit/execution_tree/annotation_2_loc.cpp
+++ b/tests/unit/execution_tree/annotation_2_loc.cpp
@@ -129,12 +129,91 @@ void test_annotation_2()
     }
 }
 
+void test_annotation_3()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[]], "test_annotation_3_1",
+                list("tile", list("columns", 0, 0), list("rows", 0, 0)))
+        )";
+
+        compile_and_run("test_annotation_3", annotation_0);
+    }
+    else
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[0, 1, 2], [3, 4, 5]], "test_annotation_3_1",
+                list("tile", list("columns", 0, 3), list("rows", 0, 2)))
+        )";
+
+        compile_and_run("test_annotation_3", annotation_0);
+    }
+}
+
+void test_annotation_4()
+{
+    // having overlapped spans
+    if (hpx::get_locality_id() == 0)
+    {
+        std::string annotation_0 = R"(
+            annotate_d([1, 2], "test_annotation_4_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("rows", 0, 2))))
+        )";
+
+        compile_and_run("test_annotation_4", annotation_0);
+    }
+    else
+    {
+        std::string annotation_0 = R"(
+            annotate_d([2, 3, 4], "test_annotation_4_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("rows", 1, 4))))
+        )";
+
+        compile_and_run("test_annotation_4", annotation_0);
+    }
+}
+
+void test_annotation_5()
+{
+    // having overlapped spans
+    if (hpx::get_locality_id() == 0)
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[1, 2], [-1, -2]], "test_annotation_5_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("rows", 0, 2), list("columns", 0, 2))))
+        )";
+
+        compile_and_run("test_annotation_4", annotation_0);
+    }
+    else
+    {
+        std::string annotation_0 = R"(
+            annotate_d([[-1, -2], [11, 12]], "test_annotation_5_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("rows", 1, 3), list("columns", 0, 2))))
+        )";
+
+        compile_and_run("test_annotation_5", annotation_0);
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
     test_annotation_0();
     test_annotation_1();
     test_annotation_2();
+    test_annotation_3();
+    test_annotation_4();
+    test_annotation_5();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
@@ -95,7 +95,7 @@ void test_slice_column_1()
                     list("tile", list("columns", 2, 3), list("rows", 0, 3)))),
             1)
         )", R"(
-            annotate_d(nil, "array_1_sliced/1",
+            annotate_d([], "array_1_sliced/1",
                 list("tile", list("columns", 0, 0)))
         )");
     }
@@ -138,7 +138,7 @@ void test_slice_row_1()
                     list("tile", list("columns", 0, 3), list("rows", 0, 1)))),
             2)
         )", R"(
-            annotate_d(nil, "array_3_sliced/1",
+            annotate_d([], "array_3_sliced/1",
                 list("tile", list("rows", 0, 0)))
         )");
     }
@@ -253,6 +253,38 @@ void test_slice_row_assign_4()
     }
 }
 
+void test_slice_row_assign_5()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_5", R"(
+            define(a, annotate_d([[1, 2, 3]], "array_7",
+                list("tile", list("columns", 0, 3), list("rows", 0, 1))))
+            define(v, annotate_d([], "value_3",
+                list("tile", list("columns", 0, 0))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[1, 2, 3]], "array_7/1",
+                list("tile", list("rows", 0, 1), list("columns", 0, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_5", R"(
+            define(a, annotate_d([[4, 5, 6], [7, 8, 9]], "array_7",
+                list("tile", list("columns", 0, 3), list("rows", 1, 3))))
+            define(v, annotate_d([-7, -8, -9], "value_3",
+                list("tile", list("columns", 0, 3))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[4, 5, 6], [-7, -8, -9]], "array_7/1",
+                list("tile", list("rows", 1, 3), list("columns", 0, 3)))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -264,6 +296,7 @@ int hpx_main(int argc, char* argv[])
     test_slice_row_assign_2();
     test_slice_row_assign_3();
     test_slice_row_assign_4();
+    test_slice_row_assign_5();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
@@ -348,6 +348,52 @@ void test_slice_row_assign_4()
     }
 }
 
+void test_slice_row_assign_5()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_5", R"(
+            define(a, annotate_d([[1, 2], [4, 5]], "array_7",
+                list("tile", list("columns", 0, 2), list("rows", 0, 2))))
+            define(v, annotate_d([], "value_3",
+                list("tile", list("rows", 0, 0))))
+            store(slice_row(a, 1), v)
+            a
+        )", R"(
+            annotate_d([[1, 2], [42, 43]], "array_7/1",
+                list("tile", list("rows", 0, 2), list("columns", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_row_2loc_5", R"(
+            define(a, annotate_d([[7, 8], [10, 11]], "array_7",
+                list("tile", list("columns", 0, 2), list("rows", 2, 4))))
+            define(v, annotate_d([], "value_3",
+                list("tile", list("rows", 0, 0))))
+            store(slice_row(a, 1), v)
+            a
+        )", R"(
+            annotate_d([[7, 8], [10, 11]], "array_7/1",
+                list("tile", list("rows", 2, 4), list("columns", 0, 2)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_5", R"(
+            define(a, annotate_d([[3], [6], [9], [12]], "array_7",
+                list("tile", list("columns", 2, 3), list("rows", 0, 4))))
+            define(v, annotate_d([42, 43, 44], "value_3",
+                list("tile", list("rows", 0, 3))))
+            store(slice_row(a, 1), v)
+            a
+        )", R"(
+            annotate_d([[3], [44], [9], [12]], "array_7/1",
+                list("tile", list("rows", 0, 4), list("columns", 2, 3)))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -359,6 +405,7 @@ int hpx_main(int argc, char* argv[])
     test_slice_row_assign_2();
     test_slice_row_assign_3();
     test_slice_row_assign_4();
+    test_slice_row_assign_5();
 
 
     hpx::finalize();

--- a/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
@@ -96,7 +96,7 @@ void test_slice_column_1()
                     list("tile", list("columns", 2, 4), list("rows", 0, 4)))),
             1)
         )", R"(
-            annotate_d(nil, "array_1_sliced/1",
+            annotate_d([], "array_1_sliced/1",
                 list("tile", list("columns", 0, 0)))
         )");
     }
@@ -204,7 +204,7 @@ void test_slice_row_1()
                     list("tile", list("columns", 0, 2), list("rows", 2, 4)))),
             1)
         )", R"(
-            annotate_d(nil, "array_3_sliced/1",
+            annotate_d([], "array_3_sliced/1",
                 list("tile", list("rows", 0, 0)))
         )");
     }
@@ -302,6 +302,52 @@ void test_slice_row_assign_3()
     }
 }
 
+void test_slice_row_assign_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_slice_d_operation("test_slice_row_2loc_4", R"(
+            define(a, annotate_d([[1, 2], [4, 5], [7, 8]], "array_6",
+                list("tile", list("columns", 0, 2), list("rows", 0, 3))))
+            define(v, annotate_d([], "value_2",
+                list("tile", list("columns", 0, 0))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[1, 2], [4, 5], [-7, -8]], "array_6/1",
+                list("tile", list("rows", 0, 3), list("columns", 0, 2)))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_slice_d_operation("test_slice_row_2loc_4", R"(
+            define(a, annotate_d([[3], [6], [9]], "array_6",
+                list("tile", list("columns", 2, 3), list("rows", 0, 3))))
+            define(v, annotate_d([-7, -8], "value_2",
+                list("tile", list("columns", 0, 2))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[3], [6], [-9]], "array_6/1",
+                list("tile", list("rows", 0, 3), list("columns", 2, 3)))
+        )");
+    }
+    else
+    {
+        test_slice_d_operation("test_slice_row_2loc_4", R"(
+            define(a, annotate_d([[10, 11, 12]], "array_6",
+                list("tile", list("columns", 0, 3), list("rows", 3, 4))))
+            define(v, annotate_d([-9], "value_2",
+                list("tile", list("columns", 2, 3))))
+            store(slice_row(a, 2), v)
+            a
+        )", R"(
+            annotate_d([[10, 11, 12]], "array_6/1",
+                list("tile", list("rows", 3, 4), list("columns", 0, 3)))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -312,6 +358,7 @@ int hpx_main(int argc, char* argv[])
     test_slice_row_1();
     test_slice_row_assign_2();
     test_slice_row_assign_3();
+    test_slice_row_assign_4();
 
 
     hpx::finalize();


### PR DESCRIPTION
This PR is an attempt to resolve #1160.
It considers having empty arrays and show them with an empty array and invalid (0, 0) spans on each dimension.
`annotate_d` checks annotation to comply with the array in the number of dimensions and size of each dimension. It also considers that the whole span on each dimension starts from 0 and there is no gap between parts of it while it can accept overlaps.
These are the annotation samples that will throw exceptions:
```c++
// does not start from 0
void test_annotation_4()
{
    if (hpx::get_locality_id() == 0)
    {
        std::string annotation_0 = R"(
            annotate_d([], "test_annotation_4_1",
                list("args",
                    list("locality", 0, 2),
                    list("tile", list("rows", 0, 0))))
        )";

        compile_and_run("test_annotation_4", annotation_0);
    }
    else
    {
        std::string annotation_0 = R"(
            annotate_d([3, 4, 5], "test_annotation_4_1",
                list("args",
                    list("locality", 1, 2),
                    list("tile", list("rows", 1, 4))))
        )";

        compile_and_run("test_annotation_4", annotation_0);
    }
}
```
```C++
// on locality 0 we have a vector while on locality 1 we have a matrix
void test_annotation_4()
{
    if (hpx::get_locality_id() == 0)
    {
        std::string annotation_0 = R"(
            annotate_d([1, 2], "test_annotation_4_1",
                list("args",
                    list("locality", 0, 2),
                    list("tile", list("columns", 0, 2))))
        )";

        compile_and_run("test_annotation_4", annotation_0);
    }
    else
    {
        std::string annotation_0 = R"(
            annotate_d([[3, 4, 5]], "test_annotation_4_1",
                list("args",
                    list("locality", 1, 2),
                    list("tile", list("columns", 2, 5),list("rows", 0, 1))))
        )";

        compile_and_run("test_annotation_4", annotation_0);
    }
}
```
```C++
// a vector cannot be a mix of rows and columns on different localities
void test_annotation_4()
{
    if (hpx::get_locality_id() == 0)
    {
        std::string annotation_0 = R"(
            annotate_d([1, 2], "test_annotation_4_1",
                list("args",
                    list("locality", 0, 2),
                    list("tile", list("columns", 0, 2))))
        )";

        compile_and_run("test_annotation_4", annotation_0);
    }
    else
    {
        std::string annotation_0 = R"(
            annotate_d([3, 4, 5], "test_annotation_4_1",
                list("args",
                    list("locality", 1, 2),
                    list("tile", list("rows", 2, 5))))
        )";

        compile_and_run("test_annotation_4", annotation_0);
    }
}
```