### PR TITLE
Adding infrastructure for PhySL stack traces

### DIFF
--- a/phylanx/execution_tree/primitives/primitive_component_base.hpp
+++ b/phylanx/execution_tree/primitives/primitive_component_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -123,6 +123,9 @@ namespace phylanx { namespace execution_tree
 
         protected:
             std::string generate_error_message(std::string const& msg) const;
+            std::string generate_error_message(
+                std::string const& msg, eval_context const& ctx) const;
+
             static bool get_sync_execution();
             static std::int64_t get_ec_threshold();
             static std::int64_t get_exec_upper_threshold();

--- a/phylanx/util/generate_error_message.hpp
+++ b/phylanx/util/generate_error_message.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,12 +10,17 @@
 #include <phylanx/execution_tree/compiler/primitive_name.hpp>
 
 #include <string>
+#include <vector>
 
 namespace phylanx { namespace util
 {
     ///////////////////////////////////////////////////////////////////////////
     PHYLANX_EXPORT std::string generate_error_message(std::string const& msg,
         std::string const& name = "", std::string const& codename = "");
+
+    PHYLANX_EXPORT std::string generate_error_message(std::string const& msg,
+        std::string const& name, std::string const& codename,
+        std::vector<std::string>&& frames);
 
     PHYLANX_EXPORT std::string generate_error_message(std::string const& msg,
         execution_tree::compiler::primitive_name_parts const& parts,

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -363,7 +363,8 @@ class PhySL:
             else:
                 # the static method compiler_state is constructed only once
                 PhySL.compiler_state = \
-                    phylanx.execution_tree.global_compiler_state(self.file_name)
+                    phylanx.execution_tree.global_compiler_state(
+                        self.wrapped_function.__name__, self.file_name)
 
     def _compile_or_load(self):
         """Compile or load this function from database"""

--- a/python/phylanx/execution_tree/__init__.py
+++ b/python/phylanx/execution_tree/__init__.py
@@ -32,7 +32,7 @@ if __name__ != '__main__':
 _compiler_state = None
 
 
-def global_compiler_state(file_name=None):
+def global_compiler_state(name=None, file_name=None):
 
     global _compiler_state
     if _compiler_state is None:
@@ -40,10 +40,13 @@ def global_compiler_state(file_name=None):
         if not PhylanxSession.is_initialized:
             PhylanxSession.init(1)
 
+        if name is None:
+            name = '<unknown>'
+
         if file_name is None:
             file_name = _name_of_importing_file
 
-        _compiler_state = compiler_state(file_name)
+        _compiler_state = compiler_state(name, file_name)
 
     return _compiler_state
 

--- a/python/src/bindings/binding_helpers.hpp
+++ b/python/src/bindings/binding_helpers.hpp
@@ -42,6 +42,9 @@ namespace phylanx { namespace bindings
         phylanx::execution_tree::compiler::function_list eval_snippets;
         phylanx::execution_tree::eval_context eval_ctx;
 
+        // name of the calling Python function
+        std::string name_;
+
         // name of the main source compiled file
         std::string codename_;
 
@@ -71,10 +74,12 @@ namespace phylanx { namespace bindings
                 });
         }
 
-        compiler_state(std::string codename)
+        compiler_state(std::string name, std::string codename)
           : m(import_phylanx())
           , eval_env(construct_default_environment())
           , eval_snippets()
+          , eval_ctx(name, codename, phylanx::execution_tree::language::python)
+          , name_(std::move(name))
           , codename_(std::move(codename))
           , enable_measurements(false)
         {

--- a/python/src/bindings/execution_tree.cpp
+++ b/python/src/bindings/execution_tree.cpp
@@ -31,7 +31,7 @@ void phylanx::bindings::bind_execution_tree(pybind11::module m)
     // Compiler State
     pybind11::class_<phylanx::bindings::compiler_state>(
             execution_tree, "compiler_state")
-        .def(pybind11::init<std::string>());
+        .def(pybind11::init<std::string, std::string>());
 
     ///////////////////////////////////////////////////////////////////////////
     execution_tree.def("compile", phylanx::bindings::expression_compiler,

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -66,7 +66,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "argument count out of bounds, expected at least "
                         PHYLANX_FORMAT_SPEC(1) " argument(s) while only "
                         PHYLANX_FORMAT_SPEC(2) " argument(s) were supplied",
-                        argnum_ + 1, params.size())));
+                        argnum_ + 1, params.size()), ctx));
             }
             target = extract_ref_value(operands_[1], name_, codename_);
         }
@@ -189,10 +189,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         if (data.size() != 1)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "access_argument::store",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_argument::store",
                 generate_error_message(
-                    "invoking store with slicing parameters is not supported"));
+                    "invoking store with slicing parameters is not supported",
+                    ctx));
         }
 
         primitive_argument_type target;
@@ -207,7 +207,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "argument count out of bounds, expected at least "
                         PHYLANX_FORMAT_SPEC(1) " argument(s) while only "
                         PHYLANX_FORMAT_SPEC(2) " argument(s) were supplied",
-                        argnum_ + 1, params.size())));
+                        argnum_ + 1, params.size()), ctx));
             }
             target = extract_ref_value(operands_[1], name_, codename_);
         }
@@ -250,7 +250,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "store",
                         generate_error_message(
                             "assignment to (non-sliced) function argument is "
-                            "not supported (yet)"));
+                            "not supported (yet)", ctx));
                 }
                 break;
 
@@ -294,7 +294,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::primitives::access_argument::store",
                 generate_error_message(
-                    "storing a value to a local value has no effect"));
+                    "storing a value to a local value has no effect", ctx));
         }
     }
 
@@ -313,7 +313,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         "argument count out of bounds, expected at least "
                         PHYLANX_FORMAT_SPEC(1) " argument(s) while only "
                         PHYLANX_FORMAT_SPEC(2) " argument(s) were supplied",
-                        argnum_ + 1, params.size())));
+                        argnum_ + 1, params.size()), ctx));
             }
             target = extract_ref_value(operands_[1], name_, codename_);
         }
@@ -372,7 +372,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                             "store",
                         generate_error_message(
                             "assignment to (non-sliced) function argument is "
-                            "not supported (yet)"));
+                            "not supported (yet)", ctx));
                 }
 
             case 3:
@@ -415,7 +415,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::primitives::access_argument::store",
                 generate_error_message(
-                    "storing a value to a local value has no effect"));
+                    "storing a value to a local value has no effect", ctx));
         }
     }
 }}}

--- a/src/execution_tree/primitives/access_function.cpp
+++ b/src/execution_tree/primitives/access_function.cpp
@@ -65,7 +65,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     hpx::util::format("the variable '{}' is unbound in the "
                                       "current execution environment",
-                        target_name_)));
+                        target_name_), ctx));
         }
 
         if (!(ctx.mode_ & eval_dont_wrap_functions) && !params.empty())
@@ -107,7 +107,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     hpx::util::format("the variable '{}' is unbound in the "
                                       "current execution environment",
-                        target_name_)));
+                        target_name_), ctx));
         }
 
         primitive* p = util::get_if<primitive>(target);
@@ -130,7 +130,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     hpx::util::format("the variable '{}' is unbound in the "
                                       "current execution environment",
-                        target_name_)));
+                        target_name_), ctx));
         }
 
         primitive* p = util::get_if<primitive>(target);

--- a/src/execution_tree/primitives/access_variable.cpp
+++ b/src/execution_tree/primitives/access_variable.cpp
@@ -69,7 +69,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     hpx::util::format("the variable '{}' is unbound in the "
                                       "current execution environment",
-                        target_name_)));
+                        target_name_), ctx));
         }
 
         // handle slicing, we can replace the params with our slicing
@@ -159,10 +159,10 @@ namespace phylanx { namespace execution_tree { namespace primitives
     {
         if (vals.size() != 1)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter,
-                "access_variable::store",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_variable::store",
                 generate_error_message(
-                    "invoking store with slicing parameters is not supported"));
+                    "invoking store with slicing parameters is not supported",
+                ctx));
         }
 
         // access variable from execution context
@@ -174,7 +174,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     hpx::util::format("the variable '{}' is unbound in the "
                                       "current execution environment",
-                        target_name_)));
+                        target_name_), ctx));
         }
 
         // handle slicing, simply append the slicing parameters to the end of
@@ -209,7 +209,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     hpx::util::format("the variable '{}' is unbound in the "
                                       "current execution environment",
-                        target_name_)));
+                        target_name_), ctx));
         }
 
         if (operands_.size() > 1)

--- a/src/execution_tree/primitives/annotate_primitive.cpp
+++ b/src/execution_tree/primitives/annotate_primitive.cpp
@@ -152,7 +152,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "annotate_primitive::eval_annotate",
                 generate_error_message(
-                    "the annotate primitive requires two operands"));
+                    "the annotate primitive requires two operands", ctx));
         }
 
         auto f = value_operand(operands[0], args, name_, codename_, ctx);
@@ -178,7 +178,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "annotate_primitive::eval_annotate_d",
                 generate_error_message(
-                    "the annotate primitive requires three operands"));
+                    "the annotate primitive requires three operands", ctx));
         }
 
         auto ftarget = value_operand(operands[0], args, name_, codename_, ctx);

--- a/src/execution_tree/primitives/assert_condition.cpp
+++ b/src/execution_tree/primitives/assert_condition.cpp
@@ -62,23 +62,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "assert_condition",
                 generate_error_message(
-                    "Assert requires exactly one argument"));
+                    "Assert requires exactly one argument", ctx));
         }
 
+        auto arg =
+            scalar_boolean_operand(operands_[0], args, name_, codename_, ctx);
+
         auto this_ = this->shared_from_this();
-        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](std::uint8_t cond)
-            -> primitive_argument_type
+        return hpx::dataflow(
+            hpx::launch::sync,
+            [this_ = std::move(this_), ctx = std::move(ctx)](
+                hpx::future<std::uint8_t>&& cond) -> primitive_argument_type
             {
-                if (cond == 0)
+                if (cond.get() == 0)
                 {
                     HPX_THROW_EXCEPTION(hpx::bad_parameter,
                         "assert_condition",
-                        this_->generate_error_message("Assertion failed"));
+                        this_->generate_error_message("Assertion failed", ctx));
                 }
                 return {};
-            }),
-            scalar_boolean_operand(
-                operands_[0], args, name_, codename_, std::move(ctx)));
+            },
+            std::move(arg));
     }
 }}}

--- a/src/execution_tree/primitives/call_function.cpp
+++ b/src/execution_tree/primitives/call_function.cpp
@@ -60,7 +60,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "call_function::eval",
                 generate_error_message(
                     "the expression representing the function target "
-                        "has not been initialized"));
+                        "has not been initialized", ctx));
         }
 
         primitive_arguments_type fargs;
@@ -111,21 +111,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "call_function::store",
                 generate_error_message(
                     "the expression representing the function target "
-                        "has already been initialized"));
+                        "has already been initialized", ctx));
         }
         if (data.empty())
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "call_function::store",
                 generate_error_message(
-                    "the right hand side expression is not valid"));
+                    "the right hand side expression is not valid", ctx));
         }
         if (!params.empty())
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "call_function::store",
                 generate_error_message(
-                    "store shouldn't be called with dynamic arguments"));
+                    "store shouldn't be called with dynamic arguments", ctx));
         }
 
         operands_[0] = extract_copy_value(std::move(data[0]), name_, codename_);

--- a/src/execution_tree/primitives/enable_tracing.cpp
+++ b/src/execution_tree/primitives/enable_tracing.cpp
@@ -59,7 +59,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "enable_tracing::eval",
                 generate_error_message(
-                    "expected one (boolean) argument"));
+                    "expected one (boolean) argument", ctx));
         }
 
         if (!valid(operands[0]))
@@ -68,7 +68,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "enable_tracing::eval",
                 generate_error_message(
                     "the enable_tracing primitive requires that the "
-                        "argument given by the operand is valid"));
+                        "argument given by the operand is valid", ctx));
         }
 
         primitive::enable_tracing =

--- a/src/execution_tree/primitives/format_string.cpp
+++ b/src/execution_tree/primitives/format_string.cpp
@@ -285,7 +285,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "format_string::eval",
                 generate_error_message(
                     "the format_string primitive expects to be invoked with "
-                    "at least one argument"));
+                    "at least one argument", ctx));
         }
 
         auto this_ = this->shared_from_this();

--- a/src/execution_tree/primitives/function.cpp
+++ b/src/execution_tree/primitives/function.cpp
@@ -72,7 +72,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "function::eval",
                 generate_error_message(
                     "the expression representing the function target "
-                        "has not been initialized"));
+                        "has not been initialized", ctx));
         }
 
         primitive const* p = util::get_if<primitive>(&operands_[0]);
@@ -100,7 +100,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "function::bind",
                 generate_error_message(
                     "the expression representing the function target "
-                        "has not been initialized"));
+                        "has not been initialized", ctx));
         }
         return true;
     }
@@ -113,14 +113,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "function::store",
                 generate_error_message(
-                    "the right hand side expression is not valid"));
+                    "the right hand side expression is not valid", ctx));
         }
         if (!params.empty())
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "function::store",
                 generate_error_message(
-                    "store shouldn't be called with dynamic arguments"));
+                    "store shouldn't be called with dynamic arguments", ctx));
         }
 
         operands_[0] = extract_copy_value(std::move(data), name_, codename_);

--- a/src/execution_tree/primitives/lambda.cpp
+++ b/src/execution_tree/primitives/lambda.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -105,7 +105,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             eval_mode(eval_dont_evaluate_lambdas | eval_dont_wrap_functions));
 
         return value_operand(operands_[0], args, name_, codename_,
-            add_frame(std::move(next_ctx)));
+            add_frame(std::move(next_ctx), name_, codename_));
     }
 
     void lambda::store(primitive_arguments_type&& data,
@@ -117,21 +117,21 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "lambda::store",
                 generate_error_message(
                     "the expression representing the function target "
-                        "has already been initialized"));
+                        "has already been initialized", ctx));
         }
         if (data.empty())
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "lambda::store",
                 generate_error_message(
-                    "the right hand side expression is not valid"));
+                    "the right hand side expression is not valid", ctx));
         }
         if (!params.empty())
         {
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "lambda::store",
                 generate_error_message(
-                    "store shouldn't be called with dynamic arguments"));
+                    "store shouldn't be called with dynamic arguments", ctx));
         }
 
         // initialize the lambda's body

--- a/src/execution_tree/primitives/phyname.cpp
+++ b/src/execution_tree/primitives/phyname.cpp
@@ -63,7 +63,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phyname::eval",
                 generate_error_message(
-                    "phylanx.name requires exactly one argument"));
+                    "phylanx.name requires exactly one argument", ctx));
         }
 
         auto this_ = this->shared_from_this();

--- a/src/execution_tree/primitives/phytype.cpp
+++ b/src/execution_tree/primitives/phytype.cpp
@@ -64,7 +64,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phytype::eval",
                 generate_error_message(
-                    "phylanx.name requires exactly one argument"));
+                    "phylanx.name requires exactly one argument", ctx));
         }
 
         auto this_ = this->shared_from_this();

--- a/src/execution_tree/primitives/primitive_argument_type.cpp
+++ b/src/execution_tree/primitives/primitive_argument_type.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Hartmut Kaiser
+// Copyright (c) 2017-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -17,6 +17,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace phylanx { namespace execution_tree
 {
@@ -52,13 +53,37 @@ namespace phylanx { namespace execution_tree
     void variable_frame::serialize(
         hpx::serialization::output_archive& ar, unsigned)
     {
-        ar & variables_;
+        int lang = static_cast<int>(lang_);
+        ar & variables_ & lang & name_ & codename_;
     }
 
     void variable_frame::serialize(
         hpx::serialization::input_archive& ar, unsigned)
     {
-        ar & variables_;
+        int lang = 0;
+        ar & variables_ & lang & name_ & codename_;
+        lang_ = static_cast<language>(lang);
+    }
+
+    std::vector<std::string> variable_frame::back_trace() const
+    {
+        std::vector<std::string> result;
+        if (nextframe_)
+        {
+            result = nextframe_->back_trace();
+        }
+
+        if (lang_ == language::cxx)
+        {
+            result.push_back(
+                util::generate_error_message("(PhySL)", name_, codename_));
+        }
+        else
+        {
+            result.push_back(
+                util::generate_error_message("(Python)", name_, codename_));
+        }
+        return result;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/execution_tree/primitives/primitive_component_base.cpp
+++ b/src/execution_tree/primitives/primitive_component_base.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -190,19 +190,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
             "phylanx::execution_tree::primitives::primitive_component_base::"
                 "eval",
             generate_error_message(
-                "eval function should be implemented by all primitives"));
+                "eval function should be implemented by all primitives", ctx));
     }
 
     // store_action
     void primitive_component_base::store(primitive_arguments_type&&,
-        primitive_arguments_type&&, eval_context)
+        primitive_arguments_type&&, eval_context ctx)
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::primitives::primitive_component_base::"
                 "store",
             generate_error_message(
                 "store function should only be called for the primitives that "
-                "support it (e.g. variables)"));
+                "support it (e.g. variables)", ctx));
     }
 
     void primitive_component_base::store(primitive_argument_type&& param,
@@ -256,19 +256,19 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "primitive_component_base::bind",
             generate_error_message(
                 "bind function should only be called for the "
-                    "primitives that support it (e.g. variable/function)"));
+                    "primitives that support it (e.g. variable/function)", ctx));
         return true;
     }
 
     // initialize evaluation context (used by target-reference only)
-    void primitive_component_base::set_eval_context(eval_context)
+    void primitive_component_base::set_eval_context(eval_context ctx)
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::primitives::primitive_component_base::"
                 "set_eval_context",
             generate_error_message(
                 "set_eval_context function should only be called for the "
-                "primitives that support it (e.g. target-references)"));
+                "primitives that support it (e.g. target-references)", ctx));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -276,6 +276,13 @@ namespace phylanx { namespace execution_tree { namespace primitives
         std::string const& msg) const
     {
         return util::generate_error_message(msg, name_, codename_);
+    }
+
+    std::string primitive_component_base::generate_error_message(
+        std::string const& msg, eval_context const& ctx) const
+    {
+        return util::generate_error_message(
+            msg, name_, codename_, ctx.back_trace());
     }
 
     std::int64_t primitive_component_base::get_eval_count(bool reset) const

--- a/src/execution_tree/primitives/store_operation.cpp
+++ b/src/execution_tree/primitives/store_operation.cpp
@@ -73,7 +73,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "store_operation::eval",
                 generate_error_message(
                     "the store_operation primitive requires exactly "
-                        "two operands"));
+                        "two operands", ctx));
         }
 
         if (!valid(operands_[0]) || is_implicit_nil(operands_[1]))
@@ -82,7 +82,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "store_operation::store_operation",
                 generate_error_message(
                     "the store_operation primitive requires that "
-                    "the arguments given by the operands array is valid"));
+                    "the arguments given by the operands array is valid", ctx));
         }
 
         if (!is_primitive_operand(operands_[0]))
@@ -92,7 +92,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     "the first argument of the store primitive must "
                         "refer to a another primitive and can't be a "
-                        "literal value"));
+                        "literal value", ctx));
         }
 
         auto this_ = this->shared_from_this();
@@ -136,7 +136,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "store_operation::eval",
                 generate_error_message(
                     "the store_operation primitive requires exactly "
-                        "two  operands"));
+                        "two  operands", ctx));
         }
 
         if (!valid(operands_[0]) || !valid(operands_[1]))
@@ -145,7 +145,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "store_operation::store_operation",
                 generate_error_message(
                     "the store_operation primitive requires that "
-                    "the arguments given by the operands array is valid"));
+                    "the arguments given by the operands array is valid", ctx));
         }
 
         if (!is_primitive_operand(operands_[0]))
@@ -155,7 +155,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     "the first argument of the store primitive must "
                         "refer to a another primitive and can't be a "
-                        "literal value"));
+                        "literal value", ctx));
         }
 
         auto this_ = this->shared_from_this();

--- a/src/execution_tree/primitives/target_reference.cpp
+++ b/src/execution_tree/primitives/target_reference.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2019 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -90,12 +90,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
             eval_context next_ctx = set_mode(std::move(ctx), eval_default);
             if (target_)
             {
-                return target_->eval(
-                    std::move(fargs), add_frame(std::move(next_ctx)));
+                return target_->eval(std::move(fargs),
+                    add_frame(std::move(next_ctx), name_, codename_));
             }
 
             return value_operand(operands_[0], std::move(fargs), name_,
-                codename_, add_frame(std::move(next_ctx)));
+                codename_, add_frame(std::move(next_ctx), name_, codename_));
         }
 
         eval_context next_ctx =
@@ -103,11 +103,12 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
         if (target_)
         {
-            return target_->eval(params, add_frame(std::move(next_ctx)));
+            return target_->eval(
+                params, add_frame(std::move(next_ctx), name_, codename_));
         }
 
         return value_operand(operands_[0], params, name_, codename_,
-            add_frame(std::move(next_ctx)));
+            add_frame(std::move(next_ctx), name_, codename_));
     }
 
     hpx::future<primitive_argument_type> target_reference::eval(
@@ -136,23 +137,24 @@ namespace phylanx { namespace execution_tree { namespace primitives
 
             if (target_)
             {
-                return target_->eval(fargs, add_frame(std::move(next_ctx)));
+                return target_->eval(
+                    fargs, add_frame(std::move(next_ctx), name_, codename_));
             }
 
             return value_operand(operands_[0], std::move(fargs), name_,
-                codename_, add_frame(std::move(next_ctx)));
+                codename_, add_frame(std::move(next_ctx), name_, codename_));
         }
 
         eval_context next_ctx =
             set_mode(std::move(ctx), eval_dont_wrap_functions);
         if (target_)
         {
-            return target_->eval_single(
-                std::move(param), add_frame(std::move(next_ctx)));
+            return target_->eval_single(std::move(param),
+                add_frame(std::move(next_ctx), name_, codename_));
         }
 
         return value_operand(operands_[0], std::move(param), name_, codename_,
-            add_frame(std::move(next_ctx)));
+            add_frame(std::move(next_ctx), name_, codename_));
     }
 
     bool target_reference::bind(

--- a/src/execution_tree/primitives/timer.cpp
+++ b/src/execution_tree/primitives/timer.cpp
@@ -67,7 +67,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "timer::eval",
                 generate_error_message(
-                    "the timer primitive requires exactly two operands"));
+                    "the timer primitive requires exactly two operands", ctx));
         }
 
         if (!valid(operands[0]) || !valid(operands[1]))
@@ -76,7 +76,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                 "timer::eval",
                 generate_error_message(
                     "the timer primitive requires that the "
-                    "arguments given by the operands array are valid"));
+                    "arguments given by the operands array are valid", ctx));
         }
 
         auto this_ = this->shared_from_this();
@@ -95,7 +95,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                         "timer::eval",
                         this_->generate_error_message(
                             "the first argument to timer must be an "
-                            "invocable object"));
+                            "invocable object", ctx));
                 }
 
                 primitive_argument_type result = p->eval(hpx::launch::sync,
@@ -113,7 +113,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                         "timer::eval",
                         this_->generate_error_message(
                             "the second argument to timer must be an "
-                            "invocable object"));
+                            "invocable object", ctx));
                 }
 
                 r->eval(hpx::launch::sync, primitive_argument_type{elapsed},

--- a/src/execution_tree/primitives/variable.cpp
+++ b/src/execution_tree/primitives/variable.cpp
@@ -80,7 +80,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "variable::eval",
                 generate_error_message(
                     "the expression representing the variable target "
-                    "has not been initialized"));
+                    "has not been initialized", ctx));
         }
 
         primitive_argument_type const& target =
@@ -191,7 +191,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "variable::eval",
                 generate_error_message(
                     "the expression representing the variable target "
-                    "has not been initialized"));
+                    "has not been initialized", ctx));
         }
 
         primitive_argument_type const& target =
@@ -239,7 +239,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "variable::bind",
                 generate_error_message(
                     "the expression representing the variable target "
-                        "has not been initialized"));
+                        "has not been initialized", ctx));
         }
 
         primitive const* p = util::get_if<primitive>(&operands_[0]);
@@ -266,7 +266,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "variable::store1dslice",
                 generate_error_message(
                     "in order for slicing to be possible a variable must have "
-                    "a value bound to it"));
+                    "a value bound to it", ctx));
         }
 
         auto result = slice(std::move(bound_value_),
@@ -285,7 +285,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "variable::store2dslice",
                 generate_error_message(
                     "in order for slicing to be possible a variable must have "
-                    "a value bound to it"));
+                    "a value bound to it", ctx));
         }
 
         auto data1 =
@@ -306,7 +306,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "variable::store3dslice",
                 generate_error_message(
                     "in order for slicing to be possible a variable must have "
-                    "a value bound to it"));
+                    "a value bound to it", ctx));
         }
 
         auto data1 = value_operand_sync(data[1], params, name_, codename_, ctx);
@@ -331,7 +331,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "variable::store",
                 generate_error_message(
-                    "the right hand side expression is not valid"));
+                    "the right hand side expression is not valid", ctx));
         }
 
         if (!value_set_ || !valid(operands_[0]))
@@ -342,7 +342,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     "variable::store",
                     generate_error_message(
                         "the initial expression a variable is bound to is "
-                        "not allowed to have slicing parameters"));
+                        "not allowed to have slicing parameters", ctx));
             }
 
             operands_[0] =
@@ -380,7 +380,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "variable::store",
                 generate_error_message(
-                    "there can be at most two slicing arguments"));
+                    "there can be at most two slicing arguments", ctx));
         }
     }
 
@@ -393,14 +393,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
             HPX_THROW_EXCEPTION(hpx::invalid_status,
                 "variable::store",
                 generate_error_message(
-                    "the right hand side expression is not valid"));
+                    "the right hand side expression is not valid", ctx));
         }
 //         if (!params.empty())
 //         {
 //             HPX_THROW_EXCEPTION(hpx::invalid_status,
 //                 "valiable::store",
 //                 generate_error_message(
-//                     "store shouldn't be called with dynamic arguments"));
+//                     "store shouldn't be called with dynamic arguments", ctx));
 //         }
 
         if (!value_set_ || !valid(operands_[0]))

--- a/src/execution_tree/primitives/variable_factory.cpp
+++ b/src/execution_tree/primitives/variable_factory.cpp
@@ -106,7 +106,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 "variable_factory::store",
                 generate_error_message(
                     "the variable_factory primitive's store method should be "
-                    "called only once"));
+                    "called only once", ctx));
         }
         operands_[0] = std::move(data);
     }

--- a/src/util/generate_error_message.cpp
+++ b/src/util/generate_error_message.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2018 Hartmut Kaiser
+//  Copyright (c) 2017-2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +10,8 @@
 #include <hpx/modules/format.hpp>
 
 #include <string>
+#include <utility>
+#include <vector>
 
 namespace phylanx { namespace util
 {
@@ -19,6 +21,33 @@ namespace phylanx { namespace util
     {
         return generate_error_message(msg,
             execution_tree::compiler::compose_primitive_name(parts), codename);
+    }
+
+    namespace detail
+    {
+        std::string format_frame(int frame_no, std::string&& frame)
+        {
+            return hpx::util::format(
+                "  [{}]: {}\n", frame_no, std::move(frame));
+        }
+    }
+
+    std::string generate_error_message(std::string const& msg,
+        std::string const& name, std::string const& codename,
+        std::vector<std::string>&& frames)
+    {
+        std::string trace = "\n<stack frames>\n";
+
+        int frame_no = 0;
+        for (auto&& frame : frames)
+        {
+            trace += detail::format_frame(++frame_no, std::move(frame));
+        }
+
+        trace += detail::format_frame(++frame_no,
+            generate_error_message("(PhySL)\n", name, codename));
+
+        return trace + msg;
     }
 
     std::string generate_error_message(std::string const& msg,

--- a/tests/regressions/python/passing_compiler_state_453.py
+++ b/tests/regressions/python/passing_compiler_state_453.py
@@ -11,7 +11,7 @@ from phylanx import Phylanx, PhylanxSession
 
 PhylanxSession.init(1)
 
-cs = et.compiler_state(__name__)
+cs = et.compiler_state('global', __name__)
 
 src_mul2 = """
 define(mul2, n,

--- a/tests/unit/python/execution_tree/eval.py
+++ b/tests/unit/python/execution_tree/eval.py
@@ -12,7 +12,7 @@ import numpy as np
 PhylanxSession.init(1)
 
 et = phylanx.execution_tree
-cs = et.compiler_state(__name__)
+cs = et.compiler_state('global', __name__)
 
 fib10 = et.eval(cs, """
 block(


### PR DESCRIPTION
This PR adds the infrastructure for generating stack traces on exceptions thrown from Phylanx execution tree evaluations. It also enables generating those for some of the main primitives. More work is required to generate stack traces from all exceptions.