### PR TITLE
Evaluate values for default arguments in Python context

### DIFF
--- a/python/phylanx/ast/physl.py
+++ b/python/phylanx/ast/physl.py
@@ -681,6 +681,9 @@ class PhySL:
                 result = (*result, a)
             else:
                 op = get_symbol_info(arg, '__arg')
+                default_name = re.sub(r'\$\d+', '', default)
+                if default_name in self.fglobals:
+                    default = '%s' % self.fglobals[default_name]
                 result = (*result, [op, (a, default)])
         return result
 

--- a/tests/regressions/python/1206_improper_defaults.py
+++ b/tests/regressions/python/1206_improper_defaults.py
@@ -1,0 +1,27 @@
+#  Copyright (c) 2020 Steven R. Brandt
+#
+#  Distributed under the Boost Software License, Version 1.0. (See accompanying
+#  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+# #1206: Improper handling of defaults
+from phylanx import Phylanx
+
+
+q = 57
+
+
+@Phylanx
+def test1(n=q):
+    return n
+
+
+@Phylanx
+def test2(n=10):
+    return n
+
+
+result = test1()
+assert result == 57, result
+
+result = test2()
+assert result == 10, result

--- a/tests/regressions/python/CMakeLists.txt
+++ b/tests/regressions/python/CMakeLists.txt
@@ -52,6 +52,7 @@ set(tests
     1056_client_base
     1104_no_arg_lambda
     1170_no_error
+    1206_improper_defaults
     1224_dictionary_len
     1225_iterate_dictionary
     1230_assign_argument_dictionary


### PR DESCRIPTION
Fixes #1206, supersedes #1208