### PR TITLE
Adding argument names to statistics primitives

### DIFF
--- a/phylanx/plugins/common/statistics_nd.hpp
+++ b/phylanx/plugins/common/statistics_nd.hpp
@@ -25,7 +25,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template <template <class T> class Op>
     PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type statisticsnd(
@@ -33,7 +33,7 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common
 

--- a/phylanx/plugins/dist_statistics/dist_statistics_base.hpp
+++ b/phylanx/plugins/dist_statistics/dist_statistics_base.hpp
@@ -53,52 +53,50 @@ namespace phylanx { namespace execution_tree { namespace primitives {
             std::string const& name, std::string const& codename);
 
     private:
-        primitive_argument_type statistics0d(
-            primitive_argument_type&& arg, ir::range&& axes,
-            bool keepdims, primitive_argument_type&& initial) const;
+        primitive_argument_type statistics0d(primitive_argument_type&& arg,
+            ir::range&& axes, bool keepdims, primitive_argument_type&& initial,
+            node_data_type dtype, eval_context ctx) const;
 
-        primitive_argument_type statistics1d(
-            primitive_argument_type&& arg, ir::range&& axes,
-            bool keepdims, primitive_argument_type&& initial) const;
+        primitive_argument_type statistics1d(primitive_argument_type&& arg,
+            ir::range&& axes, bool keepdims, primitive_argument_type&& initial,
+            node_data_type dtype, eval_context ctx) const;
 
-        primitive_argument_type statistics2d(
-            primitive_argument_type&& arg, ir::range&& axes,
-            bool keepdims, primitive_argument_type&& initial) const;
+        primitive_argument_type statistics2d(primitive_argument_type&& arg,
+            ir::range&& axes, bool keepdims, primitive_argument_type&& initial,
+            node_data_type dtype, eval_context ctx) const;
 
-        primitive_argument_type statistics3d(
-            primitive_argument_type&& arg, ir::range&& axes,
-            bool keepdims, primitive_argument_type&& initial) const;
+        primitive_argument_type statistics3d(primitive_argument_type&& arg,
+            ir::range&& axes, bool keepdims, primitive_argument_type&& initial,
+            node_data_type dtype, eval_context ctx) const;
 
-        primitive_argument_type statisticsnd(
-            primitive_argument_type&& arg, ir::range&& axes,
-            bool keepdims, primitive_argument_type&& initial) const;
+        primitive_argument_type statisticsnd(primitive_argument_type&& arg,
+            ir::range&& axes, bool keepdims, primitive_argument_type&& initial,
+            node_data_type dtype, eval_context ctx) const;
 
-        primitive_argument_type statistics0d(
-            primitive_argument_type&& arg,
+        primitive_argument_type statistics0d(primitive_argument_type&& arg,
             hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-            primitive_argument_type&& initial) const;
+            primitive_argument_type&& initial, node_data_type dtype,
+            eval_context ctx) const;
 
-        primitive_argument_type statistics1d(
-            primitive_argument_type&& arg,
+        primitive_argument_type statistics1d(primitive_argument_type&& arg,
             hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-            primitive_argument_type&& initial) const;
+            primitive_argument_type&& initial, node_data_type dtype,
+            eval_context ctx) const;
 
-        primitive_argument_type statistics2d(
-            primitive_argument_type&& arg,
+        primitive_argument_type statistics2d(primitive_argument_type&& arg,
             hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-            primitive_argument_type&& initial) const;
+            primitive_argument_type&& initial, node_data_type dtype,
+            eval_context ctx) const;
 
-        primitive_argument_type statistics3d(
-            primitive_argument_type&& arg,
+        primitive_argument_type statistics3d(primitive_argument_type&& arg,
             hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-            primitive_argument_type&& initial) const;
+            primitive_argument_type&& initial, node_data_type dtype,
+            eval_context ctx) const;
 
-        primitive_argument_type statisticsnd(
-            primitive_argument_type&& arg,
+        primitive_argument_type statisticsnd(primitive_argument_type&& arg,
             hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-            primitive_argument_type&& initial) const;
-
-        node_data_type dtype_;
+            primitive_argument_type&& initial, node_data_type dtype,
+            eval_context ctx) const;
     };
 }}}    // namespace phylanx::execution_tree::primitives
 

--- a/phylanx/plugins/dist_statistics/dist_statistics_base_impl.hpp
+++ b/phylanx/plugins/dist_statistics/dist_statistics_base_impl.hpp
@@ -40,7 +40,6 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         primitive_arguments_type&& operands, std::string const& name,
         std::string const& codename)
       : primitive_component_base(std::move(operands), name, codename)
-      , dtype_(extract_dtype(name_))
     {
     }
 
@@ -48,48 +47,58 @@ namespace phylanx { namespace execution_tree { namespace primitives {
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics0d(
         primitive_argument_type&& arg, ir::range&& axes, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), std::move(axes),
-            keepdims, std::move(initial), dtype_, name_, codename_);
+            keepdims, std::move(initial), dtype, name_, codename_,
+            std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics1d(
         primitive_argument_type&& arg, ir::range&& axes, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), std::move(axes),
-            keepdims, std::move(initial), dtype_, name_, codename_);
+            keepdims, std::move(initial), dtype, name_, codename_,
+            std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics2d(
         primitive_argument_type&& arg, ir::range&& axes, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), std::move(axes),
-            keepdims, std::move(initial), dtype_, name_, codename_);
+            keepdims, std::move(initial), dtype, name_, codename_,
+            std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics3d(
         primitive_argument_type&& arg, ir::range&& axes, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), std::move(axes),
-            keepdims, std::move(initial), dtype_, name_, codename_);
+            keepdims, std::move(initial), dtype, name_, codename_,
+            std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statisticsnd(
         primitive_argument_type&& arg, ir::range&& axes, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         if (!arg.has_annotation())
         {
             return common::statisticsnd<Op>(std::move(arg), std::move(axes),
-                keepdims, std::move(initial), dtype_, name_, codename_);
+                keepdims, std::move(initial), dtype, name_, codename_,
+                std::move(ctx));
         }
 
         std::size_t a_dims =
@@ -97,26 +106,27 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         switch (a_dims)
         {
         case 0:
-            return statistics0d(
-                std::move(arg), std::move(axes), keepdims, std::move(initial));
+            return statistics0d(std::move(arg), std::move(axes), keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         case 1:
-            return statistics1d(
-                std::move(arg), std::move(axes), keepdims, std::move(initial));
+            return statistics1d(std::move(arg), std::move(axes), keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         case 2:
-            return statistics2d(
-                std::move(arg), std::move(axes), keepdims, std::move(initial));
+            return statistics2d(std::move(arg), std::move(axes), keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         case 3:
-            return statistics3d(
-                std::move(arg), std::move(axes), keepdims, std::move(initial));
+            return statistics3d(std::move(arg), std::move(axes), keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "dist_argminmax<Op, Derived>::eval",
                 generate_error_message(
-                    "operand a has an invalid number of dimensions"));
+                    "operand a has an invalid number of dimensions",
+                    std::move(ctx)));
         }
     }
 
@@ -125,52 +135,57 @@ namespace phylanx { namespace execution_tree { namespace primitives {
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics0d(
         primitive_argument_type&& arg,
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), axis, keepdims,
-            std::move(initial), dtype_, name_, codename_);
+            std::move(initial), dtype, name_, codename_, std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics1d(
         primitive_argument_type&& arg,
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), axis, keepdims,
-            std::move(initial), dtype_, name_, codename_);
+            std::move(initial), dtype, name_, codename_, std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics2d(
         primitive_argument_type&& arg,
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), axis, keepdims,
-            std::move(initial), dtype_, name_, codename_);
+            std::move(initial), dtype, name_, codename_, std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statistics3d(
         primitive_argument_type&& arg,
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         return common::statisticsnd<Op>(std::move(arg), axis, keepdims,
-            std::move(initial), dtype_, name_, codename_);
+            std::move(initial), dtype, name_, codename_, std::move(ctx));
     }
 
     template <template <class T> class Op, typename Derived>
     primitive_argument_type dist_statistics_base<Op, Derived>::statisticsnd(
         primitive_argument_type&& arg,
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
-        primitive_argument_type&& initial) const
+        primitive_argument_type&& initial, node_data_type dtype,
+        eval_context ctx) const
     {
         if (!arg.has_annotation())
         {
             return common::statisticsnd<Op>(std::move(arg), axis, keepdims,
-                std::move(initial), dtype_, name_, codename_);
+                std::move(initial), dtype, name_, codename_, std::move(ctx));
         }
 
         std::size_t a_dims =
@@ -178,26 +193,27 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         switch (a_dims)
         {
         case 0:
-            return statistics0d(
-                std::move(arg), axis, keepdims, std::move(initial));
+            return statistics0d(std::move(arg), axis, keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         case 1:
-            return statistics1d(
-                std::move(arg), axis, keepdims, std::move(initial));
+            return statistics1d(std::move(arg), axis, keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         case 2:
-            return statistics2d(
-                std::move(arg), axis, keepdims, std::move(initial));
+            return statistics2d(std::move(arg), axis, keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         case 3:
-            return statistics3d(
-                std::move(arg), axis, keepdims, std::move(initial));
+            return statistics3d(std::move(arg), axis, keepdims,
+                std::move(initial), dtype, std::move(ctx));
 
         default:
             HPX_THROW_EXCEPTION(hpx::bad_parameter,
                 "dist_argminmax<Op, Derived>::eval",
                 generate_error_message(
-                    "operand a has an invalid number of dimensions"));
+                    "operand a has an invalid number of dimensions",
+                    std::move(ctx)));
         }
     }
 
@@ -208,39 +224,27 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         primitive_arguments_type const& operands,
         primitive_arguments_type const& args, eval_context ctx) const
     {
-        if (operands.empty() ||
-            operands.size() > derived().match_data.patterns_.size())
+        if (operands.empty() || operands.size() > 5)
         {
-            HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_statistics::eval",
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "statistics::eval",
                 generate_error_message(
-                    "the statistics primitive requires exactly one, two, or "
-                    "three operands"));
+                    "the statistics primitive requires between one and five "
+                    "operands", std::move(ctx)));
         }
 
-        std::size_t count = 0;
-        for (auto const& i : operands)
-        {
-            // axis (arg1) and keepdims (arg2) are allowed to be nil
-            if (count != 1 && count != 2 && !valid(i))
-            {
-                HPX_THROW_EXCEPTION(hpx::bad_parameter, "dist_statistics::eval",
-                    generate_error_message(
-                        "the statistics_operation primitive requires that the "
-                        "arguments given by the operands array are valid"));
-            }
-            ++count;
-        }
-
+        auto ctx_copy = ctx;
         auto this_ = this->shared_from_this();
-        return hpx::dataflow(hpx::launch::sync,
-            hpx::util::unwrapping([this_ = std::move(this_)](
-                                      primitive_arguments_type&& args)
-                                      -> primitive_argument_type {
+        return hpx::dataflow(hpx::launch::sync, hpx::util::unwrapping(
+            [this_ = std::move(this_), ctx = std::move(ctx)](
+                primitive_arguments_type&& args) mutable
+            -> primitive_argument_type
+            {
                 // Extract axis and keepdims
                 // Presence of axis changes behavior for >1d cases
                 hpx::util::optional<std::int64_t> axis;
                 bool keepdims = false;
                 primitive_argument_type initial;
+                node_data_type dtype = node_data_type_double;
 
                 if (args.size() > 1)
                 {
@@ -257,6 +261,14 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                         initial = std::move(args[3]);
                     }
 
+                    // dtype is (optional) argument #5
+                    if (args.size() > 4 && valid(args[4]))
+                    {
+                        dtype =
+                            map_dtype(extract_string_value(std::move(args[4]),
+                                this_->name_, this_->codename_));
+                    }
+
                     // axis is (optional) argument #2
                     if (valid(args[1]) && !is_explicit_nil(args[1]))
                     {
@@ -266,7 +278,8 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                             return this_->statisticsnd(std::move(args[0]),
                                 extract_list_value_strict(std::move(args[1]),
                                     this_->name_, this_->codename_),
-                                keepdims, std::move(initial));
+                                keepdims, std::move(initial), dtype,
+                                std::move(ctx));
                         }
 
                         // ... or a single integer
@@ -275,11 +288,11 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                     }
                 }
 
-                return this_->statisticsnd(
-                    std::move(args[0]), axis, keepdims, std::move(initial));
+                return this_->statisticsnd(std::move(args[0]), axis, keepdims,
+                    std::move(initial), dtype, std::move(ctx));
             }),
             detail::map_operands(operands, functional::value_operand{}, args,
-                name_, codename_, std::move(ctx)));
+                name_, codename_, std::move(ctx_copy)));
     }
 }}}    // namespace phylanx::execution_tree::primitives
 

--- a/phylanx/plugins/statistics/statistics_base.hpp
+++ b/phylanx/plugins/statistics/statistics_base.hpp
@@ -51,9 +51,6 @@ namespace phylanx { namespace execution_tree { namespace primitives {
 
         statistics_base(primitive_arguments_type&& operands,
             std::string const& name, std::string const& codename);
-
-    private:
-        node_data_type dtype_;
     };
 }}}    // namespace phylanx::execution_tree::primitives
 

--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -78,9 +78,7 @@ numpy_constants = {
 methods_supporting_dtype = [
     'linearmatrix',
     'linspace',
-    'mean',
-    'power',
-    'prod'
+    'power'
 ]
 
 

--- a/src/execution_tree/primitives/access_function.cpp
+++ b/src/execution_tree/primitives/access_function.cpp
@@ -56,6 +56,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> access_function::eval(
         primitive_arguments_type const& params, eval_context ctx) const
     {
+        if (!ctx)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_function::eval",
+                generate_error_message(
+                    hpx::util::format(
+                        "the execution context used to access the function "
+                        "'{}' is invalid",
+                        target_name_)));
+        }
+
         // access variable from execution context
         auto const* target = ctx.get_var(target_name_);
         if (target == nullptr)
@@ -98,6 +108,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     void access_function::store(primitive_arguments_type&& vals,
         primitive_arguments_type&& params, eval_context ctx)
     {
+        if (!ctx)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_function::store",
+                generate_error_message(
+                    hpx::util::format(
+                        "the execution context used to access the function "
+                        "'{}' is invalid",
+                        target_name_)));
+        }
+
         // access variable from execution context
         auto* target = ctx.get_var(target_name_);
         if (target == nullptr)
@@ -121,6 +141,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     void access_function::store(primitive_argument_type&& val,
         primitive_arguments_type&& params, eval_context ctx)
     {
+        if (!ctx)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_function::store",
+                generate_error_message(
+                    hpx::util::format(
+                        "the execution context used to access the function "
+                        "'{}' is invalid",
+                        target_name_)));
+        }
+
         // access variable from execution context
         auto* target = ctx.get_var(target_name_);
         if (target == nullptr)

--- a/src/execution_tree/primitives/access_variable.cpp
+++ b/src/execution_tree/primitives/access_variable.cpp
@@ -60,6 +60,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     hpx::future<primitive_argument_type> access_variable::eval(
         primitive_arguments_type const& params, eval_context ctx) const
     {
+        if (!ctx)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_variable::eval",
+                generate_error_message(
+                    hpx::util::format(
+                        "the execution context used to access the variable "
+                        "'{}' is invalid",
+                        target_name_)));
+        }
+
         // access variable from execution context
         auto const* target = ctx.get_var(target_name_);
         if (target == nullptr)
@@ -69,7 +79,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 generate_error_message(
                     hpx::util::format("the variable '{}' is unbound in the "
                                       "current execution environment",
-                        target_name_), ctx));
+                        target_name_), std::move(ctx)));
         }
 
         // handle slicing, we can replace the params with our slicing
@@ -160,6 +170,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     void access_variable::store(primitive_arguments_type&& vals,
         primitive_arguments_type&& params, eval_context ctx)
     {
+        if (!ctx)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_variable::store",
+                generate_error_message(
+                    hpx::util::format(
+                        "the execution context used to access the variable "
+                        "'{}' is invalid",
+                        target_name_)));
+        }
+
         if (vals.size() != 1)
         {
             HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_variable::store",
@@ -203,6 +223,16 @@ namespace phylanx { namespace execution_tree { namespace primitives
     void access_variable::store(primitive_argument_type&& val,
         primitive_arguments_type&& params, eval_context ctx)
     {
+        if (!ctx)
+        {
+            HPX_THROW_EXCEPTION(hpx::bad_parameter, "access_variable::store",
+                generate_error_message(
+                    hpx::util::format(
+                        "the execution context used to access the variable "
+                        "'{}' is invalid",
+                        target_name_)));
+        }
+
         // access variable from execution context
         auto* target = ctx.get_var(target_name_);
         if (target == nullptr)

--- a/src/execution_tree/primitives/timer.cpp
+++ b/src/execution_tree/primitives/timer.cpp
@@ -85,7 +85,7 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                     hpx::future<primitive_argument_type>&& l) mutable
                 -> primitive_argument_type
             {
-                hpx::util::high_resolution_timer t;
+                hpx::chrono::high_resolution_timer t;
 
                 // execute body
                 primitive const* p = util::get_if<primitive>(&func);

--- a/src/plugins/arithmetics/cumprod.cpp
+++ b/src/plugins/arithmetics/cumprod.cpp
@@ -36,7 +36,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 axis (int, optional) : Axis along which the cumulative product is
                     computed. The default (None) is to compute the cumprod over
                     the flattened array.
-                dtype (nil, optional) : the data-type of the returned array,
+                dtype (string, optional) : the data-type of the returned array,
                   defaults to dtype of input arrays.
 
             Returns:
@@ -61,7 +61,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 InIter begin, InIter end, OutIter dest, T init) const
             {
                 return hpx::parallel::inclusive_scan(
-                    hpx::parallel::execution::seq, begin, end, dest,
+                    hpx::execution::seq, begin, end, dest,
                     std::multiplies<>{}, init);
             }
         };

--- a/src/plugins/arithmetics/cumsum.cpp
+++ b/src/plugins/arithmetics/cumsum.cpp
@@ -58,7 +58,7 @@ namespace phylanx { namespace execution_tree { namespace primitives
                 InIter begin, InIter end, OutIter dest, T init) const
             {
                 return hpx::parallel::inclusive_scan(
-                    hpx::parallel::execution::seq, begin, end, dest,
+                    hpx::execution::seq, begin, end, dest,
                     std::plus<>{}, init);
             }
         };

--- a/src/plugins/common/all_operation.cpp
+++ b/src/plugins/common/all_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_all_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/any_operation.cpp
+++ b/src/plugins/common/any_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_any_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/conv1d_all_paddings.cpp
+++ b/src/plugins/common/conv1d_all_paddings.cpp
@@ -42,7 +42,7 @@ namespace phylanx { namespace common {
 
         blaze::DynamicTensor<double> result(batch, result_length, out_channels);
 
-        hpx::parallel::for_loop(hpx::parallel::execution::par, std::size_t(0),
+        hpx::for_loop(hpx::execution::par, std::size_t(0),
             batch, [&](std::size_t p) {
                 for (std::size_t c = 0; c != out_channels; ++c)
                 {
@@ -76,8 +76,8 @@ namespace phylanx { namespace common {
 
         blaze::DynamicTensor<double> result(batch, result_length, out_channels);
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);
@@ -120,8 +120,8 @@ namespace phylanx { namespace common {
 
         blaze::DynamicTensor<double> result(batch, result_length, out_channels);
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);
@@ -157,8 +157,8 @@ namespace phylanx { namespace common {
 
         blaze::DynamicTensor<double> result(batch, data_length, out_channels);
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);
@@ -212,8 +212,8 @@ namespace phylanx { namespace common {
         blaze::DynamicTensor<double> result(batch, result_length, out_channels);
         std::size_t pad_top = pad_width / 2;
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);
@@ -251,8 +251,8 @@ namespace phylanx { namespace common {
         blaze::DynamicTensor<double> result(
             batch, data_length, out_channels, 0.);
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);
@@ -294,8 +294,8 @@ namespace phylanx { namespace common {
 
         blaze::DynamicTensor<double> result(batch, data_length, out_channels);
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);
@@ -335,8 +335,8 @@ namespace phylanx { namespace common {
 
         blaze::DynamicTensor<double> result(batch, result_length, out_channels);
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);
@@ -374,8 +374,8 @@ namespace phylanx { namespace common {
 
         blaze::DynamicTensor<double> result(batch, data_length, out_channels);
 
-        hpx::parallel::for_loop(
-            hpx::parallel::execution::par, std::size_t(0), out_channels,
+        hpx::for_loop(
+            hpx::execution::par, std::size_t(0), out_channels,
             [&](std::size_t c)
             {
                 auto kslice = blaze::columnslice(k, c);

--- a/src/plugins/common/logsumexp_operation.cpp
+++ b/src/plugins/common/logsumexp_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_logsumexp_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/max_operation.cpp
+++ b/src/plugins/common/max_operation.cpp
@@ -29,7 +29,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_max_op>(
@@ -37,6 +37,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/mean_operation.cpp
+++ b/src/plugins/common/mean_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_mean_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/min_operation.cpp
+++ b/src/plugins/common/min_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_min_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/prod_operation.cpp
+++ b/src/plugins/common/prod_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_prod_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/stddev_operation.cpp
+++ b/src/plugins/common/stddev_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_stddev_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/sum_operation.cpp
+++ b/src/plugins/common/sum_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_sum_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/common/var_operation.cpp
+++ b/src/plugins/common/var_operation.cpp
@@ -28,7 +28,7 @@ namespace phylanx { namespace common {
         execution_tree::primitive_argument_type&& arg, ir::range&& axes,
         bool keepdims, execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
     template PHYLANX_COMMON_EXPORT execution_tree::primitive_argument_type
     statisticsnd<statistics_var_op>(
@@ -36,6 +36,6 @@ namespace phylanx { namespace common {
         hpx::util::optional<std::int64_t> const& axis, bool keepdims,
         execution_tree::primitive_argument_type&& initial,
         execution_tree::node_data_type dtype, std::string const& name,
-        std::string const& codename);
+        std::string const& codename, execution_tree::eval_context ctx);
 
 }}    // namespace phylanx::common

--- a/src/plugins/dist_statistics/max_d_operation.cpp
+++ b/src/plugins/dist_statistics/max_d_operation.cpp
@@ -19,10 +19,11 @@ namespace phylanx { namespace execution_tree { namespace primitives {
     ///////////////////////////////////////////////////////////////////////////
     match_pattern_type const max_d_operation::match_data = {
         match_pattern_type{"amax_d",
-            std::vector<std::string>{"amax_d(_1)", "amax_d(_1, _2)",
-                "amax_d(_1, _2, _3)", "amax_d(_1, _2, _3, _4)"},
+            std::vector<std::string>{
+                "amax_d(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_initial, nil), __arg(_5_dtype, nil))"},
             &create_amax_d_operation, &create_primitive<max_d_operation>, R"(
-            a, axis, keepdims, initial
+            a, axis, keepdims, initial, dtype
             Args:
 
                 a (vector or matrix): a scalar, a vector or a matrix
@@ -33,11 +34,12 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                    one. False by default
                 initial (optional, scalar): The minimum value of an output
                    element.
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 
-            Returns the maximum of an array or maximum along an axis.)",
-            true}};
+            Returns the maximum of an array or maximum along an axis.)"}};
 
     ///////////////////////////////////////////////////////////////////////////
     max_d_operation::max_d_operation(primitive_arguments_type&& operands,

--- a/src/plugins/statistics/all_operation.cpp
+++ b/src/plugins/statistics/all_operation.cpp
@@ -21,13 +21,16 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "all",
             std::vector<std::string>{
-                "all(_1)", "all(_1, _2)", "all(_1, _2, _3)"
+                "all(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_dummy0, nil), __arg(_5_dummy1, nil))"
             },
             &create_all_operation, &create_primitive<all_operation>, R"(
-            a, axis, keepdims, initial
+            arg, axis, keepdims, initial
             Args:
 
-                arg (matrix or vector of numbers) : the input values
+                arg (array of numbers) : the input values
+                axis (optional, integer) : a axis to sum along
+                keepdims (optional, boolean) : keep dimension of input
 
             Returns:
 

--- a/src/plugins/statistics/any_operation.cpp
+++ b/src/plugins/statistics/any_operation.cpp
@@ -21,13 +21,16 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "any",
             std::vector<std::string>{
-                "any(_1)", "any(_1, _2)", "any(_1, _2, _3)"
+                "any(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_dummy0, nil), __arg(_5_dummy1, nil))"
             },
             &create_any_operation, &create_primitive<any_operation>, R"(
-            a, axis, keepdims, initial
+            arg, axis, keepdims, initial
             Args:
 
-                arg (matrix or vector of numbers) : the input values
+                arg (array of numbers) : the input values
+                axis (optional, integer) : a axis to sum along
+                keepdims (optional, boolean) : keep dimension of input
 
             Returns:
 

--- a/src/plugins/statistics/logsumexp_operation.cpp
+++ b/src/plugins/statistics/logsumexp_operation.cpp
@@ -22,17 +22,20 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "logsumexp",
             std::vector<std::string>{
-                "logsumexp(_1)", "logsumexp(_1, _2)", "logsumexp(_1, _2, _3)"
+                "logsumexp(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_dummy_, nil), __arg(_5_dtype, nil))"
             },
             &create_logsumexp_operation, &create_primitive<logsumexp_operation>,
             R"(
-            a, axis, keepdims
+            arg, axis, keepdims, initial, dummy_, dtype
             Args:
 
-                a (array) : a scalar, a vector, a matrix or a tensor
-                axis (optional, integer): Axis over which the sum is taken.
-                    By default axis is None, and all elements are summed.
-                keepdims (optional, boolean): keep dimension of input
+                arg (array of numbers) : the input values
+                axis (optional, integer) : a axis to sum along
+                keepdims (optional, boolean) : keep dimension of input
+                dummy_ (nil) : unused
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 

--- a/src/plugins/statistics/max_operation.cpp
+++ b/src/plugins/statistics/max_operation.cpp
@@ -22,11 +22,11 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "amax",
             std::vector<std::string>{
-                "amax(_1)", "amax(_1, _2)", "amax(_1, _2, _3)",
-                "amax(_1, _2, _3, _4)"
+                "amax(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_initial, nil), __arg(_5_dtype, nil))"
             },
             &create_amax_operation, &create_primitive<max_operation>, R"(
-            a, axis, keepdims, initial
+            a, axis, keepdims, initial, dtype
             Args:
 
                 a (vector or matrix): a scalar, a vector or a matrix
@@ -37,11 +37,12 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                    one. False by default
                 initial (optional, scalar): The minimum value of an output
                    element.
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 
-            Returns the maximum of an array or maximum along an axis.)",
-            true
+            Returns the maximum of an array or maximum along an axis.)"
         }
     };
 

--- a/src/plugins/statistics/mean_operation.cpp
+++ b/src/plugins/statistics/mean_operation.cpp
@@ -21,22 +21,25 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "mean",
             std::vector<std::string>{
-                "mean(_1, _2, _3)", "mean(_1, _2)", "mean(_1)"
+                "mean(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_dummy_, nil), __arg(_5_dtype, nil))"
             },
             &create_mean_operation,
             &create_primitive<mean_operation>, R"(
-            ar, axis, keepdims
+            arg, axis, keepdims, initial, dummy_, dtype
             Args:
 
-                ar (array) : an array of values
-                axis (optional, int) : the axis along which to calculate the mean
-                keepdims (optional, boolean): keep dimension of input
+                arg (array of numbers) : the input values
+                axis (optional, integer) : a axis to sum along
+                keepdims (optional, boolean) : keep dimension of input
+                dummy_ (nil) : unused
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 
             The mean of the array. If an axis is specified, the result is the
-            vector created when the mean is taken along the specified axis.)",
-            true
+            vector created when the mean is taken along the specified axis.)"
         }
     };
 

--- a/src/plugins/statistics/min_operation.cpp
+++ b/src/plugins/statistics/min_operation.cpp
@@ -22,11 +22,11 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "amin",
             std::vector<std::string>{
-                "amin(_1)", "amin(_1, _2)", "amin(_1, _2, _3)",
-                "amin(_1, _2, _3, _4)"
+                "amin(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_initial, nil), __arg(_5_dtype, nil))"
             },
             &create_amin_operation, &create_primitive<min_operation>, R"(
-            a, axis, keepdims, initial
+            a, axis, keepdims, initial, dtype
             Args:
 
                 a (vector or matrix): a scalar, a vector or a matrix
@@ -37,10 +37,12 @@ namespace phylanx { namespace execution_tree { namespace primitives {
                    one. False by default
                 initial (optional, scalar): The maximum value of an output
                    element.
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
+
             Returns:
 
-            Returns the minimum of an array or minimum along an axis.)",
-            true
+            Returns the minimum of an array or minimum along an axis.)"
         }
     };
 

--- a/src/plugins/statistics/prod_operation.cpp
+++ b/src/plugins/statistics/prod_operation.cpp
@@ -26,22 +26,23 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "prod",
             std::vector<std::string>{
-                "prod(_1)", "prod(_1, _2)", "prod(_1, _2, _3)",
-                "prod(_1, _2, _3, _4)"
+                "prod(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_initial, nil), __arg(_5_dtype, nil))"
             },
             &create_prod_operation, &create_primitive<prod_operation>, R"(
-            v, axis, keepdims, initial
+            v, axis, keepdims, initial, dtype
             Args:
 
                 v (vector or matrix) : a vector or matrix
                 axis (optional, integer): a axis to sum along
                 keepdims (optional, boolean): keep dimension of input
                 initial (optional, scalar): The starting value for the product
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 
-            The product of all values along the specified axis.)",
-            true
+            The product of all values along the specified axis.)"
         }
     };
 

--- a/src/plugins/statistics/std_operation.cpp
+++ b/src/plugins/statistics/std_operation.cpp
@@ -21,20 +21,23 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "std",
             std::vector<std::string>{
-                "std(_1)", "std(_1, _2)", "std(_1, _2, _3)"
+                "std(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_dummy_, nil), __arg(_5_dtype, nil))"
             },
             &create_std_operation, &create_primitive<std_operation>, R"(
-            v, axis, keepdims
+            arg, axis, keepdims, initial, dummy_, dtype
             Args:
 
-                v (vector or matrix) : a vector or matrix
-                axis (optional, integer): a axis to sum along
-                keepdims (optional, boolean): keep dimension of input
+                arg (array of numbers) : the input values
+                axis (optional, integer) : a axis to sum along
+                keepdims (optional, boolean) : keep dimension of input
+                dummy_ (nil) : unused
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 
-            The standard deviation of all values along the specified axis.)",
-            true
+            The standard deviation of all values along the specified axis.)"
         }
     };
 

--- a/src/plugins/statistics/sum_operation.cpp
+++ b/src/plugins/statistics/sum_operation.cpp
@@ -22,22 +22,23 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "sum",
             std::vector<std::string>{
-                "sum(_1)", "sum(_1, _2)", "sum(_1, _2, _3)",
-                "sum(_1, _2, _3, _4)"
+                "sum(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_initial, nil), __arg(_5_dtype, nil))"
             },
             &create_sum_operation, &create_primitive<sum_operation>, R"(
-            v, axis, keepdims, initial
+            v, axis, keepdims, initial, dtype
             Args:
 
                 v (vector or matrix) : a vector or matrix
                 axis (optional, integer): a axis to sum along
                 keepdims (optional, boolean): keep dimension of input
                 initial (optional, scalar): The starting value for the sum
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 
-            The sum of all values along the specified axis.)",
-            true
+            The sum of all values along the specified axis.)"
         }
     };
 

--- a/src/plugins/statistics/var_operation.cpp
+++ b/src/plugins/statistics/var_operation.cpp
@@ -21,20 +21,23 @@ namespace phylanx { namespace execution_tree { namespace primitives {
         match_pattern_type{
             "var",
             std::vector<std::string>{
-                "var(_1)", "var(_1, _2)", "var(_1, _2, _3)"
+                "var(_1, __arg(_2_axis, nil), __arg(_3_keepdims, nil), "
+                    "__arg(_4_dummy_, nil), __arg(_5_dtype, nil))"
             },
             &create_var_operation, &create_primitive<var_operation>, R"(
-            v, axis, keepdims
+            arg, axis, keepdims, initial, dummy_, dtype
             Args:
 
-                v (vector or matrix) : a vector or matrix
-                axis (optional, integer): a axis to sum along
-                keepdims (optional, boolean): keep dimension of input
+                arg (array of numbers) : the input values
+                axis (optional, integer) : a axis to sum along
+                keepdims (optional, boolean) : keep dimension of input
+                dummy_ (nil) : unused
+                dtype (optional, string) : the data-type of the returned array,
+                  defaults to dtype of input array.
 
             Returns:
 
-            The statistical variance of all values along the specified axis.)",
-            true
+            The statistical variance of all values along the specified axis.)"
         }
     };
 

--- a/tests/regressions/python/1266_sum_axis_argument.py
+++ b/tests/regressions/python/1266_sum_axis_argument.py
@@ -1,0 +1,18 @@
+#  Copyright (c) 2020 Hartmut Kaiser
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #1266: np.sum does not know the axis argument
+
+from phylanx import Phylanx
+import numpy as np
+
+
+@Phylanx
+def test_sum(d):
+    return np.sum(d, axis=0, dtype='int')
+
+
+result = test_sum(np.array([1, 2, 3, 4, 5]))
+assert result == 15, result

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -60,6 +60,7 @@ set(tests
     1242_list_comparison
     1244_function_call
     1255_assign_string
+    1266_sum_axis_argument
     array_len_494
     array_shape_486
     array_subscript_403

--- a/tests/unit/plugins/statistics/std_operation.cpp
+++ b/tests/unit/plugins/statistics/std_operation.cpp
@@ -38,11 +38,12 @@ int main(int argc, char* argv[])
     // scalars
     test_count_std_operation("std(1.0)", "0.0");
     test_count_std_operation("std(1)", "0.0");
-    test_count_std_operation("std__float(1)", "0.0");
+    test_count_std_operation("std(1, __arg(dtype, \"float\"))", "0.0");
 
     // vectors
     test_count_std_operation("std([1.0, 2.0, 3.0, 4.0])", "sqrt(1.25)");
-    test_count_std_operation("std__float([1, 2, 3, 4])", "sqrt(1.25)");
+    test_count_std_operation(
+        "std([1, 2, 3, 4], __arg(dtype, \"float\"))", "sqrt(1.25)");
 
     test_count_std_operation("std([1.0, 2.0, 3.0, 4.0], 0)", "sqrt(1.25)");
     test_count_std_operation("std([1.0, 2.0, 3.0, 4.0], -1)", "sqrt(1.25)");

--- a/tests/unit/plugins/statistics/var_operation.cpp
+++ b/tests/unit/plugins/statistics/var_operation.cpp
@@ -38,11 +38,12 @@ int main(int argc, char* argv[])
     // scalars
     test_count_var_operation("var(1.0)", "0.0");
     test_count_var_operation("var(1)", "0.0");
-    test_count_var_operation("var__float(1)", "0.0");
+    test_count_var_operation("var(1, __arg(dtype, \"float\"))", "0.0");
 
     // vectors
     test_count_var_operation("var([1.0, 2.0, 3.0, 4.0])", "1.25");
-    test_count_var_operation("var__float([1, 2, 3, 4])", "1.25");
+    test_count_var_operation(
+        "var([1, 2, 3, 4], __arg(dtype, \"float\"))", "1.25");
 
     test_count_var_operation("var([1.0, 2.0, 3.0, 4.0], 0)", "1.25");
     test_count_var_operation("var([1.0, 2.0, 3.0, 4.0], -1)", "1.25");


### PR DESCRIPTION
- flyby: implement dtype for statistics primitives
- flyby: make sure stack traces are generated for errors from
  statistic primitives

Fixes #1266