### PR TITLE
Updating HPX includes to fix deprecation warnings

### DIFF
--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -12,7 +12,7 @@
 #include <hpx/assertion.hpp>
 #include <hpx/errors.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 
 #include <array>

--- a/phylanx/execution_tree/compiler_component.hpp
+++ b/phylanx/execution_tree/compiler_component.hpp
@@ -17,7 +17,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/future.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 
 #include <cstddef>
 #include <string>

--- a/phylanx/execution_tree/localities_annotation.hpp
+++ b/phylanx/execution_tree/localities_annotation.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/ir/ranges.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/execution_tree/locality_annotation.hpp
+++ b/phylanx/execution_tree/locality_annotation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/annotation.hpp>
 #include <phylanx/ir/ranges.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <string>

--- a/phylanx/execution_tree/meta_annotation.hpp
+++ b/phylanx/execution_tree/meta_annotation.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/annotation.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 

--- a/phylanx/execution_tree/primitives/access_function.hpp
+++ b/phylanx/execution_tree/primitives/access_function.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/util/hashed_string.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <set>
 #include <string>

--- a/phylanx/execution_tree/primitives/access_variable.hpp
+++ b/phylanx/execution_tree/primitives/access_variable.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/util/hashed_string.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <set>

--- a/phylanx/execution_tree/primitives/annotate_primitive.hpp
+++ b/phylanx/execution_tree/primitives/annotate_primitive.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <set>

--- a/phylanx/execution_tree/primitives/assert_condition.hpp
+++ b/phylanx/execution_tree/primitives/assert_condition.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/call_function.hpp
+++ b/phylanx/execution_tree/primitives/call_function.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/phylanx/execution_tree/primitives/console_output.hpp
+++ b/phylanx/execution_tree/primitives/console_output.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/debug_output.hpp
+++ b/phylanx/execution_tree/primitives/debug_output.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/define_variable.hpp
+++ b/phylanx/execution_tree/primitives/define_variable.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/util/hashed_string.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <set>

--- a/phylanx/execution_tree/primitives/enable_tracing.hpp
+++ b/phylanx/execution_tree/primitives/enable_tracing.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <vector>

--- a/phylanx/execution_tree/primitives/find_all_localities.hpp
+++ b/phylanx/execution_tree/primitives/find_all_localities.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/format_string.hpp
+++ b/phylanx/execution_tree/primitives/format_string.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <iosfwd>
 #include <memory>

--- a/phylanx/execution_tree/primitives/function.hpp
+++ b/phylanx/execution_tree/primitives/function.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <set>

--- a/phylanx/execution_tree/primitives/generic_function.hpp
+++ b/phylanx/execution_tree/primitives/generic_function.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/async.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/execution_tree/primitives/lambda.hpp
+++ b/phylanx/execution_tree/primitives/lambda.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <set>

--- a/phylanx/execution_tree/primitives/phyname.hpp
+++ b/phylanx/execution_tree/primitives/phyname.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/phytype.hpp
+++ b/phylanx/execution_tree/primitives/phytype.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/primitive_component.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component.hpp
@@ -14,7 +14,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/future.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -13,7 +13,7 @@
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 
 #include <cstddef>

--- a/phylanx/execution_tree/primitives/store_operation.hpp
+++ b/phylanx/execution_tree/primitives/store_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/string_output.hpp
+++ b/phylanx/execution_tree/primitives/string_output.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/execution_tree/primitives/target_reference.hpp
+++ b/phylanx/execution_tree/primitives/target_reference.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <set>

--- a/phylanx/execution_tree/primitives/variable.hpp
+++ b/phylanx/execution_tree/primitives/variable.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/phylanx/execution_tree/primitives/variable_factory.hpp
+++ b/phylanx/execution_tree/primitives/variable_factory.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <set>

--- a/phylanx/plugins/algorithms/als.hpp
+++ b/phylanx/plugins/algorithms/als.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/algorithms/kmeans.hpp
+++ b/phylanx/plugins/algorithms/kmeans.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/phylanx/plugins/algorithms/lra.hpp
+++ b/phylanx/plugins/algorithms/lra.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/arithmetics/add_operation.hpp
+++ b/phylanx/plugins/arithmetics/add_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/arithmetics/numeric.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/arithmetics/cumprod.hpp
+++ b/phylanx/plugins/arithmetics/cumprod.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/arithmetics/cumulative.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/arithmetics/cumulative.hpp
+++ b/phylanx/plugins/arithmetics/cumulative.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/arithmetics/div_operation.hpp
+++ b/phylanx/plugins/arithmetics/div_operation.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/arithmetics/numeric.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/arithmetics/generic_operation.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <map>
 #include <memory>

--- a/phylanx/plugins/arithmetics/generic_operation_bool.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_bool.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <map>

--- a/phylanx/plugins/arithmetics/maximum.hpp
+++ b/phylanx/plugins/arithmetics/maximum.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/arithmetics/numeric.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/arithmetics/minimum.hpp
+++ b/phylanx/plugins/arithmetics/minimum.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/arithmetics/numeric.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/arithmetics/mul_operation.hpp
+++ b/phylanx/plugins/arithmetics/mul_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/arithmetics/numeric.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/arithmetics/numeric.hpp
+++ b/phylanx/plugins/arithmetics/numeric.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/arithmetics/sub_operation.hpp
+++ b/phylanx/plugins/arithmetics/sub_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/arithmetics/numeric.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/arithmetics/unary_minus_operation.hpp
+++ b/phylanx/plugins/arithmetics/unary_minus_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/booleans/comparison.hpp
+++ b/phylanx/plugins/booleans/comparison.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/booleans/logical_operation.hpp
+++ b/phylanx/plugins/booleans/logical_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/booleans/nonzero_where.hpp
+++ b/phylanx/plugins/booleans/nonzero_where.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/booleans/unary_not_operation.hpp
+++ b/phylanx/plugins/booleans/unary_not_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/controls/async_operation.hpp
+++ b/phylanx/plugins/controls/async_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/controls/block_operation.hpp
+++ b/phylanx/plugins/controls/block_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/phylanx/plugins/controls/filter_operation.hpp
+++ b/phylanx/plugins/controls/filter_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/fmap_operation.hpp
+++ b/phylanx/plugins/controls/fmap_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/fold_left_operation.hpp
+++ b/phylanx/plugins/controls/fold_left_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/fold_right_operation.hpp
+++ b/phylanx/plugins/controls/fold_right_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/for_each.hpp
+++ b/phylanx/plugins/controls/for_each.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/for_operation.hpp
+++ b/phylanx/plugins/controls/for_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/if_conditional.hpp
+++ b/phylanx/plugins/controls/if_conditional.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/parallel_block_operation.hpp
+++ b/phylanx/plugins/controls/parallel_block_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/parallel_map_operation.hpp
+++ b/phylanx/plugins/controls/parallel_map_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/controls/range_operation.hpp
+++ b/phylanx/plugins/controls/range_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/controls/while_operation.hpp
+++ b/phylanx/plugins/controls/while_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/dist_matrixops/dist_cannon_product.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/dist_matrixops/dist_constant.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_constant.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/dist_matrixops/dist_diag.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_diag.hpp
@@ -15,7 +15,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/dist_matrixops/dist_dot_operation.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_dot_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/execution_tree/localities_annotation.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/dist_matrixops/dist_identity.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_identity.hpp
@@ -15,7 +15,7 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/dist_matrixops/dist_inverse_operation.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_inverse_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/dist_matrixops/dist_random.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_random.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/util/random.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/dist_matrixops/dist_transpose_operation.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_transpose_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/dist_matrixops/retile_annotations.hpp
+++ b/phylanx/plugins/dist_matrixops/retile_annotations.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/fileio/file_read.hpp
+++ b/phylanx/plugins/fileio/file_read.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/fileio/file_read_csv.hpp
+++ b/phylanx/plugins/fileio/file_read_csv.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/fileio/file_read_hdf5.hpp
+++ b/phylanx/plugins/fileio/file_read_hdf5.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <string>
 #include <utility>

--- a/phylanx/plugins/fileio/file_write.hpp
+++ b/phylanx/plugins/fileio/file_write.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/fileio/file_write_csv.hpp
+++ b/phylanx/plugins/fileio/file_write_csv.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/fileio/file_write_hdf5.hpp
+++ b/phylanx/plugins/fileio/file_write_hdf5.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/keras_support/avg_pool2d_operation.hpp
+++ b/phylanx/plugins/keras_support/avg_pool2d_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/keras_support/avg_pool3d_operation.hpp
+++ b/phylanx/plugins/keras_support/avg_pool3d_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/keras_support/batch_dot_operation.hpp
+++ b/phylanx/plugins/keras_support/batch_dot_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/keras_support/bias_add_operation.hpp
+++ b/phylanx/plugins/keras_support/bias_add_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/phylanx/plugins/keras_support/binary_crossentropy_operation.hpp
+++ b/phylanx/plugins/keras_support/binary_crossentropy_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/keras_support/categorical_crossentropy_operation.hpp
+++ b/phylanx/plugins/keras_support/categorical_crossentropy_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/keras_support/conv1d_operation.hpp
+++ b/phylanx/plugins/keras_support/conv1d_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/keras_support/conv2d_operation.hpp
+++ b/phylanx/plugins/keras_support/conv2d_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/keras_support/conv2d_transpose_operation.hpp
+++ b/phylanx/plugins/keras_support/conv2d_transpose_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/keras_support/ctc_decode_operation.hpp
+++ b/phylanx/plugins/keras_support/ctc_decode_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/elu_operation.hpp
+++ b/phylanx/plugins/keras_support/elu_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/hard_sigmoid_operation.hpp
+++ b/phylanx/plugins/keras_support/hard_sigmoid_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/l2_normalize_operation.hpp
+++ b/phylanx/plugins/keras_support/l2_normalize_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/max_pool2d_operation.hpp
+++ b/phylanx/plugins/keras_support/max_pool2d_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/keras_support/max_pool3d_operation.hpp
+++ b/phylanx/plugins/keras_support/max_pool3d_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/keras_support/one_hot_operation.hpp
+++ b/phylanx/plugins/keras_support/one_hot_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/relu_operation.hpp
+++ b/phylanx/plugins/keras_support/relu_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/keras_support/resize_operation.hpp
+++ b/phylanx/plugins/keras_support/resize_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/separable_conv1d_operation.hpp
+++ b/phylanx/plugins/keras_support/separable_conv1d_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/keras_support/sigmoid_operation.hpp
+++ b/phylanx/plugins/keras_support/sigmoid_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/softmax_operation.hpp
+++ b/phylanx/plugins/keras_support/softmax_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/softplus_operation.hpp
+++ b/phylanx/plugins/keras_support/softplus_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/softsign_operation.hpp
+++ b/phylanx/plugins/keras_support/softsign_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/keras_support/spatial_2d_padding_operation.hpp
+++ b/phylanx/plugins/keras_support/spatial_2d_padding_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/phylanx/plugins/keras_support/switch_operation.hpp
+++ b/phylanx/plugins/keras_support/switch_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/listops/append_operation.hpp
+++ b/phylanx/plugins/listops/append_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/listops/car_cdr_operation.hpp
+++ b/phylanx/plugins/listops/car_cdr_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/listops/dictionary_operation.hpp
+++ b/phylanx/plugins/listops/dictionary_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/listops/len_operation.hpp
+++ b/phylanx/plugins/listops/len_operation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/listops/make_list.hpp
+++ b/phylanx/plugins/listops/make_list.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/listops/prepend_operation.hpp
+++ b/phylanx/plugins/listops/prepend_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/arange.hpp
+++ b/phylanx/plugins/matrixops/arange.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/argminmax.hpp
+++ b/phylanx/plugins/matrixops/argminmax.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/argsort.hpp
+++ b/phylanx/plugins/matrixops/argsort.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/astype.hpp
+++ b/phylanx/plugins/matrixops/astype.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/clip.hpp
+++ b/phylanx/plugins/matrixops/clip.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/concatenate.hpp
+++ b/phylanx/plugins/matrixops/concatenate.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/constant.hpp
+++ b/phylanx/plugins/matrixops/constant.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/phylanx/plugins/matrixops/count_nonzero_operation.hpp
+++ b/phylanx/plugins/matrixops/count_nonzero_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/cross_operation.hpp
+++ b/phylanx/plugins/matrixops/cross_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/determinant.hpp
+++ b/phylanx/plugins/matrixops/determinant.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/diag_operation.hpp
+++ b/phylanx/plugins/matrixops/diag_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/dot_operation.hpp
+++ b/phylanx/plugins/matrixops/dot_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/expand_dims.hpp
+++ b/phylanx/plugins/matrixops/expand_dims.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/extract_shape.hpp
+++ b/phylanx/plugins/matrixops/extract_shape.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/eye_operation.hpp
+++ b/phylanx/plugins/matrixops/eye_operation.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/flip_operation.hpp
+++ b/phylanx/plugins/matrixops/flip_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/gauss_inverse.hpp
+++ b/phylanx/plugins/matrixops/gauss_inverse.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/gradient_operation.hpp
+++ b/phylanx/plugins/matrixops/gradient_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/identity.hpp
+++ b/phylanx/plugins/matrixops/identity.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/insert.hpp
+++ b/phylanx/plugins/matrixops/insert.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/ir/node_data.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/inverse_operation.hpp
+++ b/phylanx/plugins/matrixops/inverse_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/linearmatrix.hpp
+++ b/phylanx/plugins/matrixops/linearmatrix.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/linspace.hpp
+++ b/phylanx/plugins/matrixops/linspace.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/ndim.hpp
+++ b/phylanx/plugins/matrixops/ndim.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/pad.hpp
+++ b/phylanx/plugins/matrixops/pad.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/power_operation.hpp
+++ b/phylanx/plugins/matrixops/power_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/random.hpp
+++ b/phylanx/plugins/matrixops/random.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/util/random.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/matrixops/repeat_operation.hpp
+++ b/phylanx/plugins/matrixops/repeat_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/reshape_operation.hpp
+++ b/phylanx/plugins/matrixops/reshape_operation.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/shuffle_operation.hpp
+++ b/phylanx/plugins/matrixops/shuffle_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/matrixops/size.hpp
+++ b/phylanx/plugins/matrixops/size.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/slicing_operation.hpp
+++ b/phylanx/plugins/matrixops/slicing_operation.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/util/small_vector.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/matrixops/sort.hpp
+++ b/phylanx/plugins/matrixops/sort.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/squeeze_operation.hpp
+++ b/phylanx/plugins/matrixops/squeeze_operation.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/ir/node_data.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/stack_operation.hpp
+++ b/phylanx/plugins/matrixops/stack_operation.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/tile_operation.hpp
+++ b/phylanx/plugins/matrixops/tile_operation.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/phylanx/plugins/matrixops/transpose_operation.hpp
+++ b/phylanx/plugins/matrixops/transpose_operation.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/matrixops/unique.hpp
+++ b/phylanx/plugins/matrixops/unique.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/plugins/solvers/decomposition.hpp
+++ b/phylanx/plugins/solvers/decomposition.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/solvers/linear_solver.hpp
+++ b/phylanx/plugins/solvers/linear_solver.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <memory>
 #include <string>

--- a/phylanx/plugins/statistics/statistics_base.hpp
+++ b/phylanx/plugins/statistics/statistics_base.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/util/distributed_matrix.hpp
+++ b/phylanx/util/distributed_matrix.hpp
@@ -22,7 +22,7 @@
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/get_num_localities.hpp>
 #include <hpx/runtime/get_ptr.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 

--- a/phylanx/util/distributed_object.hpp
+++ b/phylanx/util/distributed_object.hpp
@@ -21,7 +21,7 @@
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/get_num_localities.hpp>
 #include <hpx/runtime/get_ptr.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 

--- a/phylanx/util/distributed_vector.hpp
+++ b/phylanx/util/distributed_vector.hpp
@@ -22,7 +22,7 @@
 #include <hpx/runtime/get_locality_id.hpp>
 #include <hpx/runtime/get_num_localities.hpp>
 #include <hpx/runtime/get_ptr.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/synchronization/spinlock.hpp>
 #include <hpx/thread_support/unlock_guard.hpp>
 

--- a/phylanx/util/future_or_value.hpp
+++ b/phylanx/util/future_or_value.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/util/variant.hpp>
 
 #include <hpx/async.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/traits/acquire_future.hpp>
 #include <hpx/traits/future_traits.hpp>

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -24,7 +24,7 @@
 #include <hpx/include/serialization.hpp>
 #include <hpx/include/sync.hpp>
 #include <hpx/logging.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 
 #include <array>
 #include <cstddef>

--- a/src/execution_tree/primitives/primitive_component.cpp
+++ b/src/execution_tree/primitives/primitive_component.cpp
@@ -14,7 +14,7 @@
 #include <hpx/include/util.hpp>
 #include <hpx/include/serialization.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -12,7 +12,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/runtime/config_entry.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 #include <hpx/errors/throw_exception.hpp>
 

--- a/src/plugins/controls/apply.cpp
+++ b/src/plugins/controls/apply.cpp
@@ -11,7 +11,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/runtime/launch_policy.hpp>
+#include <hpx/async_base/launch_policy.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cstddef>

--- a/src/plugins/dist_matrixops/dist_inverse_operation.cpp
+++ b/src/plugins/dist_matrixops/dist_inverse_operation.cpp
@@ -20,7 +20,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <algorithm>
 #include <cmath>

--- a/src/plugins/matrixops/gauss_inverse.cpp
+++ b/src/plugins/matrixops/gauss_inverse.cpp
@@ -14,7 +14,7 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/lcos/future.hpp>
+#include <hpx/futures/future.hpp>
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
Updating hpx/lcos/future.hpp to hpx/futures/future.hpp and hpx/runtime/launch_policy.hpp to hpx/async_base/launch_policy.hpp