### PR TITLE
Frontend: Support `ast.Constant` (python 3.6+).

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -915,7 +915,7 @@ class PhySL:
 
     def _Constant(self, node):
         """A constant value."""
-        return node.value
+        return self._apply_rule(node.value)
 
     def _Div(self, node):
         """Leaf node, returning raw string of the 'division' operation."""

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -913,6 +913,10 @@ class PhySL:
 
         return comprehension
 
+    def _Constant(self, node):
+        """A constant value."""
+        return node.value
+
     def _Div(self, node):
         """Leaf node, returning raw string of the 'division' operation."""
 


### PR DESCRIPTION
Fix  #1218.