### PR TITLE
Properly propagate annotations for logical operations primitives

### DIFF
--- a/examples/interpreter/physl.cpp
+++ b/examples/interpreter/physl.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/execution_tree/compiler/primitive_name.hpp>
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <fstream>
 #include <iostream>

--- a/phylanx/execution_tree/annotation.hpp
+++ b/phylanx/execution_tree/annotation.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -142,6 +142,7 @@ namespace phylanx { namespace execution_tree {
         explicit annotation_wrapper(primitive_argument_type const& op);
         annotation_wrapper(primitive_argument_type const& op1,
             primitive_argument_type const& op2);
+        explicit annotation_wrapper(primitive_arguments_type const& ops);
 
         primitive_argument_type propagate(primitive_argument_type&& val,
             std::string const& name, std::string const& codename);

--- a/phylanx/plugins/arithmetics/numeric_impl.hpp
+++ b/phylanx/plugins/arithmetics/numeric_impl.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2020 Hartmut Kaiser
 // Copyright (c) 2018 Shahrzad Shirzad
 // Copyright (c) 2018 Parsa Amini
 //
@@ -540,7 +540,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
             [this_ = std::move(this_)](primitive_arguments_type&& ops)
             ->  primitive_argument_type
             {
-                return this_->handle_numeric_operands(std::move(ops));
+                annotation_wrapper wrap(ops);
+                return wrap.propagate(
+                    this_->handle_numeric_operands(std::move(ops)),
+                    this_->name_, this_->codename_);
             }),
             detail::map_operands(
                 operands, functional::value_operand{}, args,

--- a/phylanx/plugins/booleans/logical_operation_impl.hpp
+++ b/phylanx/plugins/booleans/logical_operation_impl.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //  Copyright (c) 2018 Shahrzad Shirzad
 //  Copyright (c) 2018 Tiany Zhang
 //
@@ -9,6 +9,7 @@
 #define PHYLANX_PRIMITIVES_LOGICAL_OPERATION_IMPL_SEP_02_2018_0703PM
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/annotation.hpp>
 #include <phylanx/execution_tree/primitives/node_data_helpers.hpp>
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/ir/ranges.hpp>
@@ -499,15 +500,22 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         auto this_ = this->shared_from_this();
-        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](primitive_argument_type&& op1,
-                    primitive_argument_type&& op2)
+        return hpx::dataflow(hpx::launch::sync,
+            [this_ = std::move(this_)](
+                    hpx::future<primitive_argument_type>&& lhs,
+                    hpx::future<primitive_argument_type>&& rhs)
             ->  primitive_argument_type
             {
+                auto&& op1 = lhs.get();
+                auto&& op2 = rhs.get();
+
+                annotation_wrapper wrap(op1, op2);
+
                 return primitive_argument_type(
-                    util::visit(visit_logical{*this_},
-                        std::move(op1.variant()), std::move(op2.variant())));
-            }),
+                    wrap.propagate(util::visit(visit_logical{*this_},
+                        std::move(op1.variant()), std::move(op2.variant())),
+                    this_->name_, this_->codename_));
+            },
             value_operand(operands[0], args, name_, codename_, ctx),
             value_operand(operands[1], args, name_, codename_, ctx));
     }

--- a/python/src/bindings/binding_helpers.cpp
+++ b/python/src/bindings/binding_helpers.cpp
@@ -7,7 +7,7 @@
 
 #include <phylanx/phylanx.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <bindings/binding_helpers.hpp>
 #include <bindings/type_casters.hpp>

--- a/python/src/bindings/util.cpp
+++ b/python/src/bindings/util.cpp
@@ -14,7 +14,7 @@
 
 #include <pybind11/pybind11.h>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <cstdint>
 #include <vector>

--- a/src/execution_tree/annotation.cpp
+++ b/src/execution_tree/annotation.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2019 Hartmut Kaiser
+//  Copyright (c) 2019-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -435,6 +435,18 @@ namespace phylanx { namespace execution_tree {
         else if (op2.has_annotation())
         {
             ann_ = op2.annotation();
+        }
+    }
+
+    annotation_wrapper::annotation_wrapper(primitive_arguments_type const& ops)
+    {
+        for (auto const& op : ops)
+        {
+            if (op.has_annotation())
+            {
+                ann_ = op.annotation();
+                break;
+            }
         }
     }
 

--- a/src/execution_tree/primitives/assert_condition.cpp
+++ b/src/execution_tree/primitives/assert_condition.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/assert_condition.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/primitives/console_output.cpp
+++ b/src/execution_tree/primitives/console_output.cpp
@@ -6,7 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/console_output.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/primitives/debug_output.cpp
+++ b/src/execution_tree/primitives/debug_output.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/execution_tree/primitives/debug_output.hpp>
 #include <phylanx/execution_tree/primitives/generic_function.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/primitives/find_all_localities.cpp
+++ b/src/execution_tree/primitives/find_all_localities.cpp
@@ -6,7 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/find_all_localities.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/primitives/format_string.cpp
+++ b/src/execution_tree/primitives/format_string.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/execution_tree/primitives/format_string.hpp>
 #include <phylanx/util/generate_error_message.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/primitives/phyname.cpp
+++ b/src/execution_tree/primitives/phyname.cpp
@@ -6,7 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/phyname.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/primitives/phytype.cpp
+++ b/src/execution_tree/primitives/phytype.cpp
@@ -6,7 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/phytype.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/algorithms/als.cpp
+++ b/src/plugins/algorithms/als.cpp
@@ -6,7 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/algorithms/als.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>

--- a/src/plugins/algorithms/kmeans.cpp
+++ b/src/plugins/algorithms/kmeans.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/plugins/algorithms/kmeans.hpp>
 #include <phylanx/util/random.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>

--- a/src/plugins/algorithms/lra.cpp
+++ b/src/plugins/algorithms/lra.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/util/detail/add_simd.hpp>
 #include <phylanx/util/detail/div_simd.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>

--- a/src/plugins/matrixops/argsort.cpp
+++ b/src/plugins/matrixops/argsort.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/plugins/matrixops/argsort.hpp>
 #include <phylanx/util/matrix_iterators.hpp>
 
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/tests/regressions/execution_tree/543_compile_twice.cpp
+++ b/tests/regressions/execution_tree/543_compile_twice.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/817_cout_nil.cpp
+++ b/tests/regressions/execution_tree/817_cout_nil.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <sstream>

--- a/tests/regressions/execution_tree/allow_return_nil_432.cpp
+++ b/tests/regressions/execution_tree/allow_return_nil_432.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/assign_variable_twice_491.cpp
+++ b/tests/regressions/execution_tree/assign_variable_twice_491.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/assign_wrong_variable_245.cpp
+++ b/tests/regressions/execution_tree/assign_wrong_variable_245.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <sstream>

--- a/tests/regressions/execution_tree/cout_noargs_prints_nothing_159.cpp
+++ b/tests/regressions/execution_tree/cout_noargs_prints_nothing_159.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/cout_prints_twice_155.cpp
+++ b/tests/regressions/execution_tree/cout_prints_twice_155.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/define_loses_values_177.cpp
+++ b/tests/regressions/execution_tree/define_loses_values_177.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <sstream>

--- a/tests/regressions/execution_tree/empty_hstack_509.cpp
+++ b/tests/regressions/execution_tree/empty_hstack_509.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/external_functions_337.cpp
+++ b/tests/regressions/execution_tree/external_functions_337.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/list_iter_space_429.cpp
+++ b/tests/regressions/execution_tree/list_iter_space_429.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/list_of_variables_244.cpp
+++ b/tests/regressions/execution_tree/list_of_variables_244.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/out_of_scope_variable_232.cpp
+++ b/tests/regressions/execution_tree/out_of_scope_variable_232.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_main.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/replace_names_374.cpp
+++ b/tests/regressions/execution_tree/replace_names_374.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/regressions/execution_tree/vector_of_variables_244.cpp
+++ b/tests/regressions/execution_tree/vector_of_variables_244.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <string>

--- a/tests/unit/distributed/remote_add.cpp
+++ b/tests/unit/distributed/remote_add.cpp
@@ -10,7 +10,7 @@
 #include <phylanx/util/random.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/distributed/remote_run.cpp
+++ b/tests/unit/distributed/remote_run.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/plugins/plugin_factory.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstdint>

--- a/tests/unit/execution_tree/annotation_2_loc.cpp
+++ b/tests/unit/execution_tree/annotation_2_loc.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_keras_support/dist_conv1d_2_loc.cpp
+++ b/tests/unit/plugins/dist_keras_support/dist_conv1d_2_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_keras_support/dist_conv1d_3_loc.cpp
+++ b/tests/unit/plugins/dist_keras_support/dist_conv1d_3_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_keras_support/dist_conv1d_4_loc.cpp
+++ b/tests/unit/plugins/dist_keras_support/dist_conv1d_4_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/all_gather_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/all_gather_2_loc.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/all_gather_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/all_gather_4_loc.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_argmax_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_argmax_3_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_argmin_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_argmin_2_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product_4_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_cannon_product_9_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_constant_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_2_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_constant_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_3_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_4_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_constant_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_constant_6_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_diag_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_diag_2_loc.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_diag_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_diag_4_loc.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_diag_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_diag_6_loc.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_dot_operation_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_dot_operation_2_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_inverse_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_inverse_2_loc.cpp
@@ -10,7 +10,7 @@
 
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_inverse_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_inverse_3_loc.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_2_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_random_4_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_4_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_random_5_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_random_5_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_2_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_slice_3_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_2_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_3_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/retile_6_loc.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/phylanx.hpp>
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
 

--- a/tests/unit/plugins/matrixops/gauss_inverse.cpp
+++ b/tests/unit/plugins/matrixops/gauss_inverse.cpp
@@ -9,7 +9,7 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/include/iostreams.hpp>
+#include <hpx/distributed/iostream.hpp>
 
 #include <chrono>
 #include <cstdint>


### PR DESCRIPTION
- flyby: adapt #include for recent HPX changes