### PR TITLE
namespace fixes for hpx::collectives

### DIFF
--- a/phylanx/plugins/dist_matrixops/dist_argminmax_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_argminmax_impl.hpp
@@ -171,12 +171,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             std::int64_t index,
             execution_tree::localities_information const& locs)
         {
-            auto p = hpx::all_reduce(
+            auto p = hpx::collectives::all_reduce(
                 ("all_reduce_" + locs.annotation_.name_).c_str(),
                 std::make_pair(value, index), all_reduce_op_0d<Op>{},
-                locs.locality_.num_localities_, std::size_t(-1),
-                locs.locality_.locality_id_)
-                         .get();
+                hpx::collectives::num_sites_arg{locs.locality_.num_localities_},
+		hpx::collectives::this_site_arg{std::size_t(-1)},
+                hpx::collectives::generation_arg{locs.locality_.locality_id_})
+                .get();
 
             return execution_tree::primitive_argument_type{p.second};
         }
@@ -271,12 +272,13 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
                         return std::make_pair(value, index);
                     });
 
-            auto p = hpx::all_reduce(
+            auto p = hpx::collectives::all_reduce(
                 ("all_reduce_" + locs.annotation_.name_).c_str(),
                 value_index_vector, all_reduce_op_1d<Op>{},
-                locs.locality_.num_localities_, std::size_t(-1),
-                locs.locality_.locality_id_)
-                         .get();
+                hpx::collectives::num_sites_arg{locs.locality_.num_localities_},
+		hpx::collectives::this_site_arg{std::size_t(-1)},
+                hpx::collectives::generation_arg{locs.locality_.locality_id_})
+                .get();
 
             blaze::DynamicVector<std::int64_t> res = blaze::map(
                 p, [](std::pair<T, std::int64_t> r) { return r.second; });

--- a/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
+++ b/phylanx/plugins/dist_matrixops/dist_dot_operation_impl.hpp
@@ -44,6 +44,10 @@
 using std_int64_t = std::int64_t;
 using std_uint8_t = std::uint8_t;
 
+using hpx::collectives::num_sites_arg;
+using hpx::collectives::this_site_arg;
+using hpx::collectives::generation_arg;
+
 ////////////////////////////////////////////////////////////////////////////////
 REGISTER_DISTRIBUTED_VECTOR_DECLARATION(double);
 REGISTER_DISTRIBUTED_VECTOR_DECLARATION(std_int64_t);
@@ -187,11 +191,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         // collect overall result if left hand side vector is distributed
         if (lhs_localities.locality_.num_localities_ > 1)
         {
-            lhs = hpx::all_reduce(
+            lhs = hpx::collectives::all_reduce(
                 ("all_reduce_" + lhs_localities.annotation_.name_).c_str(),
                 dot_result, std::plus<T>{},
-                lhs_localities.locality_.num_localities_, std::size_t(-1),
-                lhs_localities.locality_.locality_id_)
+                num_sites_arg{lhs_localities.locality_.num_localities_},
+		this_site_arg{std::size_t(-1)},
+                generation_arg{lhs_localities.locality_.locality_id_})
                       .get();
         }
         else
@@ -309,12 +314,12 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
         if (lhs_localities.locality_.num_localities_ > 1)
         {
             result =
-                execution_tree::primitive_argument_type{hpx::all_reduce(
+                execution_tree::primitive_argument_type{hpx::collectives::all_reduce(
                     ("all_reduce_" + lhs_localities.annotation_.name_)
                         .c_str(),
                     dot_result, blaze::Add{},
-                    lhs_localities.locality_.num_localities_,
-                    std::size_t(-1), lhs_localities.locality_.locality_id_)
+                    num_sites_arg{lhs_localities.locality_.num_localities_},
+                    this_site_arg{std::size_t(-1)}, generation_arg{lhs_localities.locality_.locality_id_})
                                                             .get()};
 
         }
@@ -525,13 +530,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             else
             {
                 result =
-                    execution_tree::primitive_argument_type{hpx::all_reduce(
+                    execution_tree::primitive_argument_type{hpx::collectives::all_reduce(
                         ("all_reduce_" + lhs_localities.annotation_.name_)
                             .c_str(),
                         dot_result, blaze::Add{},
-                        lhs_localities.locality_.num_localities_,
-                        std::size_t(-1), lhs_localities.locality_.locality_id_)
-                                                                .get()};
+                        num_sites_arg{lhs_localities.locality_.num_localities_},
+                        this_site_arg{std::size_t(-1)},
+			generation_arg{lhs_localities.locality_.locality_id_})
+                        .get()};
             }
         }
         else
@@ -710,13 +716,14 @@ namespace phylanx { namespace dist_matrixops { namespace primitives {
             else
             {
                 result =
-                    execution_tree::primitive_argument_type{hpx::all_reduce(
+                    execution_tree::primitive_argument_type{hpx::collectives::all_reduce(
                         ("all_reduce_" + lhs_localities.annotation_.name_)
                             .c_str(),
                         result_matrix, blaze::Add{},
-                        lhs_localities.locality_.num_localities_,
-                        std::size_t(-1), lhs_localities.locality_.locality_id_)
-                                                                .get()};
+                        num_sites_arg{lhs_localities.locality_.num_localities_},
+                        this_site_arg{std::size_t(-1)},
+			generation_arg{lhs_localities.locality_.locality_id_})
+                        .get()};
             }
         }
         else

--- a/src/execution_tree/meta_annotation.cpp
+++ b/src/execution_tree/meta_annotation.cpp
@@ -92,9 +92,10 @@ namespace phylanx { namespace execution_tree
             extract_locality_information(locality_ann, name, codename);
 
         hpx::future<std::vector<annotation>> f =
-            hpx::all_gather(("all_gather_" + ann_name).c_str(), std::move(ann),
-                locality_info.num_localities_, std::size_t(-1),
-                locality_info.locality_id_);
+            hpx::collectives::all_gather(("all_gather_" + ann_name).c_str(), std::move(ann),
+                hpx::collectives::num_sites_arg{locality_info.num_localities_},
+		hpx::collectives::this_site_arg{std::size_t(-1)},
+                hpx::collectives::generation_arg{locality_info.locality_id_});
 
         return f.then(hpx::launch::sync,
             [](hpx::future<std::vector<annotation>>&& f) -> annotation

--- a/src/plugins/dist_matrixops/all_gather.cpp
+++ b/src/plugins/dist_matrixops/all_gather.cpp
@@ -221,11 +221,11 @@ namespace phylanx { namespace dist_matrixops { namespace primitives
 
         blaze::DynamicMatrix<T> m = arr.matrix();
         // use hpx::all_gather to get a vector of values
-        auto p = hpx::all_gather(
+        auto p = hpx::collectives::all_gather(
             ("all_gather_" + locs.annotation_.name_).c_str(),
-            m, locs.locality_.num_localities_,
-            std::size_t(-1),
-            locs.locality_.locality_id_)
+            m, hpx::collectives::num_sites_arg{locs.locality_.num_localities_},
+            hpx::collectives::this_site_arg{std::size_t(-1)},
+            hpx::collectives::generation_arg{locs.locality_.locality_id_})
                 .get();
 
         // row and column dimensions of the whole array


### PR DESCRIPTION
provides namespace fixes for hpx::collectives. in most cases, these fixes wrap parameters to collective algorithms.