### PR TITLE
Adding random_sample functionality

### DIFF
--- a/phylanx/plugins/matrixops/random.hpp
+++ b/phylanx/plugins/matrixops/random.hpp
@@ -39,7 +39,8 @@ namespace phylanx { namespace execution_tree { namespace primitives
         enum class operation
         {
             random,
-            random_sample
+            random_sample,
+            random_integers
         };
 
     public:
@@ -146,6 +147,11 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& operands,
             primitive_arguments_type const& args,
             eval_context ctx) const override;
+
+        hpx::future<primitive_argument_type> eval_random_integers(
+            primitive_arguments_type const& operands,
+            primitive_arguments_type const& args,
+            eval_context ctx) const;
 
         primitive_argument_type random0d(distribution_parameters_type&& params,
             node_data_type, eval_context ctx) const;

--- a/phylanx/plugins/matrixops/random.hpp
+++ b/phylanx/plugins/matrixops/random.hpp
@@ -36,7 +36,14 @@ namespace phylanx { namespace execution_tree { namespace primitives
       , public std::enable_shared_from_this<random>
     {
     public:
-        static match_pattern_type const match_data;
+        enum class operation
+        {
+            random,
+            random_sample
+        };
+
+    public:
+        static std::vector<match_pattern_type> const match_data;
 
         random() = default;
 
@@ -140,19 +147,26 @@ namespace phylanx { namespace execution_tree { namespace primitives
             primitive_arguments_type const& args,
             eval_context ctx) const override;
 
-        primitive_argument_type random0d(
-            distribution_parameters_type&& params, node_data_type) const;
+        primitive_argument_type random0d(distribution_parameters_type&& params,
+            node_data_type, eval_context ctx) const;
         primitive_argument_type random1d(std::size_t dim,
-            distribution_parameters_type&& params, node_data_type) const;
+            distribution_parameters_type&& params, node_data_type,
+            eval_context ctx) const;
         primitive_argument_type random2d(
             std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
-            distribution_parameters_type&& params, node_data_type) const;
+            distribution_parameters_type&& params, node_data_type,
+            eval_context ctx) const;
         primitive_argument_type random3d(
             std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
-            distribution_parameters_type&& params, node_data_type) const;
+            distribution_parameters_type&& params, node_data_type,
+            eval_context ctx) const;
         primitive_argument_type random4d(
             std::array<std::size_t, PHYLANX_MAX_DIMENSIONS> const& dims,
-            distribution_parameters_type&& params, node_data_type) const;
+            distribution_parameters_type&& params, node_data_type,
+            eval_context ctx) const;
+
+    private:
+        operation random_operation_;
     };
 
     inline primitive create_random(hpx::id_type const& locality,

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -95,7 +95,9 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(page_slicing_operation_plugin,
 PHYLANX_REGISTER_PLUGIN_FACTORY(power_operation_plugin,
     phylanx::execution_tree::primitives::power_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(random_plugin,
-    phylanx::execution_tree::primitives::random::match_data);
+    phylanx::execution_tree::primitives::random::match_data[0]);
+PHYLANX_REGISTER_PLUGIN_FACTORY(random_sample_plugin,
+    phylanx::execution_tree::primitives::random::match_data[1]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(repeat_operation_plugin,
     phylanx::execution_tree::primitives::repeat_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(reshape_operation_plugin,

--- a/src/plugins/matrixops/matrixops.cpp
+++ b/src/plugins/matrixops/matrixops.cpp
@@ -98,6 +98,8 @@ PHYLANX_REGISTER_PLUGIN_FACTORY(random_plugin,
     phylanx::execution_tree::primitives::random::match_data[0]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(random_sample_plugin,
     phylanx::execution_tree::primitives::random::match_data[1]);
+PHYLANX_REGISTER_PLUGIN_FACTORY(random_integers_plugin,
+    phylanx::execution_tree::primitives::random::match_data[2]);
 PHYLANX_REGISTER_PLUGIN_FACTORY(repeat_operation_plugin,
     phylanx::execution_tree::primitives::repeat_operation::match_data);
 PHYLANX_REGISTER_PLUGIN_FACTORY(reshape_operation_plugin,

--- a/tests/regressions/python/1267_random_integers.py
+++ b/tests/regressions/python/1267_random_integers.py
@@ -1,0 +1,42 @@
+#  Copyright (c) 2020 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #1267: np.random.random_sample is not available
+
+from phylanx import Phylanx
+import numpy as np
+
+
+@Phylanx
+def test_random_integers1(low):
+    return np.random.random_integers(low)
+
+
+@Phylanx
+def test_random_integers2(low, high):
+    return np.random.random_integers(low, high)
+
+
+@Phylanx
+def test_random_integers3(low, high, size):
+    return np.random.random_integers(low, high, size)
+
+
+for i in range(10):
+    result = test_random_integers1(10)
+    assert result >= 1 and result <= 10, result
+
+    result = test_random_integers2(10, 20)
+    assert result >= 10 and result <= 20, result
+
+    result = test_random_integers3(10, 20, 10)
+    assert len(result) == 10, result
+    for v in result:
+        assert v >= 10 and v <= 20, v
+
+    result = test_random_integers3(10, 20, (10,))
+    assert len(result) == 10, result
+    for v in result:
+        assert v >= 10 and v <= 20, v

--- a/tests/regressions/python/1267_random_sample.py
+++ b/tests/regressions/python/1267_random_sample.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2020 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #1267: np.random.random_sample is not available
+
+from phylanx import Phylanx
+import numpy as np
+
+
+@Phylanx
+def sample():
+    return np.random.random_sample()
+
+
+result = sample()
+assert result >= 0.0 and result < 1.0, result

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -60,6 +60,7 @@ set(tests
     1242_list_comparison
     1244_function_call
     1255_assign_string
+    1267_random_sample
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -60,6 +60,7 @@ set(tests
     1242_list_comparison
     1244_function_call
     1255_assign_string
+    1267_random_integers
     1267_random_sample
     array_len_494
     array_shape_486


### PR DESCRIPTION
This adds the `random_sample` and `random_integers` primitives

- flyby: enable stack traces for errors coming out of random primitive

Fixes #1267