### PR TITLE
[WIP] Change the CMakeLists.txt to output phylanx wheel

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -81,7 +81,7 @@ if (PYTHON_EXECUTABLE)
 
   # for the install step it does not matter which setup.py we use
   install(CODE
-    "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY}_${__install_config}.py install --user)")
+    "execute_process(COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY}_${__install_config}.py bdist_wheel)")
 
 endif()
 


### PR DESCRIPTION
The changes in code will output a wheel after the build instead of the installation on system. The wheel file will only contain the python library and _phylanx(d).cpython-37m-x86_64-linux-gnu.so. The shared libraries generated during the build and phylanx dependencies are then packed with the wheel. The rpaths of these binaries is fixed to remove external dependency of wheel to make it a standalone package with no external dependencies.