### PR TITLE
Phydef

### DIFF
--- a/python/phylanx/__init__.py
+++ b/python/phylanx/__init__.py
@@ -5,5 +5,5 @@
 
 from .core import *
 from .core.config import *
-from .ast.transducer import Phylanx
+from .ast.transducer import Phylanx, PhyDef, is_python
 from .execution_tree import parallel

--- a/python/phylanx/ast/transducer.py
+++ b/python/phylanx/ast/transducer.py
@@ -230,6 +230,7 @@ def Phylanx(__phylanx_arg=None, **kwargs):
     else:
         return _PhylanxDecorator
 
+
 class PhyDef:
     """
     PhyDef makes it possible to define two versions of the same function,
@@ -237,7 +238,7 @@ class PhyDef:
     from Python.
 
     Example:
-    
+
     from phylanx import PhyDef
     from numpy import zeros
 
@@ -258,23 +259,34 @@ class PhyDef:
         frame = inspect.currentframe()
         outer = inspect.getouterframes(frame)
         self.gs = outer[1].frame.f_globals
+
     def __enter__(self):
         self.save = self.gs.get(self.fname, None)
+
     def __exit__(self, ex_type, ex_val, trace):
         assert self.fname in self.gs and self.gs[self.fname] != self.save, \
             "Missing definition for '%s'" % self.fname
-        self.gs[self.fname+"_phylanx"] = self.gs[self.fname]
+        self.gs[self.fname + "_phylanx"] = self.gs[self.fname]
         self.gs[self.fname] = self.save
 
+
+@Phylanx
 def is_python():
     """
     The is_python() function can be used inside a function so
     that that a method can determine whether it's using phylanx
     or python.
     """
+    return False
+
+
+@Phylanx
+def is_python_phylanx():
+    return False
+
+
+def is_python_():
     return True
 
-with PhyDef("is_python"):
-    @Phylanx
-    def is_python():
-        return False
+
+globals()["is_python"] = is_python_


### PR DESCRIPTION
Add PhyDef:
    PhyDef makes it possible to define two versions of the same function,
    one that can be called from Phylanx and the other that can be called
    from Python.

    Example:

    from phylanx import PhyDef
    from numpy import zeros

    with PhyDef("zeros"):
        @Phylanx
        def zeros(shape,dtype):
            return constant(0,shape,dtype)

    a = zeros([3,3],dtype="float64") # call numpy zeros
    a2 = zeros_phylanx([3,3],dtype="float64") # call phylanx zeros

    @Phylanx
    def foo():
        a = zeros([3,3],dtype="float64") # call phylanx zeros

Also add is_python() to allow routines to write code that evaluates differently inside or outside phylanx.