### PR TITLE
Give the option to physl to start a phylanx function at line one.

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -230,13 +230,13 @@ def print_physl_src(src, with_symbol_info=False, tag=4):
     print("", sep="")
 
 
-def get_symbol_info(symbol, name, line_offset):
+def get_symbol_info(symbol, name):
     """Adds symbol info (line and column number) to the symbol."""
 
     if name in numpy_constants.keys():
         return name
     else:
-        return '%s$%d$%d' % (name, symbol.lineno - line_offset, symbol.col_offset)
+        return '%s$%d$%d' % (name, symbol.lineno, symbol.col_offset)
 
 
 def remove_line(a):
@@ -463,12 +463,6 @@ class PhySL:
         self.__src__ = None
         self.__ast__ = None
         self.ir = None
-        startatlineone = kwargs.get('startatlineone', False)
-        if startatlineone:
-            c = inspect.currentframe()
-            self.line_offset = inspect.getouterframes(c)[2].lineno
-        else:
-            self.line_offset = 0
         self.python_tree = tree
         if 'doc_src' in kwargs and kwargs['doc_src']:
             self.doc_src = func.__doc__
@@ -636,7 +630,7 @@ class PhySL:
             we can use this to let user provide type information!?!
         """
 
-        arg = get_symbol_info(node, node.arg, self.line_offset)
+        arg = get_symbol_info(node, node.arg)
         return arg
 
     def _arguments(self, node):
@@ -665,7 +659,7 @@ class PhySL:
             if default is None:
                 result = (*result, a)
             else:
-                op = get_symbol_info(arg, '__arg', self.line_offset)
+                op = get_symbol_info(arg, '__arg')
                 result = (*result, [op, (a, default)])
         return result
 
@@ -691,9 +685,9 @@ class PhySL:
         if isinstance(symbol, str):
             symbol_name = re.sub(r'\$\d+', '', symbol)
             if symbol_name in self.defined:
-                op = get_symbol_info(node.targets[0], "store", self.line_offset)
+                op = get_symbol_info(node.targets[0], "store")
             else:
-                op = get_symbol_info(node.targets[0], "define", self.line_offset)
+                op = get_symbol_info(node.targets[0], "define")
                 # TODO:
                 # For now `self.defined` is a set containing names of symbols
                 # with no extra information. We may want to make it a
@@ -702,7 +696,7 @@ class PhySL:
                 self.defined.add(symbol_name)
         # lhs is a subscript.
         else:
-            op = get_symbol_info(node.targets[0], "store", self.line_offset)
+            op = get_symbol_info(node.targets[0], "store")
 
         target = self._apply_rule(node.targets[0])
         value = self._apply_rule(node.value)
@@ -770,8 +764,8 @@ class PhySL:
             kw = self._apply_rule(k.value)
             return (k.arg, kw)
 
-        oplist = get_symbol_info(node.func, 'list', self.line_offset)
-        oparg = get_symbol_info(node.func, '__arg', self.line_offset)
+        oplist = get_symbol_info(node.func, 'list')
+        oparg = get_symbol_info(node.func, '__arg')
 
         symbol = self._apply_rule(node.func)
         args = tuple(self._apply_rule(arg) for arg in node.args)
@@ -1023,11 +1017,11 @@ class PhySL:
             We ignore decorator_list and returns.
         """
 
-        op = get_symbol_info(node, 'define', self.line_offset)
-        symbol = get_symbol_info(node, node.name, self.line_offset)
+        op = get_symbol_info(node, 'define')
+        symbol = get_symbol_info(node, node.name)
         args = self._apply_rule(node.args)
         body = self._block(node.body)
-        lambda_op = get_symbol_info(node, 'lambda', self.line_offset)
+        lambda_op = get_symbol_info(node, 'lambda')
 
         if (args):
             return [op, (symbol, args, body)]
@@ -1173,7 +1167,7 @@ class PhySL:
         `ctx` is one of `Load`, `Store`, `Del`.
         """
 
-        symbol = get_symbol_info(node, primitive_name(node.id), self.line_offset)
+        symbol = get_symbol_info(node, primitive_name(node.id))
         return symbol
 
     def _NameConstant(self, node):

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -41,7 +41,8 @@ def Phylanx(__phylanx_arg=None, **kwargs):
                 'compiler_state',
                 'doc_src',
                 'performance',
-                'localities'
+                'localities',
+                'startatlineone'
             ]
 
             self.backends_map = {'PhySL': PhySL, 'OpenSCoP': OpenSCoP}

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -47,6 +47,7 @@ def Phylanx(__phylanx_arg=None, **kwargs):
 
             self.backends_map = {'PhySL': PhySL, 'OpenSCoP': OpenSCoP}
             self.backend = self.get_backend(kwargs.get('target'))
+            self.startatlineone = kwargs.get("startatlineone", False)
             for key in kwargs.keys():
                 if key not in valid_kwargs:
                     raise NotImplementedError("Unknown Phylanx argument '%s'." % key)
@@ -90,7 +91,10 @@ def Phylanx(__phylanx_arg=None, **kwargs):
             """Generates the Python AST."""
 
             tree = ast.parse(src)
-            actual_lineno = inspect.getsourcelines(f)[-1]
+            if self.startatlineone:
+                actual_lineno = 0
+            else:
+                actual_lineno = inspect.getsourcelines(f)[-1]
             ast.increment_lineno(tree, actual_lineno)
             assert len(tree.body) == 1
             return tree


### PR DESCRIPTION
When running a Phylanx function, it's sometimes beneficial to start the line numbers for the function at line 1 rather than whatever the line is in the source file in which it is embedded. This PR provides an option to make that possible.