### PR TITLE
Changes in test cases to correct misspelled imports and in setup.py.in to automate NumPy installation

### DIFF
--- a/cmake/templates/setup.py.in
+++ b/cmake/templates/setup.py.in
@@ -75,6 +75,7 @@ setup_args = {
     'cmdclass': {
         'build_ext': CopyBuildExt
     },
+    'install_requires': ['numpy'],
     'platforms': 'All',
     'zip_safe': False,
     'license': 'Boost Software License, '

--- a/tests/unit/python/ir/test_nodes.py
+++ b/tests/unit/python/ir/test_nodes.py
@@ -3,7 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-from rhylanx.ir import nodes
+from phylanx.ir import nodes
 import pytest
 
 

--- a/tests/unit/python/ir/test_symbol_table.py
+++ b/tests/unit/python/ir/test_symbol_table.py
@@ -4,7 +4,7 @@
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 from collections import defaultdict
-import rhylanx.ir as ir
+import phylanx.ir as ir
 
 
 class TestNameSpace:


### PR DESCRIPTION
There is a misspelling in the import statement in 2 of the tests.
`phylanx -> rhylanx`
It will result in the failure of those tests even though Phylanx works fine. PR will fix this issue.

There was also a need to install NumPy after installing Phylanx. The changes will automate the installation of the latest NumPy along with Phylanx reducing a step in the installation.