### PR TITLE
fixes for hpx v1.4.1

### DIFF
--- a/phylanx/ast/match_ast.hpp
+++ b/phylanx/ast/match_ast.hpp
@@ -13,10 +13,10 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/util/variant.hpp>
 
-#include <hpx/assert.hpp>
-#include <hpx/modules/datastructures.hpp>
-#include <hpx/modules/functional.hpp>
-#include <hpx/modules/type_support.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/datastructures.hpp>
+#include <hpx/functional.hpp>
+#include <hpx/type_support.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -179,7 +179,7 @@ namespace phylanx { namespace ast
 
             template <typename Ast1, typename Ast2, std::size_t... Is>
             inline bool call(Ast1 const& ast1, Ast2 const& ast2,
-                hpx::util::pack_c<std::size_t, Is...>) const
+                hpx::util::detail::pack_c<std::size_t, Is...>) const
             {
                 return match_ast(ast1, ast2, f_, hpx::util::get<Is>(t_)...);
             }
@@ -188,7 +188,7 @@ namespace phylanx { namespace ast
             bool operator()(Ast1 const& ast1, Ast2 const& ast2) const
             {
                 return call(ast1, ast2,
-                    typename hpx::util::make_index_pack<
+                    typename hpx::util::detail::make_index_pack<
                             sizeof...(Ts)
                          >::type());
             }

--- a/phylanx/ast/traverse.hpp
+++ b/phylanx/ast/traverse.hpp
@@ -10,8 +10,8 @@
 #include <phylanx/ast/node.hpp>
 #include <phylanx/util/variant.hpp>
 
-#include <hpx/modules/concepts.hpp>
-#include <hpx/modules/functional.hpp>
+#include <hpx/concepts.hpp>
+#include <hpx/functional.hpp>
 
 #include <cstdint>
 #include <list>

--- a/phylanx/execution_tree/compiler/actors.hpp
+++ b/phylanx/execution_tree/compiler/actors.hpp
@@ -9,10 +9,10 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 
-#include <hpx/assert.hpp>
-#include <hpx/exception.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/errors/exception.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>
 
 #if !defined(PHYLANX_HAVE_CXX17_SHARED_PTR_ARRAY)

--- a/phylanx/execution_tree/compiler/primitive_name.hpp
+++ b/phylanx/execution_tree/compiler/primitive_name.hpp
@@ -10,7 +10,7 @@
 
 #include <hpx/include/util.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
-#include <hpx/runtime_local/get_locality_id.hpp>
+#include <hpx/runtime/get_locality_id.hpp>
 
 #include <cstdint>
 #include <string>

--- a/phylanx/execution_tree/compiler_component.hpp
+++ b/phylanx/execution_tree/compiler_component.hpp
@@ -17,7 +17,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/future.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 
 #include <cstddef>
 #include <string>

--- a/phylanx/execution_tree/localities_annotation.hpp
+++ b/phylanx/execution_tree/localities_annotation.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/ir/ranges.hpp>
 
-#include <hpx/futures/future.hpp>
+#include <hpx/lcos/future.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/execution_tree/locality_annotation.hpp
+++ b/phylanx/execution_tree/locality_annotation.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/annotation.hpp>
 #include <phylanx/ir/ranges.hpp>
 
-#include <hpx/futures/future.hpp>
+#include <hpx/lcos/future.hpp>
 
 #include <cstdint>
 #include <string>

--- a/phylanx/execution_tree/meta_annotation.hpp
+++ b/phylanx/execution_tree/meta_annotation.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/annotation.hpp>
 
-#include <hpx/futures/future.hpp>
+#include <hpx/lcos/future.hpp>
 
 #include <string>
 

--- a/phylanx/execution_tree/primitives/primitive_argument_type.hpp
+++ b/phylanx/execution_tree/primitives/primitive_argument_type.hpp
@@ -16,7 +16,7 @@
 #include <phylanx/util/variant.hpp>
 
 #include <hpx/allocator_support/internal_allocator.hpp>
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/serialization/serialization_fwd.hpp>

--- a/phylanx/execution_tree/primitives/primitive_component.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component.hpp
@@ -14,7 +14,7 @@
 #include <hpx/include/components.hpp>
 #include <hpx/include/future.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -13,7 +13,7 @@
 #include <hpx/allocator_support/internal_allocator.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/async_base/launch_policy.hpp>
+#include <hpx/runtime/launch_policy.hpp>
 #include <hpx/runtime/naming_fwd.hpp>
 
 #include <cstddef>

--- a/phylanx/execution_tree/primitives/python_gil_hook.hpp
+++ b/phylanx/execution_tree/primitives/python_gil_hook.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/util/runs_in_python.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/runtime/get_lva.hpp>
 #include <hpx/runtime/threads/coroutines/coroutine.hpp>
 #include <hpx/traits/action_decorate_function.hpp>

--- a/phylanx/execution_tree/primitives/slice_node_data_1d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_1d.hpp
@@ -16,8 +16,8 @@
 #include <phylanx/ir/ranges.hpp>
 #include <phylanx/util/slicing_helpers.hpp>
 
-#include <hpx/assert.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/format.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cstddef>

--- a/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
@@ -19,7 +19,7 @@
 #include <phylanx/util/index_calculation_helper.hpp>
 #include <phylanx/util/slicing_helpers.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/phylanx/execution_tree/primitives/slice_node_data_3d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_3d.hpp
@@ -16,7 +16,7 @@
 #include <phylanx/ir/ranges.hpp>
 #include <phylanx/util/slicing_helpers.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cstddef>

--- a/phylanx/plugins/arithmetics/cumulative_impl.hpp
+++ b/phylanx/plugins/arithmetics/cumulative_impl.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/plugins/arithmetics/cumulative.hpp>
 
 #include <hpx/datastructures/optional.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/parallel_scan.hpp>

--- a/phylanx/plugins/arithmetics/generic_operation_0d.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_0d.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cmath>

--- a/phylanx/plugins/arithmetics/generic_operation_1d.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_1d.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cmath>

--- a/phylanx/plugins/arithmetics/generic_operation_2d.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_2d.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cmath>

--- a/phylanx/plugins/arithmetics/generic_operation_3d.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_3d.hpp
@@ -14,7 +14,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cmath>

--- a/phylanx/plugins/arithmetics/generic_operation_3d_definitions.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_3d_definitions.hpp
@@ -15,7 +15,7 @@
 #include <phylanx/plugins/arithmetics/generic_operation.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation_3d.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cmath>

--- a/phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp
+++ b/phylanx/plugins/arithmetics/generic_operation_bool_nd.hpp
@@ -12,7 +12,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <cmath>

--- a/phylanx/plugins/dist_matrixops/all_gather.hpp
+++ b/phylanx/plugins/dist_matrixops/all_gather.hpp
@@ -15,12 +15,12 @@
 #include <phylanx/execution_tree/primitives/primitive_component_base.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/modules/collectives.hpp>
+#include <hpx/collectives.hpp>
 
 #include <array>
 #include <cstddef>

--- a/phylanx/plugins/dist_matrixops/dist_argminmax_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_argminmax_impl.hpp
@@ -18,8 +18,8 @@
 #include <phylanx/util/serialization/blaze.hpp>
 #include <phylanx/util/tensor_iterators.hpp>
 
-#include <hpx/assert.hpp>
-#include <hpx/modules/collectives.hpp>
+#include <hpx/assertion.hpp>
+#include <hpx/collectives.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_cannon_product_impl.hpp
@@ -19,7 +19,7 @@
 #include <phylanx/plugins/dist_matrixops/dist_cannon_product.hpp>
 #include <phylanx/util/distributed_matrix.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
@@ -20,7 +20,7 @@
 #include <phylanx/util/distributed_matrix.hpp>
 #include <phylanx/util/distributed_vector.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/collectives/all_reduce.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>

--- a/phylanx/plugins/plugin_factory_base.hpp
+++ b/phylanx/plugins/plugin_factory_base.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/plugin_base.hpp>
 
-#include <hpx/modules/plugin.hpp>
+#include <hpx/plugin.hpp>
 #include <hpx/plugins/plugin_factory_base.hpp>
 #include <hpx/type_support/pack.hpp>
 

--- a/phylanx/plugins/statistics/statistics_base_impl.hpp
+++ b/phylanx/plugins/statistics/statistics_base_impl.hpp
@@ -13,7 +13,7 @@
 #include <phylanx/plugins/statistics/statistics_base.hpp>
 #include <phylanx/util/matrix_iterators.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/datastructures/optional.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/phylanx/util/distributed_matrix.hpp
+++ b/phylanx/util/distributed_matrix.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/util/serialization/blaze.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/actions_base/component_action.hpp>

--- a/phylanx/util/distributed_object.hpp
+++ b/phylanx/util/distributed_object.hpp
@@ -10,7 +10,7 @@
 
 #include <phylanx/config.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/actions_base/component_action.hpp>

--- a/phylanx/util/distributed_tensor.hpp
+++ b/phylanx/util/distributed_tensor.hpp
@@ -11,7 +11,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/util/serialization/blaze.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/actions_base/component_action.hpp>

--- a/phylanx/util/distributed_vector.hpp
+++ b/phylanx/util/distributed_vector.hpp
@@ -10,7 +10,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/util/serialization/blaze.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/preprocessor/cat.hpp>
 #include <hpx/actions_base/component_action.hpp>

--- a/phylanx/util/future_or_value.hpp
+++ b/phylanx/util/future_or_value.hpp
@@ -9,7 +9,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/util/variant.hpp>
 
-#include <hpx/modules/async.hpp>
+#include <hpx/async.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/memory/intrusive_ptr.hpp>
 #include <hpx/traits/acquire_future.hpp>

--- a/phylanx/util/index_calculation_helper.hpp
+++ b/phylanx/util/index_calculation_helper.hpp
@@ -8,7 +8,7 @@
 #if !defined(PHYLANX_UTIL_INDEX_CALCULATION_HELPER)
 #define PHYLANX_UTIL_INDEX_CALCULATION_HELPER
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/phylanx/util/truncated_normal_distribution.hpp
+++ b/phylanx/util/truncated_normal_distribution.hpp
@@ -8,7 +8,7 @@
 
 #include <phylanx/config.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/src/execution_tree/annotation.cpp
+++ b/src/execution_tree/annotation.cpp
@@ -13,7 +13,7 @@
 #include <phylanx/util/repr_manip.hpp>
 
 #include <hpx/errors/throw_exception.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 #include <hpx/serialization/serialize.hpp>
 
 #include <cctype>

--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -11,7 +11,7 @@
 #include <phylanx/execution_tree/compiler_component.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
 
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 #include <hpx/include/naming.hpp>
 
 #include <algorithm>

--- a/src/execution_tree/compiler_component.cpp
+++ b/src/execution_tree/compiler_component.cpp
@@ -13,7 +13,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component.hpp>
 
 #include <hpx/async.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 #include <hpx/include/agas.hpp>
 #include <hpx/include/components.hpp>
 

--- a/src/execution_tree/localities_annotation.cpp
+++ b/src/execution_tree/localities_annotation.cpp
@@ -11,9 +11,9 @@
 #include <phylanx/ir/ranges.hpp>
 #include <phylanx/util/generate_error_message.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/assertion.hpp>
 #include <hpx/errors/throw_exception.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 
 #include <algorithm>
 #include <array>

--- a/src/execution_tree/meta_annotation.cpp
+++ b/src/execution_tree/meta_annotation.cpp
@@ -13,7 +13,7 @@
 
 #include <hpx/include/components.hpp>
 #include <hpx/include/util.hpp>
-#include <hpx/modules/collectives.hpp>
+#include <hpx/collectives.hpp>
 
 #include <algorithm>
 #include <array>

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/execution_tree/primitives/access_argument.hpp>
 #include <phylanx/execution_tree/primitives/slice.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>

--- a/src/execution_tree/primitives/define_variable.cpp
+++ b/src/execution_tree/primitives/define_variable.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component.hpp>
 #include <phylanx/execution_tree/primitives/variable.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>

--- a/src/execution_tree/primitives/format_string.cpp
+++ b/src/execution_tree/primitives/format_string.cpp
@@ -12,7 +12,7 @@
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>
 #include <hpx/errors/throw_exception.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 
 #include <boost/utility/string_ref.hpp>
 

--- a/src/execution_tree/primitives/lambda.cpp
+++ b/src/execution_tree/primitives/lambda.cpp
@@ -6,7 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/execution_tree/primitives/lambda.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/primitives/node_data_helpers0d.cpp
+++ b/src/execution_tree/primitives/node_data_helpers0d.cpp
@@ -10,7 +10,7 @@
 #include <phylanx/execution_tree/primitives/primitive_argument_type.hpp>
 #include <phylanx/ir/node_data.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
 
 #include <algorithm>

--- a/src/execution_tree/primitives/slice.cpp
+++ b/src/execution_tree/primitives/slice.cpp
@@ -13,7 +13,7 @@
 #include <phylanx/ir/ranges.hpp>
 #include <phylanx/util/generate_error_message.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/execution_tree/primitives/slice_node_data.cpp
+++ b/src/execution_tree/primitives/slice_node_data.cpp
@@ -14,7 +14,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/ir/ranges.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/errors/exception.hpp>
 
 #include <algorithm>

--- a/src/execution_tree/primitives/slice_range.cpp
+++ b/src/execution_tree/primitives/slice_range.cpp
@@ -10,7 +10,7 @@
 #include <phylanx/util/generate_error_message.hpp>
 #include <phylanx/util/slicing_helpers.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/errors/exception.hpp>
 
 #include <algorithm>

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -11,7 +11,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/util/slicing_helpers.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/execution_tree/tiling_annotations.cpp
+++ b/src/execution_tree/tiling_annotations.cpp
@@ -8,9 +8,9 @@
 #include <phylanx/execution_tree/tiling_annotations.hpp>
 #include <phylanx/util/generate_error_message.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 
 #include <array>
 #include <cstddef>

--- a/src/plugins/arithmetics/generic_operation.cpp
+++ b/src/plugins/arithmetics/generic_operation.cpp
@@ -11,7 +11,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/arithmetics/generic_operation_bool.cpp
+++ b/src/plugins/arithmetics/generic_operation_bool.cpp
@@ -10,7 +10,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/arithmetics/generic_operation_bool.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/booleans/nonzero_where.cpp
+++ b/src/plugins/booleans/nonzero_where.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/booleans/nonzero_where.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/controls/apply.cpp
+++ b/src/plugins/controls/apply.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/execution_tree/primitives/primitive_argument_type.hpp>
 #include <phylanx/plugins/controls/apply.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/controls/fmap_operation.cpp
+++ b/src/plugins/controls/fmap_operation.cpp
@@ -6,7 +6,7 @@
 #include <phylanx/config.hpp>
 #include <phylanx/plugins/controls/fmap_operation.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/dist_matrixops/all_gather.cpp
+++ b/src/plugins/dist_matrixops/all_gather.cpp
@@ -19,7 +19,7 @@
 #include <phylanx/util/generate_error_message.hpp>
 
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/src/plugins/dist_matrixops/dist_diag.cpp
+++ b/src/plugins/dist_matrixops/dist_diag.cpp
@@ -21,7 +21,7 @@
 #include <phylanx/util/generate_error_message.hpp>
 #include <phylanx/util/index_calculation_helper.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/errors/throw_exception.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>

--- a/src/plugins/dist_matrixops/retile_annotations.cpp
+++ b/src/plugins/dist_matrixops/retile_annotations.cpp
@@ -21,7 +21,7 @@
 #include <phylanx/util/distributed_vector.hpp>
 #include <phylanx/util/index_calculation_helper.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/keras_support/binary_crossentropy_operation.cpp
+++ b/src/plugins/keras_support/binary_crossentropy_operation.cpp
@@ -11,7 +11,7 @@
 #include <phylanx/util/blaze_traits.hpp>
 #include <phylanx/util/assign.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/keras_support/categorical_crossentropy_operation.cpp
+++ b/src/plugins/keras_support/categorical_crossentropy_operation.cpp
@@ -13,7 +13,7 @@
 #include <phylanx/plugins/statistics/statistics_base.hpp>
 #include <phylanx/plugins/statistics/sum_operation.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/listops/car_cdr_operation.cpp
+++ b/src/plugins/listops/car_cdr_operation.cpp
@@ -9,7 +9,7 @@
 
 #include <phylanx/ir/ranges.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/matrixops/constant.cpp
+++ b/src/plugins/matrixops/constant.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/plugins/matrixops/constant.hpp>
 #include <phylanx/util/detail/range_dimension.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/matrixops/random.cpp
+++ b/src/plugins/matrixops/random.cpp
@@ -11,7 +11,7 @@
 #include <phylanx/util/random.hpp>
 #include <phylanx/util/truncated_normal_distribution.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/matrixops/slicing_operation.cpp
+++ b/src/plugins/matrixops/slicing_operation.cpp
@@ -12,7 +12,7 @@
 #include <phylanx/util/slicing_helpers.hpp>
 #include <phylanx/util/small_vector.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/solvers/decomposition.cpp
+++ b/src/plugins/solvers/decomposition.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/solvers/decomposition.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/solvers/linear_solver.cpp
+++ b/src/plugins/solvers/linear_solver.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/ir/node_data.hpp>
 #include <phylanx/plugins/solvers/linear_solver.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/lcos.hpp>
 #include <hpx/include/naming.hpp>
 #include <hpx/include/util.hpp>

--- a/src/plugins/statistics/std_operation.cpp
+++ b/src/plugins/statistics/std_operation.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/plugins/statistics/statistics_base_impl.hpp>
 #include <phylanx/util/blaze_traits.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <cmath>
 #include <cstddef>

--- a/src/plugins/statistics/var_operation.cpp
+++ b/src/plugins/statistics/var_operation.cpp
@@ -8,7 +8,7 @@
 #include <phylanx/plugins/statistics/statistics_base_impl.hpp>
 #include <phylanx/util/blaze_traits.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <cstddef>
 #include <functional>

--- a/src/util/generate_error_message.cpp
+++ b/src/util/generate_error_message.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/execution_tree/compiler/primitive_name.hpp>
 #include <phylanx/util/generate_error_message.hpp>
 
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 
 #include <string>
 

--- a/src/util/performance_data.cpp
+++ b/src/util/performance_data.cpp
@@ -9,7 +9,7 @@
 #include <phylanx/execution_tree/primitives/primitive_component.hpp>
 #include <phylanx/util/performance_data.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 #include <hpx/include/agas.hpp>
 #include <hpx/include/future.hpp>
 #include <hpx/include/lcos.hpp>

--- a/src/util/slicing_helpers.cpp
+++ b/src/util/slicing_helpers.cpp
@@ -11,7 +11,7 @@
 #include <phylanx/ir/ranges.hpp>
 #include <phylanx/util/slicing_helpers.hpp>
 
-#include <hpx/assert.hpp>
+#include <hpx/util/assert.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -7,7 +7,7 @@
 #include <phylanx/config/user_main_config.hpp>
 #include <phylanx/version.hpp>
 
-#include <hpx/modules/format.hpp>
+#include <hpx/format.hpp>
 #include <hpx/preprocessor/expand.hpp>
 #include <hpx/preprocessor/stringize.hpp>
 


### PR DESCRIPTION
hpx v1.4.1 does not provide support for hpx::all_gather, however, this PR contains header file and some implementation file fixes to support hpx v1.4.1