### PR TITLE
Renaming gradient variable to prevent error as reported in #1200

### DIFF
--- a/examples/algorithms/lra/lra.cpp
+++ b/examples/algorithms/lra/lra.cpp
@@ -25,7 +25,7 @@ char const* const lra_code = R"(block(
             define(transx, transpose(x)),                        // transx:  [2, 30]
             define(pred, constant(0.0, shape(x, 0))),
             define(error, constant(0.0, shape(x, 0))),
-            define(gradient, constant(0.0, shape(x, 1))),
+            define(grad, constant(0.0, shape(x, 1))),
             define(step, 0),
             while(
                 step < iterations,
@@ -34,9 +34,9 @@ char const* const lra_code = R"(block(
                     // exp(-dot(x, weights)): [30], pred: [30]
                     store(pred, sigmoid(dot(x, weights))),
                     store(error, pred - y),                      // error: [30]
-                    store(gradient, dot(transx, error)),         // gradient: [2]
+                    store(grad, dot(transx, error)),         // grad: [2]
                     parallel_block(
-                        store(weights, weights - (alpha * gradient)),
+                        store(weights, weights - (alpha * grad)),
                         store(step, step + 1)
                     )
                 )

--- a/examples/algorithms/lra/lra_csv.cpp
+++ b/examples/algorithms/lra/lra_csv.cpp
@@ -64,7 +64,7 @@ char const* const lra_code = R"(block(
             define(transx, transpose(x)),                           // transx:  [M, N]
             define(pred, constant(0.0, shape(x, 0))),
             define(error, constant(0.0, shape(x, 0))),
-            define(gradient, constant(0.0, shape(x, 1))),
+            define(grad, constant(0.0, shape(x, 1))),
             define(step, 0),
             while(
                 step < iterations,
@@ -73,9 +73,9 @@ char const* const lra_code = R"(block(
                     // exp(-dot(x, weights)): [N], pred: [N]
                     store(pred, sigmoid(dot(x, weights))),
                     store(error, pred - y),                         // error: [N]
-                    store(gradient, dot(transx, error)),            // gradient: [M]
+                    store(grad, dot(transx, error)),            // grad: [M]
                     parallel_block(
-                        store(weights, weights - (alpha * gradient)),
+                        store(weights, weights - (alpha * grad)),
                         store(step, step + 1)
                     )
                 )

--- a/examples/algorithms/lra/phylanx_lra_csv.py
+++ b/examples/algorithms/lra/phylanx_lra_csv.py
@@ -18,15 +18,15 @@ def lra(file_name, xlo1, xhi1, ylo1, yhi1, xlo2, xhi2, ylo2, yhi2, alpha,
     transx = transpose(x)
     pred = constant(0.0, shape(x, 0))
     error = constant(0.0, shape(x, 0))
-    gradient = constant(0.0, shape(x, 1))
+    grad = constant(0.0, shape(x, 1))
     step = 0
     while step < iterations:
         if enable_output:
             print("step: ", step, ", ", weights)
         pred = 1.0 / (1.0 + exp(-dot(x, weights)))
         error = pred - y
-        gradient = dot(transx, error)
-        weights = weights - (alpha * gradient)
+        grad = dot(transx, error)
+        weights = weights - (alpha * grad)
         step += 1
     return weights
 

--- a/examples/algorithms/lra/phylanx_lra_csv_np.py
+++ b/examples/algorithms/lra/phylanx_lra_csv_np.py
@@ -14,15 +14,15 @@ def lra(x, y, alpha, iterations, enable_output):
     transx = np.transpose(x)
     pred = constant(0.0, shape(x, 0))
     error = constant(0.0, shape(x, 0))
-    gradient = constant(0.0, shape(x, 1))
+    grad = constant(0.0, shape(x, 1))
     step = 0
     while step < iterations:
         if (enable_output):
             print("step: ", step, ", ", weights)
         pred = 1.0 / (1.0 + np.exp(-np.dot(x, weights)))
         error = pred - y
-        gradient = np.dot(transx, error)
-        weights = weights - (alpha * gradient)
+        grad = np.dot(transx, error)
+        weights = weights - (alpha * grad)
         step += 1
     return weights
 


### PR DESCRIPTION
As suggested, renamed "gradient" variable to "grad" in order to avoid runtime error.