### PR TITLE
Adding timer() primitive

### DIFF
--- a/phylanx/execution_tree/primitives.hpp
+++ b/phylanx/execution_tree/primitives.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //                2018 R. Tohid
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,6 +28,7 @@
 #include <phylanx/execution_tree/primitives/store_operation.hpp>
 #include <phylanx/execution_tree/primitives/string_output.hpp>
 #include <phylanx/execution_tree/primitives/target_reference.hpp>
+#include <phylanx/execution_tree/primitives/timer.hpp>
 #include <phylanx/execution_tree/primitives/variable.hpp>
 #include <phylanx/execution_tree/primitives/variable_factory.hpp>
 

--- a/phylanx/execution_tree/primitives/timer.hpp
+++ b/phylanx/execution_tree/primitives/timer.hpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(PHYLANX_PRIMITIVES_TIMER_JUL_17_2020_0439PM)
+#define PHYLANX_PRIMITIVES_TIMER_JUL_17_2020_0439PM
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
+
+#include <hpx/futures/future.hpp>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace phylanx { namespace execution_tree { namespace primitives {
+
+    class timer
+      : public primitive_component_base
+      , public std::enable_shared_from_this<timer>
+    {
+    protected:
+        hpx::future<primitive_argument_type> eval(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const override;
+
+    public:
+        static match_pattern_type const match_data;
+
+        timer() = default;
+
+        timer(primitive_arguments_type&& operands, std::string const& name,
+            std::string const& codename);
+    };
+
+    PHYLANX_EXPORT primitive create_timer(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name = "",
+        std::string const& codename = "");
+
+}}}    // namespace phylanx::execution_tree::primitives
+
+#endif

--- a/phylanx/util/distributed_matrix.hpp
+++ b/phylanx/util/distributed_matrix.hpp
@@ -13,7 +13,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
-#include <hpx/runtime/actions/component_action.hpp>
+#include <hpx/actions_base/component_action.hpp>
 #include <hpx/runtime/basename_registration_fwd.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/runtime/components/new.hpp>

--- a/phylanx/util/distributed_object.hpp
+++ b/phylanx/util/distributed_object.hpp
@@ -13,7 +13,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
-#include <hpx/runtime/actions/component_action.hpp>
+#include <hpx/actions_base/component_action.hpp>
 #include <hpx/runtime/basename_registration_fwd.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/runtime/components/new.hpp>

--- a/phylanx/util/distributed_tensor.hpp
+++ b/phylanx/util/distributed_tensor.hpp
@@ -14,7 +14,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
-#include <hpx/runtime/actions/component_action.hpp>
+#include <hpx/actions_base/component_action.hpp>
 #include <hpx/runtime/basename_registration_fwd.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/runtime/components/new.hpp>

--- a/phylanx/util/distributed_vector.hpp
+++ b/phylanx/util/distributed_vector.hpp
@@ -13,7 +13,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
-#include <hpx/runtime/actions/component_action.hpp>
+#include <hpx/actions_base/component_action.hpp>
 #include <hpx/runtime/basename_registration_fwd.hpp>
 #include <hpx/runtime/components/component_factory.hpp>
 #include <hpx/runtime/components/new.hpp>

--- a/src/execution_tree/patterns.cpp
+++ b/src/execution_tree/patterns.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License}, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -129,14 +129,16 @@ namespace phylanx { namespace execution_tree
 
         pattern_list get_all_known_patterns()
         {
-            pattern_list patterns = {// debugging support
-                PHYLANX_MATCH_DATA(find_all_localities),
+            pattern_list patterns = {
+                // debugging support
+                PHYLANX_MATCH_DATA(assert_condition),
                 PHYLANX_MATCH_DATA(console_output),
                 PHYLANX_MATCH_DATA(debug_output),
                 PHYLANX_MATCH_DATA(enable_tracing),
+                PHYLANX_MATCH_DATA(find_all_localities),
                 PHYLANX_MATCH_DATA(format_string),
                 PHYLANX_MATCH_DATA(string_output),
-                PHYLANX_MATCH_DATA(assert_condition),
+                PHYLANX_MATCH_DATA(timer),
 
                 // special purpose primitives
                 PHYLANX_MATCH_DATA_VERBATIM(

--- a/src/execution_tree/primitives/function.cpp
+++ b/src/execution_tree/primitives/function.cpp
@@ -78,6 +78,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
         primitive const* p = util::get_if<primitive>(&operands_[0]);
         if (p != nullptr)
         {
+            // we represent function calls with empty argument lists as
+            // a function call with a single nil argument to be able to
+            // distinguish func() from invoke(func)
+            if (args.size() == 1 && args[0].is_implicit_nil())
+            {
+                return p->eval(primitive_arguments_type{}, std::move(ctx));
+            }
             return p->eval(args, std::move(ctx));
         }
         return hpx::make_ready_future(

--- a/src/execution_tree/primitives/timer.cpp
+++ b/src/execution_tree/primitives/timer.cpp
@@ -1,0 +1,128 @@
+//  Copyright (c) 2020 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+#include <phylanx/execution_tree/primitives/timer.hpp>
+
+#include <hpx/errors/throw_exception.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/naming.hpp>
+#include <hpx/include/util.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace phylanx { namespace execution_tree { namespace primitives {
+
+    ///////////////////////////////////////////////////////////////////////////
+    primitive create_timer(hpx::id_type const& locality,
+        primitive_arguments_type&& operands, std::string const& name,
+        std::string const& codename)
+    {
+        static std::string type("timer");
+        return create_primitive_component(
+            locality, type, std::move(operands), name, codename);
+    }
+
+    match_pattern_type const timer::match_data = {
+
+        hpx::util::make_tuple("timer",
+            std::vector<std::string>{"timer(_1, _2)"}, &create_timer,
+            &create_primitive<timer>,
+            R"(arg, done
+            This primitive allows to measure the execution time of the embedded
+            expression 'arg' and reports it to the supplied reporting function
+            'done'.
+
+            Args:
+
+                arg : the operation to measure the execution time for
+                done : a function that will be called with the measured time
+
+            Returns:
+
+            whatever the evaluation of 'arg' returns)"
+        )};
+
+    ///////////////////////////////////////////////////////////////////////////
+    timer::timer(primitive_arguments_type&& operands, std::string const& name,
+        std::string const& codename)
+      : primitive_component_base(std::move(operands), name, codename)
+    {
+    }
+
+    hpx::future<primitive_argument_type> timer::eval(
+        primitive_arguments_type const& operands,
+        primitive_arguments_type const& args, eval_context ctx) const
+    {
+        if (operands.size() != 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "timer::eval",
+                generate_error_message(
+                    "the timer primitive requires exactly two operands"));
+        }
+
+        if (!valid(operands[0]) || !valid(operands[1]))
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                "timer::eval",
+                generate_error_message(
+                    "the timer primitive requires that the "
+                    "arguments given by the operands array are valid"));
+        }
+
+        auto this_ = this->shared_from_this();
+        return hpx::dataflow(hpx::launch::sync,
+                [this_ = std::move(this_), ctx, func = operands[0], args](
+                        hpx::future<primitive_argument_type>&& l) mutable
+                    -> primitive_argument_type
+                {
+                    hpx::util::high_resolution_timer t;
+
+                    // execute body
+                    primitive const* p = util::get_if<primitive>(&func);
+                    if (p == nullptr)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "timer::eval",
+                            this_->generate_error_message(
+                                "the first argument to timer must be an "
+                                "invocable object"));
+                    }
+
+                    primitive_argument_type result = p->eval(hpx::launch::sync,
+                        primitive_argument_type{}, ctx);
+
+                    double elapsed = t.elapsed();
+
+                    // report timings
+                    auto&& arg = l.get();
+
+                    primitive const* r = util::get_if<primitive>(&arg);
+                    if (p == nullptr)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                            "timer::eval",
+                            this_->generate_error_message(
+                                "the second argument to timer must be an "
+                                "invocable object"));
+                    }
+
+                    r->eval(hpx::launch::sync, primitive_argument_type{elapsed},
+                        std::move(ctx));
+
+                    // return overall result
+                    return result;
+                },
+            value_operand(operands[1], args, name_, codename_,
+                add_mode(ctx, eval_dont_evaluate_lambdas)));
+    }
+}}}    // namespace phylanx::execution_tree::primitives

--- a/src/plugins/controls/fmap_operation.cpp
+++ b/src/plugins/controls/fmap_operation.cpp
@@ -648,7 +648,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
         }
 
         // the first argument must be an invokable
-        if (util::get_if<primitive>(&operands_[0]) == nullptr)
+        if (util::get_if<primitive>(&operands[0]) == nullptr)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "fmap_operation::eval",

--- a/tests/regressions/execution_tree/1213_timer_problem.cpp
+++ b/tests/regressions/execution_tree/1213_timer_problem.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 Bita Hasheminezhad
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/util.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+char const* const conv1d_code = R"(block(
+    define(conv,
+        block(
+            define(array,
+                random_d(list(8, 10, 2))),
+            define(kernel,
+                random(list(4, 2, 100))),
+            timer(
+                conv1d_d(array, kernel),
+                lambda(time, cout("locality", find_here(), ":", time))
+            )
+        )
+    ),
+    conv
+))";
+
+////////////////////////////////////////////////////////////////////////////////
+int hpx_main(int argc, char* argv[])
+{
+    using namespace phylanx::execution_tree;
+
+    // compile the given code
+    compiler::function_list snippets;
+    auto const& compiled_code = compile("conv", conv1d_code, snippets);
+    auto conv = compiled_code.run();
+
+
+    conv();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> cfg = { "hpx.run_hpx_main!=1" };
+
+    return hpx::init(argc, argv, cfg);
+}

--- a/tests/regressions/execution_tree/CMakeLists.txt
+++ b/tests/regressions/execution_tree/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tests
     817_cout_nil
     817_lambda_nil
     1198_inaccessible_variable
+    1213_timer_problem
     allow_empty_blocks_278
     assign_variable_twice_491
     assign_wrong_variable_245
@@ -45,6 +46,7 @@ set(out_of_scope_variable_232_FLAGS DEPENDENCIES HPX::iostreams_component)
 set(external_functions_337_FLAGS DEPENDENCIES HPX::iostreams_component)
 
 set(random_d_1139_PARAMETERS LOCALITIES 2)
+set(1213_timer_problem_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/tests/unit/execution_tree/primitives/CMakeLists.txt
+++ b/tests/unit/execution_tree/primitives/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 Hartmut Kaiser
+# Copyright (c) 2017-2020 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -15,6 +15,7 @@ set(tests
     invoke_operation
     literal_value
     store_operation
+    timer
    )
 
 foreach(test ${tests})

--- a/tests/unit/execution_tree/primitives/timer.cpp
+++ b/tests/unit/execution_tree/primitives/timer.cpp
@@ -1,0 +1,53 @@
+//   Copyright (c) 2020 Hartmut Kaiser
+//
+//   Distributed under the Boost Software License, Version 1.0. (See accompanying
+//   file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+#include <phylanx/phylanx.hpp>
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/distributed/iostream.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <sstream>
+#include <string>
+
+void test_timer_operation(char const* expr, double expected)
+{
+    phylanx::execution_tree::compiler::function_list snippets;
+    auto const& code = phylanx::execution_tree::compile(expr, snippets);
+    auto f = code.run();
+
+    HPX_TEST_EQ(expected,
+        phylanx::execution_tree::extract_numeric_value(
+            f()
+        )[0]);
+}
+
+int hpx_main(int argc, char* argv[])
+{
+    test_timer_operation(R"(
+        timer(
+            block(
+                define(x, 3.14),
+                x
+            ),
+            lambda(x, debug("time: ", x, " [s]"))
+        )
+    )", 3.14);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+
+    std::stringstream const& strm = hpx::get_consolestream();
+    std::string result = strm.str();
+    HPX_TEST(result.find("time: ") == 0);
+    HPX_TEST(result.find(" [s]") == result.size() - 5);
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
- flyby: fixing #includes for HPX changes

Fixes: #1211 

@taless474 could you please verify that this is doing what you need? The syntax is as outlined in #1211:
```
timer(<any_expression>, <any_unary_function>)
```
where 
- `<any_expression>` is -- well -- any PhySL expression you would like to measure the execution time for
- `<any_unary_function>` is any function that will be invoked with a single argument - the execution time of the expression in seconds (float)

The `timer()` primitive will return whatever the expression has returned. Thus this primitive can be easily inserted into any spot in an existing PhySL code without changing its semantics. A simple example would be:
```
timer(
    block(
        define(x, 3.14),
        x
    ),
    lambda(x, cout("time: ", x, " [s]"))
)
```
which would evaluate to `3.14` as expected, but would additionally print the measured time.