### PR TITLE
Making sure not to reuse the names of built-in primitives

### DIFF
--- a/examples/algorithms/als/als.cpp
+++ b/examples/algorithms/als/als.cpp
@@ -29,7 +29,7 @@ char const* const als_code = R"(
     //
     //
     //
-    define(als, ratings, regularization, num_factors, iterations, alpha, enable_output,
+    define(__als, ratings, regularization, num_factors, iterations, alpha, enable_output,
         block(
             define(num_users, shape(ratings, 0)),
             define(num_items, shape(ratings, 1)),
@@ -100,7 +100,7 @@ char const* const als_code = R"(
             list(X, Y)
         )
     )
-    als
+    __als
 )";
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/examples/algorithms/als/als_csv.cpp
+++ b/examples/algorithms/als/als_csv.cpp
@@ -30,7 +30,7 @@ char const* const als_code = R"(
     //
     // Alternating Least squares algorithm
     //
-    define(als, ratings, regularization, num_factors, iterations, alpha, enable_output,
+    define(__als, ratings, regularization, num_factors, iterations, alpha, enable_output,
         block(
             define(num_users, shape(ratings, 0)),
             define(num_items, shape(ratings, 1)),
@@ -101,7 +101,7 @@ char const* const als_code = R"(
             list(X, Y)
         )
     )
-    als
+    __als
 )";
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/examples/algorithms/kmeans/kmeans.cpp
+++ b/examples/algorithms/kmeans/kmeans.cpp
@@ -61,7 +61,7 @@ char const* const kmeans_code = R"(
         )
     ))
 
-    define(kmeans, points, k, iterations, block(
+    define(__kmeans, points, k, iterations, block(
         define(centroids, initialize_centroids(points, k)),
         for(define(i, 0), i < iterations, store(i, i + 1), block(
             store(centroids,

--- a/examples/algorithms/kmeans/kmeans_fix_points.cpp
+++ b/examples/algorithms/kmeans/kmeans_fix_points.cpp
@@ -66,7 +66,7 @@ char const* const kmeans_code = R"(
         ), result
     ))
 
-    define(kmeans, points, iterations, initial_centroids, enable_output,
+    define(__kmeans, points, iterations, initial_centroids, enable_output,
         block(
             define(centroids, initial_centroids),
             define(num_centroids, shape(centroids, 0)),

--- a/examples/algorithms/kmeans/kmeans_fix_points_3d.cpp
+++ b/examples/algorithms/kmeans/kmeans_fix_points_3d.cpp
@@ -46,7 +46,7 @@ char const* const kmeans_code = R"(
         )
     ))
 
-    define(kmeans, points, iterations, initial_centroids, enable_output,
+    define(__kmeans, points, iterations, initial_centroids, enable_output,
         block(
             define(centroids, initial_centroids),
             for(define(i, 0), i < iterations, store(i, i + 1),

--- a/examples/algorithms/lra/lra.cpp
+++ b/examples/algorithms/lra/lra.cpp
@@ -19,7 +19,7 @@ char const* const lra_code = R"(block(
     //
     //   x: [30, 2]
     //   y: [30]
-    define(lra, x, y, alpha, iterations, enable_output,
+    define(__lra, x, y, alpha, iterations, enable_output,
         block(
             define(weights, constant(0.0, shape(x, 1))),         // weights: [2]
             define(transx, transpose(x)),                        // transx:  [2, 30]
@@ -44,7 +44,7 @@ char const* const lra_code = R"(block(
             weights
         )
     ),
-    lra
+    __lra
 ))";
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/examples/algorithms/lra/lra_csv.cpp
+++ b/examples/algorithms/lra/lra_csv.cpp
@@ -58,7 +58,7 @@ char const* const lra_code = R"(block(
     //   x: [N, M]
     //   y: [N]
     //
-    define(lra, x, y, alpha, iterations, enable_output,
+    define(__lra, x, y, alpha, iterations, enable_output,
         block(
             define(weights, constant(0.0, shape(x, 1))),            // weights: [M]
             define(transx, transpose(x)),                           // transx:  [M, N]
@@ -83,7 +83,7 @@ char const* const lra_code = R"(block(
             weights
         )
     ),
-    lra
+    __lra
 ))";
 
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/examples/algorithms/lra/lra_csv_distributed.cpp
+++ b/examples/algorithms/lra/lra_csv_distributed.cpp
@@ -73,7 +73,7 @@ char const* const lra_code = R"(block(
     //   x: [N, M]
     //   y: [N]
     //
-    define(lra, x, y, alpha, iterations, enable_output,
+    define(__lra, x, y, alpha, iterations, enable_output,
         block(
             define(transx, transpose_d(x)),                     // transx:   [M, N]
             define(error, constant(0.0, shape(x, 0))),          // error:    [N]
@@ -97,7 +97,7 @@ char const* const lra_code = R"(block(
             weights
         )
     ),
-    lra
+    __lra
 ))";
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #1200