### PR TITLE
Address the removal of Python 2 from CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -291,7 +291,7 @@ jobs:
             - run:
                 name: Check the formatting of Phylanx's Python files
                 environment:
-                    PYTHONPATH: "/phylanx/build/python/build/lib.linux-x86_64-3.7"
+                    PYTHONPATH: "/phylanx/build/python/build/lib.linux-x86_64-3.8"
                 command: |
                     python3 tools/check_help/check_help.py >/code_format/phylanx_help_report.xml
                     cp /code_format/phylanx_help_report.xml /artifacts/phylanx_help_report.txt

--- a/tools/circleci/check_test_coverage.py
+++ b/tools/circleci/check_test_coverage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2019 Parsa Amini
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/tools/flake8/flake_to_junit.py
+++ b/tools/flake8/flake_to_junit.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# Copyright (c) 2018 Parsa Amini
+#!/usr/bin/env python3
+# Copyright (c) 2018-2020 Parsa Amini
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/tools/inspect/inspect_to_junit.py
+++ b/tools/inspect/inspect_to_junit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright (c) 2018 Parsa Amini
 #
 # Distributed under the Boost Software License, Version 1.0. (See accompanying


### PR DESCRIPTION
Addresses:
* Removal of Python 2 from the Docker image
* Update `PYTHONPATH` to reflect Python 3.7 to 3.8 upgrade for the `help_format` check.

Note:
* The test fails do not look relevant. Need to be investigated separately:
    * <https://gist.github.com/parsa/d603f60b8827229ccc476e3e0a6dc5a8>