### PR TITLE
Adding additional debugging support to frontend

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -366,11 +366,18 @@ class PhySL:
                     phylanx.execution_tree.global_compiler_state(
                         self.wrapped_function.__name__, self.file_name)
 
+    def _print_progress(self, msg):
+        if self.kwargs.get("print_progress"):
+            msg += ' %s(%s)'
+            print(msg % (self.wrapped_function.__name__, self.file_name))
+
     def _compile_or_load(self):
         """Compile or load this function from database"""
 
         physl_db = None
         try:
+            self._print_progress('physl: compiling')
+
             # create/open database representing the function in this file
             physl_db = db(self.file_name)   # _name_of_importing_file)
 
@@ -379,6 +386,8 @@ class PhySL:
                 self.wrapped_function.__name__)
 
             if self.__src__ is None:
+                self._print_progress('physl: not found in db')
+
                 # this function is not in database, generate physl
                 self.ir = self._apply_rule(self.python_tree.body[0])
                 check_return(self.ir)
@@ -421,6 +430,8 @@ class PhySL:
         if self.kwargs.get("debug"):
             print_physl_src(self.__src__)
             print(end="", flush="")
+
+        self._print_progress('physl: compiled')
 
     def _ensure_global_state(self):
         """Ensure global PhySL session has been initialized"""

--- a/python/phylanx/core/config.py
+++ b/python/phylanx/core/config.py
@@ -25,6 +25,12 @@ class PhylanxSession:
 
     is_initialized = False
 
+    # global settings for decorator
+    startatlineone = False
+    print_progress = False
+    debug = False
+    disable_decorator = False
+
     @staticmethod
     def init(num_threads=1):
         if not PhylanxSession.is_initialized:


### PR DESCRIPTION
This PR enables to globally enable additional options that simplify debugging.
```
from phylanx import Phylanx, PhylanxSession

PhylanxSession.print_progress = True       # print additional information about PhySL compilation
PhylanxSession.debug = True                # default value for @Phylanx(debug=...)
PhylanxSession.disable_decorator = True    # default value for @Phylanx(disable_decorator=...)
```
This code needs to be executed before the first `@Phylanx` decorator is encountered.

Fixes #1264