### PR TITLE
Teaching the front end about assert

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -1333,6 +1333,20 @@ class PhySL:
         expr = tuple(map(self._apply_rule, node.elts))
         return expr
 
+    def _Assert(self, node):
+        """class Assert(test, msg)
+
+       `test`: holds a single expression to evaluate
+       `msg`: an optional expression to evaluate (and print) if test fails.
+       """
+        symbol = '%s' % get_symbol_info(node, 'assert')
+        test = self._apply_rule(node.test)
+        if node.msg:
+            msg = self._apply_rule(node.msg)
+            return [symbol, (test, msg)]
+
+        return [symbol, (test,)]
+
     def _UAdd(self, node):
         """
 

--- a/src/execution_tree/compiler/compiler.cpp
+++ b/src/execution_tree/compiler/compiler.cpp
@@ -65,11 +65,11 @@ namespace phylanx { namespace execution_tree { namespace compiler {
                 if (p.supports_dtype_)
                 {
                     result.define_variable(p.primitive_type_ + "__bool",
-                        builtin_function(
-                            p.create_primitive_, default_locality), "<builtin>");
+                        builtin_function(p.create_primitive_, default_locality),
+                        "<builtin>");
                     result.define_variable(p.primitive_type_ + "__int",
-                        builtin_function(
-                            p.create_primitive_, default_locality), "<builtin>");
+                        builtin_function(p.create_primitive_, default_locality),
+                        "<builtin>");
                     result.define_variable(p.primitive_type_ + "__float",
                         builtin_function(p.create_primitive_, default_locality),
                         "<builtin>");
@@ -1234,13 +1234,15 @@ namespace phylanx { namespace execution_tree { namespace compiler {
             // find the first pattern that has a sufficient number of
             // placeholders
             auto it = p.first;
-            while (it != p.second && !it->second.expect_variadics() &&
-                exprs.size() > it->second.args_.size())
+            auto jt = it;
+            while (jt != p.second && !jt->second.expect_variadics() &&
+                exprs.size() > jt->second.args_.size())
             {
-                it = ++p.first;
+                it = jt;
+                jt = ++p.first;
             }
 
-            if (it == p.second)
+            if (jt == p.second)
             {
                 HPX_THROW_EXCEPTION(hpx::bad_parameter,
                     "phylanx::execution_tree::compiler::"
@@ -1596,7 +1598,7 @@ namespace phylanx { namespace execution_tree { namespace compiler {
 
                     // Handle slice(_1, __2) and slice_row(_1, _2)
                     if (function_name == "slice" ||
-                        function_name == "slice_row"||
+                        function_name == "slice_row" ||
                         function_name == "slice_row_d")
                     {
                         placeholder_map_type placeholders;


### PR DESCRIPTION
- adding second (optional) argument to assert_condition()
  primitive (message to print)
- flyby: fix compiler output if number of arguments does not match
  expected interface

Fixes #1260