### PR TITLE
Adding stack traces to all error message generated from indexing/slicing

### DIFF
--- a/phylanx/execution_tree/primitives/base_primitive.hpp
+++ b/phylanx/execution_tree/primitives/base_primitive.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Hartmut Kaiser
+// Copyright (c) 2017-2020 Hartmut Kaiser
 // Copyright (c) 2018 Parsa Amini
 // Copyright (c) 2018 Tianyi Zhang
 //
@@ -145,6 +145,8 @@ namespace phylanx { namespace execution_tree
         std::string const& name = "",
         std::string const& codename = "<unknown>");
     PHYLANX_EXPORT bool is_dictionary_operand(
+        primitive_argument_type const& val);
+    PHYLANX_EXPORT bool is_hashable_operand(
         primitive_argument_type const& val);
 
     // Extract a dictionary type from a given primitive_argument_type,

--- a/phylanx/execution_tree/primitives/detail/advanced_indexes.hpp
+++ b/phylanx/execution_tree/primitives/detail/advanced_indexes.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -22,9 +22,9 @@
 namespace phylanx { namespace execution_tree { namespace detail
 {
     ///////////////////////////////////////////////////////////////////////////
-    HPX_FORCEINLINE std::int64_t
-    check_index(std::int64_t index, std::size_t size, std::string const& name,
-        std::string const& codename)
+    HPX_FORCEINLINE std::int64_t check_index(std::int64_t index,
+        std::size_t size, std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (index < 0)
         {
@@ -37,7 +37,7 @@ namespace phylanx { namespace execution_tree { namespace detail
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::detail::check_index",
                 util::generate_error_message(
-                    "index out of range", name, codename));
+                    "index out of range", name, codename, ctx.back_trace()));
         }
 #endif
         return index;
@@ -133,7 +133,7 @@ namespace phylanx { namespace execution_tree { namespace detail
     std::size_t slicing_size(
         execution_tree::primitive_argument_type const& indices,
         std::size_t arg_size, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         if (is_list_operand_strict(indices))
         {
@@ -144,7 +144,7 @@ namespace phylanx { namespace execution_tree { namespace detail
             {
                 // basic slicing and indexing
                 return util::slicing_helpers::slicing_size(
-                    indices, arg_size, name, codename);
+                    indices, arg_size, name, codename, ctx);
             }
 
             if (t == slicing_index_advanced_integer)
@@ -179,7 +179,7 @@ namespace phylanx { namespace execution_tree { namespace detail
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slicing_size",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 }}}
 

--- a/phylanx/execution_tree/primitives/slice.hpp
+++ b/phylanx/execution_tree/primitives/slice.hpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2018 Parsa Amini
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,59 +13,62 @@
 
 #include <string>
 
-namespace phylanx { namespace execution_tree
-{
+namespace phylanx { namespace execution_tree {
     ///////////////////////////////////////////////////////////////////////////
     // return a slice of the given node_data instance
     PHYLANX_EXPORT primitive_argument_type slice(
         primitive_argument_type const& data,
         primitive_argument_type const& indices, std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     PHYLANX_EXPORT primitive_argument_type dist_slice(
         primitive_argument_type const& data,
         primitive_argument_type const& indices, std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     PHYLANX_EXPORT primitive_argument_type slice(
         primitive_argument_type const& data,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     PHYLANX_EXPORT primitive_argument_type dist_slice(
         primitive_argument_type const& data,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     PHYLANX_EXPORT primitive_argument_type slice(
         primitive_argument_type const& data,
         primitive_argument_type const& pages,
         primitive_argument_type const& rows,
-        primitive_argument_type const& columns,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        primitive_argument_type const& columns, std::string const& name = "",
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     ///////////////////////////////////////////////////////////////////////////
     // modify a slice of the given primitive_argument_type instance
     PHYLANX_EXPORT primitive_argument_type slice(primitive_argument_type&& data,
         primitive_argument_type const& indices, primitive_argument_type&& value,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     PHYLANX_EXPORT primitive_argument_type slice(primitive_argument_type&& data,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, primitive_argument_type&& value,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     PHYLANX_EXPORT primitive_argument_type slice(primitive_argument_type&& data,
         primitive_argument_type const& pages,
         primitive_argument_type const& rows,
-        primitive_argument_type const& columns,
-        primitive_argument_type&& value, std::string const& name = "",
-        std::string const& codename = "<unknown>");
-}}
+        primitive_argument_type const& columns, primitive_argument_type&& value,
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
+}}    // namespace phylanx::execution_tree
 
 #endif

--- a/phylanx/execution_tree/primitives/slice_node_data.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -13,30 +13,29 @@
 
 #include <string>
 
-namespace phylanx { namespace execution_tree
-{
+namespace phylanx { namespace execution_tree {
     ///////////////////////////////////////////////////////////////////////////
     // extract a slice from the given node_data instance
     template <typename T>
     PHYLANX_EXPORT ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& indices,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT execution_tree::primitive_argument_type dist_slice_extract(
         ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& indices,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT execution_tree::primitive_argument_type dist_slice_extract(
@@ -44,16 +43,16 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& pages,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     ///////////////////////////////////////////////////////////////////////////
     // modify a slice of the given node_data instance
@@ -61,7 +60,8 @@ namespace phylanx { namespace execution_tree
     PHYLANX_EXPORT ir::node_data<T> slice_assign(ir::node_data<T>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<T>&& value, std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT execution_tree::primitive_argument_type dist_slice_assign(
@@ -70,8 +70,8 @@ namespace phylanx { namespace execution_tree
         ir::node_data<T>&& value,
         execution_tree::localities_information&& arr_localities,
         execution_tree::localities_information&& val_localities,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT execution_tree::primitive_argument_type dist_slice_assign(
@@ -79,15 +79,16 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<T>&& value,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT ir::node_data<T> slice_assign(ir::node_data<T>&& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<T>&& value, std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     template <typename T>
     PHYLANX_EXPORT ir::node_data<T> slice_assign(ir::node_data<T>&& data,
@@ -95,7 +96,8 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<T>&& value, std::string const& name = "",
-        std::string const& codename = "<unknown>");
-}}
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
+}}    // namespace phylanx::execution_tree
 
 #endif

--- a/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_2d.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -53,7 +53,8 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_basic_basic(Data&& m,
         ir::slicing_indices const& rows, ir::slicing_indices const& columns,
-        F const& f, std::string const& name, std::string const& codename)
+        F const& f, std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numrows = m.rows();
         if (rows.start() >= std::int64_t(numrows) ||
@@ -63,7 +64,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice2d_basic_basic",
                 util::generate_error_message(
                     "cannot extract the requested matrix elements",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t row_start = rows.start();
@@ -74,8 +75,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice2d_basic_basic",
-                util::generate_error_message(
-                    "row-step can not be zero", name, codename));
+                util::generate_error_message("row-step can not be zero", name,
+                    codename, ctx.back_trace()));
         }
 
         std::size_t numcols = m.columns();
@@ -86,7 +87,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice2d_basic_basic",
                 util::generate_error_message(
                     "cannot extract the requested matrix elements",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t col_start = columns.start();
@@ -97,8 +98,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice2d_basic_basic",
-                util::generate_error_message(
-                    "column-step can not be zero", name, codename));
+                util::generate_error_message("column-step can not be zero",
+                    name, codename, ctx.back_trace()));
         }
 
         std::size_t num_matrix_rows = m.rows();
@@ -248,7 +249,8 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice2d_basic_integer(Data&& m,
         ir::slicing_indices const& rows,
         ir::node_data<std::int64_t> && columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numrows = m.rows();
         if (rows.start() >= std::int64_t(numrows) ||
@@ -258,7 +260,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice2d_basic_integer",
                 util::generate_error_message(
                     "cannot extract the requested matrix elements",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t row_start = rows.start();
@@ -269,8 +271,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice2d_basic_integer",
-                util::generate_error_message(
-                    "row-step can not be zero", name, codename));
+                util::generate_error_message("row-step can not be zero", name,
+                    codename, ctx.back_trace()));
         }
 
         std::size_t numcols = m.columns();
@@ -278,7 +280,7 @@ namespace phylanx { namespace execution_tree
         for (std::size_t i = 0; i != index_size; ++i)
         {
             columns[i] =
-                detail::check_index(columns[i], numcols, name, codename);
+                detail::check_index(columns[i], numcols, name, codename, ctx);
         }
 
         // return a value and not a vector
@@ -344,9 +346,9 @@ namespace phylanx { namespace execution_tree
 
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_basic_boolean(Data&& m,
-        ir::slicing_indices const& rows,
-        ir::node_data<std::uint8_t> && columns, F const& f,
-        std::string const& name, std::string const& codename)
+        ir::slicing_indices const& rows, ir::node_data<std::uint8_t>&& columns,
+        F const& f, std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numrows = m.rows();
         if (rows.start() >= std::int64_t(numrows) ||
@@ -356,21 +358,22 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice2d_basic_boolean",
                 util::generate_error_message(
                     "cannot extract the requested matrix elements",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         if (rows.step() == 0 && !rows.single_value())
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice2d_basic_boolean",
-                util::generate_error_message(
-                    "row-step can not be zero", name, codename));
+                util::generate_error_message("row-step can not be zero", name,
+                    codename, ctx.back_trace()));
         }
 
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_basic_boolean",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
 
         return {};
     }
@@ -379,7 +382,8 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_basic_column(Data&& m,
         ir::slicing_indices const& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numcols = m.columns();
         if (columns.start() >= std::int64_t(numcols) ||
@@ -389,7 +393,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice2d_basic_column",
                 util::generate_error_message(
                     "cannot extract the requested matrix elements",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t col_start = columns.start();
@@ -400,8 +404,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice2d_basic_basic",
-                util::generate_error_message(
-                    "column-step can not be zero", name, codename));
+                util::generate_error_message("column-step can not be zero",
+                    name, codename, ctx.back_trace()));
         }
 
         if (columns.single_value())
@@ -477,7 +481,8 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice2d_integer_basic(Data&& m,
         ir::node_data<std::int64_t> && rows,
         ir::slicing_indices const& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numcols = m.columns();
         if (columns.start() >= std::int64_t(numcols) ||
@@ -487,7 +492,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice2d_integer_basic",
                 util::generate_error_message(
                     "cannot extract the requested matrix elements",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t col_start = columns.start();
@@ -498,8 +503,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice2d_integer_basic",
-                util::generate_error_message(
-                    "column-step can not be zero", name, codename));
+                util::generate_error_message("column-step can not be zero",
+                    name, codename, ctx.back_trace()));
         }
 
         std::size_t numrows = m.rows();
@@ -507,7 +512,7 @@ namespace phylanx { namespace execution_tree
         for (std::size_t i = 0; i != index_size; ++i)
         {
             rows[i] =
-                detail::check_index(rows[i], numrows, name, codename);
+                detail::check_index(rows[i], numrows, name, codename, ctx);
         }
 
         if (rows.size() == 1)
@@ -561,9 +566,9 @@ namespace phylanx { namespace execution_tree
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_boolean_basic(Data&& m,
-        ir::node_data<std::uint8_t> && rows,
-        ir::slicing_indices const& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        ir::node_data<std::uint8_t>&& rows, ir::slicing_indices const& columns,
+        F const& f, std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numcols = m.columns();
         if (columns.start() >= std::int64_t(numcols) ||
@@ -573,21 +578,22 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice2d_boolean_basic",
                 util::generate_error_message(
                     "cannot extract the requested matrix elements",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         if (columns.step() == 0 && !columns.single_value())
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice2d_boolean_basic",
-                util::generate_error_message(
-                    "column-step can not be zero", name, codename));
+                util::generate_error_message("column-step can not be zero",
+                    name, codename, ctx.back_trace()));
         }
 
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_boolean_basic",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
 
         return {};
     }
@@ -597,13 +603,15 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice2d_integer_integer(Data&& m,
         ir::node_data<std::int64_t> && rows,
         ir::node_data<std::int64_t> && columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numrows = m.rows();
         std::size_t rows_index_size = rows.size();
         for (std::size_t i = 0; i != rows_index_size; ++i)
         {
-            rows[i] = detail::check_index(rows[i], numrows, name, codename);
+            rows[i] =
+                detail::check_index(rows[i], numrows, name, codename, ctx);
         }
 
         std::size_t numcols = m.columns();
@@ -611,7 +619,7 @@ namespace phylanx { namespace execution_tree
         for (std::size_t i = 0; i != columns_index_size; ++i)
         {
             columns[i] =
-                detail::check_index(columns[i], numcols, name, codename);
+                detail::check_index(columns[i], numcols, name, codename, ctx);
         }
 
         // broadcast both index arrays, use result to index elements in matrix
@@ -649,41 +657,46 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice2d_integer_boolean(Data&& m,
         ir::node_data<std::int64_t> && rows,
         ir::node_data<std::uint8_t> && columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numrows = m.rows();
         std::size_t rows_index_size = rows.size();
         for (std::size_t i = 0; i != rows_index_size; ++i)
         {
-            rows[i] = detail::check_index(rows[i], numrows, name, codename);
+            rows[i] =
+                detail::check_index(rows[i], numrows, name, codename, ctx);
         }
 
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_integer_boolean",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
 
         return {};
     }
 
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_boolean_integer(Data&& m,
-        ir::node_data<std::uint8_t> && rows,
-        ir::node_data<std::int64_t> && columns, F const& f,
-        std::string const& name, std::string const& codename)
+        ir::node_data<std::uint8_t>&& rows,
+        ir::node_data<std::int64_t>&& columns, F const& f,
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numcols = m.columns();
         std::size_t columns_index_size = columns.size();
         for (std::size_t i = 0; i != columns_index_size; ++i)
         {
             columns[i] =
-                detail::check_index(columns[i], numcols, name, codename);
+                detail::check_index(columns[i], numcols, name, codename, ctx);
         }
 
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_boolean_integer",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
 
         return {};
     }
@@ -706,12 +719,13 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer_0d(Data&& m,
         ir::node_data<std::int64_t>&& rows, bool explicit_nil, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         HPX_ASSERT(rows.size() == 1);
 
         auto row = blaze::row(
-            m, detail::check_index(rows[0], m.rows(), name, codename));
+            m, detail::check_index(rows[0], m.rows(), name, codename, ctx));
 
         return f.vector(m, std::move(row));
 
@@ -720,11 +734,13 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer_1d(Data&& m,
         ir::node_data<std::int64_t>&& rows, bool explicit_nil, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         for (std::size_t i = 0; i != rows.size(); ++i)
         {
-            rows[i] = detail::check_index(rows[i], m.rows(), name, codename);
+            rows[i] =
+                detail::check_index(rows[i], m.rows(), name, codename, ctx);
         }
 
         // general case, pick arbitrary rows from matrix
@@ -743,40 +759,43 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer_2d(Data&& m,
         ir::node_data<std::int64_t>&& rows, bool explicit_nil, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (!explicit_nil && rows.size() == 1)
         {
             typename ir::node_data<T>::storage3d_type result(1, 1, m.columns());
             blaze::row(blaze::pageslice(result, 0), 0) = blaze::row(
-                m, detail::check_index(rows[0], m.rows(), name, codename));
+                m, detail::check_index(rows[0], m.rows(), name, codename, ctx));
             return f.tensor(m, std::move(result));
         }
 
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_integer_2d",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
     }
 
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer(Data&& m,
         ir::node_data<std::int64_t>&& rows, bool explicit_nil, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (rows.num_dimensions())
         {
         case 0:
             return slice2d_integer_0d<T>(std::forward<Data>(m),
-                std::move(rows), explicit_nil, f, name, codename);
+                std::move(rows), explicit_nil, f, name, codename, ctx);
 
         case 1:
             return slice2d_integer_1d<T>(std::forward<Data>(m),
-                std::move(rows), explicit_nil, f, name, codename);
+                std::move(rows), explicit_nil, f, name, codename, ctx);
 
         case 2:
             return slice2d_integer_2d<T>(std::forward<Data>(m),
-                std::move(rows), explicit_nil, f, name, codename);
+                std::move(rows), explicit_nil, f, name, codename, ctx);
 
         default:
             break;
@@ -785,31 +804,34 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_integer",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer_column_0d(Data&& m,
         ir::node_data<std::int64_t>&& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         HPX_ASSERT(columns.size() == 1);
 
-        auto column = blaze::column(
-            m, detail::check_index(columns[0], m.columns(), name, codename));
+        auto column = blaze::column(m,
+            detail::check_index(columns[0], m.columns(), name, codename, ctx));
         return f.vector(m, std::move(column));
     }
 
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer_column_1d(Data&& m,
         ir::node_data<std::int64_t>&& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         for (std::size_t i = 0; i != columns.size(); ++i)
         {
-            columns[i] =
-                detail::check_index(columns[i], m.columns(), name, codename);
+            columns[i] = detail::check_index(
+                columns[i], m.columns(), name, codename, ctx);
         }
 
         // general case, pick arbitrary rows from matrix
@@ -821,40 +843,44 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer_column_2d(Data&& m,
         ir::node_data<std::int64_t>&& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (columns.size() == 1)
         {
             typename ir::node_data<T>::storage3d_type result(1, m.rows(), 1);
-            blaze::column(blaze::pageslice(result, 0), 0) = blaze::column(
-                m, detail::check_index(columns[0], m.columns(), name, codename));
+            blaze::column(blaze::pageslice(result, 0), 0) = blaze::column(m,
+                detail::check_index(
+                    columns[0], m.columns(), name, codename, ctx));
             return f.tensor(m, std::move(result));
         }
 
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_integer_column_2d",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
     }
 
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_integer_column(Data&& m,
         ir::node_data<std::int64_t>&& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (columns.num_dimensions())
         {
         case 0:
             return slice2d_integer_column_0d<T>(std::forward<Data>(m),
-                std::move(columns), f, name, codename);
+                std::move(columns), f, name, codename, ctx);
 
         case 1:
             return slice2d_integer_column_1d<T>(std::forward<Data>(m),
-                std::move(columns), f, name, codename);
+                std::move(columns), f, name, codename, ctx);
 
         case 2:
             return slice2d_integer_column_2d<T>(std::forward<Data>(m),
-                std::move(columns), f, name, codename);
+                std::move(columns), f, name, codename, ctx);
 
         default:
             break;
@@ -863,25 +889,28 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice2d_integer_column",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d_boolean(Data&& m,
         ir::node_data<std::uint8_t> && columns, bool explicit_nil, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         return slice2d_integer<T>(std::forward<Data>(m),
             util::slicing_helpers::create_list_slice(columns),
-            explicit_nil, f, name, codename);
+            explicit_nil, f, name, codename, ctx);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d(Data&& m,
         ir::slicing_indices const& rows, primitive_argument_type const& columns,
-        F const& f, std::string const& name, std::string const& codename)
+        F const& f, std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (is_list_operand_strict(columns))
         {
@@ -892,8 +921,8 @@ namespace phylanx { namespace execution_tree
                     std::size_t num_cols = m.columns();
                     return slice2d_basic_basic<T>(std::forward<Data>(m), rows,
                         util::slicing_helpers::extract_slicing(
-                            columns, num_cols, name, codename),
-                        f, name, codename);
+                            columns, num_cols, name, codename, ctx),
+                        f, name, codename, ctx);
                 }
 
             case detail::slicing_index_advanced_integer:
@@ -902,7 +931,7 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_integer_index(
                             columns, name, codename),
                         name, codename),
-                    f, name, codename);
+                    f, name, codename, ctx);
 
             case detail::slicing_index_advanced_boolean:
                 return slice2d_basic_boolean<T>(std::forward<Data>(m), rows,
@@ -910,40 +939,41 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_boolean_index(
                             columns, name, codename),
                         name, codename),
-                    f, name, codename);
+                    f, name, codename, ctx);
             }
         }
         else if (is_boolean_operand_strict(columns))
         {
             return slice2d_basic_boolean<T>(std::forward<Data>(m),
                 rows, extract_boolean_value_strict(columns, name, codename), f,
-                name, codename);
+                name, codename, ctx);
         }
         else if (is_integer_operand(columns))
         {
             return slice2d_basic_integer<T>(std::forward<Data>(m),
                 rows, extract_integer_value(columns, name, codename), f,
-                name, codename);
+                name, codename, ctx);
         }
         else if (!valid(columns))
         {
             std::size_t num_cols = m.columns();
             return slice2d_basic_basic<T>(std::forward<Data>(m), rows,
                 util::slicing_helpers::extract_slicing(
-                    columns, num_cols, name, codename),
-                f, name, codename);
+                    columns, num_cols, name, codename, ctx),
+                f, name, codename, ctx);
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice2d",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice2d(Data&& m,
         primitive_argument_type const& rows, ir::slicing_indices const& columns,
-        F const& f, std::string const& name, std::string const& codename)
+        F const& f, std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (is_list_operand_strict(rows))
         {
@@ -954,8 +984,8 @@ namespace phylanx { namespace execution_tree
                     std::size_t num_rows = m.rows();
                     return slice2d_basic_basic<T>(std::forward<Data>(m),
                         util::slicing_helpers::extract_slicing(
-                            rows, num_rows, name, codename),
-                        columns, f, name, codename);
+                            rows, num_rows, name, codename, ctx),
+                        columns, f, name, codename, ctx);
                 }
 
             case detail::slicing_index_advanced_integer:
@@ -964,7 +994,7 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_integer_index(
                             rows, name, codename),
                         name, codename),
-                    columns, f, name, codename);
+                    columns, f, name, codename, ctx);
 
             case detail::slicing_index_advanced_boolean:
                 return slice2d_boolean_basic<T>(std::forward<Data>(m),
@@ -972,31 +1002,31 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_boolean_index(
                             rows, name, codename),
                         name, codename),
-                    columns, f, name, codename);
+                    columns, f, name, codename, ctx);
             }
         }
         else if (is_boolean_operand_strict(rows))
         {
             return slice2d_boolean_basic<T>(std::forward<Data>(m),
                 extract_boolean_value_strict(rows, name, codename),
-                columns, f, name, codename);
+                columns, f, name, codename, ctx);
         }
         else if (is_integer_operand(rows))
         {
             return slice2d_integer_basic<T>(std::forward<Data>(m),
                 extract_integer_value(rows, name, codename), columns, f,
-                name, codename);
+                name, codename, ctx);
         }
         else if (!valid(rows))
         {
             return slice2d_basic_column<T>(
-                std::forward<Data>(m), columns, f, name, codename);
+                std::forward<Data>(m), columns, f, name, codename, ctx);
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice2d",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1023,7 +1053,8 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice2d(Data&& m,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (is_list_operand_strict(rows))
         {
@@ -1034,8 +1065,8 @@ namespace phylanx { namespace execution_tree
                     std::size_t num_rows = m.rows();
                     return slice2d<T>(std::forward<Data>(m),
                         util::slicing_helpers::extract_slicing(
-                            rows, num_rows, name, codename),
-                        columns, f, name, codename);
+                            rows, num_rows, name, codename, ctx),
+                        columns, f, name, codename, ctx);
                 }
 
             case detail::slicing_index_advanced_integer:
@@ -1044,7 +1075,7 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_integer_index(
                             rows, name, codename),
                         name, codename),
-                    columns, f, name, codename);
+                    columns, f, name, codename, ctx);
 
             case detail::slicing_index_advanced_boolean:
                 return slice2d<T>(std::forward<Data>(m),
@@ -1052,7 +1083,7 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_boolean_index(
                             rows, name, codename),
                         name, codename),
-                    columns, f, name, codename);
+                    columns, f, name, codename, ctx);
             }
         }
         else if (is_list_operand_strict(columns))
@@ -1064,8 +1095,8 @@ namespace phylanx { namespace execution_tree
                     std::size_t num_cols = m.columns();
                     return slice2d<T>(std::forward<Data>(m), rows,
                         util::slicing_helpers::extract_slicing(
-                            columns, num_cols, name, codename),
-                        f, name, codename);
+                            columns, num_cols, name, codename, ctx),
+                        f, name, codename, ctx);
                 }
 
             case detail::slicing_index_advanced_integer:
@@ -1074,7 +1105,7 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_integer_index(
                             columns, name, codename),
                         name, codename),
-                    f, name, codename);
+                    f, name, codename, ctx);
 
             case detail::slicing_index_advanced_boolean:
                 return slice2d<T>(std::forward<Data>(m), rows,
@@ -1082,7 +1113,7 @@ namespace phylanx { namespace execution_tree
                         detail::extract_advanced_boolean_index(
                             columns, name, codename),
                         name, codename),
-                    f, name, codename);
+                    f, name, codename, ctx);
             }
         }
         else if (is_boolean_operand_strict(rows))
@@ -1092,14 +1123,14 @@ namespace phylanx { namespace execution_tree
                 return slice2d<T>(std::forward<Data>(m),
                     extract_boolean_value_strict(rows, name, codename),
                     extract_boolean_value_strict(columns, name, codename),
-                    f, name, codename);
+                    f, name, codename, ctx);
             }
             if (is_integer_operand(columns))
             {
                 return slice2d<T>(std::forward<Data>(m),
                     extract_boolean_value_strict(rows, name, codename),
                     extract_integer_value(columns, name, codename),
-                    f, name, codename);
+                    f, name, codename, ctx);
             }
             if (!valid(columns))
             {
@@ -1107,7 +1138,7 @@ namespace phylanx { namespace execution_tree
                     "phylanx::execution_tree::slice2d",
                     util::generate_error_message(
                         "this operation is not supported (yet)",
-                        name, codename));
+                        name, codename, ctx.back_trace()));
             }
         }
         else if (is_integer_operand(rows))
@@ -1118,7 +1149,7 @@ namespace phylanx { namespace execution_tree
                     std::forward<Data>(m),
                     extract_integer_value(rows, name, codename),
                     extract_boolean_value_strict(columns, name, codename), f,
-                    name, codename);
+                    name, codename, ctx);
             }
             if (is_integer_operand(columns))
             {
@@ -1126,13 +1157,13 @@ namespace phylanx { namespace execution_tree
                     std::forward<Data>(m),
                     extract_integer_value(rows, name, codename),
                     extract_integer_value(columns, name, codename), f,
-                    name, codename);
+                    name, codename, ctx);
             }
             if (!valid(columns))
             {
                 return slice2d_integer<T>(std::forward<Data>(m),
                     extract_integer_value(rows, name, codename),
-                    is_explicit_nil(columns), f, name, codename);
+                    is_explicit_nil(columns), f, name, codename, ctx);
             }
         }
         else if (!valid(rows))
@@ -1142,7 +1173,7 @@ namespace phylanx { namespace execution_tree
                 // an explicit 'nil' is equivalent to np.newaxis
                 return slice2d_boolean<T>(std::forward<Data>(m),
                     extract_boolean_value_strict(columns, name, codename),
-                    is_explicit_nil(rows), f, name, codename);
+                    is_explicit_nil(rows), f, name, codename, ctx);
             }
             if (is_integer_operand(columns))
             {
@@ -1150,13 +1181,13 @@ namespace phylanx { namespace execution_tree
                 {
                     return slice2d_integer<T>(std::forward<Data>(m),
                         extract_integer_value(columns, name, codename),
-                        true, f, name, codename);
+                        true, f, name, codename, ctx);
                 }
 
-                // special handling for column_slice primtive
+                // special handling for column_slice primitive
                 return slice2d_integer_column<T>(std::forward<Data>(m),
                     extract_integer_value(columns, name, codename),
-                    f, name, codename);
+                    f, name, codename, ctx);
             }
             if (!valid(columns))
             {
@@ -1168,17 +1199,18 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice2d",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
     ir::node_data<T> slice1d_extract2d(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& indices,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         return slice2d<T>(data.matrix(), indices, primitive_argument_type{},
-            detail::slice_identity<T>{}, name, codename);
+            detail::slice_identity<T>{}, name, codename, ctx);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1187,7 +1219,8 @@ namespace phylanx { namespace execution_tree
         ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& indices,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (!is_integer_operand_strict(indices))
         {
@@ -1196,7 +1229,7 @@ namespace phylanx { namespace execution_tree
                 util::generate_error_message(
                     "only integer indexing for slice_row is suppoted for "
                     "distributed arrays extracting a 1d slice from a matrix",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t row_index =
@@ -1253,10 +1286,11 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice2d_extract2d(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         return slice2d<T>(data.matrix(), rows, columns,
-            detail::slice_identity<T>{}, name, codename);
+            detail::slice_identity<T>{}, name, codename, ctx);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1266,7 +1300,8 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (!is_integer_operand_strict(columns) || valid(rows))
         {
@@ -1275,7 +1310,7 @@ namespace phylanx { namespace execution_tree
                 util::generate_error_message(
                     "only integer indexing for slice_column is suppoted for "
                     "distributed arrays extracting a 1d slice from a matrix",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t column_index =
@@ -1334,7 +1369,7 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         switch (value.num_dimensions())
         {
@@ -1347,9 +1382,9 @@ namespace phylanx { namespace execution_tree
                 std::size_t numcols = m.columns();
 
                 std::size_t rows_size =
-                    detail::slicing_size(rows, numrows, name, codename);
+                    detail::slicing_size(rows, numrows, name, codename, ctx);
                 std::size_t columns_size =
-                    detail::slicing_size(columns, numcols, name, codename);
+                    detail::slicing_size(columns, numcols, name, codename, ctx);
 
                 typename ir::node_data<T>::storage2d_type result;
                 extract_value_matrix(result, std::move(value), rows_size,
@@ -1359,11 +1394,12 @@ namespace phylanx { namespace execution_tree
                 if (data.is_ref())
                 {
                     return slice2d<T>(std::move(m), rows, columns,
-                        detail::slice_assign_matrix<T>{rhs}, name, codename);
+                        detail::slice_assign_matrix<T>{rhs}, name, codename,
+                        ctx);
                 }
 
                 return slice2d<T>(data.matrix_non_ref(), rows, columns,
-                    detail::slice_assign_matrix<T>{rhs}, name, codename);
+                    detail::slice_assign_matrix<T>{rhs}, name, codename, ctx);
             }
             break;
 
@@ -1375,7 +1411,7 @@ namespace phylanx { namespace execution_tree
             "phylanx::execution_tree::slice2d_assign2d",
             util::generate_error_message(
                 "source ir::node_data object holds unsupported data type", name,
-                codename));
+                codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -1384,7 +1420,7 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice1d_assign2d(ir::node_data<T>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         switch (value.num_dimensions())
         {
@@ -1395,8 +1431,8 @@ namespace phylanx { namespace execution_tree
                 auto m = data.matrix();
                 std::size_t columns = m.columns();
 
-                std::size_t result_size =
-                    detail::slicing_size(indices, m.rows(), name, codename);
+                std::size_t result_size = detail::slicing_size(
+                    indices, m.rows(), name, codename, ctx);
 
                 typename ir::node_data<T>::storage2d_type result;
                 extract_value_matrix(result, std::move(value),
@@ -1407,12 +1443,13 @@ namespace phylanx { namespace execution_tree
                 {
                     return slice2d<T>(std::move(m), indices,
                         ir::slicing_indices{0ll, std::int64_t(columns), 1ll},
-                        detail::slice_assign_matrix<T>{rhs}, name, codename);
+                        detail::slice_assign_matrix<T>{rhs}, name, codename,
+                        ctx);
                 }
 
                 return slice2d<T>(data.matrix_non_ref(), indices,
                     ir::slicing_indices{0ll, std::int64_t(columns), 1ll},
-                    detail::slice_assign_matrix<T>{rhs}, name, codename);
+                    detail::slice_assign_matrix<T>{rhs}, name, codename, ctx);
             }
 
         default:
@@ -1423,7 +1460,7 @@ namespace phylanx { namespace execution_tree
             "phylanx::execution_tree::slice1d_assign2d",
             util::generate_error_message(
                 "source ir::node_data object holds unsupported data type",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -1433,7 +1470,8 @@ namespace phylanx { namespace execution_tree
         ir::node_data<T>&& value,
         execution_tree::localities_information&& arr_localities,
         execution_tree::localities_information&& val_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t val_ndim = val_localities.num_dimensions();
         if (val_ndim > 1)
@@ -1442,7 +1480,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::dist_slice1d_assign2d",
                 util::generate_error_message("cannot assign a non vector value "
                                              "to a 1d slice of a matrix",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::uint32_t const loc_id = arr_localities.locality_.locality_id_;
@@ -1480,7 +1518,7 @@ namespace phylanx { namespace execution_tree
                 util::generate_error_message(
                     "only integer indexing for slice_row is suppoted for "
                     "distributed arrays assigning a 1d slice to a matrix",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::size_t columns = arr_localities.columns(name, codename);
@@ -1491,7 +1529,7 @@ namespace phylanx { namespace execution_tree
                 util::generate_error_message(
                     "cannot assign a vector to a 1d slice of a matrix when "
                     "the slice and the vector have different sizes",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t row_start = tile_info.spans_[0].start_;
@@ -1583,7 +1621,8 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<T>&& value,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
 
         std::uint32_t const loc_id = arr_localities.locality_.locality_id_;
@@ -1614,7 +1653,7 @@ namespace phylanx { namespace execution_tree
                 util::generate_error_message(
                     "indexing for slice_row is suppoted for "
                     "distributed arrays assigning a 1d slice to a matrix",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t row_start = tile_info.spans_[0].start_;
@@ -1627,7 +1666,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice1d_extract2d",
                 util::generate_error_message(
                     "indexing is out of dimensions",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         // assignment can be done locally

--- a/phylanx/execution_tree/primitives/slice_node_data_3d.hpp
+++ b/phylanx/execution_tree/primitives/slice_node_data_3d.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -36,7 +36,8 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice3d_basic_basic_basic(Data&& t,
         ir::slicing_indices const& pages, ir::slicing_indices const& rows,
         ir::slicing_indices const& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numpages = t.pages();
         if (pages.start() >= std::int64_t(numpages) ||
@@ -46,7 +47,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice3d_basic_basic_basic",
                 util::generate_error_message(
                     "cannot extract the requested tensor element(s)",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t page_start = pages.start();
@@ -57,8 +58,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice3d_basic_basic_basic",
-                util::generate_error_message(
-                    "page-step can not be zero", name, codename));
+                util::generate_error_message("page-step can not be zero", name,
+                    codename, ctx.back_trace()));
         }
 
         std::size_t numrows = t.rows();
@@ -69,7 +70,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice3d_basic_basic_basic",
                 util::generate_error_message(
                     "cannot extract the requested tensor element(s)",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t row_start = rows.start();
@@ -80,8 +81,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice3d_basic_basic_basic",
-                util::generate_error_message(
-                    "row-step can not be zero", name, codename));
+                util::generate_error_message("row-step can not be zero", name,
+                    codename, ctx.back_trace()));
         }
 
         std::size_t numcols = t.columns();
@@ -92,7 +93,7 @@ namespace phylanx { namespace execution_tree
                 "phylanx::execution_tree::slice3d_basic_basic_basic",
                 util::generate_error_message(
                     "cannot extract the requested tensor element(s)",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         std::int64_t col_start = columns.start();
@@ -103,8 +104,8 @@ namespace phylanx { namespace execution_tree
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice3d_basic_basic_basic",
-                util::generate_error_message(
-                    "column-step can not be zero", name, codename));
+                util::generate_error_message("column-step can not be zero",
+                    name, codename, ctx.back_trace()));
         }
 
         // handle special cases
@@ -242,7 +243,7 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice3d_basic_basic_basic",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -251,20 +252,23 @@ namespace phylanx { namespace execution_tree
         ir::node_data<std::int64_t> && pages,
         ir::node_data<std::int64_t> && rows,
         ir::node_data<std::int64_t> && columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numpages = t.pages();
         std::size_t pages_index_size = pages.size();
         for (std::size_t i = 0; i != pages_index_size; ++i)
         {
-            pages[i] = detail::check_index(pages[i], numpages, name, codename);
+            pages[i] =
+                detail::check_index(pages[i], numpages, name, codename, ctx);
         }
 
         std::size_t numrows = t.rows();
         std::size_t rows_index_size = rows.size();
         for (std::size_t i = 0; i != rows_index_size; ++i)
         {
-            rows[i] = detail::check_index(rows[i], numrows, name, codename);
+            rows[i] =
+                detail::check_index(rows[i], numrows, name, codename, ctx);
         }
 
         std::size_t numcols = t.columns();
@@ -272,7 +276,7 @@ namespace phylanx { namespace execution_tree
         for (std::size_t i = 0; i != columns_index_size; ++i)
         {
             columns[i] =
-                detail::check_index(columns[i], numcols, name, codename);
+                detail::check_index(columns[i], numcols, name, codename, ctx);
         }
 
         // broadcast all index arrays, use result to index elements in tensor
@@ -283,7 +287,8 @@ namespace phylanx { namespace execution_tree
             HPX_THROW_EXCEPTION(hpx::not_implemented,
                 "phylanx::execution_tree::slice3d_integer_integer_integer",
                 util::generate_error_message(
-                    "this operation is not supported (yet)", name, codename));
+                    "this operation is not supported (yet)", name, codename,
+                    ctx.back_trace()));
         }
 
         if (largest_dimensionality == 0)
@@ -314,20 +319,23 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice3d_integer_integer(Data&& t,
         ir::node_data<std::int64_t> && pages,
         ir::node_data<std::int64_t> && rows, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numpages = t.pages();
         std::size_t pages_index_size = pages.size();
         for (std::size_t i = 0; i != pages_index_size; ++i)
         {
-            pages[i] = detail::check_index(pages[i], numpages, name, codename);
+            pages[i] =
+                detail::check_index(pages[i], numpages, name, codename, ctx);
         }
 
         std::size_t numrows = t.rows();
         std::size_t rows_index_size = rows.size();
         for (std::size_t i = 0; i != rows_index_size; ++i)
         {
-            rows[i] = detail::check_index(rows[i], numrows, name, codename);
+            rows[i] =
+                detail::check_index(rows[i], numrows, name, codename, ctx);
         }
 
         // broadcast both index arrays, use result to index elements in matrix
@@ -338,7 +346,8 @@ namespace phylanx { namespace execution_tree
             HPX_THROW_EXCEPTION(hpx::not_implemented,
                 "phylanx::execution_tree::slice3d_integer_integer",
                 util::generate_error_message(
-                    "this operation is not supported (yet)", name, codename));
+                    "this operation is not supported (yet)", name, codename,
+                    ctx.back_trace()));
         }
 
         if (largest_dimensionality == 0)
@@ -369,11 +378,12 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice3d_integer_0d(Data&& t,
         ir::node_data<std::int64_t> && pages, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         // handle single value page-slicing result
         auto pageslice = blaze::pageslice(
-            t, detail::check_index(pages[0], t.pages(), name, codename));
+            t, detail::check_index(pages[0], t.pages(), name, codename, ctx));
 
         return f.matrix(t, std::move(pageslice));
     }
@@ -381,7 +391,8 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice3d_integer_1d(Data&& t,
         ir::node_data<std::int64_t> && pages, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t numpages = t.pages();
         std::size_t pages_index_size = pages.size();
@@ -391,8 +402,8 @@ namespace phylanx { namespace execution_tree
 
         for (std::size_t i = 0; i != pages_index_size; ++i)
         {
-            blaze::pageslice(result, i) = blaze::pageslice(
-                t, detail::check_index(pages[i], numpages, name, codename));
+            blaze::pageslice(result, i) = blaze::pageslice(t,
+                detail::check_index(pages[i], numpages, name, codename, ctx));
         }
 
         return f.tensor(t, std::move(result));
@@ -401,17 +412,18 @@ namespace phylanx { namespace execution_tree
     template <typename T, typename Data, typename F>
     ir::node_data<T> slice3d_integer(Data&& t,
         ir::node_data<std::int64_t> && pages, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (pages.num_dimensions())
         {
         case 0:
             return slice3d_integer_0d<T>(std::forward<Data>(t),
-                std::move(pages), f, name, codename);
+                std::move(pages), f, name, codename, ctx);
 
         case 1:
             return slice3d_integer_1d<T>(std::forward<Data>(t),
-                std::move(pages), f, name, codename);
+                std::move(pages), f, name, codename, ctx);
 
         default:
             break;
@@ -420,7 +432,8 @@ namespace phylanx { namespace execution_tree
         HPX_THROW_EXCEPTION(hpx::not_implemented,
             "phylanx::execution_tree::slice3d_integer",
             util::generate_error_message(
-                "this operation is not supported (yet)", name, codename));
+                "this operation is not supported (yet)", name, codename,
+                ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -429,12 +442,13 @@ namespace phylanx { namespace execution_tree
         ir::node_data<std::uint8_t> && pages,
         ir::node_data<std::uint8_t> && rows,
         ir::node_data<std::uint8_t> && columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice3d_boolean_boolean_boolean",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
 //         auto t = data.tensor();
@@ -442,7 +456,7 @@ namespace phylanx { namespace execution_tree
 //         ir::slicing_indices columns{0ll, std::int64_t(t.columns()), 1ll};
 //         return slice3d_basic_basic_basic<T>(t,
 //             util::slicing_helpers::extract_slicing(
-//                 indices, t.pages(), name, codename),
+//                 indices, t.pages(), name, codename, ctx),
 //             rows, columns, detail::slice_identity<T>{}, name, codename);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -451,7 +465,8 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice3d(Data&& t, primitive_argument_type const& pages,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, F const& f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (is_list_operand_strict(rows) && is_list_operand_strict(columns) &&
             is_list_operand_strict(pages))
@@ -468,14 +483,15 @@ namespace phylanx { namespace execution_tree
                 page_type == detail::slicing_index_basic)
             {
                 auto page_indices = util::slicing_helpers::extract_slicing(
-                    pages, t.pages(), name, codename);
+                    pages, t.pages(), name, codename, ctx);
                 auto row_indices = util::slicing_helpers::extract_slicing(
-                    rows, t.rows(), name, codename);
+                    rows, t.rows(), name, codename, ctx);
                 auto col_indices = util::slicing_helpers::extract_slicing(
-                    columns, t.columns(), name, codename);
+                    columns, t.columns(), name, codename, ctx);
 
                 return slice3d_basic_basic_basic<T>(std::forward<Data>(t),
-                    page_indices, row_indices, col_indices, f, name, codename);
+                    page_indices, row_indices, col_indices, f, name, codename,
+                    ctx);
             }
             else if (column_type == detail::slicing_index_advanced_integer &&
                 row_type == detail::slicing_index_advanced_integer &&
@@ -496,7 +512,7 @@ namespace phylanx { namespace execution_tree
 
                 return slice3d_integer_integer_integer<T>(std::forward<Data>(t),
                     std::move(page_indices), std::move(row_indices),
-                    std::move(col_indices), f, name, codename);
+                    std::move(col_indices), f, name, codename, ctx);
             }
             else if (column_type == detail::slicing_index_advanced_boolean &&
                 row_type == detail::slicing_index_advanced_boolean &&
@@ -517,7 +533,7 @@ namespace phylanx { namespace execution_tree
 
                 return slice3d_boolean_boolean_boolean<T>(std::forward<Data>(t),
                     std::move(page_indices), std::move(row_indices),
-                    std::move(col_indices), f, name, codename);
+                    std::move(col_indices), f, name, codename, ctx);
             }
         }
         else if (is_boolean_operand_strict(rows) &&
@@ -528,7 +544,7 @@ namespace phylanx { namespace execution_tree
                 extract_boolean_value_strict(pages, name, codename),
                 extract_boolean_value_strict(rows, name, codename),
                 extract_boolean_value_strict(columns, name, codename), f, name,
-                codename);
+                codename, ctx);
         }
         else if (is_integer_operand(pages))
         {
@@ -542,7 +558,7 @@ namespace phylanx { namespace execution_tree
                         extract_integer_value(pages, name, codename),
                         extract_integer_value(rows, name, codename),
                         extract_integer_value(columns, name, codename), f, name,
-                        codename);
+                        codename, ctx);
                 }
                 else if (!valid(columns))
                 {
@@ -553,7 +569,7 @@ namespace phylanx { namespace execution_tree
                     return slice3d_integer_integer<T>(std::forward<Data>(t),
                         extract_integer_value(pages, name, codename),
                         extract_integer_value(rows, name, codename), f, name,
-                        codename);
+                        codename, ctx);
                 }
             }
             else if (!valid(rows) && !valid(columns))
@@ -563,14 +579,14 @@ namespace phylanx { namespace execution_tree
 
                 return slice3d_integer<T>(std::forward<Data>(t),
                     extract_integer_value(pages, name, codename), f, name,
-                    codename);
+                    codename, ctx);
             }
         }
 
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice3d",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -580,10 +596,11 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& pages,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         return slice3d<T>(data.tensor(), pages, rows, columns,
-            detail::slice_identity<T>{}, name, codename);
+            detail::slice_identity<T>{}, name, codename, ctx);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -592,11 +609,12 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice2d_extract3d(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         return slice3d<T>(data.tensor(), rows, columns,
             primitive_argument_type{}, detail::slice_identity<T>{}, name,
-            codename);
+            codename, ctx);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -604,11 +622,12 @@ namespace phylanx { namespace execution_tree
     template <typename T>
     ir::node_data<T> slice1d_extract3d(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& indices,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         return slice3d<T>(data.tensor(), indices, primitive_argument_type{},
             primitive_argument_type{}, detail::slice_identity<T>{}, name,
-            codename);
+            codename, ctx);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -617,12 +636,12 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice1d_assign3d(ir::node_data<T>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice1d_assign3d",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -632,12 +651,12 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice2d_assign3d",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -648,12 +667,12 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         HPX_THROW_EXCEPTION(hpx::bad_parameter,
             "phylanx::execution_tree::slice3d",
             util::generate_error_message(
-                "unsupported indexing type", name, codename));
+                "unsupported indexing type", name, codename, ctx.back_trace()));
     }
 }}
 

--- a/phylanx/execution_tree/primitives/slice_range.hpp
+++ b/phylanx/execution_tree/primitives/slice_range.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,21 +12,21 @@
 
 #include <string>
 
-namespace phylanx { namespace execution_tree
-{
+namespace phylanx { namespace execution_tree {
+
     ///////////////////////////////////////////////////////////////////////////
     // extract a slice from the given range instance
     PHYLANX_EXPORT primitive_argument_type slice_list(ir::range&& data,
-        primitive_argument_type const& indices,
-        std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        primitive_argument_type const& indices, std::string const& name = "",
+        std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
 
     ///////////////////////////////////////////////////////////////////////////
     // modify a slice of the given list instance
     PHYLANX_EXPORT primitive_argument_type slice_list(ir::range&& data,
-        primitive_argument_type const& indices,
-        primitive_argument_type&& value, std::string const& name = "",
-        std::string const& codename = "<unknown>");
-}}
+        primitive_argument_type const& indices, primitive_argument_type&& value,
+        std::string const& name = "", std::string const& codename = "<unknown>",
+        eval_context const& ctx = eval_context{});
+}}    // namespace phylanx::execution_tree
 
 #endif

--- a/phylanx/util/slicing_helpers.hpp
+++ b/phylanx/util/slicing_helpers.hpp
@@ -1,5 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2018 Bibek Wagle
+//  Copyright (c) 2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -19,8 +20,8 @@
 #include <utility>
 #include <vector>
 
-namespace phylanx { namespace util { namespace slicing_helpers
-{
+namespace phylanx { namespace util { namespace slicing_helpers {
+
     ///////////////////////////////////////////////////////////////////////////
     // extract a single integer from the given node_data instance
     PHYLANX_EXPORT std::int64_t extract_integer(
@@ -43,12 +44,16 @@ namespace phylanx { namespace util { namespace slicing_helpers
     PHYLANX_EXPORT ir::slicing_indices extract_slicing(
         execution_tree::primitive_argument_type const& arg,
         std::size_t arg_size, std::string const& name = "",
-        std::string const& codename = "<unknown>");
+        std::string const& codename = "<unknown>",
+        execution_tree::eval_context const& ctx =
+            execution_tree::eval_context{});
 
     PHYLANX_EXPORT std::size_t slicing_size(
         execution_tree::primitive_argument_type const& arg,
         std::size_t arg_size, std::string const& name = "",
-        std::string const& codename = "<unknown>");
-}}}
+        std::string const& codename = "<unknown>",
+        execution_tree::eval_context const& ctx =
+            execution_tree::eval_context{});
+}}}    // namespace phylanx::util::slicing_helpers
 
-#endif //PHYLANX_SLICING_HELPERS_HPP
+#endif    //PHYLANX_SLICING_HELPERS_HPP

--- a/src/execution_tree/primitives/access_argument.cpp
+++ b/src/execution_tree/primitives/access_argument.cpp
@@ -123,19 +123,20 @@ namespace phylanx { namespace execution_tree { namespace primitives
                     // handle row/column-slicing
                     auto op1 = value_operand(
                         operands_[2], params, name_, codename_, ctx);
+                    auto op2 = value_operand(
+                        operands_[3], params, name_, codename_, ctx);
                     return hpx::dataflow(
                         hpx::launch::sync,
-                        [this_ = std::move(this_), target = std::move(target)](
+                        [this_ = std::move(this_), target = std::move(target),
+                            ctx = std::move(ctx)](
                                 hpx::future<primitive_argument_type>&& rows,
                                 hpx::future<primitive_argument_type>&& cols)
                         ->  primitive_argument_type
                         {
                             return slice(target, rows.get(), cols.get(),
-                                this_->name_, this_->codename_);
+                                this_->name_, this_->codename_, ctx);
                         },
-                        op1,
-                        value_operand(operands_[3], params, name_, codename_,
-                            std::move(ctx)));
+                        op1, op2);
                 }
 
                 if (operands_.size() > 4)
@@ -145,33 +146,36 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         operands_[2], params, name_, codename_, ctx);
                     auto op2 = value_operand(
                         operands_[3], params, name_, codename_, ctx);
+                    auto op3 = value_operand(
+                        operands_[4], params, name_, codename_, ctx);
                     return hpx::dataflow(
                         hpx::launch::sync,
-                        [this_ = std::move(this_), target = std::move(target)](
-                                hpx::future<primitive_argument_type>&& pages,
-                                hpx::future<primitive_argument_type>&& rows,
-                                hpx::future<primitive_argument_type>&& cols)
-                        ->  primitive_argument_type
+                        [this_ = std::move(this_), target = std::move(target),
+                            ctx = std::move(ctx)](
+                            hpx::future<primitive_argument_type>&& pages,
+                            hpx::future<primitive_argument_type>&& rows,
+                            hpx::future<primitive_argument_type>&& cols)
+                            -> primitive_argument_type
                         {
-                            return slice(target, pages.get(), rows.get(), cols.get(),
-                                this_->name_, this_->codename_);
+                            return slice(target, pages.get(), rows.get(),
+                                cols.get(), this_->name_, this_->codename_,
+                                ctx);
                         },
-                        op1, op2,
-                        value_operand(operands_[4], params, name_, codename_,
-                            std::move(ctx)));
+                        op1, op2, op3);
                 }
 
                 // handle row-slicing
-                return value_operand(
-                        operands_[2], params, name_, codename_, std::move(ctx))
-                    .then(hpx::launch::sync,
-                        [this_ = std::move(this_), target = std::move(target)](
-                            hpx::future<primitive_argument_type>&& rows)
+                auto op =
+                    value_operand(operands_[2], params, name_, codename_, ctx);
+                return op.then(hpx::launch::sync,
+                    [this_ = std::move(this_), target = std::move(target),
+                        ctx = std::move(ctx)](
+                        hpx::future<primitive_argument_type>&& rows)
                         -> primitive_argument_type
-                        {
-                            return slice(target, rows.get(), this_->name_,
-                                this_->codename_);
-                        });
+                    {
+                        return slice(target, rows.get(), this_->name_,
+                            this_->codename_, ctx);
+                    });
             }
 
         default:
@@ -258,7 +262,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 slice(std::move(target),
                     value_operand_sync(std::move(operands_[2]),
                         std::move(params), name_, codename_, std::move(ctx)),
-                    std::move(data[0]), name_, codename_);
+                    std::move(data[0]), name_, codename_, ctx);
                 return;
 
             case 4:
@@ -267,8 +271,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         operands_[2], params, name_, codename_, ctx);
                     slice(std::move(target), std::move(data1),
                         value_operand_sync(operands_[3], std::move(params),
-                            name_, codename_, std::move(ctx)),
-                        std::move(data[0]), name_, codename_);
+                            name_, codename_, ctx),
+                        std::move(data[0]), name_, codename_, ctx);
                 }
                 return;
 
@@ -280,8 +284,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         operands_[3], params, name_, codename_, ctx);
                     slice(std::move(target), std::move(data1), std::move(data2),
                         value_operand_sync(operands_[4], std::move(params),
-                            name_, codename_, std::move(ctx)),
-                        std::move(data[0]), name_, codename_);
+                            name_, codename_, ctx),
+                        std::move(data[0]), name_, codename_, ctx);
                 }
                 return;
 
@@ -379,7 +383,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 slice(std::move(target),
                     value_operand_sync(std::move(operands_[2]),
                         std::move(params), name_, codename_, std::move(ctx)),
-                    std::move(data), name_, codename_);
+                    std::move(data), name_, codename_, ctx);
                 return;
 
             case 4:
@@ -388,8 +392,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         operands_[2], params, name_, codename_, ctx);
                     slice(std::move(target), std::move(data1),
                         value_operand_sync(operands_[3], std::move(params),
-                            name_, codename_, std::move(ctx)),
-                        std::move(data), name_, codename_);
+                            name_, codename_, ctx),
+                        std::move(data), name_, codename_, ctx);
                 }
                 return;
 
@@ -401,8 +405,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
                         operands_[3], params, name_, codename_, ctx);
                     slice(std::move(target), std::move(data1), std::move(data2),
                         value_operand_sync(operands_[4], std::move(params),
-                            name_, codename_, std::move(ctx)),
-                        std::move(data), name_, codename_);
+                            name_, codename_, ctx),
+                        std::move(data), name_, codename_, ctx);
                 }
                 return;
 

--- a/src/execution_tree/primitives/base_primitive.cpp
+++ b/src/execution_tree/primitives/base_primitive.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2019 Hartmut Kaiser
+// Copyright (c) 2017-2020 Hartmut Kaiser
 // Copyright (c) 2018 Tianyi Zhang
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -2733,6 +2733,27 @@ namespace phylanx { namespace execution_tree
         return false;
     }
 
+    bool is_hashable_operand(primitive_argument_type const& val)
+    {
+        switch (val.index())
+        {
+        case primitive_argument_type::bool_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::int64_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::string_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::float64_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::future_index:
+            return true;
+
+        case primitive_argument_type::nil_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::primitive_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::list_index: HPX_FALLTHROUGH;
+        case primitive_argument_type::dictionary_index: HPX_FALLTHROUGH;
+        default:
+            break;
+        }
+        return false;
+    }
+
     ir::dictionary extract_dictionary_value(
         primitive_argument_type const& val, std::string const& name,
         std::string const& codename)
@@ -4569,7 +4590,7 @@ namespace std
 
         case primitive_argument_type::nil_index: HPX_FALLTHROUGH;
         case primitive_argument_type::primitive_index: HPX_FALLTHROUGH;
-        case primitive_argument_type::list_index: HPX_FALLTHROUGH;   // ir::range
+        case primitive_argument_type::list_index: HPX_FALLTHROUGH;
         case primitive_argument_type::dictionary_index: HPX_FALLTHROUGH;
         default:
             break;

--- a/src/execution_tree/primitives/slice.cpp
+++ b/src/execution_tree/primitives/slice.cpp
@@ -28,36 +28,45 @@ namespace phylanx { namespace execution_tree
     // return a slice of the given primitive_argument_type instance
     primitive_argument_type slice(primitive_argument_type const& data,
         primitive_argument_type const& indices, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         if (is_integer_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_integer_value_strict(data, name, codename), indices,
-                name, codename)};
+                name, codename, ctx)};
         }
         if (is_numeric_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_numeric_value_strict(data, name, codename), indices,
-                name, codename)};
+                name, codename, ctx)};
         }
         if (is_boolean_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_boolean_value_strict(data, name, codename), indices,
-                name, codename)};
+                name, codename, ctx)};
         }
         if (is_list_operand_strict(data))
         {
             return slice_list(extract_list_value_strict(data, name, codename),
-                indices, name, codename);
+                indices, name, codename, ctx);
         }
         if (is_dictionary_operand_strict(data))
         {
             auto&& dict =
                 phylanx::execution_tree::extract_dictionary_value_strict(
                     data, name, codename);
+            if (!is_hashable_operand(indices))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::slice",
+                    util::generate_error_message(
+                        "the given index cannot be used for indexing a "
+                        "dictionary",
+                        name, codename, ctx.back_trace()));
+            }
             return dict[indices];
         }
 
@@ -65,12 +74,13 @@ namespace phylanx { namespace execution_tree
             "phylanx::execution_tree::slice",
             util::generate_error_message(
                 "target object does not hold a numeric, range, or dictionary "
-                "type and as such does not support slicing", name, codename));
+                "type and as such does not support slicing",
+                name, codename, ctx.back_trace()));
     }
 
     primitive_argument_type dist_slice(primitive_argument_type const& data,
         primitive_argument_type const& indices, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         localities_information arr_localities =
             extract_localities_information(data, name, codename);
@@ -78,64 +88,64 @@ namespace phylanx { namespace execution_tree
         {
             return dist_slice_extract(
                 extract_integer_value_strict(data, name, codename), indices,
-                std::move(arr_localities), name, codename);
+                std::move(arr_localities), name, codename, ctx);
         }
         if (is_numeric_operand_strict(data))
         {
             return dist_slice_extract(
                 extract_numeric_value_strict(data, name, codename), indices,
-                std::move(arr_localities), name, codename);
+                std::move(arr_localities), name, codename, ctx);
         }
         if (is_boolean_operand_strict(data))
         {
             return dist_slice_extract(
                 extract_boolean_value_strict(data, name, codename), indices,
-                std::move(arr_localities), name, codename);
+                std::move(arr_localities), name, codename, ctx);
         }
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
-            util::generate_error_message("distributed target object does "
-                                         "not hold a numeric type and as "
-                                         "such does not support slicing",
-                name, codename));
-
+            util::generate_error_message(
+                "distributed target object does not hold a numeric type and as "
+                "such does not support slicing",
+                name, codename, ctx.back_trace()));
     }
 
     primitive_argument_type slice(primitive_argument_type const& data,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         if (is_integer_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_integer_value_strict(data, name, codename),
-                rows, columns, name, codename)};
+                rows, columns, name, codename, ctx)};
         }
         if (is_numeric_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_numeric_value_strict(data, name, codename),
-                rows, columns, name, codename)};
+                rows, columns, name, codename, ctx)};
         }
         if (is_boolean_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_boolean_value_strict(data, name, codename),
-                rows, columns, name, codename)};
+                rows, columns, name, codename, ctx)};
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
                 "target object does not hold a numeric data type and "
-                "as such does not support slicing", name, codename));
+                "as such does not support slicing",
+                name, codename, ctx.back_trace()));
     }
 
     primitive_argument_type dist_slice(primitive_argument_type const& data,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         localities_information arr_localities =
             extract_localities_information(data, name, codename);
@@ -143,26 +153,26 @@ namespace phylanx { namespace execution_tree
         {
             return dist_slice_extract(
                 extract_integer_value_strict(data, name, codename), rows,
-                columns, std::move(arr_localities), name, codename);
+                columns, std::move(arr_localities), name, codename, ctx);
         }
         if (is_numeric_operand_strict(data))
         {
             return dist_slice_extract(
                 extract_numeric_value_strict(data, name, codename), rows,
-                columns, std::move(arr_localities), name, codename);
+                columns, std::move(arr_localities), name, codename, ctx);
         }
         if (is_boolean_operand_strict(data))
         {
             return dist_slice_extract(
                 extract_boolean_value_strict(data, name, codename), rows,
-                columns, std::move(arr_localities), name, codename);
+                columns, std::move(arr_localities), name, codename, ctx);
         }
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
                 "target object does not hold a numeric data type and "
                 "as such does not support slicing",
-                name, codename));
+                name, codename, ctx.back_trace()));
 
     }
 
@@ -170,39 +180,41 @@ namespace phylanx { namespace execution_tree
         primitive_argument_type const& pages,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         if (is_integer_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_integer_value_strict(data, name, codename),
-                pages, rows, columns, name, codename)};
+                pages, rows, columns, name, codename, ctx)};
         }
         if (is_numeric_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_numeric_value_strict(data, name, codename),
-                pages, rows, columns, name, codename)};
+                pages, rows, columns, name, codename, ctx)};
         }
         if (is_boolean_operand_strict(data))
         {
             return primitive_argument_type{slice_extract(
                 extract_boolean_value_strict(data, name, codename),
-                pages, rows, columns, name, codename)};
+                pages, rows, columns, name, codename, ctx)};
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
                 "target object does not hold a numeric data type and "
-                "as such does not support slicing", name, codename));
+                "as such does not support slicing",
+                name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // modify a slice of the given primitive_argument_type instance
     primitive_argument_type slice(primitive_argument_type&& data,
         primitive_argument_type const& indices, primitive_argument_type&& value,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
 
         if (data.has_annotation() && value.has_annotation())
@@ -223,7 +235,7 @@ namespace phylanx { namespace execution_tree
                         extract_integer_value_strict(
                             std::move(value), name, codename),
                         std::move(arr_localities), std::move(val_localities),
-                        name, codename);
+                        name, codename, ctx);
                 }
 
                 return dist_slice_assign(extract_integer_value_strict(
@@ -231,7 +243,7 @@ namespace phylanx { namespace execution_tree
                     indices,
                     extract_integer_value(std::move(value), name, codename),
                     std::move(arr_localities), std::move(val_localities), name,
-                    codename);
+                    codename, ctx);
             }
             else if (is_numeric_operand_strict(data))
             {
@@ -243,7 +255,7 @@ namespace phylanx { namespace execution_tree
                         extract_numeric_value_strict(
                             std::move(value), name, codename),
                         std::move(arr_localities), std::move(val_localities),
-                        name, codename);
+                        name, codename, ctx);
                 }
 
                 return dist_slice_assign(extract_numeric_value_strict(
@@ -251,7 +263,7 @@ namespace phylanx { namespace execution_tree
                     indices,
                     extract_numeric_value(std::move(value), name, codename),
                     std::move(arr_localities), std::move(val_localities), name,
-                    codename);
+                    codename, ctx);
             }
             else if (is_boolean_operand_strict(data))
             {
@@ -263,7 +275,7 @@ namespace phylanx { namespace execution_tree
                         extract_boolean_value_strict(
                             std::move(value), name, codename),
                         std::move(arr_localities), std::move(val_localities),
-                        name, codename);
+                        name, codename, ctx);
                 }
 
                 return dist_slice_assign(extract_boolean_value_strict(
@@ -271,7 +283,7 @@ namespace phylanx { namespace execution_tree
                     indices,
                     extract_boolean_value(std::move(value), name, codename),
                     std::move(arr_localities), std::move(val_localities), name,
-                    codename);
+                    codename, ctx);
             }
 
             HPX_THROW_EXCEPTION(hpx::invalid_status,
@@ -279,7 +291,7 @@ namespace phylanx { namespace execution_tree
                 util::generate_error_message(
                     "distributed target object does not hold a numeric type "
                     "and as such does not support slicing",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
         if (data.has_annotation())
@@ -296,14 +308,14 @@ namespace phylanx { namespace execution_tree
                         indices,
                         extract_integer_value_strict(
                             std::move(value), name, codename),
-                        std::move(arr_localities), name, codename);
+                        std::move(arr_localities), name, codename, ctx);
                 }
 
                 return dist_slice_assign(extract_integer_value_strict(
                     std::move(data), name, codename),
                     indices,
                     extract_integer_value(std::move(value), name, codename),
-                    std::move(arr_localities), name, codename);
+                    std::move(arr_localities), name, codename, ctx);
             }
             else if (is_numeric_operand_strict(data))
             {
@@ -314,14 +326,14 @@ namespace phylanx { namespace execution_tree
                         indices,
                         extract_numeric_value_strict(
                             std::move(value), name, codename),
-                        std::move(arr_localities), name, codename);
+                        std::move(arr_localities), name, codename, ctx);
                 }
 
                 return dist_slice_assign(extract_numeric_value_strict(
                     std::move(data), name, codename),
                     indices,
                     extract_numeric_value(std::move(value), name, codename),
-                    std::move(arr_localities), name, codename);
+                    std::move(arr_localities), name, codename, ctx);
             }
             else if (is_boolean_operand_strict(data))
             {
@@ -332,14 +344,14 @@ namespace phylanx { namespace execution_tree
                         indices,
                         extract_boolean_value_strict(
                             std::move(value), name, codename),
-                        std::move(arr_localities), name, codename);
+                        std::move(arr_localities), name, codename, ctx);
                 }
 
                 return dist_slice_assign(extract_boolean_value_strict(
                     std::move(data), name, codename),
                     indices,
                     extract_boolean_value(std::move(value), name, codename),
-                    std::move(arr_localities), name, codename);
+                    std::move(arr_localities), name, codename, ctx);
             }
 
             HPX_THROW_EXCEPTION(hpx::invalid_status,
@@ -347,7 +359,7 @@ namespace phylanx { namespace execution_tree
                 util::generate_error_message(
                     "distributed target object does not hold a numeric type "
                     "and as such does not support slicing",
-                    name, codename));
+                    name, codename, ctx.back_trace()));
         }
 
 
@@ -356,7 +368,7 @@ namespace phylanx { namespace execution_tree
             return primitive_argument_type{slice_list(
                 extract_list_value_strict(std::move(data), name, codename),
                 indices, extract_value(std::move(value), name, codename), name,
-                codename)};
+                codename, ctx)};
         }
         else if (is_integer_operand_strict(data))
         {
@@ -368,14 +380,14 @@ namespace phylanx { namespace execution_tree
                     indices,
                     extract_integer_value_strict(
                         std::move(value), name, codename),
-                    name, codename)};
+                    name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_integer_value_strict(std::move(data), name, codename),
                 indices,
                 extract_integer_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
         else if (is_numeric_operand_strict(data))
         {
@@ -387,14 +399,14 @@ namespace phylanx { namespace execution_tree
                     indices,
                     extract_numeric_value_strict(
                         std::move(value), name, codename),
-                    name, codename)};
+                    name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_numeric_value_strict(std::move(data), name, codename),
                 indices,
                 extract_numeric_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
         else if (is_boolean_operand_strict(data))
         {
@@ -406,20 +418,29 @@ namespace phylanx { namespace execution_tree
                     indices,
                     extract_boolean_value_strict(
                         std::move(value), name, codename),
-                    name, codename)};
+                    name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_boolean_value_strict(std::move(data), name, codename),
                 indices,
                 extract_boolean_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
         else if (is_dictionary_operand_strict(data))
         {
             auto&& dict =
                 phylanx::execution_tree::extract_dictionary_value_strict(
                     std::move(data));
+            if (!is_hashable_operand(indices))
+            {
+                HPX_THROW_EXCEPTION(hpx::bad_parameter,
+                    "phylanx::execution_tree::slice",
+                    util::generate_error_message(
+                        "the given index cannot be used for indexing a "
+                        "dictionary",
+                        name, codename, ctx.back_trace()));
+            }
             dict[indices] = std::move(value);
             return primitive_argument_type{std::move(dict)};
         }
@@ -428,13 +449,15 @@ namespace phylanx { namespace execution_tree
             "phylanx::execution_tree::slice",
             util::generate_error_message(
                 "target object does not hold a numeric, range, or dictionary "
-                "type and as such does not support slicing", name, codename));
+                "type and as such does not support slicing",
+                name, codename, ctx.back_trace()));
     }
 
     primitive_argument_type slice(primitive_argument_type&& data,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, primitive_argument_type&& value,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (is_integer_operand_strict(data))
         {
@@ -447,14 +470,14 @@ namespace phylanx { namespace execution_tree
                         rows, columns,
                         extract_integer_value_strict(
                             std::move(value), name, codename),
-                        name, codename)};
+                        name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_integer_value_strict(std::move(data), name, codename),
                 rows, columns,
                 extract_integer_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
         if (is_numeric_operand_strict(data))
         {
@@ -467,14 +490,14 @@ namespace phylanx { namespace execution_tree
                         rows, columns,
                         extract_numeric_value_strict(
                             std::move(value), name, codename),
-                        name, codename)};
+                        name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_numeric_value_strict(std::move(data), name, codename),
                 rows, columns,
                 extract_numeric_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
         if (is_boolean_operand_strict(data))
         {
@@ -487,28 +510,30 @@ namespace phylanx { namespace execution_tree
                         rows, columns,
                         extract_boolean_value_strict(
                             std::move(value), name, codename),
-                        name, codename)};
+                        name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_boolean_value_strict(std::move(data), name, codename),
                 rows, columns,
                 extract_boolean_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
                 "target object does not hold a numeric data type and "
-                "as such does not support slicing", name, codename));
+                "as such does not support slicing",
+                name, codename, ctx.back_trace()));
     }
 
     primitive_argument_type slice(primitive_argument_type&& data,
         primitive_argument_type const& pages,
         primitive_argument_type const& rows,
         primitive_argument_type const& columns, primitive_argument_type&& value,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         if (is_integer_operand_strict(data))
         {
@@ -521,14 +546,14 @@ namespace phylanx { namespace execution_tree
                         pages, rows, columns,
                         extract_integer_value_strict(
                             std::move(value), name, codename),
-                        name, codename)};
+                        name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_integer_value_strict(std::move(data), name, codename),
                 pages, rows, columns,
                 extract_integer_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
         if (is_numeric_operand_strict(data))
         {
@@ -541,14 +566,14 @@ namespace phylanx { namespace execution_tree
                         pages, rows, columns,
                         extract_numeric_value_strict(
                             std::move(value), name, codename),
-                        name, codename)};
+                        name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_numeric_value_strict(std::move(data), name, codename),
                 pages, rows, columns,
                 extract_numeric_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
         if (is_boolean_operand_strict(data))
         {
@@ -561,21 +586,22 @@ namespace phylanx { namespace execution_tree
                         pages, rows, columns,
                         extract_boolean_value_strict(
                             std::move(value), name, codename),
-                        name, codename)};
+                        name, codename, ctx)};
             }
 
             return primitive_argument_type{slice_assign(
                 extract_boolean_value_strict(std::move(data), name, codename),
                 pages, rows, columns,
                 extract_boolean_value(std::move(value), name, codename),
-                name, codename)};
+                name, codename, ctx)};
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice",
             util::generate_error_message(
                 "target object does not hold a numeric data type and "
-                "as such does not support slicing", name, codename));
+                "as such does not support slicing",
+                name, codename, ctx.back_trace()));
     }
 }}
 

--- a/src/execution_tree/primitives/slice_node_data.cpp
+++ b/src/execution_tree/primitives/slice_node_data.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -32,21 +32,22 @@ namespace phylanx { namespace execution_tree
     template <typename T>
     ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& indices,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 0:
-            return slice1d_extract0d(data, indices, name, codename);
+            return slice1d_extract0d(data, indices, name, codename, ctx);
 
         case 1:
-            return slice1d_extract1d(data, indices, name, codename);
+            return slice1d_extract1d(data, indices, name, codename, ctx);
 
         case 2:
-            return slice1d_extract2d(data, indices, name, codename);
+            return slice1d_extract2d(data, indices, name, codename, ctx);
 
         case 3:
-            return slice1d_extract3d(data, indices, name, codename);
+            return slice1d_extract3d(data, indices, name, codename, ctx);
 
         default:
             break;
@@ -56,7 +57,7 @@ namespace phylanx { namespace execution_tree
             "phylanx::execution_tree::slice_extract",
             util::generate_error_message(
                 "target ir::node_data object holds unsupported data type", name,
-                codename));
+                codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -64,31 +65,33 @@ namespace phylanx { namespace execution_tree
         ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& indices,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 2:
             return dist_slice1d_extract2d(
-                data, indices, std::move(arr_localities), name, codename);
+                data, indices, std::move(arr_localities), name, codename, ctx);
 
         default:
             break;
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
-            "phylanx::execution_tree::slice_extract",
+            "phylanx::execution_tree::dist_slice_extract",
             util::generate_error_message(
                 "distributed target ir::node_data object has an unsupported "
                 "number of dimensions",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     template <typename T>
     ir::node_data<T> slice_extract(ir::node_data<T> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
@@ -97,22 +100,22 @@ namespace phylanx { namespace execution_tree
                 if (valid(rows))
                 {
                     HPX_ASSERT(!valid(columns));
-                    return slice1d_extract1d(data, rows, name, codename);
+                    return slice1d_extract1d(data, rows, name, codename, ctx);
                 }
 
                 if (valid(columns))
                 {
                     HPX_ASSERT(!valid(rows));
-                    return slice1d_extract1d(data, columns, name, codename);
+                    return slice1d_extract1d(data, columns, name, codename, ctx);
                 }
             }
             break;
 
         case 2:
-            return slice2d_extract2d(data, rows, columns, name, codename);
+            return slice2d_extract2d(data, rows, columns, name, codename, ctx);
 
         case 3:
-            return slice2d_extract3d(data, rows, columns, name, codename);
+            return slice2d_extract3d(data, rows, columns, name, codename, ctx);
 
         case 0: HPX_FALLTHROUGH;
         default:
@@ -124,7 +127,7 @@ namespace phylanx { namespace execution_tree
             util::generate_error_message(
                 "target ir::node_data object holds data type that does not "
                 "support 2d slicing",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -133,24 +136,25 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 2:
-            return dist_slice2d_extract2d(
-                data, rows, columns, std::move(arr_localities), name, codename);
+            return dist_slice2d_extract2d(data, rows, columns,
+                std::move(arr_localities), name, codename, ctx);
 
         default:
             break;
         }
 
         HPX_THROW_EXCEPTION(hpx::invalid_status,
-            "phylanx::execution_tree::slice_extract",
+            "phylanx::execution_tree::dist_slice_extract",
             util::generate_error_message(
                 "distributed target ir::node_data object has an unsupported "
                 "number of dimensions",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -158,12 +162,14 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& pages,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 3:
-            return slice3d_extract3d(data, pages, rows, columns, name, codename);
+            return slice3d_extract3d(
+                data, pages, rows, columns, name, codename, ctx);
 
         case 0: HPX_FALLTHROUGH;
         case 1: HPX_FALLTHROUGH;
@@ -177,7 +183,7 @@ namespace phylanx { namespace execution_tree
             util::generate_error_message(
                 "target ir::node_data object holds data type that does not "
                 "support 3d slicing",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -185,95 +191,110 @@ namespace phylanx { namespace execution_tree
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>
     slice_extract<std::uint8_t>(ir::node_data<std::uint8_t> const& data,
         execution_tree::primitive_argument_type const& indices,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<double>
     slice_extract<double>(ir::node_data<double> const& data,
         execution_tree::primitive_argument_type const& indices,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::int64_t>
     slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
         execution_tree::primitive_argument_type const& indices,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_extract<std::uint8_t>(ir::node_data<std::uint8_t> const& data,
         execution_tree::primitive_argument_type const& indices,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_extract<double>(ir::node_data<double> const& data,
         execution_tree::primitive_argument_type const& indices,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
         execution_tree::primitive_argument_type const& indices,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>
     slice_extract<std::uint8_t>(ir::node_data<std::uint8_t> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<double>
     slice_extract<double>(ir::node_data<double> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::int64_t>
     slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_extract<std::uint8_t>(ir::node_data<std::uint8_t> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_extract<double>(ir::node_data<double> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>
     slice_extract<std::uint8_t>(ir::node_data<std::uint8_t> const& data,
         execution_tree::primitive_argument_type const& pages,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<double>
     slice_extract<double>(ir::node_data<double> const& data,
         execution_tree::primitive_argument_type const& pages,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::int64_t>
     slice_extract<std::int64_t>(ir::node_data<std::int64_t> const& data,
         execution_tree::primitive_argument_type const& pages,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     ///////////////////////////////////////////////////////////////////////////
     // Modifying slice functionality
@@ -281,25 +302,25 @@ namespace phylanx { namespace execution_tree
     ir::node_data<T> slice_assign(ir::node_data<T>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 0:
             return slice1d_assign0d(std::move(data), indices, std::move(value),
-                name, codename);
+                name, codename, ctx);
 
         case 1:
             return slice1d_assign1d(std::move(data), indices, std::move(value),
-                name, codename);
+                name, codename, ctx);
 
         case 2:
             return slice1d_assign2d(std::move(data), indices, std::move(value),
-                name, codename);
+                name, codename, ctx);
 
         case 3:
             return slice1d_assign3d(std::move(data), indices, std::move(value),
-                name, codename);
+                name, codename, ctx);
 
         default:
             break;
@@ -309,7 +330,7 @@ namespace phylanx { namespace execution_tree
             "phylanx::execution_tree::slice_assign",
             util::generate_error_message(
                 "target ir::node_data object holds unsupported data type", name,
-                codename));
+                codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -319,14 +340,15 @@ namespace phylanx { namespace execution_tree
         ir::node_data<T>&& value,
         execution_tree::localities_information&& arr_localities,
         execution_tree::localities_information&& val_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 2:
             return dist_slice1d_assign2d(std::move(data), indices, std::move(value),
                 std::move(arr_localities), std::move(val_localities), name,
-                codename);
+                codename, ctx);
 
         default:
             break;
@@ -337,7 +359,7 @@ namespace phylanx { namespace execution_tree
             util::generate_error_message(
                 "distributed target ir::node_data object has an "
                 "unsupported number of dimensions",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -346,13 +368,15 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<T>&& value,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 2:
-            return dist_slice1d_assign2d(std::move(data), indices, std::move(value),
-                std::move(arr_localities), name, codename);
+            return dist_slice1d_assign2d(std::move(data), indices,
+                std::move(value), std::move(arr_localities), name, codename,
+                ctx);
 
         default:
             break;
@@ -363,7 +387,7 @@ namespace phylanx { namespace execution_tree
             util::generate_error_message(
                 "distributed target ir::node_data object has an "
                 "unsupported number of dimensions",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -371,21 +395,21 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         switch (data.num_dimensions())
         {
         case 1:
             return slice2d_assign1d(std::move(data), rows, columns,
-                std::move(value), name, codename);
+                std::move(value), name, codename, ctx);
 
         case 2:
             return slice2d_assign2d(std::move(data), rows, columns,
-                std::move(value), name, codename);
+                std::move(value), name, codename, ctx);
 
         case 3:
             return slice2d_assign3d(std::move(data), rows, columns,
-                std::move(value), name, codename);
+                std::move(value), name, codename, ctx);
 
         case 0: HPX_FALLTHROUGH;
         default:
@@ -397,7 +421,7 @@ namespace phylanx { namespace execution_tree
             util::generate_error_message(
                 "target ir::node_data object holds data type that does not "
                 "support 2d slicing",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     template <typename T>
@@ -406,14 +430,14 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<T>&& value, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         HPX_THROW_EXCEPTION(hpx::invalid_status,
             "phylanx::execution_tree::slice_assign",
             util::generate_error_message(
                 "target ir::node_data object holds data type that does not "
                 "support 3d slicing",
-                name, codename));
+                name, codename, ctx.back_trace()));
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -422,19 +446,19 @@ namespace phylanx { namespace execution_tree
     slice_assign<std::uint8_t>(ir::node_data<std::uint8_t>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<std::uint8_t>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<double>
     slice_assign<double>(ir::node_data<double>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<double>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::int64_t>
     slice_assign<std::int64_t>(ir::node_data<std::int64_t>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<std::int64_t>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_assign<std::uint8_t>(ir::node_data<std::uint8_t>&& data,
@@ -442,7 +466,8 @@ namespace phylanx { namespace execution_tree
         ir::node_data<std::uint8_t>&& value,
         execution_tree::localities_information&& arr_localities,
         execution_tree::localities_information&& val_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_assign<double>(ir::node_data<double>&& data,
@@ -450,7 +475,8 @@ namespace phylanx { namespace execution_tree
         ir::node_data<double>&& value,
         execution_tree::localities_information&& arr_localities,
         execution_tree::localities_information&& val_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_assign<std::int64_t>(ir::node_data<std::int64_t>&& data,
@@ -458,49 +484,53 @@ namespace phylanx { namespace execution_tree
         ir::node_data<std::int64_t>&& value,
         execution_tree::localities_information&& arr_localities,
         execution_tree::localities_information&& val_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_assign<std::uint8_t>(ir::node_data<std::uint8_t>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<std::uint8_t>&& value,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_assign<double>(ir::node_data<double>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<double>&& value,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT execution_tree::primitive_argument_type
     dist_slice_assign<std::int64_t>(ir::node_data<std::int64_t>&& data,
         execution_tree::primitive_argument_type const& indices,
         ir::node_data<std::int64_t>&& value,
         execution_tree::localities_information&& arr_localities,
-        std::string const& name, std::string const& codename);
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>
     slice_assign<std::uint8_t>(ir::node_data<std::uint8_t>&& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<std::uint8_t>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<double>
     slice_assign<double>(ir::node_data<double>&& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<double>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::int64_t>
     slice_assign<std::int64_t>(ir::node_data<std::int64_t>&& data,
         execution_tree::primitive_argument_type const& rows,
         execution_tree::primitive_argument_type const& columns,
         ir::node_data<std::int64_t>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::uint8_t>
     slice_assign<std::uint8_t>(ir::node_data<std::uint8_t>&& data,
@@ -508,7 +538,7 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& columns,
         execution_tree::primitive_argument_type const& page,
         ir::node_data<std::uint8_t>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<double>
     slice_assign<double>(ir::node_data<double>&& data,
@@ -516,7 +546,7 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& columns,
         execution_tree::primitive_argument_type const& page,
         ir::node_data<double>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 
     template PHYLANX_EXPORT ir::node_data<std::int64_t>
     slice_assign<std::int64_t>(ir::node_data<std::int64_t>&& data,
@@ -524,5 +554,5 @@ namespace phylanx { namespace execution_tree
         execution_tree::primitive_argument_type const& columns,
         execution_tree::primitive_argument_type const& page,
         ir::node_data<std::int64_t>&& value, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, eval_context const& ctx);
 }}

--- a/src/execution_tree/primitives/slice_range.cpp
+++ b/src/execution_tree/primitives/slice_range.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 Hartmut Kaiser
+// Copyright (c) 2018-2020 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -27,7 +27,7 @@ namespace phylanx { namespace execution_tree
     // extract a slice from the given range instance
     primitive_argument_type slice_list(ir::range&& list,
         ir::slicing_indices const& indices, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         std::size_t list_size = list.size();
 
@@ -40,7 +40,7 @@ namespace phylanx { namespace execution_tree
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice_list",
                 util::generate_error_message(
-                    "step can not be zero", name, codename));
+                    "step can not be zero", name, codename, ctx.back_trace()));
         }
 
         // handle single element to return
@@ -130,20 +130,21 @@ namespace phylanx { namespace execution_tree
     // extract a slice from the given range instance
     primitive_argument_type slice_list(ir::range&& data,
         primitive_argument_type const& indices, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, eval_context const& ctx)
     {
         std::size_t size = data.size();
         return slice_list(std::move(data),
             util::slicing_helpers::extract_slicing(
-                indices, size, name, codename),
-            name, codename);
+                indices, size, name, codename, ctx),
+            name, codename, ctx);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename F>
     primitive_argument_type slice_list(ir::range&& list,
         ir::slicing_indices const& indices, F && f,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
 //         std::size_t list_size = list.size();
 
@@ -156,7 +157,7 @@ namespace phylanx { namespace execution_tree
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "phylanx::execution_tree::slice_list",
                 util::generate_error_message(
-                    "step can not be zero", name, codename));
+                    "step can not be zero", name, codename, ctx.back_trace()));
         }
 
         // handle single element to return
@@ -255,7 +256,8 @@ namespace phylanx { namespace execution_tree
             "phylanx::execution_tree::slice_list",
             util::generate_error_message(
                 "assignment to list elements based on an index list is not "
-                "supported (yet)", name, codename));
+                "supported (yet)",
+                name, codename, ctx.back_trace()));
 
         return primitive_argument_type{std::move(list)};
     }
@@ -310,7 +312,8 @@ namespace phylanx { namespace execution_tree
     // modify a slice of the given range instance
     primitive_argument_type slice_list(ir::range&& data,
         primitive_argument_type const& indices, primitive_argument_type&& value,
-        std::string const& name, std::string const& codename)
+        std::string const& name, std::string const& codename,
+        eval_context const& ctx)
     {
         std::size_t size = data.size();
 
@@ -319,13 +322,13 @@ namespace phylanx { namespace execution_tree
             ir::range rhs = extract_list_value_strict(value, name, codename);
             return slice_list(std::move(data),
                 util::slicing_helpers::extract_slicing(
-                    indices, size, name, codename),
-                detail::slice_assign_list{rhs}, name, codename);
+                    indices, size, name, codename, ctx),
+                detail::slice_assign_list{rhs}, name, codename, ctx);
         }
 
         return slice_list(std::move(data),
             util::slicing_helpers::extract_slicing(
-                indices, size, name, codename),
-            detail::slice_assign_value{value}, name, codename);
+                indices, size, name, codename, ctx),
+            detail::slice_assign_value{value}, name, codename, ctx);
     }
 }}

--- a/src/plugins/matrixops/slicing_operation.cpp
+++ b/src/plugins/matrixops/slicing_operation.cpp
@@ -208,8 +208,10 @@ namespace phylanx {namespace execution_tree {    namespace primitives
         }
 
         auto this_ = this->shared_from_this();
+        auto ctx_copy = ctx;
         return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
-            [this_ = std::move(this_)](primitive_arguments_type&& ops)
+            [this_ = std::move(this_), ctx = std::move(ctx_copy)](
+                primitive_arguments_type&& ops)
             ->  primitive_argument_type
             {
                 primitive_arguments_type args;
@@ -248,32 +250,32 @@ namespace phylanx {namespace execution_tree {    namespace primitives
                             if (this_->slice_rows_)
                             {
                                 return slice(args[0], args[1],
-                                    this_->name_, this_->codename_);
+                                    this_->name_, this_->codename_, ctx);
                             }
                             else if (this_->slice_columns_)
                             {
                                 return slice(args[0], {}, args[1],
-                                    this_->name_, this_->codename_);
+                                    this_->name_, this_->codename_, ctx);
                             }
                             else if (this_->slice_pages_)
                             {
                                 return slice(args[0], args[1], {},
-                                    this_->name_, this_->codename_);
+                                    this_->name_, this_->codename_, ctx);
                             }
                             else
                             {
                                 return slice(args[0], args[1],
-                                    this_->name_, this_->codename_);
+                                    this_->name_, this_->codename_, ctx);
                             }
                         }
 
                     case 3:
                         return slice(args[0], args[1], args[2],
-                            this_->name_, this_->codename_);
+                            this_->name_, this_->codename_, ctx);
 
                     case 4:
                         return slice(args[0], args[1], args[2], args[3],
-                            this_->name_, this_->codename_);
+                            this_->name_, this_->codename_, ctx);
 
                     default:
                         break;
@@ -287,35 +289,33 @@ namespace phylanx {namespace execution_tree {    namespace primitives
                             if (this_->slice_rows_d_)
                             {
                                 return dist_slice(args[0], args[1],
-                                    this_->name_, this_->codename_);
+                                    this_->name_, this_->codename_, ctx);
                             }
                             else if (this_->slice_columns_d_)
                             {
                                 return dist_slice(args[0], {}, args[1],
-                                    this_->name_, this_->codename_);
+                                    this_->name_, this_->codename_, ctx);
                             }
                             else
                             {
                                 return dist_slice(args[0], args[1],
-                                    this_->name_, this_->codename_);
+                                    this_->name_, this_->codename_, ctx);
                             }
                         }
                     case 3:
                             return slice(args[0], args[1], args[2],
-                                this_->name_, this_->codename_);
+                                this_->name_, this_->codename_, ctx);
                     default:
                         break;
                     }
-
                 }
-
 
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::primitives::"
                         "slicing_operation::eval",
                     this_->generate_error_message(
                         "the slicing_operation primitive requires "
-                            "either one, two, or three arguments"));
+                            "either one, two, or three arguments", ctx));
             }),
             detail::map_operands(
                 operands, functional::value_operand{}, args,

--- a/src/util/slicing_helpers.cpp
+++ b/src/util/slicing_helpers.cpp
@@ -1,5 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2018 Bibek Wagle
+//  Copyright (c) 2020 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -38,7 +39,8 @@ namespace phylanx { namespace util { namespace slicing_helpers
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::util::slicing_helpers::extract_integer",
-                    "slicing arguments cannot be empty");
+                    util::generate_error_message(
+                        "slicing arguments cannot be empty", name, codename));
             }
 
             return nd[0];
@@ -123,7 +125,7 @@ namespace phylanx { namespace util { namespace slicing_helpers
     ir::slicing_indices extract_slicing(
         execution_tree::primitive_argument_type const& arg,
         std::size_t arg_size, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, execution_tree::eval_context const& ctx)
     {
         ir::slicing_indices indices;
 
@@ -144,7 +146,8 @@ namespace phylanx { namespace util { namespace slicing_helpers
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::util::slicing_helpers::extract_slicing",
-                    "too many indicies given");
+                    util::generate_error_message("too many indices given",
+                        name, codename, ctx.back_trace()));
             }
 
             if (size == 0)
@@ -238,10 +241,9 @@ namespace phylanx { namespace util { namespace slicing_helpers
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    std::size_t slicing_size(
-        execution_tree::primitive_argument_type const& arg,
+    std::size_t slicing_size(execution_tree::primitive_argument_type const& arg,
         std::size_t arg_size, std::string const& name,
-        std::string const& codename)
+        std::string const& codename, execution_tree::eval_context const& ctx)
     {
         // Extract the list or the single integer index
         // from second argument (row-> start, stop, step)
@@ -260,7 +262,8 @@ namespace phylanx { namespace util { namespace slicing_helpers
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::util::slicing_helpers::extract_slicing",
-                    "too many indicies given");
+                    util::generate_error_message("too many indicies given",
+                        name, codename, ctx.back_trace()));
             }
 
             if (size == 0)

--- a/tests/unit/plugins/dist_matrixops/CMakeLists.txt
+++ b/tests/unit/plugins/dist_matrixops/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Hartmut Kaiser
+# Copyright (c) 2019-2020 Hartmut Kaiser
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -81,6 +81,7 @@ foreach(test ${tests})
     SOURCES ${sources}
     ${${test}_FLAGS}
     EXCLUDE_FROM_ALL
+    DEPENDENCIES HPX::iostreams_component
     FOLDER "Tests/Unit/Plugins/DistMatrixOps")
 
   add_phylanx_unit_test("plugins.dist_matrixops" ${test} ${${test}_PARAMETERS})

--- a/tests/unit/plugins/dist_matrixops/dist_inverse_3_loc.cpp
+++ b/tests/unit/plugins/dist_matrixops/dist_inverse_3_loc.cpp
@@ -36,7 +36,7 @@ phylanx::execution_tree::primitive_argument_type compile_and_run(
 void test_ginv_operation(std::string const& name, std::string const& code,
     std::string const& expected_str)
 {
-    HPX_TEST_EQ(
+    HPX_TEST_EQ(hpx::cout,
         compile_and_run(name, code), compile_and_run(name, expected_str));
 }
 
@@ -51,13 +51,13 @@ void test_gauss_inverse_3loc_1()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_ginv_operation("test_3_1", R"(
-            inverse_d(
-                annotate_d( [[3.0], [2.0], [0.0]],
-                    "test_3_1a",
-                    list("tile", list("columns", 0, 1), list("rows", 0,3)))
-            )
-        )",
+            test_ginv_operation("test_3_1", R"(
+                inverse_d(
+                    annotate_d( [[3.0], [2.0], [0.0]],
+                        "test_3_1a",
+                        list("tile", list("columns", 0, 1), list("rows", 0,3)))
+                )
+            )",
             R"(
             annotate_d([[1.0], [-2.0], [-2.0]], "test_3_1a/1",
                 list("tile", list("columns", 0, 1), list("rows", 0, 3)))
@@ -65,13 +65,13 @@ void test_gauss_inverse_3loc_1()
     }
     else if (hpx::get_locality_id() == 1)
     {
-         test_ginv_operation("test_3_1", R"(
-             inverse_d(
-                annotate_d( [[-3.0], [-3.0], [-1.0]],
-                    "test_3_1a",
-                    list("tile", list("columns", 1, 2), list("rows", 0,3)))
-             )
-         )",
+             test_ginv_operation("test_3_1", R"(
+                 inverse_d(
+                    annotate_d( [[-3.0], [-3.0], [-1.0]],
+                        "test_3_1a",
+                        list("tile", list("columns", 1, 2), list("rows", 0,3)))
+                 )
+             )",
             R"(
             annotate_d([[-1.0], [3.0], [3.0]], "test_3_1a/1",
                 list("tile", list("columns", 1, 2), list("rows", 0, 3)))
@@ -79,13 +79,13 @@ void test_gauss_inverse_3loc_1()
     }
     else
     {
-        test_ginv_operation("test_3_1", R"(
-           inverse_d(
-               annotate_d( [[4.0], [4.0], [1.0]],
-                    "test_3_1a",
-                    list("tile", list("columns", 2, 3), list("rows", 0,3)))
-           )
-        )",
+            test_ginv_operation("test_3_1", R"(
+               inverse_d(
+                   annotate_d( [[4.0], [4.0], [1.0]],
+                        "test_3_1a",
+                        list("tile", list("columns", 2, 3), list("rows", 0,3)))
+               )
+            )",
             R"(
             annotate_d([[0.0], [-4.0], [-3.0]], "test_3_1a/1",
                 list("tile", list("columns", 2, 3), list("rows", 0, 3)))
@@ -103,13 +103,13 @@ void test_gauss_inverse_3loc_2()
 {
     if (hpx::get_locality_id() == 0)
     {
-        test_ginv_operation("test_3_2", R"(
-            inverse_d(
-                annotate_d( [[3.0], [0.0], [2.0]],
-                    "test_3_2a",
-                    list("tile", list("columns", 0, 1), list("rows", 0,3)))
-            )
-        )",
+            test_ginv_operation("test_3_2", R"(
+                inverse_d(
+                    annotate_d( [[3.0], [0.0], [2.0]],
+                        "test_3_2a",
+                        list("tile", list("columns", 0, 1), list("rows", 0,3)))
+                )
+            )",
             R"(
             annotate_d([[0.2], [-0.2], [0.2]], "test_3_2a/1",
                 list("tile", list("columns", 0, 1), list("rows", 0, 3)))
@@ -118,12 +118,12 @@ void test_gauss_inverse_3loc_2()
     else if (hpx::get_locality_id() == 1)
     {
         test_ginv_operation("test_3_2", R"(
-            inverse_d(
-                annotate_d( [[0.0], [1.0], [0.0]],
-                    "test_3_2a",
-                    list("tile", list("columns", 1, 2), list("rows", 0,3)))
-            )
-        )",
+                inverse_d(
+                    annotate_d( [[0.0], [1.0], [0.0]],
+                        "test_3_2a",
+                        list("tile", list("columns", 1, 2), list("rows", 0,3)))
+                )
+            )",
             R"(
             annotate_d([[0.0], [1.0], [0.0]], "test_3_2a/1",
                 list("tile", list("columns", 1, 2), list("rows", 0, 3)))
@@ -132,12 +132,12 @@ void test_gauss_inverse_3loc_2()
     else
     {
         test_ginv_operation("test_3_2", R"(
-            inverse_d(
-                annotate_d( [[2.0], [1.0], [-2.0]],
-                    "test_3_2a",
-                     list("tile", list("columns", 2, 3), list("rows", 0,3)))
-            )
-        )",
+                inverse_d(
+                    annotate_d( [[2.0], [1.0], [-2.0]],
+                        "test_3_2a",
+                         list("tile", list("columns", 2, 3), list("rows", 0,3)))
+                )
+            )",
             R"(
             annotate_d([[0.2], [0.3], [-0.3]], "test_3_2a/1",
                 list("tile", list("columns", 2, 3), list("rows", 0, 3)))
@@ -156,12 +156,12 @@ void test_gauss_inverse_3loc_3()
     if (hpx::get_locality_id() == 0)
     {
         test_ginv_operation("test_3_3", R"(
-            inverse_d(
-                annotate_d( [[1.0, 1.0], [0.0, 3.0], [2.0, 3.0], [1.0, 0.0]],
-                    "test_3_3a",
-                    list("tile", list("columns", 0, 2), list("rows", 0,4)))
-             )
-        )",
+                inverse_d(
+                    annotate_d( [[1.0, 1.0], [0.0, 3.0], [2.0, 3.0], [1.0, 0.0]],
+                        "test_3_3a",
+                        list("tile", list("columns", 0, 2), list("rows", 0,4)))
+                 )
+            )",
             R"(
             annotate_d([[-3.0, -0.5], [1.0, 0.25], [3.0, 0.25], [-3.0, 0.0]],
                 "test_3_3a/1",
@@ -171,12 +171,12 @@ void test_gauss_inverse_3loc_3()
     else if (hpx::get_locality_id() == 1)
     {
         test_ginv_operation("test_3_3", R"(
-            inverse_d(
-                annotate_d( [[1.0], [1.0], [1.0], [2.0]],
-                    "test_3_3a",
-                    list("tile", list("columns", 2, 3), list("rows", 0,4)))
-            )
-        )",
+                inverse_d(
+                    annotate_d( [[1.0], [1.0], [1.0], [2.0]],
+                        "test_3_3a",
+                        list("tile", list("columns", 2, 3), list("rows", 0,4)))
+                )
+            )",
             R"(
             annotate_d([[1.5], [-0.25], [-1.25], [1.0]], "test_3_3a/1",
                 list("tile", list("columns", 2, 3), list("rows", 0, 4)))
@@ -185,22 +185,18 @@ void test_gauss_inverse_3loc_3()
     else
     {
         test_ginv_operation("test_3_3", R"(
-            inverse_d(
-                annotate_d( [[0.0], [2.0], [0.0], [1.0]],
-                    "test_3_3a",
-                    list("tile", list("columns", 3, 4), list("rows", 0,4)))
-            )
-        )",
+                inverse_d(
+                    annotate_d( [[0.0], [2.0], [0.0], [1.0]],
+                        "test_3_3a",
+                        list("tile", list("columns", 3, 4), list("rows", 0,4)))
+                )
+            )",
             R"(
             annotate_d([[1.0], [-0.5], [-0.5], [1.0]], "test_3_3a/1",
                 list("tile", list("columns", 3, 4), list("rows", 0, 4)))
         )");
     }
 }
-
-
-
-
 
 int hpx_main(int argc, char* argv[])
 {


### PR DESCRIPTION
Fixes #1241 

for example, this code:
```python
#  Copyright (c) 2020 Steven R. Brandt
#
#  Distributed under the Boost Software License, Version 1.0. (See accompanying
#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

# #1241: Exception gives no indication of line number

from phylanx import Phylanx

@Phylanx
def foo():
    a = [1, 2, 3]
    d = {}
    d[a] = "x"

foo()
```
now yields
```
Traceback (most recent call last):
  File "D:\Devel\phylanx\tests\regressions\python\1241_missing_stacktrace.py", line 18, in <module>
    foo()
  File "D:\Devel\phylanx\build\All.v16.vcpkg\python\build\lib.win-amd64-3.6\phylanx\ast\transducer.py", line 168, in __call__
    result = self.backend.call(*mapped_args, **mapped_kwargs)
  File "D:\Devel\phylanx\build\All.v16.vcpkg\python\build\lib.win-amd64-3.6\phylanx\ast\physl.py", line 579, in call
    self.wrapped_function.__name__, *args, **kwargs)
RuntimeError:
<stack frames>
  [1]: ...\python\1241_missing_stacktrace.py: foo:: (Python)
  [2]: ...\python\1241_missing_stacktrace.py(12, 0): lambda:: (PhySL)
  [3]: ...\python\1241_missing_stacktrace.py(14, 4): variable$d:: (PhySL)

the given index cannot be used for indexing a dictionary: HPX(bad_parameter)
```