### PR TITLE
Adding distributed file_read_csv

### DIFF
--- a/phylanx/plugins/dist_matrixops/dist_constant.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_constant.hpp
@@ -16,6 +16,7 @@
 
 #include <hpx/futures/future.hpp>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -50,26 +51,32 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type constant1d_helper(
             execution_tree::primitive_argument_type&& value,
             std::size_t const& dim, std::uint32_t const& tile_idx,
-            std::uint32_t const& numtiles, std::string&& given_name) const;
+            std::uint32_t const& numtiles, std::string&& given_name,
+            std::size_t intersection) const;
 
         execution_tree::primitive_argument_type constant1d(
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-            std::string&& given_name, execution_tree::node_data_type dtype) const;
+            std::string&& given_name, std::size_t intersection,
+            execution_tree::node_data_type dtype) const;
 
         template <typename T>
         execution_tree::primitive_argument_type constant2d_helper(
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-            std::string&& given_name, std::string const& tiling_type) const;
+            std::string&& given_name, std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const&
+                intersections) const;
 
         execution_tree::primitive_argument_type constant2d(
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
             std::string&& given_name, std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const&
+                intersections,
             execution_tree::node_data_type dtype) const;
 
         template <typename T>
@@ -77,15 +84,18 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-            std::string&& given_name, std::string const& tiling_type) const;
+            std::string&& given_name, std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const&
+                intersections) const;
 
         execution_tree::primitive_argument_type constant3d(
             execution_tree::primitive_argument_type&& value,
             operand_type::dimensions_type const& dims,
             std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
             std::string&& given_name, std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const&
+                intersections,
             execution_tree::node_data_type dtype) const;
-
     };
 
     inline execution_tree::primitive

--- a/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
+++ b/phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp
@@ -58,15 +58,20 @@ namespace tile_calculation
         std::int64_t start, std::size_t size, std::size_t dim,
         std::size_t intersection)
     {
-        if (start + size == dim)
+        if (start + size == dim)    // bottom part
         {
             start -= intersection;
+            size += intersection;
         }
-        else if (start != 0)
+        else if (start == 0)    // top part
         {
-            start -= static_cast<std::size_t>(intersection / 2);
+            size += intersection;
         }
-        size += intersection;
+        else    // middle part
+        {
+            start -= static_cast<std::size_t>(intersection);
+            size += 2 * intersection;
+        }
 
         if (start < 0)
         {

--- a/phylanx/plugins/fileio/dist_file_read_csv.hpp
+++ b/phylanx/plugins/fileio/dist_file_read_csv.hpp
@@ -1,10 +1,12 @@
 //  Copyright (c) 2017 Alireza Kheirkhahan
+//  Copyright (c) 2020 Bita Hasheminezhad
+//  Copyright (c) 2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#if !defined(PHYLANX_PRIMITIVES_FILE_READ_CSV_OCT_26_2017_0129PM)
-#define PHYLANX_PRIMITIVES_FILE_READ_CSV_OCT_26_2017_0129PM
+#if !defined(PHYLANX_PRIMITIVES_DIST_FILE_READ_CSV)
+#define PHYLANX_PRIMITIVES_DIST_FILE_READ_CSV
 
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
@@ -20,33 +22,31 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
-    class file_read_csv
+    class dist_file_read_csv
       : public primitive_component_base
-      , public std::enable_shared_from_this<file_read_csv>
+      , public std::enable_shared_from_this<dist_file_read_csv>
     {
     public:
         static match_pattern_type const match_data;
 
-        file_read_csv() = default;
+        dist_file_read_csv() = default;
 
-        file_read_csv(primitive_arguments_type&& operands,
+        dist_file_read_csv(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
-        primitive_argument_type read(
-            std::ifstream&& infile, std::string const& filename) const;
-
+    protected:
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
             eval_context ctx) const override;
     };
 
-    inline primitive create_file_read_csv(hpx::id_type const& locality,
+    inline primitive create_dist_file_read_csv(hpx::id_type const& locality,
         primitive_arguments_type&& operands,
         std::string const& name = "", std::string const& codename = "")
     {
         return create_primitive_component(
-            locality, "file_read_csv", std::move(operands), name, codename);
+            locality, "file_read_csv_d", std::move(operands), name, codename);
     }
 }}}
 

--- a/phylanx/plugins/fileio/dist_file_read_csv.hpp
+++ b/phylanx/plugins/fileio/dist_file_read_csv.hpp
@@ -14,6 +14,9 @@
 
 #include <hpx/futures/future.hpp>
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <string>
@@ -33,6 +36,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         dist_file_read_csv(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
+
+    private:
+        primitive_argument_type dist_read_2d(std::ifstream&& infile,
+            std::string const& filename, std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const&
+                intersections,
+            std::string&& given_name, std::uint32_t numtiles) const;
+        primitive_argument_type dist_read_3d(std::ifstream&& infile,
+            std::string const& filename, std::int64_t given_nrows,
+            std::string const& tiling_type,
+            std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const&
+                intersections,
+            std::string&& given_name, std::uint32_t numtiles) const;
 
     protected:
         hpx::future<primitive_argument_type> eval(

--- a/phylanx/plugins/fileio/file_read_csv.hpp
+++ b/phylanx/plugins/fileio/file_read_csv.hpp
@@ -35,8 +35,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         file_read_csv(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
-        std::tuple<std::vector<double>, std::size_t, std::size_t> read_helper(
-            std::ifstream&& infile, std::string const& filename) const;
+    private:
+        //std::tuple<std::vector<double>, std::size_t, std::size_t> read_helper(
+        //    std::ifstream&& infile, std::string const& filename) const;
 
         primitive_argument_type read(
             std::ifstream&& infile, std::string const& filename) const;
@@ -44,6 +45,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive_argument_type read_3d(std::ifstream&& infile,
             std::string const& filename, std::int64_t given_nrows) const;
 
+    protected:
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,

--- a/phylanx/plugins/fileio/file_read_csv.hpp
+++ b/phylanx/plugins/fileio/file_read_csv.hpp
@@ -12,9 +12,12 @@
 
 #include <hpx/futures/future.hpp>
 
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -32,8 +35,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
         file_read_csv(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
+        std::tuple<std::vector<double>, std::size_t, std::size_t> read_helper(
+            std::ifstream&& infile, std::string const& filename) const;
+
         primitive_argument_type read(
             std::ifstream&& infile, std::string const& filename) const;
+
+        primitive_argument_type read_3d(std::ifstream&& infile,
+            std::string const& filename, std::int64_t given_nrows) const;
 
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,

--- a/phylanx/plugins/fileio/file_read_csv.hpp
+++ b/phylanx/plugins/fileio/file_read_csv.hpp
@@ -31,6 +31,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
         file_read_csv(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
 
+        primitive_argument_type read(
+            std::ifstream&& infile, std::string const& filename) const;
+
         hpx::future<primitive_argument_type> eval(
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,

--- a/phylanx/plugins/fileio/file_read_csv.hpp
+++ b/phylanx/plugins/fileio/file_read_csv.hpp
@@ -12,12 +12,10 @@
 
 #include <hpx/futures/future.hpp>
 
-#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <memory>
 #include <string>
-#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -36,9 +34,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename);
 
     private:
-        //std::tuple<std::vector<double>, std::size_t, std::size_t> read_helper(
-        //    std::ifstream&& infile, std::string const& filename) const;
-
         primitive_argument_type read(
             std::ifstream&& infile, std::string const& filename) const;
 

--- a/phylanx/plugins/fileio/file_read_csv_impl.hpp
+++ b/phylanx/plugins/fileio/file_read_csv_impl.hpp
@@ -25,11 +25,13 @@
 #include <boost/spirit/include/qi_real.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <iomanip>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -37,8 +39,10 @@
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {
+
     // read data from given file and return content
-    inline primitive_argument_type file_read_csv::read(
+    inline std::tuple<std::vector<double>, std::size_t, std::size_t>
+    file_read_csv::read_helper(
         std::ifstream&& infile, std::string const& filename) const
     {
         std::string line;
@@ -70,7 +74,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     else if (n_cols != (after_readln - before_readln))
                     {
                         throw std::runtime_error(generate_error_message(
-                            "wrong data format, different number "
+                            "wrong data format, different "
+                            "number "
                             "of element in this row " +
                             filename + ':' + std::to_string(n_rows)));
                     }
@@ -86,28 +91,64 @@ namespace phylanx { namespace execution_tree { namespace primitives
             }
         }
 
+        return std::move(std::make_tuple(matrix_array, n_rows, n_cols));
+    }
+
+    inline primitive_argument_type file_read_csv::read(
+        std::ifstream&& infile, std::string const& filename) const
+    {
+        std::vector<double> data;
+        std::size_t n_rows, n_cols;
+        std::tie(data, n_rows, n_cols) =
+            read_helper(std::move(infile), filename);
+
         if (n_rows == 1)
         {
             if (n_cols == 1)
             {
                 // scalar value
                 return primitive_argument_type{
-                    ir::node_data<double>{matrix_array[0]}};
+                    ir::node_data<double>{data[0]}};
             }
 
             // vector
-            blaze::DynamicVector<double> vector(n_cols, matrix_array.data());
+            blaze::DynamicVector<double> vector(n_cols, data.data());
 
             return primitive_argument_type{
                 ir::node_data<double>{std::move(vector)}};
         }
 
         // matrix
-        blaze::DynamicMatrix<double> matrix(
-            n_rows, n_cols, matrix_array.data());
+        blaze::DynamicMatrix<double> matrix(n_rows, n_cols, data.data());
 
         return primitive_argument_type{
             ir::node_data<double>{std::move(matrix)}};
+    }
+
+    inline primitive_argument_type file_read_csv::read_3d(
+        std::ifstream&& infile, std::string const& filename,
+        std::int64_t given_nrows) const
+    {
+        std::vector<double> data;
+        std::size_t n_rows, n_cols;
+        std::tie(data, n_rows, n_cols) =
+            read_helper(std::move(infile), filename);
+
+        if (n_rows % given_nrows != 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "file_read_csv::read_3d",
+                util::generate_error_message(
+                    "the number of rows in the csv file is not divisible by "
+                    "the given number of rows in a page"));
+        }
+
+        // tensor
+        blaze::DynamicTensor<double> result(
+            static_cast<std::size_t>(n_rows / given_nrows), given_nrows, n_cols,
+            data.data());
+
+        return primitive_argument_type{
+            ir::node_data<double>{std::move(result)}};
     }
 }}}
 

--- a/phylanx/plugins/fileio/file_read_csv_impl.hpp
+++ b/phylanx/plugins/fileio/file_read_csv_impl.hpp
@@ -16,7 +16,6 @@
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/runtime/threads/run_as_os_thread.hpp>
 
 #include <boost/spirit/include/qi_char.hpp>
 #include <boost/spirit/include/qi_list.hpp>
@@ -34,8 +33,6 @@
 #include <tuple>
 #include <utility>
 #include <vector>
-
-#include <blaze/Math.h>
 
 namespace phylanx { namespace execution_tree { namespace primitives
 {

--- a/phylanx/plugins/fileio/file_read_csv_impl.hpp
+++ b/phylanx/plugins/fileio/file_read_csv_impl.hpp
@@ -1,0 +1,114 @@
+//  Copyright (c) 2017 Alireza Kheirkhahan
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_FILE_READ_CSV_IMPL_HPP)
+#define PHYLANX_PRIMITIVES_FILE_READ_CSV_IMPL_HPP
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+#include <phylanx/plugins/fileio/file_read_csv.hpp>
+
+#include <hpx/futures/future.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/runtime/threads/run_as_os_thread.hpp>
+
+#include <boost/spirit/include/qi_char.hpp>
+#include <boost/spirit/include/qi_list.hpp>
+#include <boost/spirit/include/qi_lit.hpp>
+#include <boost/spirit/include/qi_parse.hpp>
+#include <boost/spirit/include/qi_real.hpp>
+
+#include <cstddef>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    // read data from given file and return content
+    inline primitive_argument_type file_read_csv::read(
+        std::ifstream&& infile, std::string const& filename) const
+    {
+        std::string line;
+        bool header_parsed = false;
+        std::vector<double> matrix_array, current_line;
+        std::size_t n_rows = 0, n_cols = 0;
+        std::size_t before_readln = 0, after_readln = 0;
+
+        while (std::getline(infile, line))
+        {
+            before_readln = matrix_array.size();
+
+            auto begin_local = line.begin();
+            if (boost::spirit::qi::parse(begin_local, line.end(),
+                    boost::spirit::qi::double_ % ',', current_line))
+            {
+                if (begin_local == line.end() || header_parsed)
+                {
+                    header_parsed = true;
+
+                    matrix_array.insert(matrix_array.end(),
+                        current_line.begin(), current_line.end());
+
+                    after_readln = matrix_array.size();
+                    if (n_rows == 0)
+                    {
+                        n_cols = matrix_array.size();
+                    }
+                    else if (n_cols != (after_readln - before_readln))
+                    {
+                        throw std::runtime_error(generate_error_message(
+                            "wrong data format, different number "
+                            "of element in this row " +
+                            filename + ':' + std::to_string(n_rows)));
+                    }
+                    n_rows++;
+                }
+                current_line.clear();
+            }
+            else
+            {
+                throw std::runtime_error(
+                    generate_error_message("wrong data format " + filename +
+                        ':' + std::to_string(n_rows)));
+            }
+        }
+
+        if (n_rows == 1)
+        {
+            if (n_cols == 1)
+            {
+                // scalar value
+                return primitive_argument_type{
+                    ir::node_data<double>{matrix_array[0]}};
+            }
+
+            // vector
+            blaze::DynamicVector<double> vector(n_cols, matrix_array.data());
+
+            return primitive_argument_type{
+                ir::node_data<double>{std::move(vector)}};
+        }
+
+        // matrix
+        blaze::DynamicMatrix<double> matrix(
+            n_rows, n_cols, matrix_array.data());
+
+        return primitive_argument_type{
+            ir::node_data<double>{std::move(matrix)}};
+    }
+}}}
+
+#endif

--- a/phylanx/plugins/fileio/file_read_csv_impl.hpp
+++ b/phylanx/plugins/fileio/file_read_csv_impl.hpp
@@ -45,7 +45,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         bool header_parsed = false;
         std::vector<double> matrix_array, current_line;
         std::size_t n_rows = 0, n_cols = 0;
-        std::size_t before_readln = 0, after_readln = 0;
+        std::size_t before_readln, after_readln;
 
         while (std::getline(infile, line))
         {

--- a/phylanx/plugins/fileio/file_read_csv_impl.hpp
+++ b/phylanx/plugins/fileio/file_read_csv_impl.hpp
@@ -42,8 +42,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
     // read data from given file and return content
     inline std::tuple<std::vector<double>, std::size_t, std::size_t>
-    file_read_csv::read_helper(
-        std::ifstream&& infile, std::string const& filename) const
+    read_helper(std::ifstream&& infile, std::string const& filename)
     {
         std::string line;
         bool header_parsed = false;
@@ -73,10 +72,9 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     }
                     else if (n_cols != (after_readln - before_readln))
                     {
-                        throw std::runtime_error(generate_error_message(
-                            "wrong data format, different "
-                            "number "
-                            "of element in this row " +
+                        throw std::runtime_error(util::generate_error_message(
+                            "wrong data format, different number of element in "
+                            "this row " +
                             filename + ':' + std::to_string(n_rows)));
                     }
                     n_rows++;
@@ -86,69 +84,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             else
             {
                 throw std::runtime_error(
-                    generate_error_message("wrong data format " + filename +
-                        ':' + std::to_string(n_rows)));
+                    util::generate_error_message("wrong data format " +
+                        filename + ':' + std::to_string(n_rows)));
             }
         }
 
         return std::move(std::make_tuple(matrix_array, n_rows, n_cols));
-    }
-
-    inline primitive_argument_type file_read_csv::read(
-        std::ifstream&& infile, std::string const& filename) const
-    {
-        std::vector<double> data;
-        std::size_t n_rows, n_cols;
-        std::tie(data, n_rows, n_cols) =
-            read_helper(std::move(infile), filename);
-
-        if (n_rows == 1)
-        {
-            if (n_cols == 1)
-            {
-                // scalar value
-                return primitive_argument_type{
-                    ir::node_data<double>{data[0]}};
-            }
-
-            // vector
-            blaze::DynamicVector<double> vector(n_cols, data.data());
-
-            return primitive_argument_type{
-                ir::node_data<double>{std::move(vector)}};
-        }
-
-        // matrix
-        blaze::DynamicMatrix<double> matrix(n_rows, n_cols, data.data());
-
-        return primitive_argument_type{
-            ir::node_data<double>{std::move(matrix)}};
-    }
-
-    inline primitive_argument_type file_read_csv::read_3d(
-        std::ifstream&& infile, std::string const& filename,
-        std::int64_t given_nrows) const
-    {
-        std::vector<double> data;
-        std::size_t n_rows, n_cols;
-        std::tie(data, n_rows, n_cols) =
-            read_helper(std::move(infile), filename);
-
-        if (n_rows % given_nrows != 0)
-        {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "file_read_csv::read_3d",
-                util::generate_error_message(
-                    "the number of rows in the csv file is not divisible by "
-                    "the given number of rows in a page"));
-        }
-
-        // tensor
-        blaze::DynamicTensor<double> result(
-            static_cast<std::size_t>(n_rows / given_nrows), given_nrows, n_cols,
-            data.data());
-
-        return primitive_argument_type{
-            ir::node_data<double>{std::move(result)}};
     }
 }}}
 

--- a/phylanx/plugins/fileio/fileio.hpp
+++ b/phylanx/plugins/fileio/fileio.hpp
@@ -6,6 +6,7 @@
 #if !defined(PHYLANX_PLUGINS_FILEIO_APR_10_2108_1130AM)
 #define PHYLANX_PLUGINS_FILEIO_APR_10_2108_1130AM
 
+#include <phylanx/plugins/fileio/dist_file_read_csv.hpp>
 #include <phylanx/plugins/fileio/file_read.hpp>
 #include <phylanx/plugins/fileio/file_read_csv.hpp>
 #include <phylanx/plugins/fileio/file_read_hdf5.hpp>

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -49,12 +49,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     __arg(_4_numtiles, num_localities()),
                     __arg(_5_name, ""),
                     __arg(_6_tiling_type, "sym"),
-                    __arg(_7_dtype, "float64")
+                    __arg(_7_itersection, nil),
+                    __arg(_8_dtype, "float64")
                 )
             )"},
             &create_dist_constant,
             &execution_tree::create_primitive<dist_constant>, R"(
-            value, shape, tile_index, numtiles, name, tiling_type, dtype
+            value, shape, tile_index, numtiles, name, tiling_type, intersection,
+            dtype
             Args:
 
                 value (float): fill value
@@ -70,8 +72,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     globally unique name will be generated.
                 tiling_type (string, optional): defaults to `sym` which is a
                     balanced way of tiling among all the numtiles localities.
-                    Other options are `row` or `column` tiling. For a vector
-                    all these three tiling_type are the same.
+                    Other options are `page`, `row` or `column` tiling. For a
+                    vector all these three tiling_type are the same.
+                intersection (int or a tuple of ints, optional): the size of
+                    overlapped part on each dimension. If an integer is given,
+                    that would be the intersection length on all dimensions
+                    that are tiled. The middle parts get to have two
+                    intersections, one with the tile before it and one with the
+                    tile after it.
                 dtype (string, optional): the data-type of the returned array,
                     defaults to 'float'.
 
@@ -106,9 +114,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     execution_tree::primitive_argument_type dist_constant::constant1d_helper(
-        execution_tree::primitive_argument_type&& value,
-        std::size_t const& dim, std::uint32_t const& tile_idx,
-        std::uint32_t const& numtiles, std::string&& given_name) const
+        execution_tree::primitive_argument_type&& value, std::size_t const& dim,
+        std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
+        std::string&& given_name, std::size_t intersection) const
     {
         using namespace execution_tree;
 
@@ -119,6 +127,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::uint32_t size;
         std::tie(start, size) =
             tile_calculation::tile_calculation_1d(tile_idx, dim, numtiles);
+
+        // adding overlap
+        if (intersection != 0)
+        {
+            std::tie(start, size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    start, size, dim, intersection);
+        }
 
         tiling_information_1d tile_info(
             tiling_information_1d::tile1d_type::columns,
@@ -145,7 +161,8 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type&& value,
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-        std::string&& given_name, execution_tree::node_data_type dtype) const
+        std::string&& given_name, std::size_t intersection,
+        execution_tree::node_data_type dtype) const
     {
         using namespace execution_tree;
 
@@ -153,16 +170,16 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         {
         case node_data_type_bool:
             return constant1d_helper<std::uint8_t>(std::move(value), dims[0],
-                tile_idx, numtiles, std::move(given_name));
+                tile_idx, numtiles, std::move(given_name), intersection);
 
         case node_data_type_int64:
             return constant1d_helper<std::int64_t>(std::move(value), dims[0],
-                tile_idx, numtiles, std::move(given_name));
+                tile_idx, numtiles, std::move(given_name), intersection);
 
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant1d_helper<double>(std::move(value), dims[0],
-                tile_idx, numtiles, std::move(given_name));
+                tile_idx, numtiles, std::move(given_name), intersection);
 
         default:
             break;
@@ -181,7 +198,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type&& value,
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-        std::string&& given_name, std::string const& tiling_type) const
+        std::string&& given_name, std::string const& tiling_type,
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersections)
+        const
     {
         using namespace execution_tree;
 
@@ -196,6 +215,22 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::tie(row_start, column_start, row_size, column_size) =
             tile_calculation::tile_calculation_2d(
                 tile_idx, row_dim, column_dim, numtiles, tiling_type);
+
+        // adding overlap
+        if (row_size != row_dim &&
+            intersections[0] != 0)    // rows overlap
+        {
+            std::tie(row_start, row_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    row_start, row_size, row_dim, intersections[0]);
+        }
+        if (column_size != column_dim &&
+            intersections[1] != 0)    // columns overlap
+        {
+            std::tie(column_start, column_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    column_start, column_size, column_dim, intersections[1]);
+        }
 
         tiling_information_2d tile_info(
             tiling_span(row_start, row_start + row_size),
@@ -225,6 +260,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type,
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersections,
         execution_tree::node_data_type dtype) const
     {
         using namespace execution_tree;
@@ -233,16 +269,18 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         {
         case node_data_type_bool:
             return constant2d_helper<std::uint8_t>(std::move(value), dims,
-                tile_idx, numtiles, std::move(given_name), tiling_type);
+                tile_idx, numtiles, std::move(given_name), tiling_type,
+                intersections);
 
         case node_data_type_int64:
             return constant2d_helper<std::int64_t>(std::move(value), dims,
-                tile_idx, numtiles, std::move(given_name), tiling_type);
+                tile_idx, numtiles, std::move(given_name), tiling_type,
+                intersections);
 
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant2d_helper<double>(std::move(value), dims, tile_idx,
-                numtiles, std::move(given_name), tiling_type);
+                numtiles, std::move(given_name), tiling_type, intersections);
 
         default:
             break;
@@ -261,7 +299,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::primitive_argument_type&& value,
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
-        std::string&& given_name, std::string const& tiling_type) const
+        std::string&& given_name, std::string const& tiling_type,
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersections)
+        const
     {
         using namespace execution_tree;
 
@@ -277,6 +317,27 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         std::tie(page_start, row_start, column_start, page_size, row_size,
             column_size) = tile_calculation::tile_calculation_3d(tile_idx,
             page_dim, row_dim, column_dim, numtiles, tiling_type);
+
+        // adding overlap
+        if (page_size != page_dim && intersections[0] != 0)    // pages overlap
+        {
+            std::tie(page_start, page_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    page_start, page_size, page_dim, intersections[0]);
+        }
+        if (row_size != row_dim && intersections[1] != 0)    // rows overlap
+        {
+            std::tie(row_start, row_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    row_start, row_size, row_dim, intersections[1]);
+        }
+        if (column_size != column_dim &&
+            intersections[2] != 0)    // columns overlap
+        {
+            std::tie(column_start, column_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    column_start, column_size, column_dim, intersections[2]);
+        }
 
         tiling_information_3d tile_info(
             tiling_span(page_start, page_start + page_size),
@@ -307,6 +368,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         operand_type::dimensions_type const& dims,
         std::uint32_t const& tile_idx, std::uint32_t const& numtiles,
         std::string&& given_name, std::string const& tiling_type,
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersections,
         execution_tree::node_data_type dtype) const
     {
         using namespace execution_tree;
@@ -315,16 +377,18 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         {
         case node_data_type_bool:
             return constant3d_helper<std::uint8_t>(std::move(value), dims,
-                tile_idx, numtiles, std::move(given_name), tiling_type);
+                tile_idx, numtiles, std::move(given_name), tiling_type,
+                intersections);
 
         case node_data_type_int64:
             return constant3d_helper<std::int64_t>(std::move(value), dims,
-                tile_idx, numtiles, std::move(given_name), tiling_type);
+                tile_idx, numtiles, std::move(given_name), tiling_type,
+                intersections);
 
         case node_data_type_unknown: HPX_FALLTHROUGH;
         case node_data_type_double:
             return constant3d_helper<double>(std::move(value), dims, tile_idx,
-                numtiles, std::move(given_name), tiling_type);
+                numtiles, std::move(given_name), tiling_type, intersections);
 
         default:
             break;
@@ -344,13 +408,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
         execution_tree::eval_context ctx) const
     {
         // verify arguments
-        if (operands.size() < 2 || operands.size() > 7)
+        if (operands.size() < 2 || operands.size() > 8)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "dist_constant::eval",
                 generate_error_message(
                     "the constant_d primitive requires "
-                        "at least 2 and at most 7 operands"));
+                        "at least 2 and at most 8 operands"));
         }
 
         if (!valid(operands[0]) || !valid(operands[1]))
@@ -455,11 +519,64 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                         }
                     }
 
-                    node_data_type dtype = node_data_type_unknown;
+                    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
+                        intersections{0};
                     if (valid(args[6]))
                     {
+                        if (is_list_operand_strict(args[6]))
+                        {
+                            ir::range&& intersection_list =
+                                extract_list_value_strict(std::move(args[6]),
+                                    this_->name_, this_->codename_);
+
+                            if (intersection_list.size() != 1 &&
+                                intersection_list.size() != numdims)
+                            {
+                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                    "dist_constant::eval",
+                                    this_->generate_error_message(
+                                        "intersection should have the same "
+                                        "number of dimensions as the array, or "
+                                        "be represented with an integer for "
+                                        "all dimensions"));
+                            }
+                            intersections =
+                                util::detail::extract_nonneg_range_dimensions(
+                                    intersection_list, this_->name_,
+                                    this_->codename_);
+                        }
+                        else if (is_numeric_operand(args[6]))
+                        {
+                            intersections[0] =
+                                extract_scalar_nonneg_integer_value_strict(
+                                    std::move(args[6]), this_->name_,
+                                    this_->codename_);
+
+                            // we assume all dimensions have the same
+                            // intersection length which is the given one
+                            for (std::size_t i = 1; i != PHYLANX_MAX_DIMENSIONS;
+                                 ++i)
+                            {
+                                if (i == numdims)
+                                    break;
+                                intersections[i] = intersections[0];
+                            }
+                        }
+                        else
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "dist_constant::eval",
+                                this_->generate_error_message(
+                                    "intersection can be an integer or a list "
+                                    "of integers"));
+                        }
+                    }
+
+                    node_data_type dtype = node_data_type_unknown;
+                    if (valid(args[7]))
+                    {
                         dtype =
-                            map_dtype(extract_string_value(std::move(args[6]),
+                            map_dtype(extract_string_value(std::move(args[7]),
                                 this_->name_, this_->codename_));
                     }
 
@@ -467,17 +584,19 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     {
                     case 1:
                         return this_->constant1d(std::move(args[0]), dims,
-                            tile_idx, numtiles, std::move(given_name), dtype);
+                            tile_idx, numtiles, std::move(given_name),
+                            intersections[0], dtype);
 
                     case 2:
                         return this_->constant2d(std::move(args[0]), dims,
                             tile_idx, numtiles, std::move(given_name),
-                            tiling_type, dtype);
+                            tiling_type, intersections, dtype);
 
                     case 3:
                         return this_->constant3d(std::move(args[0]), dims,
                             tile_idx, numtiles, std::move(given_name),
-                            tiling_type, dtype);
+                            tiling_type, intersections, dtype);
+
                     default:
                         HPX_THROW_EXCEPTION(hpx::bad_parameter,
                             "dist_constant::eval",

--- a/src/plugins/dist_matrixops/dist_constant.cpp
+++ b/src/plugins/dist_matrixops/dist_constant.cpp
@@ -49,7 +49,7 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                     __arg(_4_numtiles, num_localities()),
                     __arg(_5_name, ""),
                     __arg(_6_tiling_type, "sym"),
-                    __arg(_7_itersection, nil),
+                    __arg(_7_intersection, nil),
                     __arg(_8_dtype, "float64")
                 )
             )"},

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -69,8 +69,9 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
                 intersection (int or tuple of ints, optional): the size of
                     overlapped part on each dimension. If an integer is given,
                     that would be the intersection length on all dimensions
-                    that are tiled. If the given intersection is odd, the extra
-                    overlapped vector will be at the end of the part.
+                    that are tiled. The middle parts get to have two
+                    intersections, one with the tile before it and one with the
+                    tile after it.
                     In the `user` mode, `intersection` cannot be used.
                 numtiles (int, optional): number of tiles of the returned array
                     If not given it sets to the number of localities in the

--- a/src/plugins/fileio/CMakeLists.txt
+++ b/src/plugins/fileio/CMakeLists.txt
@@ -4,13 +4,16 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(headers
+   "${PROJECT_SOURCE_DIR}/phylanx/plugins/fileio/dist_file_read_csv.hpp"
    "${PROJECT_SOURCE_DIR}/phylanx/plugins/fileio/fileio.hpp"
    "${PROJECT_SOURCE_DIR}/phylanx/plugins/fileio/file_read.hpp"
    "${PROJECT_SOURCE_DIR}/phylanx/plugins/fileio/file_read_csv.hpp"
+   "${PROJECT_SOURCE_DIR}/phylanx/plugins/fileio/file_read_csv_impl.hpp"
    "${PROJECT_SOURCE_DIR}/phylanx/plugins/fileio/file_write.hpp"
    "${PROJECT_SOURCE_DIR}/phylanx/plugins/fileio/file_write_csv.hpp"
   )
 set(sources
+   "dist_file_read_csv.cpp"
    "fileio.cpp"
    "file_read.cpp"
    "file_read_csv.cpp"

--- a/src/plugins/fileio/dist_file_read_csv.cpp
+++ b/src/plugins/fileio/dist_file_read_csv.cpp
@@ -13,16 +13,20 @@
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/execution_tree/tiling_annotations.hpp>
 #include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/dist_matrixops/tile_calculation_helper.hpp>
 #include <phylanx/plugins/fileio/dist_file_read_csv.hpp>
 #include <phylanx/plugins/fileio/file_read_csv_impl.hpp>
+#include <phylanx/util/detail/range_dimension.hpp>
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>
-//#include <hpx/runtime/threads/run_as_os_thread.hpp>
 
+#include <array>
 #include <atomic>
+#include <cstddef>
+#include <cstdint>
 #include <fstream>
 #include <iomanip>
 #include <memory>
@@ -44,10 +48,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::vector<std::string>{R"(
                 file_read_csv_d(
                     _1_filename,
-                    __arg(_2_tiling_type, "sym"),
-                    __arg(_3_intersection, nil),
-                    __arg(_4_name, ""),
-                    __arg(_5_numtiles, num_localities())
+                    __arg(_2_mode3d, false),
+                    __arg(_3_page_nrows, 1),
+                    __arg(_4_tiling_type, "sym"),
+                    __arg(_5_intersection, nil),
+                    __arg(_6_name, ""),
+                    __arg(_7_numtiles, num_localities())
                 )
             )"},
             &create_dist_file_read_csv, &create_primitive<dist_file_read_csv>,
@@ -55,6 +61,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             Args:
 
                 filename (string) : file name including its path.
+                mode3d (bool, optional) : If sets to true, the result will be a
+                    3d array. Each page_nrows rows of the data is stored in a
+                    new page of the result.
+                page_nrows (int, optional) : it is used only whenmode3d is true.
+                    It determines the number of rows in each page of the
+                    resulted array.
                 tiling_type (string, optional): defaults to `sym` which is a
                     balanced way of tiling among all the numtiles localities.
                     Other options are `page`, `row` or `column` tiling. For a
@@ -87,12 +99,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
     ///////////////////////////////////////////////////////////////////////////
     namespace detail
     {
-        static std::atomic<std::size_t> const_count(0);
+        static std::atomic<std::size_t> csv_count(0);
         std::string generate_csv_name(std::string&& given_name)
         {
             if (given_name.empty())
             {
-                return "csv_file_" + std::to_string(++const_count);
+                return "csv_file_" + std::to_string(++csv_count);
             }
 
             return std::move(given_name);
@@ -100,11 +112,150 @@ namespace phylanx { namespace execution_tree { namespace primitives
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type dist_file_read_csv::dist_read_2d(
+        std::ifstream&& infile, std::string const& filename,
+        std::string const& tiling_type,
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersections,
+        std::string&& given_name, std::uint32_t numtiles) const
+    {
+        std::vector<double> data;
+        std::size_t n_rows, n_cols;
+        std::tie(data, n_rows, n_cols) =
+            read_helper(std::move(infile), filename);
+
+        std::int64_t row_start, column_start;
+        std::size_t row_size, column_size;
+        std::uint32_t tile_idx = hpx::get_locality_id();
+
+        std::tie(row_start, column_start, row_size, column_size) =
+            tile_calculation::tile_calculation_2d(
+                tile_idx, n_rows, n_cols, numtiles, tiling_type);
+
+        // adding overlap
+        if (row_size != n_rows && intersections[0] != 0)    // rows overlap
+        {
+            std::tie(row_start, row_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    row_start, row_size, n_rows, intersections[0]);
+        }
+        if (column_size != n_cols &&
+            intersections[1] != 0)    // columns overlap
+        {
+            std::tie(column_start, column_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    column_start, column_size, n_cols, intersections[1]);
+        }
+
+        tiling_information_2d tile_info(
+            tiling_span(row_start, row_start + row_size),
+            tiling_span(column_start, column_start + column_size));
+
+        locality_information locality_info(tile_idx, numtiles);
+        annotation locality_ann = locality_info.as_annotation();
+
+        std::string base_name =
+            detail::generate_csv_name(std::move(given_name));
+
+        annotation_information ann_info(
+            std::move(base_name), 0);    //generation 0
+
+        auto attached_annotation =
+            std::make_shared<annotation>(localities_annotation(locality_ann,
+                tile_info.as_annotation(name_, codename_), ann_info, name_,
+                codename_));
+
+        blaze::DynamicMatrix<double> whole_data(n_rows, n_cols, data.data());
+        blaze::DynamicMatrix<double> result =
+            blaze::submatrix(std::move(whole_data), row_start, column_start,
+                row_size, column_size);
+
+        return primitive_argument_type(result, attached_annotation);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive_argument_type dist_file_read_csv::dist_read_3d(
+        std::ifstream&& infile, std::string const& filename,
+        std::int64_t given_nrows, std::string const& tiling_type,
+        std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& intersections,
+        std::string&& given_name, std::uint32_t numtiles) const
+    {
+        std::vector<double> data;
+        std::size_t n_rows, n_cols;
+        std::tie(data, n_rows, n_cols) =
+            read_helper(std::move(infile), filename);
+        std::size_t n_pages = static_cast<std::size_t>(n_rows / given_nrows);
+
+        if (n_rows % given_nrows != 0)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "file_read_csv::read_3d",
+                util::generate_error_message(
+                    "the number of rows in the csv file is not divisible by "
+                    "the given number of rows in a page"));
+        }
+
+        std::int64_t page_start, row_start, column_start;
+        std::size_t page_size, row_size, column_size;
+        std::uint32_t tile_idx = hpx::get_locality_id();
+
+        std::tie(page_start, row_start, column_start, page_size, row_size,
+            column_size) = tile_calculation::tile_calculation_3d(tile_idx,
+            n_pages, given_nrows, n_cols, numtiles, tiling_type);
+
+        // adding overlap
+        if (page_size != n_pages && intersections[0] != 0)    // pages overlap
+        {
+            std::tie(page_start, page_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    page_start, page_size, n_pages, intersections[0]);
+        }
+        if (row_size != given_nrows && intersections[1] != 0)    // rows overlap
+        {
+            std::tie(row_start, row_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    row_start, row_size, given_nrows, intersections[1]);
+        }
+        if (column_size != n_cols &&
+            intersections[2] != 0)    // columns overlap
+        {
+            std::tie(column_start, column_size) =
+                tile_calculation::tile_calculation_overlap_1d(
+                    column_start, column_size, n_cols, intersections[2]);
+        }
+
+        tiling_information_3d tile_info(
+            tiling_span(page_start, page_start + page_size),
+            tiling_span(row_start, row_start + row_size),
+            tiling_span(column_start, column_start + column_size));
+
+        locality_information locality_info(tile_idx, numtiles);
+        annotation locality_ann = locality_info.as_annotation();
+
+        std::string base_name =
+            detail::generate_csv_name(std::move(given_name));
+
+        annotation_information ann_info(
+            std::move(base_name), 0);    //generation 0
+
+        auto attached_annotation =
+            std::make_shared<annotation>(localities_annotation(locality_ann,
+                tile_info.as_annotation(name_, codename_), ann_info, name_,
+                codename_));
+
+        blaze::DynamicTensor<double> whole_data(
+            n_pages, given_nrows, n_cols, data.data());
+        blaze::DynamicTensor<double> result =
+            blaze::subtensor(std::move(whole_data), page_start, row_start,
+                column_start, page_size, row_size, column_size);
+
+        return primitive_argument_type(result, attached_annotation);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> dist_file_read_csv::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
     {
-        if (operands.size() < 2 || operands.size() > 5)
+        if (operands.size() < 2 || operands.size() > 7)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_file_read_csv::eval",
                 generate_error_message("the file_read_csv_d primitive requires "
@@ -130,12 +281,29 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     std::string filename = extract_string_value_strict(
                         std::move(args[0]), this_->name_, this_->codename_);
 
+                    bool mode3d = false;
+                    if (args.size() > 1 && valid(args[1]))
+                    {
+                        mode3d = extract_scalar_boolean_value(
+                            std::move(args[1]), this_->name_, this_->codename_);
+                    }
+                    std::size_t numdims = mode3d ? 3 : 2;
+
+                    std::int64_t page_nrows;
+                    if (args.size() > 2 && valid(args[2]))
+                    {
+                        page_nrows =
+                            extract_scalar_positive_integer_value_strict(
+                                std::move(args[2]), this_->name_,
+                                this_->codename_);
+                    }
+
                     // using balanced symmetric tiles as the default
                     std::string tiling_type = "sym";
-                    if (valid(args[1]))
+                    if (args.size() > 3 && valid(args[3]))
                     {
                         tiling_type = extract_string_value(
-                            std::move(args[1]), this_->name_, this_->codename_);
+                            std::move(args[3]), this_->name_, this_->codename_);
                         if ((tiling_type != "sym" && tiling_type != "page") &&
                             tiling_type != "row" && tiling_type != "column")
                         {
@@ -150,78 +318,92 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
                     std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
                         intersections{0};
-                    if (valid(args[2]))
+                    if (args.size() > 4 && valid(args[4]))
                     {
-                        //if (is_list_operand_strict(args[2]))
-                        //{
-                        //    ir::range&& intersection_list =
-                        //        extract_list_value_strict(std::move(args[2]),
-                        //            this_->name_, this_->codename_);
+                        if (is_list_operand_strict(args[4]))
+                        {
+                            ir::range&& intersection_list =
+                                extract_list_value_strict(std::move(args[4]),
+                                    this_->name_, this_->codename_);
 
-                            //if (intersection_list.size() != 1 &&
-                            //    intersection_list.size() != numdims)
-                            //{
-                            //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                            //        "dist_constant::eval",
-                            //        this_->generate_error_message(
-                            //            "intersection should have the same "
-                            //            "number of dimensions as the array, or "
-                            //            "be represented with an integer for "
-                            //            "all dimensions"));
-                            //}
-                        //    intersections =
-                        //        util::detail::extract_nonneg_range_dimensions(
-                        //            intersection_list, this_->name_,
-                        //            this_->codename_);
-                        //}
-                        //else if (is_numeric_operand(args[2]))
-                        //{
-                        //    intersections[0] =
-                        //        extract_scalar_nonneg_integer_value_strict(
-                        //            std::move(args[2]), this_->name_,
-                        //            this_->codename_);
+                            if (intersection_list.size() != 1 &&
+                                intersection_list.size() != numdims)
+                            {
+                                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                    "dist_constant::eval",
+                                    this_->generate_error_message(
+                                        "intersection should have the same "
+                                        "number of dimensions as the array, or "
+                                        "be represented with an integer for "
+                                        "all dimensions"));
+                            }
+                            intersections =
+                                util::detail::extract_nonneg_range_dimensions(
+                                    intersection_list, this_->name_,
+                                    this_->codename_);
+                        }
+                        else if (is_numeric_operand(args[4]))
+                        {
+                            intersections[0] =
+                                extract_scalar_nonneg_integer_value_strict(
+                                    std::move(args[4]), this_->name_,
+                                    this_->codename_);
 
-                        //    // we assume all dimensions have the same
-                        //    // intersection length which is the given one
-                        //    for (std::size_t i = 1; i != PHYLANX_MAX_DIMENSIONS;
-                        //         ++i)
-                        //    {
-                        //        if (i == numdims)
-                        //            break;
-                        //        intersections[i] = intersections[0];
-                        //    }
-                        //}
-                        //else
-                        //{
-                        //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        //        "dist_constant::eval",
-                        //        this_->generate_error_message(
-                        //            "intersection can be an integer or a list "
-                        //            "of integers"));
-                        //}
+                            // we assume all dimensions have the same
+                            // intersection length which is the given one
+                            for (std::size_t i = 1; i != PHYLANX_MAX_DIMENSIONS;
+                                 ++i)
+                            {
+                                if (i == numdims)
+                                    break;
+                                intersections[i] = intersections[0];
+                            }
+                        }
+                        else
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "dist_file_read_csv::eval",
+                                this_->generate_error_message(
+                                    "intersection can be an integer or a list "
+                                    "of integers"));
+                        }
                     }
 
                     std::string given_name = "";
-                    if (valid(args[3]))
+                    if (args.size() > 5 && valid(args[5]))
                     {
-                        given_name = extract_string_value(std::move(args[3]),
+                        given_name = extract_string_value(std::move(args[5]),
                             this_->name_, this_->codename_);
                     }
 
                     std::uint32_t numtiles =
                         hpx::get_num_localities(hpx::launch::sync);
-                    if (valid(args[4]))
+                    if (args.size() > 6 && valid(args[6]))
                     {
                         extract_scalar_positive_integer_value_strict(
-                            std::move(args[4]), this_->name_, this_->codename_);
+                            std::move(args[6]), this_->name_, this_->codename_);
                     }
 
-                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                        "dist_constant::eval",
-                        util::generate_error_message(
-                            "the given shape is of an unsupported "
-                            "dimensionality",
-                            this_->name_, this_->codename_));
+                    std::ifstream infile(filename.c_str(), std::ios::in);
+
+                    if (!infile.is_open())
+                    {
+                        throw std::runtime_error(this_->generate_error_message(
+                            "couldn't open file: " + filename));
+                    }
+
+                    if (mode3d)
+                    {
+                        return this_->dist_read_3d(std::move(infile), filename,
+                            page_nrows, tiling_type, intersections,
+                            std::move(given_name), numtiles);
+                    }
+
+                    // dist_file_read_csv never considers 1d arrays. It is a
+                    // dataframe ether representing a matrix or a tensor
+                    return this_->dist_read_2d(std::move(infile), filename,
+                             tiling_type, intersections,
+                            std::move(given_name), numtiles);
                 }),
             detail::map_operands(operands, functional::value_operand{}, args,
                 name_, codename_, std::move(ctx)));

--- a/src/plugins/fileio/dist_file_read_csv.cpp
+++ b/src/plugins/fileio/dist_file_read_csv.cpp
@@ -85,8 +85,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             Returns:
 
-            Returns a distributed array representing the contents of a the
-            given csv file.
+            Returns a distributed array representing the contents of the given
+            csv file.
             )")
     };
 

--- a/src/plugins/fileio/dist_file_read_csv.cpp
+++ b/src/plugins/fileio/dist_file_read_csv.cpp
@@ -1,0 +1,229 @@
+//  Copyright (c) 2017 Alireza Kheirkhahan
+//  Copyright (c) 2020 Bita Hasheminezhad
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/annotation.hpp>
+#include <phylanx/execution_tree/localities_annotation.hpp>
+#include <phylanx/execution_tree/locality_annotation.hpp>
+#include <phylanx/execution_tree/meta_annotation.hpp>
+#include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
+#include <phylanx/execution_tree/tiling_annotations.hpp>
+#include <phylanx/ir/node_data.hpp>
+#include <phylanx/plugins/fileio/dist_file_read_csv.hpp>
+#include <phylanx/plugins/fileio/file_read_csv_impl.hpp>
+
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/errors/throw_exception.hpp>
+//#include <hpx/runtime/threads/run_as_os_thread.hpp>
+
+#include <atomic>
+#include <fstream>
+#include <iomanip>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives
+{
+    ///////////////////////////////////////////////////////////////////////////
+    match_pattern_type const dist_file_read_csv::match_data =
+    {
+        hpx::util::make_tuple("file_read_csv_d",
+            std::vector<std::string>{R"(
+                file_read_csv_d(
+                    _1_filename,
+                    __arg(_2_tiling_type, "sym"),
+                    __arg(_3_intersection, nil),
+                    __arg(_4_name, ""),
+                    __arg(_5_numtiles, num_localities())
+                )
+            )"},
+            &create_dist_file_read_csv, &create_primitive<dist_file_read_csv>,
+            R"(filename, tiling_type, intersection, name, numtiles
+            Args:
+
+                filename (string) : file name including its path.
+                tiling_type (string, optional): defaults to `sym` which is a
+                    balanced way of tiling among all the numtiles localities.
+                    Other options are `page`, `row` or `column` tiling. For a
+                    vector all these three tiling_type are the same.
+                intersection (int or a tuple of ints, optional): the size of
+                    overlapped part on each dimension. If an integer is given,
+                    that would be the intersection length on all dimensions
+                    that are tiled. The middle parts get to have two
+                    intersections, one with the tile before it and one with the
+                    tile after it.
+                name (string, optional): the array given name. If not given, a
+                    globally unique name will be generated.
+                numtiles (int, optional): number of tiles of the returned array.
+                    if not given it sets to the number of localities in the
+                    application.
+
+            Returns:
+
+            Returns a distributed array representing the contents of a the
+            given csv file.
+            )")
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    dist_file_read_csv::dist_file_read_csv(primitive_arguments_type&& operands,
+        std::string const& name, std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {}
+
+    ///////////////////////////////////////////////////////////////////////////
+    namespace detail
+    {
+        static std::atomic<std::size_t> const_count(0);
+        std::string generate_csv_name(std::string&& given_name)
+        {
+            if (given_name.empty())
+            {
+                return "csv_file_" + std::to_string(++const_count);
+            }
+
+            return std::move(given_name);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    hpx::future<primitive_argument_type> dist_file_read_csv::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.size() < 2 || operands.size() > 5)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_file_read_csv::eval",
+                generate_error_message("the file_read_csv_d primitive requires "
+                                       "at least 2 and at most 5 operands"));
+        }
+
+        if (!valid(operands[0]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "dist_file_read_csv::eval",
+                generate_error_message(
+                    "the file_read_csv_d primitive requires that the given "
+                        "operand is valid"));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+                [this_ = std::move(this_)](
+                    primitive_arguments_type&& args)
+                    -> primitive_argument_type
+                {
+
+                    std::string filename = extract_string_value_strict(
+                        std::move(args[0]), this_->name_, this_->codename_);
+
+                    // using balanced symmetric tiles as the default
+                    std::string tiling_type = "sym";
+                    if (valid(args[1]))
+                    {
+                        tiling_type = extract_string_value(
+                            std::move(args[1]), this_->name_, this_->codename_);
+                        if ((tiling_type != "sym" && tiling_type != "page") &&
+                            tiling_type != "row" && tiling_type != "column")
+                        {
+                            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                                "dist_file_read_csv::eval",
+                                this_->generate_error_message(
+                                    "invalid tiling_type. The tiling_type can "
+                                    "be one of these: `sym`, `page`, `row` or "
+                                    "`column`"));
+                        }
+                    }
+
+                    std::array<std::size_t, PHYLANX_MAX_DIMENSIONS>
+                        intersections{0};
+                    if (valid(args[2]))
+                    {
+                        //if (is_list_operand_strict(args[2]))
+                        //{
+                        //    ir::range&& intersection_list =
+                        //        extract_list_value_strict(std::move(args[2]),
+                        //            this_->name_, this_->codename_);
+
+                            //if (intersection_list.size() != 1 &&
+                            //    intersection_list.size() != numdims)
+                            //{
+                            //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            //        "dist_constant::eval",
+                            //        this_->generate_error_message(
+                            //            "intersection should have the same "
+                            //            "number of dimensions as the array, or "
+                            //            "be represented with an integer for "
+                            //            "all dimensions"));
+                            //}
+                        //    intersections =
+                        //        util::detail::extract_nonneg_range_dimensions(
+                        //            intersection_list, this_->name_,
+                        //            this_->codename_);
+                        //}
+                        //else if (is_numeric_operand(args[2]))
+                        //{
+                        //    intersections[0] =
+                        //        extract_scalar_nonneg_integer_value_strict(
+                        //            std::move(args[2]), this_->name_,
+                        //            this_->codename_);
+
+                        //    // we assume all dimensions have the same
+                        //    // intersection length which is the given one
+                        //    for (std::size_t i = 1; i != PHYLANX_MAX_DIMENSIONS;
+                        //         ++i)
+                        //    {
+                        //        if (i == numdims)
+                        //            break;
+                        //        intersections[i] = intersections[0];
+                        //    }
+                        //}
+                        //else
+                        //{
+                        //    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        //        "dist_constant::eval",
+                        //        this_->generate_error_message(
+                        //            "intersection can be an integer or a list "
+                        //            "of integers"));
+                        //}
+                    }
+
+                    std::string given_name = "";
+                    if (valid(args[3]))
+                    {
+                        given_name = extract_string_value(std::move(args[3]),
+                            this_->name_, this_->codename_);
+                    }
+
+                    std::uint32_t numtiles =
+                        hpx::get_num_localities(hpx::launch::sync);
+                    if (valid(args[4]))
+                    {
+                        extract_scalar_positive_integer_value_strict(
+                            std::move(args[4]), this_->name_, this_->codename_);
+                    }
+
+                    HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                        "dist_constant::eval",
+                        util::generate_error_message(
+                            "the given shape is of an unsupported "
+                            "dimensionality",
+                            this_->name_, this_->codename_));
+                }),
+            detail::map_operands(operands, functional::value_operand{}, args,
+                name_, codename_, std::move(ctx)));
+    }
+}}}

--- a/src/plugins/fileio/file_read_csv.cpp
+++ b/src/plugins/fileio/file_read_csv.cpp
@@ -13,14 +13,19 @@
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
+#include <cstddef>
 #include <cstdint>
 #include <fstream>
 #include <iomanip>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
+
+#include <blaze/Math.h>
+#include <blaze_tensor/Math.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace phylanx { namespace execution_tree { namespace primitives

--- a/src/plugins/fileio/file_read_csv.cpp
+++ b/src/plugins/fileio/file_read_csv.cpp
@@ -6,6 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/fileio/file_read_csv.hpp>
+#include <phylanx/plugins/fileio/file_read_csv_impl.hpp>
 
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
@@ -13,13 +14,6 @@
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/runtime/threads/run_as_os_thread.hpp>
 
-#include <boost/spirit/include/qi_char.hpp>
-#include <boost/spirit/include/qi_list.hpp>
-#include <boost/spirit/include/qi_lit.hpp>
-#include <boost/spirit/include/qi_parse.hpp>
-#include <boost/spirit/include/qi_real.hpp>
-
-#include <cstddef>
 #include <fstream>
 #include <iomanip>
 #include <memory>
@@ -55,80 +49,6 @@ namespace phylanx { namespace execution_tree { namespace primitives
             std::string const& name, std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
     {}
-
-    ///////////////////////////////////////////////////////////////////////////
-    // read data from given file and return content
-    primitive_argument_type file_read_csv::read(
-        std::ifstream&& infile, std::string const& filename) const
-    {
-        std::string line;
-        bool header_parsed = false;
-        std::vector<double> matrix_array, current_line;
-        std::size_t n_rows = 0, n_cols = 0;
-        std::size_t before_readln = 0, after_readln = 0;
-
-        while (std::getline(infile, line))
-        {
-            before_readln = matrix_array.size();
-
-            auto begin_local = line.begin();
-            if (boost::spirit::qi::parse(begin_local, line.end(),
-                    boost::spirit::qi::double_ % ',', current_line))
-            {
-                if (begin_local == line.end() || header_parsed)
-                {
-                    header_parsed = true;
-
-                    matrix_array.insert(matrix_array.end(),
-                        current_line.begin(), current_line.end());
-
-                    after_readln = matrix_array.size();
-                    if (n_rows == 0)
-                    {
-                        n_cols = matrix_array.size();
-                    }
-                    else if (n_cols != (after_readln - before_readln))
-                    {
-                        throw std::runtime_error(generate_error_message(
-                            "wrong data format, different number "
-                            "of element in this row " +
-                            filename + ':' + std::to_string(n_rows)));
-                    }
-                    n_rows++;
-                }
-                current_line.clear();
-            }
-            else
-            {
-                throw std::runtime_error(
-                    generate_error_message("wrong data format " + filename +
-                        ':' + std::to_string(n_rows)));
-            }
-        }
-
-        if (n_rows == 1)
-        {
-            if (n_cols == 1)
-            {
-                // scalar value
-                return primitive_argument_type{
-                    ir::node_data<double>{matrix_array[0]}};
-            }
-
-            // vector
-            blaze::DynamicVector<double> vector(n_cols, matrix_array.data());
-
-            return primitive_argument_type{
-                ir::node_data<double>{std::move(vector)}};
-        }
-
-        // matrix
-        blaze::DynamicMatrix<double> matrix(
-            n_rows, n_cols, matrix_array.data());
-
-        return primitive_argument_type{
-            ir::node_data<double>{std::move(matrix)}};
-    }
 
     ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> file_read_csv::eval(

--- a/src/plugins/fileio/file_read_csv.cpp
+++ b/src/plugins/fileio/file_read_csv.cpp
@@ -56,7 +56,81 @@ namespace phylanx { namespace execution_tree { namespace primitives
       : primitive_component_base(std::move(operands), name, codename)
     {}
 
+    ///////////////////////////////////////////////////////////////////////////
     // read data from given file and return content
+    primitive_argument_type file_read_csv::read(
+        std::ifstream&& infile, std::string const& filename) const
+    {
+        std::string line;
+        bool header_parsed = false;
+        std::vector<double> matrix_array, current_line;
+        std::size_t n_rows = 0, n_cols = 0;
+        std::size_t before_readln = 0, after_readln = 0;
+
+        while (std::getline(infile, line))
+        {
+            before_readln = matrix_array.size();
+
+            auto begin_local = line.begin();
+            if (boost::spirit::qi::parse(begin_local, line.end(),
+                    boost::spirit::qi::double_ % ',', current_line))
+            {
+                if (begin_local == line.end() || header_parsed)
+                {
+                    header_parsed = true;
+
+                    matrix_array.insert(matrix_array.end(),
+                        current_line.begin(), current_line.end());
+
+                    after_readln = matrix_array.size();
+                    if (n_rows == 0)
+                    {
+                        n_cols = matrix_array.size();
+                    }
+                    else if (n_cols != (after_readln - before_readln))
+                    {
+                        throw std::runtime_error(generate_error_message(
+                            "wrong data format, different number "
+                            "of element in this row " +
+                            filename + ':' + std::to_string(n_rows)));
+                    }
+                    n_rows++;
+                }
+                current_line.clear();
+            }
+            else
+            {
+                throw std::runtime_error(
+                    generate_error_message("wrong data format " + filename +
+                        ':' + std::to_string(n_rows)));
+            }
+        }
+
+        if (n_rows == 1)
+        {
+            if (n_cols == 1)
+            {
+                // scalar value
+                return primitive_argument_type{
+                    ir::node_data<double>{matrix_array[0]}};
+            }
+
+            // vector
+            blaze::DynamicVector<double> vector(n_cols, matrix_array.data());
+
+            return primitive_argument_type{
+                ir::node_data<double>{std::move(vector)}};
+        }
+
+        // matrix
+        blaze::DynamicMatrix<double> matrix(
+            n_rows, n_cols, matrix_array.data());
+
+        return primitive_argument_type{
+            ir::node_data<double>{std::move(matrix)}};
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     hpx::future<primitive_argument_type> file_read_csv::eval(
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
@@ -95,75 +169,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "couldn't open file: " + filename));
                 }
 
-                std::string line;
-                bool header_parsed = false;
-                std::vector<double> matrix_array, current_line;
-                std::size_t n_rows = 0, n_cols = 0;
-                std::size_t before_readln = 0, after_readln = 0;
-
-                while (std::getline(infile, line))
-                {
-                    before_readln = matrix_array.size();
-
-                    auto begin_local = line.begin();
-                    if (boost::spirit::qi::parse(begin_local, line.end(),
-                            boost::spirit::qi::double_ % ',', current_line))
-                    {
-                        if (begin_local == line.end() || header_parsed)
-                        {
-                            header_parsed = true;
-
-                            matrix_array.insert(matrix_array.end(),
-                                current_line.begin(), current_line.end());
-
-                            after_readln = matrix_array.size();
-                            if (n_rows == 0)
-                            {
-                                n_cols = matrix_array.size();
-                            }
-                            else if (n_cols != (after_readln - before_readln))
-                            {
-                                throw std::runtime_error(
-                                    this_->generate_error_message(
-                                        "wrong data format, different number "
-                                        "of element in this row " + filename +
-                                        ':' + std::to_string(n_rows)));
-                            }
-                            n_rows++;
-                        }
-                        current_line.clear();
-                    }
-                    else
-                    {
-                        throw std::runtime_error(
-                            this_->generate_error_message("wrong data format " +
-                                filename + ':' + std::to_string(n_rows)));
-                    }
-                }
-
-                if (n_rows == 1)
-                {
-                    if (n_cols == 1)
-                    {
-                        // scalar value
-                        return primitive_argument_type{
-                            ir::node_data<double>{matrix_array[0]}};
-                    }
-
-                    // vector
-                    blaze::DynamicVector<double> vector(n_cols,
-                        matrix_array.data());
-
-                    return primitive_argument_type{
-                        ir::node_data<double>{std::move(vector)}};
-                }
-
-                // matrix
-                blaze::DynamicMatrix<double> matrix(
-                    n_rows, n_cols, matrix_array.data());
-
-                return primitive_argument_type{
-                    ir::node_data<double>{std::move(matrix)}};
+                return this_->read(std::move(infile), filename);
             });
     }
 }}}

--- a/src/plugins/fileio/fileio.cpp
+++ b/src/plugins/fileio/fileio.cpp
@@ -9,12 +9,14 @@
 
 PHYLANX_REGISTER_PLUGIN_MODULE();
 
+PHYLANX_REGISTER_PLUGIN_FACTORY(dist_file_read_csv_plugin,
+    phylanx::execution_tree::primitives::dist_file_read_csv::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(file_read_plugin,
     phylanx::execution_tree::primitives::file_read::match_data);
-PHYLANX_REGISTER_PLUGIN_FACTORY(file_write_plugin,
-    phylanx::execution_tree::primitives::file_write::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(file_read_csv_plugin,
     phylanx::execution_tree::primitives::file_read_csv::match_data);
+PHYLANX_REGISTER_PLUGIN_FACTORY(file_write_plugin,
+    phylanx::execution_tree::primitives::file_write::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(file_write_csv_plugin,
     phylanx::execution_tree::primitives::file_write_csv::match_data);
 

--- a/tests/unit/plugins/dist_matrixops/dist_constant_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_2_loc.cpp
@@ -147,6 +147,32 @@ void test_constant_1d_3()
     }
 }
 
+void test_constant_1d_4()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_constant_d_operation("test_constant_2loc1d_4", R"(
+            constant_d(13.0, list(7), 0, 2, "const_overlap", "row", 2)
+        )", R"(
+            annotate_d([13.0, 13.0, 13.0, 13.0, 13.0, 13.0], "const_overlap",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 6))))
+        )");
+    }
+    else
+    {
+        test_constant_d_operation("test_constant_2loc1d_2", R"(
+            constant_d(13.0, list(7), 1, 2, "const_overlap", "row", 2)
+        )", R"(
+            annotate_d([13.0, 13.0, 13.0, 13.0, 13.0], "const_overlap",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 2, 7))))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 void test_constant_2d_0()
 {
@@ -288,6 +314,7 @@ int hpx_main(int argc, char* argv[])
     test_constant_1d_1();
     test_constant_1d_2();
     test_constant_1d_3();
+    test_constant_1d_4();
 
     test_constant_2d_0();
     test_constant_2d_1();

--- a/tests/unit/plugins/dist_matrixops/dist_constant_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_6_loc.cpp
@@ -289,6 +289,124 @@ void test_constant_6loc_3d_0()
     }
 }
 
+void test_constant_6loc_3d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_constant_d_operation("test_constant_6loc3d_1", R"(
+            constant_d(42, list(2, 5, 7), nil, nil, "", "sym", list(0, 1, 2))
+        )", R"(
+            annotate_d([[[42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0]],
+                        [[42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0]]],
+                "full_array_4",
+                list("args",
+                    list("locality", 0, 6),
+                    list("tile", list("pages", 0, 2),
+                        list("columns", 0, 5), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 1)
+    {
+        test_constant_d_operation("test_constant_6loc3d_1", R"(
+            constant_d(42, list(2, 5, 7), nil, nil, "", "sym", list(0, 1, 2))
+        )", R"(
+            annotate_d([[[42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0]],
+                        [[42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0]]],
+                "full_array_4",
+                list("args",
+                    list("locality", 1, 6),
+                    list("tile", list("pages", 0, 2),
+                        list("columns", 1, 7), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 2)
+    {
+        test_constant_d_operation("test_constant_6loc3d_1", R"(
+            constant_d(42, list(2, 5, 7), nil, nil, "", "sym", list(0, 1, 2))
+        )", R"(
+            annotate_d([[[42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0]],
+                        [[42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0]]],
+                "full_array_4",
+                list("args",
+                    list("locality", 2, 6),
+                    list("tile", list("pages", 0, 2),
+                        list("columns", 3, 7), list("rows", 0, 4))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 3)
+    {
+        test_constant_d_operation("test_constant_6loc3d_1", R"(
+            constant_d(42, list(2, 5, 7), nil, nil, "", "sym", list(0, 1, 2))
+        )", R"(
+            annotate_d([[[42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0]],
+                        [[42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0]]],
+                "full_array_4",
+                list("args",
+                    list("locality", 3, 6),
+                    list("tile", list("pages", 0, 2),
+                        list("columns", 0, 5), list("rows", 2, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 4)
+    {
+        test_constant_d_operation("test_constant_6loc3d_1", R"(
+            constant_d(42, list(2, 5, 7), nil, nil, "", "sym", list(0, 1, 2))
+        )", R"(
+            annotate_d([[[42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0]],
+                        [[42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0, 42.0, 42.0]]],
+                "full_array_4",
+                list("args",
+                    list("locality", 4, 6),
+                    list("tile", list("pages", 0, 2),
+                        list("columns", 1, 7), list("rows", 2, 5))))
+        )");
+    }
+    else if (hpx::get_locality_id() == 5)
+    {
+        test_constant_d_operation("test_constant_6loc3d_1", R"(
+            constant_d(42, list(2, 5, 7), nil, nil, "", "sym", list(0, 1, 2))
+        )", R"(
+            annotate_d([[[42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0]],
+                        [[42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0],
+                         [42.0, 42.0, 42.0, 42.0]]],
+                "full_array_4",
+                list("args",
+                    list("locality", 5, 6),
+                    list("tile", list("pages", 0, 2),
+                        list("columns", 3, 7), list("rows", 2, 5))))
+        )");
+    }
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
@@ -296,6 +414,7 @@ int hpx_main(int argc, char* argv[])
     test_constant_6loc_2d_1();
 
     test_constant_6loc_3d_0();
+    test_constant_6loc_3d_1();
 
     hpx::finalize();
     return hpx::util::report_errors();

--- a/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
@@ -385,8 +385,8 @@ void test_retile_3loc_1d_6()
                 "row", list(2), 3
             )
         )", R"(
-            annotate_d([5, 6, 7, 8, 9, 10], "tiled_array_1d_6_retiled/1",
-                list("tile", list("rows", 4, 10)))
+            annotate_d([4, 5, 6, 7, 8, 9, 10, 11], "tiled_array_1d_6_retiled/1",
+                list("tile", list("rows", 3, 11)))
         )");
 
     }
@@ -615,11 +615,11 @@ void test_retile_3loc_2d_3()
                 "sym", 1
             )
         )", R"(
-            annotate_d([[3, 4, 5], [-3, -4, -5], [13, 14, 15]],
+            annotate_d([[2, 3, 4, 5], [-2, -3, -4, -5], [12, 13, 14, 15]],
                 "tiled_array_2d_3_retiled/1",
                 list("args",
                     list("locality", 1, 3),
-                    list("tile", list("columns", 2, 5), list("rows", 0, 3))))
+                    list("tile", list("columns", 1, 5), list("rows", 0, 3))))
         )");
     }
     else

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -169,10 +169,10 @@ void test_retile_6loc_1d_1()
                 "sym", 1, 6
             )
         )", R"(
-            annotate_d([5, 6, 7, 8, 9], "tiled_array_1d_1_retiled/1",
+            annotate_d([4, 5, 6, 7, 8, 9], "tiled_array_1d_1_retiled/1",
                 list("args",
                     list("locality", 1, 6),
-                    list("tile", list("columns", 4, 9))))
+                    list("tile", list("columns", 3, 9))))
         )");
     }
     else if (hpx::get_locality_id() == 2)
@@ -185,10 +185,10 @@ void test_retile_6loc_1d_1()
                 "sym", 1, 6
             )
         )", R"(
-            annotate_d([9, 10, 11, 12], "tiled_array_1d_1_retiled/1",
+            annotate_d([8, 9, 10, 11, 12], "tiled_array_1d_1_retiled/1",
                 list("args",
                     list("locality", 2, 6),
-                    list("tile", list("columns", 8, 12))))
+                    list("tile", list("columns", 7, 12))))
         )");
     }
     else if (hpx::get_locality_id() == 3)
@@ -201,10 +201,10 @@ void test_retile_6loc_1d_1()
                 "sym", 1, 6
             )
         )", R"(
-            annotate_d([12, 13, 14, 15], "tiled_array_1d_1_retiled/1",
+            annotate_d([11, 12, 13, 14, 15], "tiled_array_1d_1_retiled/1",
                 list("args",
                     list("locality", 3, 6),
-                    list("tile", list("columns", 11, 15))))
+                    list("tile", list("columns", 10, 15))))
         )");
     }
     else if (hpx::get_locality_id() == 4)
@@ -217,10 +217,10 @@ void test_retile_6loc_1d_1()
                 "sym", 1, 6
             )
         )", R"(
-            annotate_d([15, 16, 17, 18], "tiled_array_1d_1_retiled/1",
+            annotate_d([14, 15, 16, 17, 18], "tiled_array_1d_1_retiled/1",
                 list("args",
                     list("locality", 4, 6),
-                    list("tile", list("columns", 14, 18))))
+                    list("tile", list("columns", 13, 18))))
         )");
     }
     else if (hpx::get_locality_id() == 5)
@@ -468,8 +468,8 @@ void test_retile_6loc_2d_2()
                 "column", 1
             )
         )", R"(
-            annotate_d([[2, 3], [-2, -3]], "tiled_array_2d_2_retiled/1",
-                list("tile", list("rows", 0, 2), list("columns", 1, 3)))
+            annotate_d([[1, 2, 3], [-1, -2, -3]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 0, 3)))
         )");
     }
     else if (hpx::get_locality_id() == 2)
@@ -482,8 +482,8 @@ void test_retile_6loc_2d_2()
                 "column", 1
             )
         )", R"(
-            annotate_d([[3, 4], [-3, -4]], "tiled_array_2d_2_retiled/1",
-                list("tile", list("rows", 0, 2), list("columns", 2, 4)))
+            annotate_d([[2, 3, 4], [-2, -3, -4]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 1, 4)))
         )");
     }
     else if (hpx::get_locality_id() == 3)
@@ -496,8 +496,8 @@ void test_retile_6loc_2d_2()
                 "column", 1
             )
         )", R"(
-            annotate_d([[4, 5], [-4, -5]], "tiled_array_2d_2_retiled/1",
-                list("tile", list("rows", 0, 2), list("columns", 3, 5)))
+            annotate_d([[3, 4, 5], [-3, -4, -5]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 2, 5)))
         )");
     }
     else if (hpx::get_locality_id() == 4)
@@ -510,8 +510,8 @@ void test_retile_6loc_2d_2()
                 "column", 1
             )
         )", R"(
-            annotate_d([[5, 6], [-5, -6]], "tiled_array_2d_2_retiled/1",
-                list("tile", list("rows", 0, 2), list("columns", 4, 6)))
+            annotate_d([[4, 5, 6], [-4, -5, -6]], "tiled_array_2d_2_retiled/1",
+                list("tile", list("rows", 0, 2), list("columns", 3, 6)))
         )");
     }
     else

--- a/tests/unit/plugins/fileio/CMakeLists.txt
+++ b/tests/unit/plugins/fileio/CMakeLists.txt
@@ -4,9 +4,12 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
+    dist_read_csv_2_loc
     file_primitives
     file_csv_primitives
    )
+
+set(dist_read_csv_2_loc_PARAMETERS LOCALITIES 2)
 
 if(PHYLANX_WITH_HIGHFIVE)
   set(tests ${tests}

--- a/tests/unit/plugins/fileio/dist_read_csv_2_loc.cpp
+++ b/tests/unit/plugins/fileio/dist_read_csv_2_loc.cpp
@@ -16,6 +16,8 @@
 #include <utility>
 #include <vector>
 
+#include <blaze/Math.h>
+
 ///////////////////////////////////////////////////////////////////////////////
 phylanx::execution_tree::primitive_argument_type compile_and_run(
     std::string const& name, std::string const& codestr)
@@ -47,7 +49,7 @@ void test_read_csv_2d_0()
     {
         test_read_csv_d_operation("test_read_csv_2loc2d_0", R"(
             file_read_csv_d(
-                "C:\\Users\\Bita\\Desktop\\test.csv",
+                "test_20200713_2loc",
                 false,
                 1,
                 "sym",
@@ -69,7 +71,7 @@ void test_read_csv_2d_0()
     {
         test_read_csv_d_operation("test_read_csv_2loc2d_0", R"(
             file_read_csv_d(
-                "C:\\Users\\Bita\\Desktop\\test.csv",
+                "test_20200713_2loc",
                 false,
                 1,
                 "sym",
@@ -95,7 +97,62 @@ void test_read_csv_3d_0()
     {
         test_read_csv_d_operation("test_read_csv_2loc3d_0", R"(
             file_read_csv_d(
-                "C:\\Users\\Bita\\Desktop\\test.csv",
+                "test_20200713_2loc",
+                true,
+                10,
+                "row",
+                1,
+                "test_1"
+            )
+        )", R"(
+            annotate_d([[[22, 30], [17.99, 10.38], [20.57, 17.77],
+                [19.69, 21.25], [11.42, 20.38], [20.29, 14.34]],
+                [[12.46, 24.04], [16.02, 23.24], [15.78, 17.89],
+                [19.17, 24.8], [15.85, 23.95], [13.73, 22.61]],
+                [[13.54, 14.36], [13.08, 15.71], [9.504, 12.44],
+                [15.34, 14.26], [21.16, 23.04], [16.65, 21.38]]],
+                "test_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2),
+                        list("pages", 0, 3), list("rows", 0, 6))))
+        )");
+    }
+    else
+    {
+        test_read_csv_d_operation("test_read_csv_2loc3d_0", R"(
+            file_read_csv_d(
+                "test_20200713_2loc",
+                true,
+                10,
+                "row",
+                1,
+                "test_1"
+            )
+        )", R"(
+            annotate_d(
+                [[[11.42, 20.38], [20.29, 14.34], [12.45, 15.7],
+                [18.25, 19.98], [13.71, 20.83], [13, 21.82]],
+                [[15.85, 23.95], [13.73, 22.61], [14.54, 27.54],
+                [14.68, 20.13], [16.13, 20.68], [19.81, 22.15]],
+                [[21.16, 23.04], [16.65, 21.38], [17.14, 16.4],
+                [14.58, 21.53], [18.61, 20.25], [15.3, 25.27]]],
+                "test_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 4, 10),
+                        list("pages", 0, 3))))
+        )");
+    }
+}
+
+void test_read_csv_3d_1()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_read_csv_d_operation("test_read_csv_2loc3d_1", R"(
+            file_read_csv_d(
+                "test_20200713_2loc",
                 true,
                 10,
                 "page"
@@ -116,9 +173,9 @@ void test_read_csv_3d_0()
     }
     else
     {
-        test_read_csv_d_operation("test_read_csv_2loc3d_0", R"(
+        test_read_csv_d_operation("test_read_csv_2loc3d_1", R"(
             file_read_csv_d(
-                "C:\\Users\\Bita\\Desktop\\test.csv",
+                "test_20200713_2loc",
                 true,
                 10,
                 "page"
@@ -140,17 +197,39 @@ void test_read_csv_3d_0()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(int argc, char* argv[])
 {
+    std::string filename = "test_20200713_2loc";
+    blaze::DynamicMatrix<double> in{{22, 30}, {17.99, 10.38}, {20.57, 17.77},
+        {19.69, 21.25}, {11.42, 20.38}, {20.29, 14.34}, {12.45, 15.7},
+        {18.25, 19.98}, {13.71, 20.83}, {13, 21.82}, {12.46, 24.04},
+        {16.02, 23.24}, {15.78, 17.89}, {19.17, 24.8}, {15.85, 23.95},
+        {13.73, 22.61}, {14.54, 27.54}, {14.68, 20.13}, {16.13, 20.68},
+        {19.81, 22.15}, {13.54, 14.36}, {13.08, 15.71}, {9.504, 12.44},
+        {15.34, 14.26}, {21.16, 23.04}, {16.65, 21.38}, {17.14, 16.4},
+        {14.58, 21.53}, {18.61, 20.25}, {15.3, 25.27}};
 
-    //test_read_csv_2d_0();
+    // write to file
+    phylanx::execution_tree::primitive outfile =
+        phylanx::execution_tree::primitives::create_file_write_csv(
+            hpx::find_here(),
+            phylanx::execution_tree::primitive_arguments_type{
+                {filename}, phylanx::ir::node_data<double>(in)});
 
-    //test_read_csv_3d_0();
+    auto f = outfile.eval();
+    f.get();
 
+    test_read_csv_2d_0();
 
+    test_read_csv_3d_0();
+    test_read_csv_3d_1();
+
+    std::remove(filename.c_str());
     hpx::finalize();
     return hpx::util::report_errors();
 }
 int main(int argc, char* argv[])
 {
+
+
     std::vector<std::string> cfg = {
         "hpx.run_hpx_main!=1"
     };

--- a/tests/unit/plugins/fileio/dist_read_csv_2_loc.cpp
+++ b/tests/unit/plugins/fileio/dist_read_csv_2_loc.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+// Copyright (c) 2020 Hartmut Kaiser
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/iostreams.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+phylanx::execution_tree::primitive_argument_type compile_and_run(
+    std::string const& name, std::string const& codestr)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    phylanx::execution_tree::compiler::environment env =
+        phylanx::execution_tree::compiler::default_environment();
+
+    auto const& code =
+        phylanx::execution_tree::compile(name, codestr, snippets, env);
+    return code.run().arg_;
+}
+
+void test_read_csv_d_operation(std::string const& name, std::string const& code,
+    std::string const& expected_str)
+{
+    phylanx::execution_tree::primitive_argument_type result =
+        compile_and_run(name, code);
+    phylanx::execution_tree::primitive_argument_type comparison =
+        compile_and_run(name, expected_str);
+
+    HPX_TEST_EQ(hpx::cout, result, comparison);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_read_csv_2d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_read_csv_d_operation("test_read_csv_2loc2d_0", R"(
+            file_read_csv_d(
+                "C:\\Users\\Bita\\Desktop\\test.csv",
+                false,
+                1,
+                "sym",
+                2
+            )
+        )", R"(
+            annotate_d([[22, 30], [17.99, 10.38], [20.57, 17.77],
+                [19.69, 21.25], [11.42, 20.38], [20.29, 14.34], [12.45, 15.7],
+                [18.25, 19.98], [13.71, 20.83], [13, 21.82], [12.46, 24.04],
+                [16.02, 23.24], [15.78, 17.89], [19.17, 24.8], [15.85, 23.95],
+                [13.73, 22.61], [14.54, 27.54]],
+                "csv_file_1",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 17))))
+        )");
+    }
+    else
+    {
+        test_read_csv_d_operation("test_read_csv_2loc2d_0", R"(
+            file_read_csv_d(
+                "C:\\Users\\Bita\\Desktop\\test.csv",
+                false,
+                1,
+                "sym",
+                2
+            )
+        )", R"(
+            annotate_d([[19.17, 24.8], [15.85, 23.95], [13.73, 22.61],
+                [14.54, 27.54], [14.68, 20.13], [16.13, 20.68], [19.81, 22.15],
+                [13.54, 14.36], [13.08, 15.71], [9.504, 12.44], [15.34, 14.26],
+                [21.16, 23.04], [16.65, 21.38], [17.14, 16.4], [14.58, 21.53],
+                [18.61, 20.25], [15.3, 25.27]],
+                "csv_file_1",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 13, 30))))
+        )");
+    }
+}
+
+void test_read_csv_3d_0()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_read_csv_d_operation("test_read_csv_2loc3d_0", R"(
+            file_read_csv_d(
+                "C:\\Users\\Bita\\Desktop\\test.csv",
+                true,
+                10,
+                "page"
+            )
+        )", R"(
+            annotate_d([[[22, 30], [17.99, 10.38], [20.57, 17.77],
+                [19.69, 21.25], [11.42, 20.38], [20.29, 14.34], [12.45, 15.7],
+                [18.25, 19.98], [13.71, 20.83], [13, 21.82]], [[12.46, 24.04],
+                [16.02, 23.24], [15.78, 17.89], [19.17, 24.8], [15.85, 23.95],
+                [13.73, 22.61], [14.54, 27.54], [14.68, 20.13], [16.13, 20.68],
+                [19.81, 22.15]]],
+                "csv_file_2",
+                list("args",
+                    list("locality", 0, 2),
+                    list("tile", list("columns", 0, 2),
+                        list("pages", 0, 2), list("rows", 0, 10))))
+        )");
+    }
+    else
+    {
+        test_read_csv_d_operation("test_read_csv_2loc3d_0", R"(
+            file_read_csv_d(
+                "C:\\Users\\Bita\\Desktop\\test.csv",
+                true,
+                10,
+                "page"
+            )
+        )", R"(
+            annotate_d(
+                [[[13.54, 14.36], [13.08, 15.71], [9.504, 12.44], [15.34, 14.26],
+                [21.16, 23.04], [16.65, 21.38], [17.14, 16.4], [14.58, 21.53],
+                [18.61, 20.25], [15.3, 25.27]]],
+                "csv_file_2",
+                list("args",
+                    list("locality", 1, 2),
+                    list("tile", list("columns", 0, 2), list("rows", 0, 10),
+                        list("pages", 2, 3))))
+        )");
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+
+    //test_read_csv_2d_0();
+
+    //test_read_csv_3d_0();
+
+
+    hpx::finalize();
+    return hpx::util::report_errors();
+}
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = {
+        "hpx.run_hpx_main!=1"
+    };
+
+    return hpx::init(argc, argv, cfg);
+}
+


### PR DESCRIPTION
This PR:

- Adds the primitive `file_read_csv_d` which returns a distributed matrix or tensor using the `tiling_type` and `intersection` value in the current locality

- Adds a mode3d flag to file_read_csv and file_read_csv_d. When on, the primitive store the data in a tensor; it gets a positive integer from the user, `page_nrows` which indicates the number of rows on each page.

- Adds the `intersection` argument to the `constant_d` primitive to produce overlapped arrays.

- Changes the definition of `intersection` for the middle parts. Before, having intersection=1 for a middle part of the array meant to have only one overlapped slice. Now, it means to have 2 overlapped slice one on each side. This makes more sense considering a filtering operation.

