### PR TITLE
Adding --phylanx:performance command line option

### DIFF
--- a/src/execution_tree/compile.cpp
+++ b/src/execution_tree/compile.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2018 Hartmut Kaiser
+// Copyright (c) 2017-2021 Hartmut Kaiser
 //
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -10,6 +10,7 @@
 #include <phylanx/execution_tree/compiler/compiler.hpp>
 #include <phylanx/execution_tree/compiler_component.hpp>
 #include <phylanx/execution_tree/primitives/base_primitive.hpp>
+#include <phylanx/util/performance_data.hpp>
 
 #include <hpx/modules/format.hpp>
 #include <hpx/include/naming.hpp>
@@ -20,6 +21,11 @@
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace phylanx { namespace util {
+
+    bool need_performance_counters();
+}}
 
 namespace phylanx { namespace execution_tree
 {
@@ -76,7 +82,16 @@ namespace phylanx { namespace execution_tree
         }
 
         // always return the last of all generated compiler-functions
-        return snippets.program_.add_entry_point(std::move(entry_point));
+        auto const& result =
+            snippets.program_.add_entry_point(std::move(entry_point));
+
+        // re-enable all performance counters, if needed
+        if (util::need_performance_counters())
+        {
+            phylanx::util::enable_measurements();
+        }
+
+        return result;
     }
 
     compiler::entry_point const& compile(std::string const& name,
@@ -94,7 +109,16 @@ namespace phylanx { namespace execution_tree
         }
 
         // always return the last of all generated compiler-functions
-        return snippets.program_.add_entry_point(std::move(entry_point));
+        auto const& result =
+            snippets.program_.add_entry_point(std::move(entry_point));
+
+        // re-enable all performance counters, if needed
+        if (util::need_performance_counters())
+        {
+            phylanx::util::enable_measurements();
+        }
+
+        return result;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -150,7 +174,16 @@ namespace phylanx { namespace execution_tree
         }
 
         // always return the last of all generated compiler-functions
-        return snippets.program_.add_entry_point(std::move(entry_point));
+        auto const& result =
+            snippets.program_.add_entry_point(std::move(entry_point));
+
+        // re-enable all performance counters, if needed
+        if (util::need_performance_counters())
+        {
+            phylanx::util::enable_measurements();
+        }
+
+        return result;
     }
 
     compiler::entry_point const& compile(std::string const& name,

--- a/src/util/command_line_options.cpp
+++ b/src/util/command_line_options.cpp
@@ -1,0 +1,62 @@
+//  Copyright (c) 2021 Hartmut Kaiser
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <phylanx/config.hpp>
+
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/program_options.hpp>
+
+#include <string>
+
+namespace phylanx { namespace util {
+
+    // This will be called to return special command line options supported by
+    // this component.
+    hpx::program_options::options_description command_line_options()
+    {
+        hpx::program_options::options_description opts(
+            "Additional command line options for the phylanx component");
+        opts.add_options()("phylanx:performance",
+            hpx::program_options::value<std::string>()->implicit_value(""),
+            "enables the performance counters "
+            "implemented by the phylanx primitives");
+        return opts;
+    }
+
+    // Parse the command line to figure out whether the sine performance
+    // counters need to be created.
+    bool need_performance_counters(std::string& filename)
+    {
+        using hpx::util::retrieve_commandline_arguments;
+
+        // Retrieve command line using the HPX ProgramOptions library.
+        hpx::program_options::variables_map vm;
+        if (!retrieve_commandline_arguments(command_line_options(), vm))
+        {
+            HPX_THROW_EXCEPTION(hpx::commandline_option_error,
+                "phylanx::util::need_performance_counters",
+                "Failed to handle command line options");
+            return false;
+        }
+
+        // We enable the performance counters if --phylanx:performance is
+        // specified on the command line.
+        if (vm.count("phylanx:performance") == 0)
+        {
+            return false;
+        }
+
+        filename = vm["phylanx:performance"].as<std::string>();
+        return true;
+    }
+}}    // namespace phylanx::util
+
+// Register a function to be called to populate the special command line
+// options supported by this component.
+//
+// Note that this macro can be used not more than once in one module.
+HPX_REGISTER_COMMANDLINE_MODULE(::phylanx::util::command_line_options);

--- a/src/util/performance_data.cpp
+++ b/src/util/performance_data.cpp
@@ -256,12 +256,17 @@ namespace phylanx { namespace util {
 
             // Collect the performance counter values
             std::vector<std::int64_t> data(counter_name_last_parts.size());
-            for (unsigned int i = 0; i < counter_values.size(); ++i)
+            for (std::size_t i = 0; i < counter_values.size(); ++i)
             {
-                HPX_ASSERT(static_cast<std::size_t>(r.second - r.first) <
-                    counter_values[i].size());
-
-                data[i] = counter_values[i][tags.sequence_number - r.first];
+                if (static_cast<std::size_t>(r.second - r.first) <
+                    counter_values[i].size())
+                {
+                    data[i] = counter_values[i][tags.sequence_number - r.first];
+                }
+                else
+                {
+                    data[i] = 0;
+                }
             }
 
             result.emplace(decltype(result)::value_type(name, data));

--- a/src/util/startup_shutdown.cpp
+++ b/src/util/startup_shutdown.cpp
@@ -4,23 +4,43 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <phylanx/config.hpp>
+#include <phylanx/execution_tree/compiler/primitive_name.hpp>
 #include <phylanx/plugins/plugin_factory.hpp>
+#include <phylanx/util/performance_data.hpp>
 
 #include <hpx/include/components.hpp>
-#include <hpx/runtime_local/startup_function.hpp>
-#include <hpx/runtime_local/shutdown_function.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/performance_counters.hpp>
+#include <hpx/modules/runtime_local.hpp>
 
-namespace phylanx
-{
-    namespace performance_counters
-    {
+#include <fstream>
+#include <iostream>
+#include <string>
+
+namespace phylanx {
+
+    namespace performance_counters {
+
         void startup_counters();
     }
-}
 
-namespace phylanx { namespace util
-{
+    namespace util {
+
+        bool need_performance_counters(std::string& filename);
+    }
+}    // namespace phylanx
+
+namespace phylanx { namespace util {
+
     phylanx::plugin::plugin_map_type plugin_map;
+
+    bool print_performance_counter_data = false;
+    std::string performance_counter_dest;
+
+    bool need_performance_counters()
+    {
+        return print_performance_counter_data;
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     void startup()
@@ -30,34 +50,86 @@ namespace phylanx { namespace util
 
         // register performance counters for all discovered primitives
         performance_counters::startup_counters();
+
+        // enable performance counters if requested on command line
+        if (need_performance_counters(performance_counter_dest))
+        {
+            phylanx::util::enable_measurements();
+            hpx::reinit_active_counters();
+            print_performance_counter_data = true;
+        }
+    }
+
+    void print_performance_counter_data_csv(std::ostream& os)
+    {
+        // CSV Header
+        os << "primitive_instance,display_name,count,time,eval_direct\n";
+
+        // Print performance data
+        for (auto const& entry : phylanx::util::retrieve_counter_data())
+        {
+            os << "\"" << entry.first << "\",\""
+               << phylanx::execution_tree::compiler::primitive_display_name(
+                      entry.first)
+               << "\"";
+            for (auto const& counter_value : entry.second)
+            {
+                os << "," << counter_value;
+            }
+            os << "\n";
+        }
+
+        os << "\n";
     }
 
     void shutdown()
     {
+        // print performance counter data, if requested
+        if (print_performance_counter_data)
+        {
+            if (performance_counter_dest.empty())
+            {
+                print_performance_counter_data_csv(std::cout);
+            }
+            else
+            {
+                std::ofstream os(performance_counter_dest);
+                if (!os.good())
+                {
+                    HPX_THROW_EXCEPTION(hpx::filesystem_error,
+                        "phylanx::util::shutdown",
+                        "Failed to open the specified file: " +
+                            performance_counter_dest);
+                }
+
+                print_performance_counter_data_csv(os);
+            }
+        }
+
         // unload all plugin modules
         plugin_map.clear();
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    bool get_startup(hpx::startup_function_type& startup_func,
-        bool& pre_startup)
+    bool get_startup(
+        hpx::startup_function_type& startup_func, bool& pre_startup)
     {
         // return our startup-function
-        startup_func = startup;   // function to run during startup
-        pre_startup = true;                 // run as pre-startup function
+        startup_func = startup;    // function to run during startup
+        pre_startup = true;        // run as pre-startup function
         return true;
     }
 
-    bool get_shutdown(hpx::shutdown_function_type& shutdown_func,
-        bool& pre_shutdown)
+    bool get_shutdown(
+        hpx::shutdown_function_type& shutdown_func, bool& pre_shutdown)
     {
         // return our startup-function
-        shutdown_func = shutdown;   // function to run during startup
-        pre_shutdown = false;                 // run as pre-startup function
+        shutdown_func = shutdown;    // function to run during shutdown
+        pre_shutdown = false;        // run as pre-shutdown function
         return true;
     }
-}}
+}}    // namespace phylanx::util
 
-// Note that this macro can be used not more than once in one module.
-HPX_REGISTER_STARTUP_SHUTDOWN_MODULE(phylanx::util::get_startup,
-    phylanx::util::get_shutdown);
+// Note that this macro can't be used more than once in one module.
+HPX_REGISTER_STARTUP_SHUTDOWN_MODULE(
+    phylanx::util::get_startup, phylanx::util::get_shutdown);


### PR DESCRIPTION
- this option is implicitly available to all Phylanx executables, it can
  have an optional argument (i.e. --phylanx:performance=<filename>) that
  will use the argument as the destination file name (default: std::cout)

Fixes #1322 

@taless474 please check if this solves your issue